### PR TITLE
[REFACTOR] use mxgraph types instead of any

### DIFF
--- a/src/component/BpmnVisu.ts
+++ b/src/component/BpmnVisu.ts
@@ -19,10 +19,9 @@ import MxGraphRenderer from './mxgraph/MxGraphRenderer';
 import { defaultBpmnParser } from './parser/BpmnParser';
 import { MxGraphFactoryService } from '../service/MxGraphFactoryService';
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 export default class BpmnVisu {
-  private mxClient: any = MxGraphFactoryService.getMxGraphProperty('mxClient');
-  private mxUtils: any = MxGraphFactoryService.getMxGraphProperty('mxUtils');
+  private mxClient: typeof mxgraph.mxClient = MxGraphFactoryService.getMxGraphProperty('mxClient');
+  private mxUtils: typeof mxgraph.mxUtils = MxGraphFactoryService.getMxGraphProperty('mxUtils');
 
   public readonly graph: mxgraph.mxGraph;
 

--- a/src/component/mxgraph/MxGraphRenderer.ts
+++ b/src/component/mxgraph/MxGraphRenderer.ts
@@ -27,8 +27,7 @@ interface Coordinate {
 }
 
 export default class MxGraphRenderer {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private mxPoint: any = MxGraphFactoryService.getMxGraphProperty('mxPoint');
+  private mxPoint: typeof mxgraph.mxPoint = MxGraphFactoryService.getMxGraphProperty('mxPoint');
   constructor(readonly graph: mxgraph.mxGraph) {}
 
   public render(bpmnModel: BpmnModel): void {

--- a/src/component/mxgraph/ShapeConfigurator.ts
+++ b/src/component/mxgraph/ShapeConfigurator.ts
@@ -37,7 +37,7 @@ export default class ShapeConfigurator {
   private initMxShapePrototype(isFF: boolean): void {
     // this change is needed for adding the custom attributes that permits identification of the BPMN elements
     this.mxShape.prototype.createSvgCanvas = function() {
-      // TODO should be 'typeof mxgraph.mxSvgCanvas2D'
+      // TODO should be 'typeof mxgraph.mxSvgCanvas2D', current type definition does not declare 'minStrokeWidth'
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const mxSvgCanvas2D: any = MxGraphFactoryService.getMxGraphProperty('mxSvgCanvas2D');
       const canvas = new mxSvgCanvas2D(this.node, false);


### PR DESCRIPTION
Use `typeof` when retrieving types from `MxGraphFactoryService`
  - BpmnVisu: add type to mxClient and mxUtils
  - MxGraphRenderer: add type to mxPoint
  - ShapeConfigurator: update todo about 'mxSvgCanvas2D' 