### PR TITLE
[INFRA] add a GH Workflow to build and publish documentation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
     paths-ignore:
+      - '.github/workflows/generate-documentation.yml'
       - '.gitignore'
       - 'docs/**'
       - '*.md'
@@ -13,6 +14,7 @@ on:
     branches:
       - master
     paths-ignore:
+      - '.github/workflows/generate-documentation.yml'
       - '.gitignore'
       - 'docs/**'
       - '*.md'

--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -1,0 +1,47 @@
+name: Generate Documentation
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'docs/**'
+      - '.github/workflows/generate-documentation.yml'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'docs/**'
+      - '.github/workflows/generate-documentation.yml'
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build
+        run: ./docs/build-doc.bash
+      - name: Upload
+        uses: actions/upload-artifact@v1
+        with:
+          name: documentation
+          path: build/docs
+
+  push-to-gh-pages:
+    # only when 'on push to master'
+    if: github.event_name == 'push' &&  github.event.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    needs: generate
+    steps:
+      - name: Download
+        uses: actions/download-artifact@v1
+        with:
+          name: documentation
+      - name: Push to gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./documentation
+          keep_files: true
+          user_name: 'process-analytics-bot'
+          user_email: '62586190+process-analytics-bot@users.noreply.github.com'


### PR DESCRIPTION
- run on push to master and pull_request
- always upload the generate documentation as artifact. On PR, this helps to
have a doc preview
- when the workflow is triggered by a `push to master`, push the generated
documentation to the `gh-pages` branch

Covers #138

**Notes**:
- The GitHub Pages push (run only after a push to the master branch) has been tested in a [playground/demo repository](https://github.com/tbouffard/playground-release-drafter-and-gh-pages/commit/6f55a7850263e66c96c1cf51d0d51f0e57d05764)
- Documentation preview for PR will be managed later, see #180
