### PR TITLE
[FEAT] render terminate end event

### DIFF
--- a/docs/bpmn-support.adoc
+++ b/docs/bpmn-support.adoc
@@ -83,8 +83,8 @@ The default rendering uses `white` as fill color and `black` as stroke color.
 |The stroke width may be adjusted
 
 |Terminate End Event
-|
-|
+|icon:check-circle-o[]
+|The stroke width may be adjusted
 |===
 
 

--- a/src/component/mxgraph/MxGraphRenderer.ts
+++ b/src/component/mxgraph/MxGraphRenderer.ts
@@ -20,8 +20,7 @@ import BpmnModel from '../../model/bpmn/BpmnModel';
 import ShapeBpmnElement, { ShapeBpmnEvent } from '../../model/bpmn/shape/ShapeBpmnElement';
 import { MxGraphFactoryService } from '../../service/MxGraphFactoryService';
 import Waypoint from '../../model/bpmn/edge/Waypoint';
-import { ShapeBpmnElementKind } from '../../model/bpmn/shape/ShapeBpmnElementKind';
-import { ShapeBpmnEventKind } from '../../model/bpmn/shape/ShapeBpmnEventKind';
+import { StyleConstant } from './StyleConfigurator';
 
 interface Coordinate {
   x: number;
@@ -66,22 +65,15 @@ export default class MxGraphRenderer {
       const bounds = shape.bounds;
       const parent = this.getParent(bpmnElement);
       const absoluteCoordinate = { x: bounds.x, y: bounds.y };
-      const style = this.getStyleName(bpmnElement);
+      const style = this.computeStyleName(bpmnElement);
       this.insertVertexGivenAbsoluteCoordinates(parent, bpmnElement.id, bpmnElement.name, absoluteCoordinate, bounds.width, bounds.height, style);
     }
   }
 
-  private getStyleName(bpmnElement: ShapeBpmnEvent | ShapeBpmnElement): string {
-    let style: string;
+  private computeStyleName(bpmnElement: ShapeBpmnEvent | ShapeBpmnElement): string {
+    let style = bpmnElement.kind as string;
     if (bpmnElement instanceof ShapeBpmnEvent) {
-      // TODO: following if is just temporary as long as Start Event (subtypes) support is not added
-      if (bpmnElement.kind === ShapeBpmnElementKind.EVENT_END) {
-        style = bpmnElement.eventKind && bpmnElement.eventKind !== ShapeBpmnEventKind.NONE ? bpmnElement.kind + '_' + bpmnElement.eventKind : bpmnElement.kind;
-      } else {
-        style = bpmnElement.kind;
-      }
-    } else {
-      style = bpmnElement.kind;
+      style += ';' + StyleConstant.BPMN_STYLE_EVENT_KIND + '=' + bpmnElement.eventKind;
     }
     return style;
   }

--- a/src/component/mxgraph/StyleConfigurator.ts
+++ b/src/component/mxgraph/StyleConfigurator.ts
@@ -16,11 +16,11 @@
 import { mxgraph } from 'ts-mxgraph';
 import { ShapeBpmnElementKind } from '../../model/bpmn/shape/ShapeBpmnElementKind';
 import { MxGraphFactoryService } from '../../service/MxGraphFactoryService';
-import { ShapeBpmnEventKind } from '../../model/bpmn/shape/ShapeBpmnEventKind';
 
 export enum StyleConstant {
   STROKE_WIDTH_THIN = 2,
   STROKE_WIDTH_THICK = 5,
+  BPMN_STYLE_EVENT_KIND = 'bpmn.eventKind',
 }
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -38,7 +38,6 @@ export default class StyleConfigurator {
     // events
     this.configureStartEventStyle();
     this.configureEndEventStyle();
-    this.configureEndEventTerminateStyle();
     // tasks
     this.configureUserTaskStyle();
     this.configureServiceTaskStyle();
@@ -61,8 +60,7 @@ export default class StyleConfigurator {
     return this.mxUtils.clone(defaultStyle);
   }
 
-  // TODO: name - shoud be reworked to accept subtypes
-  private putCellStyle(name: ShapeBpmnElementKind | string, style: any): void {
+  private putCellStyle(name: ShapeBpmnElementKind, style: any): void {
     this.getStylesheet().putCellStyle(name, style);
   }
 
@@ -115,15 +113,6 @@ export default class StyleConfigurator {
     style[this.mxConstants.STYLE_VERTICAL_ALIGN] = 'top';
     style[this.mxConstants.STYLE_STROKECOLOR] = '#000';
     this.putCellStyle(ShapeBpmnElementKind.EVENT_END, style);
-  }
-
-  private configureEndEventTerminateStyle(): void {
-    const style = this.cloneDefaultVertexStyle();
-    style[this.mxConstants.STYLE_SHAPE] = ShapeBpmnElementKind.EVENT_END;
-    style[this.mxConstants.STYLE_PERIMETER] = this.mxPerimeter.EllipsePerimeter;
-    style[this.mxConstants.STYLE_VERTICAL_ALIGN] = 'top';
-    style[this.mxConstants.STYLE_STROKECOLOR] = '#F00';
-    this.putCellStyle(ShapeBpmnElementKind.EVENT_END + '_' + ShapeBpmnEventKind.TERMINATE, style);
   }
 
   private configureServiceTaskStyle(): void {


### PR DESCRIPTION
Introduce a new way of managing EndEvent shapes
  - when creating a vertex, set the event type as part of the style
  - the event type style information are used by the Event shape to display the
  related event icon
To prepare StartEvent shapes to act in the same way, a top level Event shape
already manages some parts of the rendering.

This simplifies style declaration: there is no need to define a new style each
time we want to support a new event type nor update anything else.
Our custom mxGraph Renderer will always add the event type to the style
associated to the vertex.
Thanks to that, any new supported event type will be rendered as a None Event by
 default.

closes #137 
