### PR TITLE
[DOC] improve html rendering

### DIFF
--- a/docs/bpmn-support-roadmap.adoc
+++ b/docs/bpmn-support-roadmap.adoc
@@ -1,6 +1,6 @@
 [[bpmn-support-roadmap]]
 
-== Description of the BPMN support Roadmap
+== BPMN Support Roadmap
 :icons: font
 
 NOTE: The list of supported BPMN elements is available in <<supported-bpmn-elements,supported BPMN elements>>

--- a/docs/bpmn-support.adoc
+++ b/docs/bpmn-support.adoc
@@ -1,13 +1,13 @@
 [[supported-bpmn-elements]]
 
-== Description of the supported BPMN elements
+== Supported BPMN Elements
 :icons: font
 
 NOTE: The support roadmap is available in <<bpmn-support-roadmap,BPMN Support Roadmap>>
 
 
-This page presents BPMN elements that can be displayed by the lib and states which is their rendering status i.e. if the
-BPMN elements are rendered with their final shapes.
+The following presents BPMN elements that can be displayed by the lib and states which is their rendering status i.e. if
+the BPMN elements are rendered with their final shapes.
 
 The default rendering uses `white` as fill color and `black` as stroke color.
 

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -2,13 +2,13 @@
 :toc: left
 // see: https://asciidoctor.org/docs/user-manual/#table-of-contents-summary
 :toc-title: Table of Contents
-// how many headline levels to display in table of contents?
-:toclevels: 5
+// how many headline levels to display in the table of contents?
+:toclevels: 2
 // https://asciidoctor.org/docs/user-manual/#sections-summary
 // turn numbering on or off (:sectnums!:)
 :sectnums:
 // enumerate how many section levels?
-:sectnumlevels: 2
+:sectnumlevels: 5
 // show anchors when hovering over section headers
 :sectanchors:
 // render section headings as self referencing links


### PR DESCRIPTION
  - toc: only display 2 levels. Previously, it was set to '5' which is too much
  for now as we do not have a lot of content
  - set numeration also on deep sections. We previously stopped at 2, so
  sections like 'XML Parser' were un-numerated
  - fix title of sections about 'BPMN Support'. Previous wording was too long
  and contained useless words (' Description of the')
  - supported BPMN elements: remove 'page' words. Even if the AsciiDoctor source
  is in a single file/page, it is intended to be included in a single html doc,
  so 'page' is not accurate here.