### PR TITLE
[FEAT] render user task

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,4 @@ To build the project, see the [Contributing guide](CONTRIBUTING.md#Build) :sligh
 Some BPMN icons used by `bpmn-visualization-js` are derived from existing projects. See the [BPMN Support page](docs/bpmn-support.adoc)
 for more details:
 - [draw.io](https://github.com/jgraph/drawio) (Apache-2.0)
+- [primer octicons](https://github.com/primer/octicons) (MIT)

--- a/docs/architecture/bpmn-support-how-to.adoc
+++ b/docs/architecture/bpmn-support-how-to.adoc
@@ -33,3 +33,11 @@ which associates the `mxShape` name (used in style definition) with the `mxShape
 
 ===== BPMN icon tips
 
+The icon of the BPMN elements must be defined in the mxGraph custom shapes and this currently must be done using `TypeScript`
+code.
+
+It is possible to adapt an SVG icon thanks to https://github.com/process-analytics/mxgraph-svg2shape[mxgraph-svg2shape],
+a Java tool that will let you transform your SVG file into a set of `TypeScript` commands.
+
+Please be aware that the tool is not able to support all SVG files, and you may need to adapt the SVG definition prior the
+tool can transform it. See https://github.com/process-analytics/bpmn-visualization-js/pull/210[PR #210] for instance.

--- a/docs/architecture/bpmn-support-how-to.adoc
+++ b/docs/architecture/bpmn-support-how-to.adoc
@@ -29,3 +29,7 @@ used for the rendering.
 
 The `mxShape` can be a standard `mxGraph` class or a custom BPMN `mxShape` defined by the lib. The custom `mxShapes` are registered by `ShapeConfigurator`
 which associates the `mxShape` name (used in style definition) with the `mxShape` class to be used.
+
+
+===== BPMN icon tips
+

--- a/docs/bpmn-support.adoc
+++ b/docs/bpmn-support.adoc
@@ -61,7 +61,8 @@ The default rendering uses `white` as fill color and `black` as stroke color.
 
 |User Task
 |icon:flask[]
-|Stroke color and icon are subject to change
+|Icon will be subject to a large change +
+*icon*: the task icon is currently derived from the https://github.com/primer/octicons/blob/638c6683c96ec4b357576c7897be8f19c933c052/icons/person.svg[primer octicons person svg]
 |===
 
 

--- a/src/component/mxgraph/ShapeConfigurator.ts
+++ b/src/component/mxgraph/ShapeConfigurator.ts
@@ -18,7 +18,7 @@ import { mxgraph } from 'ts-mxgraph';
 import { ShapeBpmnElementKind } from '../../model/bpmn/shape/ShapeBpmnElementKind';
 import { EndEventShape, StartEventShape } from './shape/event-shapes';
 import { ExclusiveGatewayShape } from './shape/gateway-shapes';
-import { ServiceTaskShape, TaskShape } from './shape/task-shapes';
+import { ServiceTaskShape, TaskShape, UserTaskShape } from './shape/task-shapes';
 
 export default class ShapeConfigurator {
   private mxClient: typeof mxgraph.mxClient = MxGraphFactoryService.getMxGraphProperty('mxClient');
@@ -36,6 +36,7 @@ export default class ShapeConfigurator {
     this.mxCellRenderer.registerShape(ShapeBpmnElementKind.GATEWAY_EXCLUSIVE, ExclusiveGatewayShape);
     this.mxCellRenderer.registerShape(ShapeBpmnElementKind.TASK, TaskShape);
     this.mxCellRenderer.registerShape(ShapeBpmnElementKind.TASK_SERVICE, ServiceTaskShape);
+    this.mxCellRenderer.registerShape(ShapeBpmnElementKind.TASK_USER, UserTaskShape);
   }
 
   private initMxShapePrototype(isFF: boolean): void {

--- a/src/component/mxgraph/StyleConfigurator.ts
+++ b/src/component/mxgraph/StyleConfigurator.ts
@@ -42,7 +42,6 @@ export default class StyleConfigurator {
     this.configureEventsStyle();
     // tasks
     this.configureTasksStyle();
-    this.configureUserTaskStyle();
     // gateways
     this.configureGatewaysStyle();
     this.configureParallelGatewayStyle();
@@ -116,18 +115,6 @@ export default class StyleConfigurator {
       style[this.mxConstants.STYLE_VERTICAL_ALIGN] = 'middle';
       this.putCellStyle(kind, style);
     });
-  }
-
-  // TODO: to be removed as it will be configured in configureTasksStyle
-  // left just to not break current rendering
-  private configureUserTaskStyle(): void {
-    const style = this.cloneDefaultVertexStyle();
-    style[this.mxConstants.STYLE_SHAPE] = this.mxConstants.SHAPE_RECTANGLE;
-    style[this.mxConstants.STYLE_VERTICAL_ALIGN] = 'middle';
-    style[this.mxConstants.STYLE_STROKECOLOR] = '#2C6DA3';
-    style[this.mxConstants.STYLE_STROKEWIDTH] = 2;
-    style[this.mxConstants.STYLE_ROUNDED] = true;
-    this.putCellStyle(ShapeBpmnElementKind.TASK_USER, style);
   }
 
   // TODO: to be removed as it will be configured in configureGatewaysStyle

--- a/src/component/mxgraph/extension/MxScaleFactorCanvas.ts
+++ b/src/component/mxgraph/extension/MxScaleFactorCanvas.ts
@@ -29,7 +29,7 @@ import { mxgraph } from 'ts-mxgraph';
  * canvas.lineTo(12, 25);
  */
 export default class MxScaleFactorCanvas {
-  constructor(readonly c: mxgraph.mxXmlCanvas2D, readonly scaleFactor: number) {}
+  constructor(private readonly c: mxgraph.mxXmlCanvas2D, readonly scaleFactor: number) {}
 
   arcTo(rx: number, ry: number, angle: number, largeArcFlag: number, sweepFlag: number, x: number, y: number): void {
     this.c.arcTo(rx * this.scaleFactor, ry * this.scaleFactor, angle, largeArcFlag, sweepFlag, x * this.scaleFactor, y * this.scaleFactor);
@@ -45,6 +45,10 @@ export default class MxScaleFactorCanvas {
 
   curveTo(x1: number, y1: number, x2: number, y2: number, x3: number, y3: number): void {
     this.c.curveTo(x1 * this.scaleFactor, y1 * this.scaleFactor, x2 * this.scaleFactor, y2 * this.scaleFactor, x3 * this.scaleFactor, y3 * this.scaleFactor);
+  }
+
+  fill(): void {
+    this.c.fill();
   }
 
   fillAndStroke(): void {

--- a/src/component/mxgraph/extension/MxScaleFactorCanvas.ts
+++ b/src/component/mxgraph/extension/MxScaleFactorCanvas.ts
@@ -43,6 +43,10 @@ export default class MxScaleFactorCanvas {
     this.c.close();
   }
 
+  curveTo(x1: number, y1: number, x2: number, y2: number, x3: number, y3: number): void {
+    this.c.curveTo(x1 * this.scaleFactor, y1 * this.scaleFactor, x2 * this.scaleFactor, y2 * this.scaleFactor, x3 * this.scaleFactor, y3 * this.scaleFactor);
+  }
+
   fillAndStroke(): void {
     this.c.fillAndStroke();
   }

--- a/src/component/mxgraph/shape/task-shapes.ts
+++ b/src/component/mxgraph/shape/task-shapes.ts
@@ -37,6 +37,29 @@ abstract class BaseTaskShape extends mxRectangleShape {
   }
 
   protected abstract paintTaskIcon(c: mxgraph.mxXmlCanvas2D, x: number, y: number, w: number, h: number): void;
+
+  protected translateToStartingIconPosition(c: mxgraph.mxXmlCanvas2D, parentX: number, parentY: number, parentWidth: number, parentHeight: number): void {
+    const xTranslation = parentX + parentWidth / 20;
+    const yTranslation = parentY + parentHeight / 20;
+    c.translate(xTranslation, yTranslation);
+  }
+
+  protected configureCanvasForIcon(
+    c: mxgraph.mxXmlCanvas2D,
+    parentWidth: number,
+    parentHeight: number,
+    iconOriginalSize: number,
+  ): { canvas: MxScaleFactorCanvas; scaleFactor: number } {
+    // ensure we are not impacted by the configured shape stroke width
+    c.setStrokeWidth(1);
+
+    const parentSize = Math.min(parentWidth, parentHeight);
+    const ratioFromParent = 0.25;
+    const scaleFactor = (parentSize / iconOriginalSize) * ratioFromParent;
+
+    const canvas = new MxScaleFactorCanvas(c, scaleFactor);
+    return { canvas: canvas, scaleFactor: scaleFactor };
+  }
 }
 
 export class TaskShape extends BaseTaskShape {
@@ -58,19 +81,10 @@ export class ServiceTaskShape extends BaseTaskShape {
   // this implementation is adapted from the draw.io BPMN 'Service Task' stencil
   // https://github.com/jgraph/drawio/blob/9394fb0f1430d2c869865827b2bbef5639f63478/src/main/webapp/stencils/bpmn.xml#L898
   protected paintTaskIcon(c: mxgraph.mxXmlCanvas2D, x: number, y: number, w: number, h: number): void {
-    const xTranslation = x + w / 20;
-    const yTranslation = y + h / 20;
-    c.translate(xTranslation, yTranslation);
+    // icon coordinates fill a 100x100 rectangle (approximately: 90x90 + foreground translation)
+    const { canvas, scaleFactor } = this.configureCanvasForIcon(c, w, h, 100);
+    this.translateToStartingIconPosition(c, x, y, w, h);
 
-    // ensure we are not impacted by the configured shape stroke width
-    c.setStrokeWidth(1);
-
-    const parentSize = Math.min(w, h);
-    const ratioFromParent = 0.25;
-    // coordinates below fill a box of 100x100 (approximately: 90x90 + foreground translation)
-    const scaleFactor = (parentSize / 100) * ratioFromParent;
-
-    const canvas = new MxScaleFactorCanvas(c, scaleFactor);
     // background
     this.drawIconBackground(canvas);
 
@@ -78,9 +92,6 @@ export class ServiceTaskShape extends BaseTaskShape {
     const foregroundTranslation = 14 * scaleFactor;
     c.translate(foregroundTranslation, foregroundTranslation);
     this.drawIconForeground(canvas);
-
-    // hack for translation that will be needed when managing task markers
-    // c.translate(-xTranslation, -yTranslation);
   }
 
   private drawIconBackground(canvas: MxScaleFactorCanvas): void {
@@ -187,20 +198,9 @@ export class UserTaskShape extends BaseTaskShape {
   // adapted from https://github.com/primer/octicons/blob/638c6683c96ec4b357576c7897be8f19c933c052/icons/person.svg
   // use mxgraph svg2xml to generate the xml stencil and port it to code
   protected paintTaskIcon(c: mxgraph.mxXmlCanvas2D, x: number, y: number, w: number, h: number): void {
-    // TODO duplication with serviceTaskIcon
-    const xTranslation = x + w / 20;
-    const yTranslation = y + h / 20;
-    c.translate(xTranslation, yTranslation);
-
-    // ensure we are not impacted by the configured shape stroke width
-    c.setStrokeWidth(1);
-
-    const parentSize = Math.min(w, h);
-    const ratioFromParent = 0.25;
-    // coordinates below fill a box of 12x13
-    const scaleFactor = (parentSize / 13) * ratioFromParent;
-
-    const canvas = new MxScaleFactorCanvas(c, scaleFactor);
+    // icon coordinates fill a 12x13 rectangle
+    const { canvas } = this.configureCanvasForIcon(c, w, h, 13);
+    this.translateToStartingIconPosition(c, x, y, w, h);
 
     c.setFillColor(this.stroke);
     canvas.begin();

--- a/src/component/mxgraph/shape/task-shapes.ts
+++ b/src/component/mxgraph/shape/task-shapes.ts
@@ -184,8 +184,62 @@ export class UserTaskShape extends BaseTaskShape {
     super(bounds, fill, stroke, strokewidth);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  // adapted from https://github.com/primer/octicons/blob/638c6683c96ec4b357576c7897be8f19c933c052/icons/person.svg
+  // use mxgraph svg2xml to generate the xml stencil and port it to code
   protected paintTaskIcon(c: mxgraph.mxXmlCanvas2D, x: number, y: number, w: number, h: number): void {
+    // TODO duplication with serviceTaskIcon
+    const xTranslation = x + w / 20;
+    const yTranslation = y + h / 20;
+    c.translate(xTranslation, yTranslation);
+
+    // ensure we are not impacted by the configured shape stroke width
+    c.setStrokeWidth(1);
+
+    const parentSize = Math.min(w, h);
+    const ratioFromParent = 0.25;
+    // coordinates below fill a box of 12x13
+    const scaleFactor = (parentSize / 13) * ratioFromParent;
+
+    const canvas = new MxScaleFactorCanvas(c, scaleFactor);
+
+    c.setFillColor(this.stroke);
     // TODO implement icon
+    canvas.begin();
+    // <move x="12" y="13"/>
+    canvas.moveTo(12, 13);
+    // <arc large-arc-flag="0" rx="1" ry="1" sweep-flag="1" x="11" x-axis-rotation="0" y="14"/>
+    canvas.arcTo(1, 1, 0, 0, 1, 11, 14);
+    // <line x="1" y="14"/>
+    canvas.lineTo(1, 14);
+    // <arc large-arc-flag="0" rx="1" ry="1" sweep-flag="1" x="0" x-axis-rotation="0" y="13"/>
+    canvas.arcTo(1, 1, 0, 0, 1, 0, 13);
+    // <line x="0" y="12"/>
+    canvas.lineTo(0, 12);
+    // <curve x1="0" x2="4" x3="4" y1="9.37" y2="8" y3="8"/>
+    canvas.curveTo(0, 9.37, 4, 8, 4, 8);
+    // <curve x1="4" x2="4.23" x3="4" y1="8" y2="7.59" y3="7"/>
+    canvas.curveTo(4, 8, 4.23, 8, 4, 8);
+    // <curve x1="3.16" x2="3.06" x3="3" y1="6.38" y2="5.41" y3="3"/>
+    canvas.curveTo(3.16, 6.38, 3.06, 5.41, 3, 3);
+    // <curve x1="3.17" x2="4.87" x3="6" y1="0.59" y2="0" y3="0"/>
+    canvas.curveTo(3.17, 0.59, 4.87, 0, 6, 0);
+    // <curve x1="7.13" x2="8.83" x3="9" y1="0" y2="0.59" y3="3"/>
+    canvas.curveTo(7.13, 0, 8.83, 0.59, 9, 3);
+    // // <curve x1="8.94" x2="8.84" x3="8" y1="5.41" y2="6.38" y3="7"/>
+    // canvas.curveTo(8.94, 5.41, 8.84, 6.38, 8, 7);
+    // // <curve x1="7.77" x2="8" x3="8" y1="7.59" y2="8" y3="8"/>
+    // canvas.curveTo(7.77, 7.59, 8, 8, 8, 8);
+    // replace the 2 curves above by this single one for symmetry with the other side of the shae
+    canvas.curveTo(8.94, 5.41, 8.84, 6.38, 8, 8);
+    // <curve x1="8" x2="12" x3="12" y1="8" y2="9.37" y3="12"/>
+    canvas.curveTo(8, 8, 12, 9.37, 12, 12);
+    // <line x="12" y="13"/>
+    canvas.lineTo(12, 13);
+    //     <close/>
+    canvas.close();
+    //     </path>
+    //     <fillstroke/>
+    // TODO check if fill only is ok
+    canvas.fillAndStroke();
   }
 }

--- a/src/component/mxgraph/shape/task-shapes.ts
+++ b/src/component/mxgraph/shape/task-shapes.ts
@@ -218,7 +218,6 @@ export class UserTaskShape extends BaseTaskShape {
     canvas.curveTo(8, 8, 12, 9.37, 12, 12);
     canvas.lineTo(12, 13);
     canvas.close();
-    // TODO check if fill only is ok
-    canvas.fillAndStroke();
+    canvas.fill();
   }
 }

--- a/src/component/mxgraph/shape/task-shapes.ts
+++ b/src/component/mxgraph/shape/task-shapes.ts
@@ -44,12 +44,7 @@ abstract class BaseTaskShape extends mxRectangleShape {
     c.translate(xTranslation, yTranslation);
   }
 
-  protected configureCanvasForIcon(
-    c: mxgraph.mxXmlCanvas2D,
-    parentWidth: number,
-    parentHeight: number,
-    iconOriginalSize: number,
-  ): { canvas: MxScaleFactorCanvas; scaleFactor: number } {
+  protected configureCanvasForIcon(c: mxgraph.mxXmlCanvas2D, parentWidth: number, parentHeight: number, iconOriginalSize: number): MxScaleFactorCanvas {
     // ensure we are not impacted by the configured shape stroke width
     c.setStrokeWidth(1);
 
@@ -57,8 +52,7 @@ abstract class BaseTaskShape extends mxRectangleShape {
     const ratioFromParent = 0.25;
     const scaleFactor = (parentSize / iconOriginalSize) * ratioFromParent;
 
-    const canvas = new MxScaleFactorCanvas(c, scaleFactor);
-    return { canvas: canvas, scaleFactor: scaleFactor };
+    return new MxScaleFactorCanvas(c, scaleFactor);
   }
 }
 
@@ -82,14 +76,14 @@ export class ServiceTaskShape extends BaseTaskShape {
   // https://github.com/jgraph/drawio/blob/9394fb0f1430d2c869865827b2bbef5639f63478/src/main/webapp/stencils/bpmn.xml#L898
   protected paintTaskIcon(c: mxgraph.mxXmlCanvas2D, x: number, y: number, w: number, h: number): void {
     // icon coordinates fill a 100x100 rectangle (approximately: 90x90 + foreground translation)
-    const { canvas, scaleFactor } = this.configureCanvasForIcon(c, w, h, 100);
+    const canvas = this.configureCanvasForIcon(c, w, h, 100);
     this.translateToStartingIconPosition(c, x, y, w, h);
 
     // background
     this.drawIconBackground(canvas);
 
     // foreground
-    const foregroundTranslation = 14 * scaleFactor;
+    const foregroundTranslation = 14 * canvas.scaleFactor;
     c.translate(foregroundTranslation, foregroundTranslation);
     this.drawIconForeground(canvas);
   }
@@ -199,7 +193,7 @@ export class UserTaskShape extends BaseTaskShape {
   // use mxgraph svg2xml to generate the xml stencil and port it to code
   protected paintTaskIcon(c: mxgraph.mxXmlCanvas2D, x: number, y: number, w: number, h: number): void {
     // icon coordinates fill a 12x13 rectangle
-    const { canvas } = this.configureCanvasForIcon(c, w, h, 13);
+    const canvas = this.configureCanvasForIcon(c, w, h, 13);
     this.translateToStartingIconPosition(c, x, y, w, h);
 
     c.setFillColor(this.stroke);

--- a/src/component/mxgraph/shape/task-shapes.ts
+++ b/src/component/mxgraph/shape/task-shapes.ts
@@ -203,42 +203,21 @@ export class UserTaskShape extends BaseTaskShape {
     const canvas = new MxScaleFactorCanvas(c, scaleFactor);
 
     c.setFillColor(this.stroke);
-    // TODO implement icon
     canvas.begin();
-    // <move x="12" y="13"/>
     canvas.moveTo(12, 13);
-    // <arc large-arc-flag="0" rx="1" ry="1" sweep-flag="1" x="11" x-axis-rotation="0" y="14"/>
     canvas.arcTo(1, 1, 0, 0, 1, 11, 14);
-    // <line x="1" y="14"/>
     canvas.lineTo(1, 14);
-    // <arc large-arc-flag="0" rx="1" ry="1" sweep-flag="1" x="0" x-axis-rotation="0" y="13"/>
     canvas.arcTo(1, 1, 0, 0, 1, 0, 13);
-    // <line x="0" y="12"/>
     canvas.lineTo(0, 12);
-    // <curve x1="0" x2="4" x3="4" y1="9.37" y2="8" y3="8"/>
     canvas.curveTo(0, 9.37, 4, 8, 4, 8);
-    // <curve x1="4" x2="4.23" x3="4" y1="8" y2="7.59" y3="7"/>
     canvas.curveTo(4, 8, 4.23, 8, 4, 8);
-    // <curve x1="3.16" x2="3.06" x3="3" y1="6.38" y2="5.41" y3="3"/>
     canvas.curveTo(3.16, 6.38, 3.06, 5.41, 3, 3);
-    // <curve x1="3.17" x2="4.87" x3="6" y1="0.59" y2="0" y3="0"/>
     canvas.curveTo(3.17, 0.59, 4.87, 0, 6, 0);
-    // <curve x1="7.13" x2="8.83" x3="9" y1="0" y2="0.59" y3="3"/>
     canvas.curveTo(7.13, 0, 8.83, 0.59, 9, 3);
-    // // <curve x1="8.94" x2="8.84" x3="8" y1="5.41" y2="6.38" y3="7"/>
-    // canvas.curveTo(8.94, 5.41, 8.84, 6.38, 8, 7);
-    // // <curve x1="7.77" x2="8" x3="8" y1="7.59" y2="8" y3="8"/>
-    // canvas.curveTo(7.77, 7.59, 8, 8, 8, 8);
-    // replace the 2 curves above by this single one for symmetry with the other side of the shae
     canvas.curveTo(8.94, 5.41, 8.84, 6.38, 8, 8);
-    // <curve x1="8" x2="12" x3="12" y1="8" y2="9.37" y3="12"/>
     canvas.curveTo(8, 8, 12, 9.37, 12, 12);
-    // <line x="12" y="13"/>
     canvas.lineTo(12, 13);
-    //     <close/>
     canvas.close();
-    //     </path>
-    //     <fillstroke/>
     // TODO check if fill only is ok
     canvas.fillAndStroke();
   }

--- a/src/component/mxgraph/shape/task-shapes.ts
+++ b/src/component/mxgraph/shape/task-shapes.ts
@@ -178,3 +178,14 @@ export class ServiceTaskShape extends BaseTaskShape {
     canvas.fillAndStroke();
   }
 }
+
+export class UserTaskShape extends BaseTaskShape {
+  public constructor(bounds: mxgraph.mxRectangle, fill: string, stroke: string, strokewidth: number) {
+    super(bounds, fill, stroke, strokewidth);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  protected paintTaskIcon(c: mxgraph.mxXmlCanvas2D, x: number, y: number, w: number, h: number): void {
+    // TODO implement icon
+  }
+}

--- a/test/e2e/View.test.ts
+++ b/test/e2e/View.test.ts
@@ -52,18 +52,18 @@ describe('BPMN Visualization JS', () => {
             <semantic:incoming>_d77dd5ec-e4e7-420e-bbe7-8ac9cd1df599</semantic:incoming>
             <semantic:outgoing>_2aa47410-1b0e-4f8b-ad54-d6f798080cb4</semantic:outgoing>
         </semantic:task>
-        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 3" id="_e70a6fcb-913c-4a7b-a65d-e83adc73d69c">
+        <semantic:userTask completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 3" id="userTask_3">
             <semantic:incoming>_2aa47410-1b0e-4f8b-ad54-d6f798080cb4</semantic:incoming>
             <semantic:outgoing>_8e8fe679-eb3b-4c43-a4d6-891e7087ff80</semantic:outgoing>
-        </semantic:task>
+        </semantic:userTask>
         <semantic:endEvent name="End Event" id="endEvent_1">
             <semantic:incoming>_8e8fe679-eb3b-4c43-a4d6-891e7087ff80</semantic:incoming>
             <semantic:terminateEventDefinition/>
         </semantic:endEvent>
         <semantic:sequenceFlow sourceRef="startEvent_1" targetRef="task_1" name="" id="_e16564d7-0c4c-413e-95f6-f668a3f851fb"/>
         <semantic:sequenceFlow sourceRef="task_1" targetRef="serviceTask_2" name="" id="_d77dd5ec-e4e7-420e-bbe7-8ac9cd1df599"/>
-        <semantic:sequenceFlow sourceRef="serviceTask_2" targetRef="_e70a6fcb-913c-4a7b-a65d-e83adc73d69c" name="" id="_2aa47410-1b0e-4f8b-ad54-d6f798080cb4"/>
-        <semantic:sequenceFlow sourceRef="_e70a6fcb-913c-4a7b-a65d-e83adc73d69c" targetRef="endEvent_1" name="" id="_8e8fe679-eb3b-4c43-a4d6-891e7087ff80"/>
+        <semantic:sequenceFlow sourceRef="serviceTask_2" targetRef="userTask_3" name="" id="_2aa47410-1b0e-4f8b-ad54-d6f798080cb4"/>
+        <semantic:sequenceFlow sourceRef="userTask_3" targetRef="endEvent_1" name="" id="_8e8fe679-eb3b-4c43-a4d6-891e7087ff80"/>
     </semantic:process>
     <bpmndi:BPMNDiagram documentation="" id="Trisotech_Visio-_6" name="A.1.0" resolution="96.00000267028808">
         <bpmndi:BPMNPlane bpmnElement="WFP-6-">
@@ -88,7 +88,7 @@ describe('BPMN Visualization JS', () => {
                     <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="395.3333333333333" y="344.5818763825664"/>
                 </bpmndi:BPMNLabel>
             </bpmndi:BPMNShape>
-            <bpmndi:BPMNShape bpmnElement="_e70a6fcb-913c-4a7b-a65d-e83adc73d69c" id="S1373649849861__e70a6fcb-913c-4a7b-a65d-e83adc73d69c">
+            <bpmndi:BPMNShape bpmnElement="userTask_3" id="shape_userTask_3">
                 <dc:Bounds height="68.0" width="83.0" x="522.0" y="317.0"/>
                 <bpmndi:BPMNLabel labelStyle="LS1373649849858">
                     <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="527.3333333333334" y="344.5818763825664"/>
@@ -171,6 +171,7 @@ describe('BPMN Visualization JS', () => {
     expectModelContainsBpmnEvent('endEvent_1', ShapeBpmnElementKind.EVENT_END, ShapeBpmnEventKind.TERMINATE);
     expectModelContainsCell('task_1', ShapeBpmnElementKind.TASK);
     expectModelContainsCell('serviceTask_2', ShapeBpmnElementKind.TASK_SERVICE);
+    expectModelContainsCell('userTask_3', ShapeBpmnElementKind.TASK_USER);
   });
 
   function expectModelContainsCellWithGeometry(cellId: string, parentId: string, geometry: mxgraph.mxGeometry): void {


### PR DESCRIPTION
This PR introduces the rendering of the `User Task` and add an icon based on the [person octicons](https://primer.style/octicons/person). Please note that this icon may not be the final one and may be replaced in the future.

In addition, the following internals are updated or added as part of this PR:
- generalize tasks rendering
- introduce an easy way to render icon whatever its original size (scale factor tooling)
- integration of a SVG based icon into the lib
- usage of the [mxgraph-svg2shape](https://github.com/process-analytics/mxgraph-svg2shape) / [svg2xml](https://github.com/jgraph/svg2xml) tools to simplify the SVG icon integration and to collect issue feedbacks


Closes #143 