### PR TITLE
[FEAT] display timer intermediate catch event

### DIFF
--- a/docs/bpmn-support-roadmap.adoc
+++ b/docs/bpmn-support-roadmap.adoc
@@ -36,7 +36,8 @@ BPMN elements:
 ** [x] timer start event (0.1.3)
 ** [x] none end event (0.1.1)
 ** [x] terminate end event (0.1.2)
-** [x] none throw intermediate event (0.1.3)
+** [x] timer intermediate catch event (0.1.3)
+** [x] none intermediate throw event (0.1.3)
 * flows
 ** [x] sequence flow (0.1.0)
 ** [x] way points (0.1.1)

--- a/docs/bpmn-support.adoc
+++ b/docs/bpmn-support.adoc
@@ -87,13 +87,26 @@ The default rendering uses `white` as fill color and `black` as stroke color.
 
 
 [cols="1,1,4", options="header"]
-.Intermediate Throwing Events
+.Intermediate Catch Events
 |===
 |Name
 |Rendering
 |Comments
 
-|None Intermediate Throwing Event
+|Timer Intermediate Catch Event
+|
+|Stroke fits the BPMN specification but no icon
+|===
+
+
+[cols="1,1,4", options="header"]
+.Intermediate Throw Events
+|===
+|Name
+|Rendering
+|Comments
+
+|None Intermediate Throw Event
 |icon:check-circle-o[]
 |The stroke width may be adjusted
 |===

--- a/src/component/mxgraph/ShapeConfigurator.ts
+++ b/src/component/mxgraph/ShapeConfigurator.ts
@@ -16,7 +16,7 @@
 import { MxGraphFactoryService } from '../../service/MxGraphFactoryService';
 import { mxgraph } from 'ts-mxgraph';
 import { ShapeBpmnElementKind } from '../../model/bpmn/shape/ShapeBpmnElementKind';
-import { EndEventShape, StartEventShape, ThrowIntermediateEventShape } from './shape/event-shapes';
+import { EndEventShape, StartEventShape, ThrowIntermediateEventShape, CatchIntermediateEventShape } from './shape/event-shapes';
 import { ExclusiveGatewayShape, ParallelGatewayShape } from './shape/gateway-shapes';
 import { ServiceTaskShape, TaskShape, UserTaskShape } from './shape/task-shapes';
 
@@ -31,11 +31,15 @@ export default class ShapeConfigurator {
   }
 
   private registerShapes(): void {
+    // events
     this.mxCellRenderer.registerShape(ShapeBpmnElementKind.EVENT_END, EndEventShape);
     this.mxCellRenderer.registerShape(ShapeBpmnElementKind.EVENT_START, StartEventShape);
     this.mxCellRenderer.registerShape(ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW, ThrowIntermediateEventShape);
+    this.mxCellRenderer.registerShape(ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH, CatchIntermediateEventShape);
+    // gateways
     this.mxCellRenderer.registerShape(ShapeBpmnElementKind.GATEWAY_EXCLUSIVE, ExclusiveGatewayShape);
     this.mxCellRenderer.registerShape(ShapeBpmnElementKind.GATEWAY_PARALLEL, ParallelGatewayShape);
+    // tasks
     this.mxCellRenderer.registerShape(ShapeBpmnElementKind.TASK, TaskShape);
     this.mxCellRenderer.registerShape(ShapeBpmnElementKind.TASK_SERVICE, ServiceTaskShape);
     this.mxCellRenderer.registerShape(ShapeBpmnElementKind.TASK_USER, UserTaskShape);

--- a/src/component/mxgraph/shape/event-shapes.ts
+++ b/src/component/mxgraph/shape/event-shapes.ts
@@ -94,8 +94,8 @@ export class EndEventShape extends EventShape {
   }
 }
 
-export class ThrowIntermediateEventShape extends EventShape {
-  public constructor(bounds: mxgraph.mxRectangle, fill: string, stroke: string, strokewidth: number = StyleConstant.STROKE_WIDTH_THIN) {
+abstract class IntermediateEventShape extends EventShape {
+  protected constructor(bounds: mxgraph.mxRectangle, fill: string, stroke: string, strokewidth: number = StyleConstant.STROKE_WIDTH_THIN) {
     super(bounds, fill, stroke, strokewidth);
   }
 
@@ -108,5 +108,11 @@ export class ThrowIntermediateEventShape extends EventShape {
     const inset = this.strokewidth * 2;
     c.ellipse(w * 0.02 + inset + x, h * 0.02 + inset + y, w * 0.96 - 2 * inset, h * 0.96 - 2 * inset);
     c.stroke();
+  }
+}
+
+export class ThrowIntermediateEventShape extends IntermediateEventShape {
+  public constructor(bounds: mxgraph.mxRectangle, fill: string, stroke: string, strokewidth?: number) {
+    super(bounds, fill, stroke, strokewidth);
   }
 }

--- a/src/component/mxgraph/shape/event-shapes.ts
+++ b/src/component/mxgraph/shape/event-shapes.ts
@@ -29,6 +29,13 @@ abstract class EventShape extends mxEllipse {
   }
 
   public paintVertexShape(c: mxgraph.mxXmlCanvas2D, x: number, y: number, w: number, h: number): void {
+    const eventKind = this.getBpmnEventKind();
+    // will be removed when managing the timer rendering
+    if (eventKind == ShapeBpmnEventKind.TIMER) {
+      c.setFillColor('green');
+      c.setFillAlpha(0.3);
+    }
+
     this.paintOuterShape(c, x, y, w, h);
     this.paintInnerShape(c, x, y, w, h);
   }
@@ -50,17 +57,6 @@ abstract class EventShape extends mxEllipse {
 export class StartEventShape extends EventShape {
   public constructor(bounds: mxgraph.mxRectangle, fill: string, stroke: string, strokewidth: number = StyleConstant.STROKE_WIDTH_THIN) {
     super(bounds, fill, stroke, strokewidth);
-  }
-
-  protected paintOuterShape(c: mxgraph.mxXmlCanvas2D, x: number, y: number, w: number, h: number): void {
-    const eventKind = this.getBpmnEventKind();
-    // will be removed when managing the timer rendering
-    if (eventKind == ShapeBpmnEventKind.TIMER) {
-      c.setFillColor('green');
-      c.setFillAlpha(0.3);
-    }
-
-    super.paintOuterShape(c, x, y, w, h);
   }
 }
 
@@ -111,6 +107,11 @@ abstract class IntermediateEventShape extends EventShape {
   }
 }
 
+export class CatchIntermediateEventShape extends IntermediateEventShape {
+  public constructor(bounds: mxgraph.mxRectangle, fill: string, stroke: string, strokewidth?: number) {
+    super(bounds, fill, stroke, strokewidth);
+  }
+}
 export class ThrowIntermediateEventShape extends IntermediateEventShape {
   public constructor(bounds: mxgraph.mxRectangle, fill: string, stroke: string, strokewidth?: number) {
     super(bounds, fill, stroke, strokewidth);

--- a/src/model/bpmn/shape/ShapeBpmnElementKind.ts
+++ b/src/model/bpmn/shape/ShapeBpmnElementKind.ts
@@ -26,5 +26,6 @@ export enum ShapeBpmnElementKind {
   GATEWAY_EXCLUSIVE = 'exclusiveGateway',
   EVENT_START = 'startEvent',
   EVENT_END = 'endEvent',
+  EVENT_INTERMEDIATE_CATCH = 'intermediateCatchEvent',
   EVENT_INTERMEDIATE_THROW = 'intermediateThrowEvent',
 }

--- a/test/e2e/View.test.ts
+++ b/test/e2e/View.test.ts
@@ -66,6 +66,11 @@ describe('BPMN Visualization JS', () => {
         <semantic:sequenceFlow sourceRef="serviceTask_2" targetRef="userTask_3" name="" id="_2aa47410-1b0e-4f8b-ad54-d6f798080cb4"/>
         <semantic:sequenceFlow sourceRef="userTask_3" targetRef="noneIntermediateThrowEvent" name="" id="_8e8fe679-eb3b-4c43-a4d6-891e7087ff80" />
         <semantic:sequenceFlow sourceRef="noneIntermediateThrowEvent" targetRef="endEvent_1" name="" id="_8e8fe679-eb3b-4c43-a4d6-891e7087ff22" />
+        <semantic:sequenceFlow id="Flow_028jkgv" sourceRef="startEvent_2_timer" targetRef="IntermediateCatchEvent_Timer_01" />
+        <semantic:intermediateCatchEvent id="IntermediateCatchEvent_Timer_01" name="Timer Intermediate Catch Event">
+            <semantic:incoming>Flow_028jkgv</semantic:incoming>
+            <semantic:timerEventDefinition id="TimerEventDefinition_0t6k83a" />
+        </semantic:intermediateCatchEvent>
     </semantic:process>
     <bpmndi:BPMNDiagram documentation="" id="Trisotech_Visio-_6" name="A.1.0" resolution="96.00000267028808">
         <bpmndi:BPMNPlane bpmnElement="WFP-6-">
@@ -106,6 +111,12 @@ describe('BPMN Visualization JS', () => {
                 <dc:Bounds height="32.0" width="32.0" x="648.0" y="335.0"/>
                 <bpmndi:BPMNLabel labelStyle="LS1373649849858">
                     <dc:Bounds height="12.804751171875008" width="94.93333333333335" x="616.5963254593177" y="372.3333333333333"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="shape_IntermediateCatchEvent_Timer_01" bpmnElement="IntermediateCatchEvent_Timer_01">
+                <dc:Bounds x="272" y="293" width="36" height="36" />
+                <bpmndi:BPMNLabel>
+                    <dc:Bounds x="259" y="336" width="62" height="40" />
                 </bpmndi:BPMNLabel>
             </bpmndi:BPMNShape>
             <bpmndi:BPMNEdge bpmnElement="_d77dd5ec-e4e7-420e-bbe7-8ac9cd1df599" id="E1373649849864__d77dd5ec-e4e7-420e-bbe7-8ac9cd1df599">
@@ -181,6 +192,7 @@ describe('BPMN Visualization JS', () => {
     expectModelContainsBpmnEvent('startEvent_2_timer', ShapeBpmnElementKind.EVENT_START, ShapeBpmnEventKind.TIMER);
     expectModelContainsBpmnEvent('endEvent_1', ShapeBpmnElementKind.EVENT_END, ShapeBpmnEventKind.TERMINATE);
     expectModelContainsBpmnEvent('noneIntermediateThrowEvent', ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW, ShapeBpmnEventKind.NONE);
+    expectModelContainsBpmnEvent('IntermediateCatchEvent_Timer_01', ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH, ShapeBpmnEventKind.TIMER);
     expectModelContainsCell('task_1', ShapeBpmnElementKind.TASK);
     expectModelContainsCell('serviceTask_2', ShapeBpmnElementKind.TASK_SERVICE);
     expectModelContainsCell('userTask_3', ShapeBpmnElementKind.TASK_USER);

--- a/test/unit/component/parser/json/BpmnJsonParser.event.intermediate.catch.timer.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.event.intermediate.catch.timer.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ShapeBpmnElementKind } from '../../../../../src/model/bpmn/shape/ShapeBpmnElementKind';
+import { parseJsonAndExpectOnlyEvent, parseJsonAndExpectOnlyFlowNodes, verifyShape } from './JsonTestUtils';
+import { ShapeBpmnEventKind } from '../../../../../src/model/bpmn/shape/ShapeBpmnEventKind';
+
+describe('parse bpmn as json for timer intermediate catch event', () => {
+  it('json containing one process with a timer intermediate catch event defined as empty string, timer intermediate catch event is present', () => {
+    const json = `{
+                "definitions" : {
+                    "process": {
+                        "intermediateCatchEvent": {
+                            "id":"event_id_0",
+                            "name":"event name",
+                            "timerEventDefinition": ""
+                        }
+                    },
+                    "BPMNDiagram": {
+                        "name":"process 0",
+                        "BPMNPlane": {
+                            "BPMNShape": {
+                                "id":"shape_intermediateCatchEvent_id_0",
+                                "bpmnElement":"event_id_0",
+                                "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 }
+                            }
+                        }
+                    }
+                }
+            }`;
+
+    const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.TIMER, 1);
+
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_intermediateCatchEvent_id_0',
+      bpmnElementId: 'event_id_0',
+      bpmnElementName: 'event name',
+      bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH,
+      boundsX: 362,
+      boundsY: 232,
+      boundsWidth: 36,
+      boundsHeight: 45,
+    });
+  });
+
+  it('json containing one process with a timer intermediate catch event defined as object, timer intermediate catch event is present', () => {
+    const json = `{
+                "definitions" : {
+                    "process": {
+                        "intermediateCatchEvent": {
+                            "id":"event_id_0",
+                            "name":"event name",
+                            "timerEventDefinition": { "id": "timerEventDefinition_1" }
+                        }
+                    },
+                    "BPMNDiagram": {
+                        "name":"process 0",
+                        "BPMNPlane": {
+                            "BPMNShape": {
+                                "id":"shape_intermediateCatchEvent_id_0",
+                                "bpmnElement":"event_id_0",
+                                "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 }
+                            }
+                        }
+                    }
+                }
+            }`;
+
+    const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.TIMER, 1);
+
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_intermediateCatchEvent_id_0',
+      bpmnElementId: 'event_id_0',
+      bpmnElementName: 'event name',
+      bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH,
+      boundsX: 362,
+      boundsY: 232,
+      boundsWidth: 36,
+      boundsHeight: 45,
+    });
+  });
+
+  it('json containing one process with a intermediate catch event with timer definition and another definition, timer event is NOT present', () => {
+    const json = `{
+    "definitions" : {
+        "process": {
+            "intermediateCatchEvent": { "id":"event_id_0", "timerEventDefinition": "", "messageEventDefinition": "" }
+        },
+        "BPMNDiagram": {
+            "name":"process 0",
+            "BPMNPlane": {
+                "BPMNShape": {
+                    "id":"shape_intermediateCatchEvent_id_0",
+                    "bpmnElement":"event_id_0",
+                    "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 }
+                }
+            }
+        }
+    }
+}`;
+
+    parseJsonAndExpectOnlyFlowNodes(json, 0);
+  });
+
+  it('json containing one process with a intermediate catch event with several timer definitions, timer event is NOT present', () => {
+    const json = `{
+    "definitions" : {
+        "process": {
+            "intermediateCatchEvent": { "id":"event_id_0", "timerEventDefinition": ["", ""] }
+        },
+        "BPMNDiagram": {
+            "name":"process 0",
+            "BPMNPlane": {
+                "BPMNShape": {
+                    "id":"shape_intermediateCatchEvent_id_0",
+                    "bpmnElement":"event_id_0",
+                    "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 }
+                }
+            }
+        }
+    }
+}`;
+
+    parseJsonAndExpectOnlyFlowNodes(json, 0);
+  });
+});


### PR DESCRIPTION
The shape is identified as an intermediate catch event (rounded, double thin line). As for the timer start event, we currently do not render the final icon, but the 2 events are identified in the same way (filled in green)

Event | Render
------------ | -------------
timer start event | ![image](https://user-images.githubusercontent.com/27200110/80762367-b8073480-8b3c-11ea-8d85-3fd0b71a68ba.png)
timer intermediate catch event | ![image](https://user-images.githubusercontent.com/27200110/80762014-f4866080-8b3b-11ea-9ef4-baf0bf3971b5.png)

Closes #89 