### PR TITLE
[INFRA] release-drafter continuously update github draft release

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,53 @@
+name-template: '$NEXT_PATCH_VERSION'
+tag-template: 'v$NEXT_PATCH_VERSION'
+prerelease: true
+categories:
+#  - title: 🚀 New Features and Improvements
+#    labels:
+#      - feature
+#      - enhancement
+  - title: 🚀 BPMN support
+    labels:
+      - BPMN support
+  - title: 🚀 BPMN rendering
+    labels:
+      - BPMN rendering
+  - title: 🐛 Bug Fixes
+    labels:
+      - bug
+  - title: 📝 Documentation
+    label: documentation
+  - title: 📦 Dependency updates
+    labels:
+      # Default label used by dependabot
+      - dependencies
+  - title: 👻 Maintenance
+    labels:
+      - infra:build
+      - infra:refactoring
+      - infra:repo
+      - chore
+      - internal
+exclude-labels:
+  - invalid
+  - no-changelog
+  - skip-changelog
+  - reverted
+  - wontfix
+#change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+template: |
+  Thanks to all the contributors of this release 🌈: $CONTRIBUTORS
+
+  <!-- TODO: add milestone id when publishing -->
+  See [milestone $NEXT_PATCH_VERSION](https://github.com/process-analytics/bpmn-visualization-js/milestone/x?closed=1)
+  to get the list of issues covered by this release.
+
+  # Highlights
+  <!-- TODO: add screenshots and user oriented info -->
+
+  # Changelog
+  $CHANGES
+
+replacers:
+  - search: '@dependabot-preview'
+    replace: '@dependabot'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,10 +2,6 @@ name-template: '$NEXT_PATCH_VERSION'
 tag-template: 'v$NEXT_PATCH_VERSION'
 prerelease: true
 categories:
-#  - title: 🚀 New Features and Improvements
-#    labels:
-#      - feature
-#      - enhancement
   - title: 🚀 BPMN support
     labels:
       - BPMN support
@@ -34,7 +30,6 @@ exclude-labels:
   - skip-changelog
   - reverted
   - wontfix
-#change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 template: |
   Thanks to all the contributors of this release 🌈: $CONTRIBUTORS
 
@@ -45,7 +40,7 @@ template: |
   # Highlights
   <!-- TODO: add screenshots and user oriented info -->
 
-  # Changelog
+  # What's Changed
   $CHANGES
 
 replacers:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -5,7 +5,7 @@ categories:
   - title: 🚀 BPMN support
     labels:
       - BPMN support
-  - title: 🚀 BPMN rendering
+  - title: 🚄 BPMN rendering
     labels:
       - BPMN rendering
   - title: 🐛 Bug Fixes

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
       - master
     paths-ignore:
       - '.github/workflows/generate-documentation.yml'
+      - '.github/workflows/release-drafter.yml'
       - '.gitignore'
       - 'docs/**'
       - '*.md'
@@ -15,6 +16,7 @@ on:
       - master
     paths-ignore:
       - '.github/workflows/generate-documentation.yml'
+      - '.github/workflows/release-drafter.yml'
       - '.gitignore'
       - 'docs/**'
       - '*.md'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,8 @@ on:
     branches:
       - master
     paths-ignore:
+      - '.github/workflows/fill-gh-draft-release.yml'
       - '.github/workflows/generate-documentation.yml'
-      - '.github/workflows/release-drafter.yml'
       - '.gitignore'
       - 'docs/**'
       - '*.md'
@@ -15,8 +15,8 @@ on:
     branches:
       - master
     paths-ignore:
+      - '.github/workflows/fill-gh-draft-release.yml'
       - '.github/workflows/generate-documentation.yml'
-      - '.github/workflows/release-drafter.yml'
       - '.gitignore'
       - 'docs/**'
       - '*.md'

--- a/.github/workflows/fill-gh-draft-release.yml
+++ b/.github/workflows/fill-gh-draft-release.yml
@@ -1,4 +1,4 @@
-name: Release Drafter
+name: Fill GitHub Draft Release
 
 on:
   push:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,15 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -230,11 +230,19 @@ of the `Done` column related to the milestone
 
 #### GitHub update
 
-- Ensure the latest closed milestone matches the name of the tag/version that has just been pushed
-- Create a new GitHub release
+- GitHub release
   - Open [github releases](https://github.com/process-analytics/bpmn-visualization-js/releases)
-  - Create a new release based on the newly created tags. Check `This is a pre-release`
-  - In the description, at least add a link to the related milestone
+  - The draft release for the newly tagged version should already exist:
+    - [release-drafter](https://github.com/release-drafter/release-drafter) creates or updates draft release for the
+    next version each time a pull request is merged on the `master` branch.
+    - create a new release if it is missing or rename the existing one.
+  - Assign the new tag as release target and save the draft: this ensures that next merged pull requests will be assign
+  to a new release by `release-drafter` even if the current draft is not published.
+  - Check `This is a pre-release`
+  - In the release description (check previous releases as a source of inspiration)
+    - at least add/update a link to the related milestone
+    - put screenshots/gif of the new features
+- Ensure the latest closed milestone matches the name of the tag/version that has just been pushed
 
 ### Demo environment update
 


### PR DESCRIPTION
Closes #251

**Notes**
- Testing: this is hard to do, I have done lot of testing with a [personal playground repository](https://github.com/tbouffard/playground-release-drafter-and-gh-pages)
- Current limitations
  - categories assignment: not possible to ensure several labels are set to assign to a category --> we cannot have _enhancement + bpmn suppport_ and _enhancement + bpmn rendering_, so I setup a category for the whole _bpmn suppport_ and another one for _bpmn rendering_