### PR TITLE
[FEAT] Render the Label Font of a Shape

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11595,7 +11595,7 @@
       }
     },
     "ts-mxgraph": {
-      "version": "git+https://github.com/process-analytics/ts-mxgraph.git#82d6842cc87bed6b3433537798a71d1a5c6e3fd7",
+      "version": "git+https://github.com/process-analytics/ts-mxgraph.git#50ee481f67d64ac31e45f1814b536d6d0ad7dc",
       "from": "git+https://github.com/process-analytics/ts-mxgraph.git"
     },
     "tslib": {

--- a/src/component/mxgraph/MxGraphConfigurator.ts
+++ b/src/component/mxgraph/MxGraphConfigurator.ts
@@ -47,5 +47,6 @@ export default class MxGraphConfigurator {
     this.mxGraph.prototype.edgeLabelsMovable = false;
     this.mxGraph.prototype.cellsLocked = true;
     this.mxGraph.prototype.cellsSelectable = false;
+    //  this.mxGraph.prototype.htmlLabels = true;
   }
 }

--- a/src/component/mxgraph/MxGraphConfigurator.ts
+++ b/src/component/mxgraph/MxGraphConfigurator.ts
@@ -47,6 +47,5 @@ export default class MxGraphConfigurator {
     this.mxGraph.prototype.edgeLabelsMovable = false;
     this.mxGraph.prototype.cellsLocked = true;
     this.mxGraph.prototype.cellsSelectable = false;
-    //  this.mxGraph.prototype.htmlLabels = true;
   }
 }

--- a/src/component/mxgraph/MxGraphRenderer.ts
+++ b/src/component/mxgraph/MxGraphRenderer.ts
@@ -29,6 +29,7 @@ interface Coordinate {
 
 export default class MxGraphRenderer {
   private mxPoint: typeof mxgraph.mxPoint = MxGraphFactoryService.getMxGraphProperty('mxPoint');
+  private mxConstants: typeof mxgraph.mxConstants = MxGraphFactoryService.getMxGraphProperty('mxConstants');
   constructor(readonly graph: mxgraph.mxGraph) {}
 
   public render(bpmnModel: BpmnModel): void {
@@ -65,15 +66,49 @@ export default class MxGraphRenderer {
       const bounds = shape.bounds;
       const parent = this.getParent(bpmnElement);
       const absoluteCoordinate = { x: bounds.x, y: bounds.y };
-      const style = this.computeStyleName(bpmnElement);
+      const style = this.computeStyleName(shape);
       this.insertVertexGivenAbsoluteCoordinates(parent, bpmnElement.id, bpmnElement.name, absoluteCoordinate, bounds.width, bounds.height, style);
     }
   }
 
-  private computeStyleName(bpmnElement: ShapeBpmnEvent | ShapeBpmnElement): string {
+  private computeStyleName(shape: Shape): string {
+    const bpmnElement = shape.bpmnElement;
+
     let style = bpmnElement.kind as string;
     if (bpmnElement instanceof ShapeBpmnEvent) {
       style += ';' + StyleConstant.BPMN_STYLE_EVENT_KIND + '=' + bpmnElement.eventKind;
+    }
+    style += this.computeFontStyle(shape);
+
+    return style;
+  }
+
+  private computeFontStyle(bpmnCell: Shape | Edge): string {
+    let style = '';
+
+    const label = bpmnCell.label;
+    if (label) {
+      const font = label.font;
+      if (font) {
+        if (font.name) {
+          style += ';' + this.mxConstants.STYLE_FONTFAMILY + '=' + font.name;
+        }
+
+        if (font.size) {
+          style += ';' + this.mxConstants.STYLE_FONTSIZE + '=' + font.size;
+        }
+
+        if (font.isBold) {
+          style += ';' + this.mxConstants.STYLE_FONTSTYLE + '=' + this.mxConstants.FONT_BOLD;
+        } else if (font.isItalic) {
+          style += ';' + this.mxConstants.STYLE_FONTSTYLE + '=' + this.mxConstants.FONT_ITALIC;
+        } else if (font.isStrikeThrough) {
+          // style += ';' + this.mxConstants.STYLE_FONTSTYLE + '=' + this.mxConstants.FONT_STRIKETHROUGH;
+          style += ';' + this.mxConstants.STYLE_FONTSIZE + '=8';
+        } else if (font.isStrikeThrough) {
+          style += ';' + this.mxConstants.STYLE_FONTSTYLE + '=' + this.mxConstants.FONT_UNDERLINE;
+        }
+      }
     }
     return style;
   }

--- a/src/component/mxgraph/MxGraphRenderer.ts
+++ b/src/component/mxgraph/MxGraphRenderer.ts
@@ -103,8 +103,7 @@ export default class MxGraphRenderer {
         } else if (font.isItalic) {
           style += ';' + this.mxConstants.STYLE_FONTSTYLE + '=' + this.mxConstants.FONT_ITALIC;
         } else if (font.isStrikeThrough) {
-          // style += ';' + this.mxConstants.STYLE_FONTSTYLE + '=' + this.mxConstants.FONT_STRIKETHROUGH;
-          style += ';' + this.mxConstants.STYLE_FONTSIZE + '=8';
+          style += ';' + this.mxConstants.STYLE_FONTSTYLE + '=' + this.mxConstants.FONT_STRIKETHROUGH;
         } else if (font.isStrikeThrough) {
           style += ';' + this.mxConstants.STYLE_FONTSTYLE + '=' + this.mxConstants.FONT_UNDERLINE;
         }

--- a/src/component/mxgraph/MxGraphRenderer.ts
+++ b/src/component/mxgraph/MxGraphRenderer.ts
@@ -104,7 +104,7 @@ export default class MxGraphRenderer {
           style += ';' + this.mxConstants.STYLE_FONTSTYLE + '=' + this.mxConstants.FONT_ITALIC;
         } else if (font.isStrikeThrough) {
           style += ';' + this.mxConstants.STYLE_FONTSTYLE + '=' + this.mxConstants.FONT_STRIKETHROUGH;
-        } else if (font.isStrikeThrough) {
+        } else if (font.isUnderline) {
           style += ';' + this.mxConstants.STYLE_FONTSTYLE + '=' + this.mxConstants.FONT_UNDERLINE;
         }
       }

--- a/src/component/mxgraph/MxGraphRenderer.ts
+++ b/src/component/mxgraph/MxGraphRenderer.ts
@@ -86,27 +86,24 @@ export default class MxGraphRenderer {
   private computeFontStyle(bpmnCell: Shape | Edge): string {
     let style = '';
 
-    const label = bpmnCell.label;
-    if (label) {
-      const font = label.font;
-      if (font) {
-        if (font.name) {
-          style += ';' + this.mxConstants.STYLE_FONTFAMILY + '=' + font.name;
-        }
+    const font = bpmnCell?.label?.font;
+    if (font) {
+      if (font.name) {
+        style += ';' + this.mxConstants.STYLE_FONTFAMILY + '=' + font.name;
+      }
 
-        if (font.size) {
-          style += ';' + this.mxConstants.STYLE_FONTSIZE + '=' + font.size;
-        }
+      if (font.size) {
+        style += ';' + this.mxConstants.STYLE_FONTSIZE + '=' + font.size;
+      }
 
-        if (font.isBold) {
-          style += ';' + this.mxConstants.STYLE_FONTSTYLE + '=' + this.mxConstants.FONT_BOLD;
-        } else if (font.isItalic) {
-          style += ';' + this.mxConstants.STYLE_FONTSTYLE + '=' + this.mxConstants.FONT_ITALIC;
-        } else if (font.isStrikeThrough) {
-          style += ';' + this.mxConstants.STYLE_FONTSTYLE + '=' + this.mxConstants.FONT_STRIKETHROUGH;
-        } else if (font.isUnderline) {
-          style += ';' + this.mxConstants.STYLE_FONTSTYLE + '=' + this.mxConstants.FONT_UNDERLINE;
-        }
+      if (font.isBold) {
+        style += ';' + this.mxConstants.STYLE_FONTSTYLE + '=' + this.mxConstants.FONT_BOLD;
+      } else if (font.isItalic) {
+        style += ';' + this.mxConstants.STYLE_FONTSTYLE + '=' + this.mxConstants.FONT_ITALIC;
+      } else if (font.isStrikeThrough) {
+        style += ';' + this.mxConstants.STYLE_FONTSTYLE + '=' + this.mxConstants.FONT_STRIKETHROUGH;
+      } else if (font.isUnderline) {
+        style += ';' + this.mxConstants.STYLE_FONTSTYLE + '=' + this.mxConstants.FONT_UNDERLINE;
       }
     }
     return style;

--- a/src/component/mxgraph/StyleConfigurator.ts
+++ b/src/component/mxgraph/StyleConfigurator.ts
@@ -95,7 +95,7 @@ export default class StyleConfigurator {
   private configureDefaultVertexStyle(): void {
     const style = this.getDefaultVertexStyle();
     style[this.mxConstants.STYLE_HORIZONTAL] = true;
-    style[this.mxConstants.STYLE_FONTSIZE] = 15;
+    style[this.mxConstants.STYLE_FONTSIZE] = 12;
     style[this.mxConstants.STYLE_FILLCOLOR] = 'white';
     style[this.mxConstants.STYLE_FONTCOLOR] = 'black';
     style[this.mxConstants.STYLE_STROKECOLOR] = 'black';

--- a/test/e2e/mxGraph.model.test.ts
+++ b/test/e2e/mxGraph.model.test.ts
@@ -235,8 +235,7 @@ describe('mxGraph model', () => {
       }
 
       if (expectedValue.isUnderline) {
-        // expect(state.style[mxConstants.STYLE_FONTSTYLE]).toEqual(mxConstants.FONT_STRIKETHROUGH);
-        expect(state.style[mxConstants.STYLE_FONTSTYLE]).toEqual(8);
+        expect(state.style[mxConstants.STYLE_FONTSTYLE]).toEqual(mxConstants.FONT_STRIKETHROUGH);
       }
 
       expect(state.style[mxConstants.STYLE_FONTFAMILY]).toEqual(expectedValue.name);

--- a/test/e2e/mxGraph.model.test.ts
+++ b/test/e2e/mxGraph.model.test.ts
@@ -78,7 +78,7 @@ describe('mxGraph model', () => {
             <semantic:incoming>Flow_028jkgv</semantic:incoming>
             <semantic:timerEventDefinition id="TimerEventDefinition_0t6k83a" />
         </semantic:intermediateCatchEvent>
-        <semantic:endEvent name="End Event" id="endEvent_1">
+        <semantic:endEvent name="End Event" id="terminateEndEvent">
             <semantic:incoming>_8e8fe679-eb3b-4c43-a4d6-891e7087ff80</semantic:incoming>
             <semantic:terminateEventDefinition/>
         </semantic:endEvent>
@@ -96,7 +96,7 @@ describe('mxGraph model', () => {
         </semantic:sequenceFlow>
         <semantic:sequenceFlow sourceRef="userTask_3" targetRef="noneIntermediateThrowEvent" name="" id="_8e8fe679-eb3b-4c43-a4d6-891e7087ff80" />
         <semantic:sequenceFlow sourceRef="noneIntermediateThrowEvent" targetRef="messageIntermediateThrowEvent" name="" id="_8e8fe679-eb3b-4c43-a4d6-891e7087ff22" />
-        <semantic:sequenceFlow sourceRef="messageIntermediateThrowEvent" targetRef="endEvent_1" name="" id="_8e8fe679-eb3b-4c43-a4d6-891e7087ff33" />
+        <semantic:sequenceFlow sourceRef="messageIntermediateThrowEvent" targetRef="terminateEndEvent" name="" id="_8e8fe679-eb3b-4c43-a4d6-891e7087ff33" />
         <semantic:sequenceFlow id="Flow_028jkgv" sourceRef="startEvent_2_timer" targetRef="IntermediateCatchEvent_Timer_01" />
         <semantic:sequenceFlow sourceRef="inclusiveGateway_1" targetRef="userTask_3" name="" id="conditional_sequence_flow_from_gateway_id">
           <semantic:conditionExpression xsi:type="semantic:tFormalExpression" id="_WsCFcRszEeqkhYLXtt1BFw" evaluatesToTypeRef="java:java.lang.Boolean">&quot;Contract to be written&quot;.equals(loanRequested.status)</semantic:conditionExpression>
@@ -106,7 +106,7 @@ describe('mxGraph model', () => {
         <bpmndi:BPMNPlane bpmnElement="WFP-6-">
             <bpmndi:BPMNShape bpmnElement="startEvent_1" id="shape_startEvent_1">
                 <dc:Bounds height="30.0" width="30.0" x="186.0" y="336.0"/>
-                <bpmndi:BPMNLabel labelStyle="LS1373649849858">
+                <bpmndi:BPMNLabel labelStyle="bold_font_id">
                     <dc:Bounds height="12.804751171875008" width="94.93333333333335" x="153.67766754457273" y="371.3333333333333"/>
                 </bpmndi:BPMNLabel>
             </bpmndi:BPMNShape>
@@ -118,25 +118,25 @@ describe('mxGraph model', () => {
             </bpmndi:BPMNShape>
             <bpmndi:BPMNShape bpmnElement="task_1" id="shape_task_1">
                 <dc:Bounds height="68.0" width="83.0" x="258.0" y="317.0"/>
-                <bpmndi:BPMNLabel labelStyle="LS1373649849858">
+                <bpmndi:BPMNLabel labelStyle="underline_font_id">
                     <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="263.3333333333333" y="344.5818763825664"/>
                 </bpmndi:BPMNLabel>
             </bpmndi:BPMNShape>
             <bpmndi:BPMNShape bpmnElement="serviceTask_2" id="shape_serviceTask_2">
                 <dc:Bounds height="68.0" width="83.0" x="390.0" y="317.0"/>
-                <bpmndi:BPMNLabel labelStyle="LS1373649849858">
+                <bpmndi:BPMNLabel labelStyle="bold_font_id">
                     <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="395.3333333333333" y="344.5818763825664"/>
                 </bpmndi:BPMNLabel>
             </bpmndi:BPMNShape>
             <bpmndi:BPMNShape bpmnElement="userTask_3" id="shape_userTask_3">
                 <dc:Bounds height="68.0" width="83.0" x="522.0" y="317.0"/>
-                <bpmndi:BPMNLabel labelStyle="LS1373649849858">
+                <bpmndi:BPMNLabel labelStyle="bold_font_id">
                     <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="527.3333333333334" y="344.5818763825664"/>
                 </bpmndi:BPMNLabel>
             </bpmndi:BPMNShape>
             <bpmndi:BPMNShape bpmnElement="noneIntermediateThrowEvent" id="S1373649849862_noneIntermediateThrowEvent">
 	           <dc:Bounds height="32.0" width="32.0" x="648.0" y="336.0" />
-	           <bpmndi:BPMNLabel labelStyle="LS1373649849858">
+	           <bpmndi:BPMNLabel labelStyle="strike_through_font_id">
 	              <dc:Bounds height="12.804751171875008" width="94.93333333333335" x="686.5963254593177" y="372.3333333333333" />
 	           </bpmndi:BPMNLabel>
 	        </bpmndi:BPMNShape>
@@ -146,9 +146,9 @@ describe('mxGraph model', () => {
 	         <bpmndi:BPMNShape bpmnElement="messageIntermediateCatchEvent" id="S1373649849862_messageIntermediateCatchEvent">
 	           <dc:Bounds height="32.0" width="32.0" x="98.0" y="335.0" />
 	        </bpmndi:BPMNShape>
-            <bpmndi:BPMNShape bpmnElement="endEvent_1" id="S1373649849862_endEvent_1">
+            <bpmndi:BPMNShape bpmnElement="terminateEndEvent" id="S1373649849862_terminateEndEvent">
                 <dc:Bounds height="32.0" width="32.0" x="648.0" y="335.0"/>
-                <bpmndi:BPMNLabel labelStyle="LS1373649849858">
+                <bpmndi:BPMNLabel labelStyle="italic_font_id">
                     <dc:Bounds height="12.804751171875008" width="94.93333333333335" x="616.5963254593177" y="372.3333333333333"/>
                 </bpmndi:BPMNLabel>
             </bpmndi:BPMNShape>
@@ -212,8 +212,17 @@ describe('mxGraph model', () => {
          <bpmndi:BPMNEdge bpmnElement="_8e8fe679-eb3b-4c43-a4d6-891e7087ff33" id="E1373649849867__8e8fe679-eb3b-4c43-a4d6-891e7087ff33" />
          <bpmndi:BPMNEdge bpmnElement="Flow_028jkgv" id="E1373649849867__Flow_028jkgv" />
         </bpmndi:BPMNPlane>
-        <bpmndi:BPMNLabelStyle id="LS1373649849858">
-            <dc:Font isBold="false" isItalic="false" isStrikeThrough="false" isUnderline="false" name="Arial" size="11.0"/>
+        <bpmndi:BPMNLabelStyle id="bold_font_id">
+            <dc:Font isBold="true" isItalic="false" isStrikeThrough="false" isUnderline="false" name="Arial" size="11.0"/>
+        </bpmndi:BPMNLabelStyle>
+         <bpmndi:BPMNLabelStyle id="italic_font_id">
+            <dc:Font isBold="false" isItalic="true" isStrikeThrough="false" isUnderline="false" name="Arial" size="11.0"/>
+        </bpmndi:BPMNLabelStyle>
+         <bpmndi:BPMNLabelStyle id="strike_through_font_id">
+            <dc:Font isBold="false" isItalic="false" isStrikeThrough="true" isUnderline="false" name="Arial" size="11.0"/>
+        </bpmndi:BPMNLabelStyle>
+         <bpmndi:BPMNLabelStyle id="underline_font_id">
+            <dc:Font isBold="false" isItalic="false" isStrikeThrough="false" isUnderline="true" name="Arial" size="11.0"/>
         </bpmndi:BPMNLabelStyle>
     </bpmndi:BPMNDiagram>
 </semantic:definitions>
@@ -230,11 +239,11 @@ describe('mxGraph model', () => {
         expect(state.style[mxConstants.STYLE_FONTSTYLE]).toEqual(mxConstants.FONT_ITALIC);
       }
 
-      if (expectedFont.isStrikeThrough) {
+      if (expectedFont.isUnderline) {
         expect(state.style[mxConstants.STYLE_FONTSTYLE]).toEqual(mxConstants.FONT_UNDERLINE);
       }
 
-      if (expectedFont.isUnderline) {
+      if (expectedFont.isStrikeThrough) {
         expect(state.style[mxConstants.STYLE_FONTSTYLE]).toEqual(mxConstants.FONT_STRIKETHROUGH);
       }
 
@@ -281,25 +290,40 @@ describe('mxGraph model', () => {
     bpmnVisu.load(xmlContent);
 
     // model is OK
-    // start event
-    const expectedFont = {
-      isBold: false,
+    const expectedBoldFont = {
+      isBold: true,
       isItalic: false,
       isStrikeThrough: false,
       isUnderline: false,
       name: 'Arial',
       size: 11.0,
     };
-    expectModelContainsBpmnEvent('startEvent_1', ShapeBpmnElementKind.EVENT_START, ShapeBpmnEventKind.NONE, expectedFont);
+
+    // start event
+    expectModelContainsBpmnEvent('startEvent_1', ShapeBpmnElementKind.EVENT_START, ShapeBpmnEventKind.NONE, expectedBoldFont);
     expectModelContainsBpmnEvent('startEvent_2_timer', ShapeBpmnElementKind.EVENT_START, ShapeBpmnEventKind.TIMER);
     expectModelContainsBpmnEvent('startEvent_3_message', ShapeBpmnElementKind.EVENT_START, ShapeBpmnEventKind.MESSAGE);
 
     // end event
-    expectModelContainsBpmnEvent('endEvent_1', ShapeBpmnElementKind.EVENT_END, ShapeBpmnEventKind.TERMINATE, expectedFont);
+    expectModelContainsBpmnEvent('terminateEndEvent', ShapeBpmnElementKind.EVENT_END, ShapeBpmnEventKind.TERMINATE, {
+      isBold: false,
+      isItalic: true,
+      isStrikeThrough: false,
+      isUnderline: false,
+      name: 'Arial',
+      size: 11.0,
+    });
     expectModelContainsBpmnEvent('messageEndEvent', ShapeBpmnElementKind.EVENT_END, ShapeBpmnEventKind.MESSAGE);
 
     // throw intermediate event
-    expectModelContainsBpmnEvent('noneIntermediateThrowEvent', ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW, ShapeBpmnEventKind.NONE, expectedFont);
+    expectModelContainsBpmnEvent('noneIntermediateThrowEvent', ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW, ShapeBpmnEventKind.NONE, {
+      isBold: false,
+      isItalic: false,
+      isStrikeThrough: true,
+      isUnderline: false,
+      name: 'Arial',
+      size: 11.0,
+    });
     expectModelContainsBpmnEvent('messageIntermediateThrowEvent', ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW, ShapeBpmnEventKind.MESSAGE);
 
     // catch intermediate event
@@ -307,9 +331,16 @@ describe('mxGraph model', () => {
     expectModelContainsBpmnEvent('IntermediateCatchEvent_Timer_01', ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH, ShapeBpmnEventKind.TIMER);
 
     // activity
-    expectModelContainsShape('task_1', ShapeBpmnElementKind.TASK, expectedFont);
-    expectModelContainsShape('serviceTask_2', ShapeBpmnElementKind.TASK_SERVICE, expectedFont);
-    expectModelContainsShape('userTask_3', ShapeBpmnElementKind.TASK_USER, expectedFont);
+    expectModelContainsShape('task_1', ShapeBpmnElementKind.TASK, {
+      isBold: false,
+      isItalic: false,
+      isStrikeThrough: false,
+      isUnderline: true,
+      name: 'Arial',
+      size: 11.0,
+    });
+    expectModelContainsShape('serviceTask_2', ShapeBpmnElementKind.TASK_SERVICE, expectedBoldFont);
+    expectModelContainsShape('userTask_3', ShapeBpmnElementKind.TASK_USER, expectedBoldFont);
     expectModelContainsShape('callActivity_1', ShapeBpmnElementKind.CALL_ACTIVITY, undefined, 'rectangle');
     expectModelContainsShape('receiveTask_not_instantiated', ShapeBpmnElementKind.TASK_RECEIVE);
     expectModelContainsShape('receiveTask_instantiated', ShapeBpmnElementKind.TASK_RECEIVE);

--- a/test/e2e/mxGraph.model.test.ts
+++ b/test/e2e/mxGraph.model.test.ts
@@ -220,26 +220,26 @@ describe('mxGraph model', () => {
 `;
   const bpmnVisu = new BpmnVisu(null);
 
-  function expectFont(state: mxgraph.mxCellState, expectedValue: ExpectedFont): void {
-    if (expectedValue) {
-      if (expectedValue.isBold) {
+  function expectFont(state: mxgraph.mxCellState, expectedFont: ExpectedFont): void {
+    if (expectedFont) {
+      if (expectedFont.isBold) {
         expect(state.style[mxConstants.STYLE_FONTSTYLE]).toEqual(mxConstants.FONT_BOLD);
       }
 
-      if (expectedValue.isItalic) {
+      if (expectedFont.isItalic) {
         expect(state.style[mxConstants.STYLE_FONTSTYLE]).toEqual(mxConstants.FONT_ITALIC);
       }
 
-      if (expectedValue.isStrikeThrough) {
+      if (expectedFont.isStrikeThrough) {
         expect(state.style[mxConstants.STYLE_FONTSTYLE]).toEqual(mxConstants.FONT_UNDERLINE);
       }
 
-      if (expectedValue.isUnderline) {
+      if (expectedFont.isUnderline) {
         expect(state.style[mxConstants.STYLE_FONTSTYLE]).toEqual(mxConstants.FONT_STRIKETHROUGH);
       }
 
-      expect(state.style[mxConstants.STYLE_FONTFAMILY]).toEqual(expectedValue.name);
-      expect(state.style[mxConstants.STYLE_FONTSIZE]).toEqual(expectedValue.size);
+      expect(state.style[mxConstants.STYLE_FONTFAMILY]).toEqual(expectedFont.name);
+      expect(state.style[mxConstants.STYLE_FONTSIZE]).toEqual(expectedFont.size);
     }
   }
 

--- a/test/e2e/mxGraph.model.test.ts
+++ b/test/e2e/mxGraph.model.test.ts
@@ -251,14 +251,14 @@ describe('mxGraph model', () => {
   }
 
   // styleShape is only required when the BPMN shape doesn't exist yet (use an arbitrary shape until the final render is implemented)
-  function expectModelContainsShape(cellId: string, shapeKind: ShapeBpmnElementKind, expectedValue?: ExpectedFont, styleShape?: string): mxgraph.mxCell {
+  function expectModelContainsShape(cellId: string, shapeKind: ShapeBpmnElementKind, expectedFont?: ExpectedFont, styleShape?: string): mxgraph.mxCell {
     const cell = expectModelContainsCell(cellId);
     expect(cell.style).toContain(shapeKind);
     const state = bpmnVisu.graph.getView().getState(cell);
 
     styleShape = !styleShape ? shapeKind : styleShape;
     expect(state.style[mxConstants.STYLE_SHAPE]).toEqual(styleShape);
-    expectFont(state, expectedValue);
+    expectFont(state, expectedFont);
     return cell;
   }
 
@@ -271,8 +271,8 @@ describe('mxGraph model', () => {
     return cell;
   }
 
-  function expectModelContainsBpmnEvent(cellId: string, shapeKind: ShapeBpmnElementKind, bpmnEventKind: ShapeBpmnEventKind, expectedValue?: ExpectedFont): void {
-    const cell = expectModelContainsShape(cellId, shapeKind, expectedValue);
+  function expectModelContainsBpmnEvent(cellId: string, shapeKind: ShapeBpmnElementKind, bpmnEventKind: ShapeBpmnEventKind, expectedFont?: ExpectedFont): void {
+    const cell = expectModelContainsShape(cellId, shapeKind, expectedFont);
     expect(cell.style).toContain(`bpmn.eventKind=${bpmnEventKind}`);
   }
 

--- a/test/e2e/mxGraph.model.test.ts
+++ b/test/e2e/mxGraph.model.test.ts
@@ -20,7 +20,6 @@ import { MxGraphFactoryService } from '../../src/service/MxGraphFactoryService';
 import { ShapeBpmnEventKind } from '../../src/model/bpmn/shape/ShapeBpmnEventKind';
 import { SequenceFlowKind } from '../../src/model/bpmn/edge/SequenceFlowKind';
 import { MarkerConstant } from '../../src/component/mxgraph/MarkerConfigurator';
-import Label from '../../src/model/bpmn/Label';
 
 export interface ExpectedFont {
   name?: string;


### PR DESCRIPTION
Closes #101 
(previously depended on #283 & https://github.com/process-analytics/ts-mxgraph/pull/1)

- The render when the font is define:
<img width="1628" alt="image" src="https://user-images.githubusercontent.com/4921914/83625179-d032ff00-a593-11ea-825a-7f65763315e0.png">

- The render when the font is NOT define:
<img width="1628" alt="image" src="https://user-images.githubusercontent.com/4921914/83625220-e2ad3880-a593-11ea-976f-24d30030e5b0.png">
