### PR TITLE
[FEAT] consider all Font attributes on rendering

### DIFF
--- a/src/component/mxgraph/MxGraphRenderer.ts
+++ b/src/component/mxgraph/MxGraphRenderer.ts
@@ -93,15 +93,20 @@ export default class MxGraphRenderer {
   }
 
   private getFontStyleValue(font: Font): number {
+    let value = 0;
     if (font.isBold) {
-      return this.mxConstants.FONT_BOLD;
-    } else if (font.isItalic) {
-      return this.mxConstants.FONT_ITALIC;
-    } else if (font.isStrikeThrough) {
-      return this.mxConstants.FONT_STRIKETHROUGH;
-    } else if (font.isUnderline) {
-      return this.mxConstants.FONT_UNDERLINE;
+      value += this.mxConstants.FONT_BOLD;
     }
+    if (font.isItalic) {
+      value += this.mxConstants.FONT_ITALIC;
+    }
+    if (font.isStrikeThrough) {
+      value += this.mxConstants.FONT_STRIKETHROUGH;
+    }
+    if (font.isUnderline) {
+      value += this.mxConstants.FONT_UNDERLINE;
+    }
+    return value;
   }
 
   private insertEdges(edges: Edge[]): void {

--- a/test/unit/component/mxgraph/MxGraphRenderer.test.ts
+++ b/test/unit/component/mxgraph/MxGraphRenderer.test.ts
@@ -67,6 +67,11 @@ describe('mxgraph renderer', () => {
     expect(mxGraphRenderer.computeStyle(shape)).toEqual('intermediateCatchEvent;fontFamily=Arial;fontStyle=2');
   });
 
+  it('compute style of shape with label including bold/italic font', () => {
+    const shape = new Shape('id', newShapeBpmnElement(ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW), undefined, new Label(toFont({ isBold: true, isItalic: true }), undefined));
+    expect(mxGraphRenderer.computeStyle(shape)).toEqual('intermediateThrowEvent;fontStyle=3');
+  });
+
   it('compute style of edge with no label', () => {
     const edge = new Edge('id', newSequenceFlow(SequenceFlowKind.CONDITIONAL_FROM_GATEWAY));
     expect(mxGraphRenderer.computeStyle(edge)).toEqual('conditional_from_gateway');
@@ -85,5 +90,15 @@ describe('mxgraph renderer', () => {
   it('compute style of edge with label including underline font', () => {
     const edge = new Edge('id', newSequenceFlow(SequenceFlowKind.DEFAULT), undefined, new Label(toFont({ isUnderline: true }), undefined));
     expect(mxGraphRenderer.computeStyle(edge)).toEqual('default;fontStyle=4');
+  });
+
+  it('compute style of edge with label including bold/italic/strike-through/underline font', () => {
+    const edge = new Edge(
+      'id',
+      newSequenceFlow(SequenceFlowKind.NORMAL),
+      undefined,
+      new Label(toFont({ isBold: true, isItalic: true, isStrikeThrough: true, isUnderline: true }), undefined),
+    );
+    expect(mxGraphRenderer.computeStyle(edge)).toEqual('normal;fontStyle=15');
   });
 });


### PR DESCRIPTION
Done when creating mxGraph elements.

Closes #287

## Render with [sequence flows test file](https://github.com/process-analytics/bpmn-visualization-examples/blob/7848b9873e47ed2b6617a9b2be3897a99540ccdb/bpmn-files/all_sequence_flow_types.bpmn)

**Previous implementation**
![pr_288_01_previous_implementation](https://user-images.githubusercontent.com/27200110/83774485-08b30580-a686-11ea-9f7b-627c6dd3e027.png)

**With new implementation**
![pr_288_02_new_implementation](https://user-images.githubusercontent.com/27200110/83774492-0b155f80-a686-11ea-9f2a-aa69736621b4.png)
