### PR TITLE
[REFACTOR] expected shape and bounds interface in tests

### DIFF
--- a/test/unit/component/parser/json/BpmnJsonParser.call.activity.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.call.activity.test.ts
@@ -42,16 +42,21 @@ describe('parse bpmn as json for call activity', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_call_activity_id_0',
-      bpmnElementId: 'call_activity_id_0',
-      bpmnElementName: 'call activity name',
-      bpmnElementKind: ShapeBpmnElementKind.CALL_ACTIVITY,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_call_activity_id_0',
+        bpmnElementId: 'call_activity_id_0',
+        bpmnElementName: 'call activity name',
+        bpmnElementKind: ShapeBpmnElementKind.CALL_ACTIVITY,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing one process declared as array with a single call activity', () => {
@@ -81,16 +86,21 @@ describe('parse bpmn as json for call activity', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_call_activity_id_1',
-      bpmnElementId: 'call_activity_id_1',
-      bpmnElementName: 'call activity name',
-      bpmnElementKind: ShapeBpmnElementKind.CALL_ACTIVITY,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_call_activity_id_1',
+        bpmnElementId: 'call_activity_id_1',
+        bpmnElementName: 'call activity name',
+        bpmnElementKind: ShapeBpmnElementKind.CALL_ACTIVITY,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing one process with an array of call activities  with name & without name', () => {
@@ -130,25 +140,35 @@ describe('parse bpmn as json for call activity', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_call_activity_id_0',
-      bpmnElementId: 'call_activity_id_0',
-      bpmnElementName: 'call activity name',
-      bpmnElementKind: ShapeBpmnElementKind.CALL_ACTIVITY,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
-    verifyShape(model.flowNodes[1], {
-      shapeId: 'shape_call_activity_id_1',
-      bpmnElementId: 'call_activity_id_1',
-      bpmnElementName: undefined,
-      bpmnElementKind: ShapeBpmnElementKind.CALL_ACTIVITY,
-      boundsX: 365,
-      boundsY: 235,
-      boundsWidth: 35,
-      boundsHeight: 46,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_call_activity_id_0',
+        bpmnElementId: 'call_activity_id_0',
+        bpmnElementName: 'call activity name',
+        bpmnElementKind: ShapeBpmnElementKind.CALL_ACTIVITY,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
+    verifyShape(
+      model.flowNodes[1],
+      {
+        shapeId: 'shape_call_activity_id_1',
+        bpmnElementId: 'call_activity_id_1',
+        bpmnElementName: undefined,
+        bpmnElementKind: ShapeBpmnElementKind.CALL_ACTIVITY,
+      },
+      {
+        x: 365,
+        y: 235,
+        width: 35,
+        height: 46,
+      },
+    );
   });
 });

--- a/test/unit/component/parser/json/BpmnJsonParser.call.activity.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.call.activity.test.ts
@@ -42,21 +42,18 @@ describe('parse bpmn as json for call activity', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_call_activity_id_0',
-        bpmnElementId: 'call_activity_id_0',
-        bpmnElementName: 'call activity name',
-        bpmnElementKind: ShapeBpmnElementKind.CALL_ACTIVITY,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_call_activity_id_0',
+      bpmnElementId: 'call_activity_id_0',
+      bpmnElementName: 'call activity name',
+      bpmnElementKind: ShapeBpmnElementKind.CALL_ACTIVITY,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing one process declared as array with a single call activity', () => {
@@ -86,21 +83,18 @@ describe('parse bpmn as json for call activity', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_call_activity_id_1',
-        bpmnElementId: 'call_activity_id_1',
-        bpmnElementName: 'call activity name',
-        bpmnElementKind: ShapeBpmnElementKind.CALL_ACTIVITY,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_call_activity_id_1',
+      bpmnElementId: 'call_activity_id_1',
+      bpmnElementName: 'call activity name',
+      bpmnElementKind: ShapeBpmnElementKind.CALL_ACTIVITY,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing one process with an array of call activities  with name & without name', () => {
@@ -140,35 +134,29 @@ describe('parse bpmn as json for call activity', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_call_activity_id_0',
-        bpmnElementId: 'call_activity_id_0',
-        bpmnElementName: 'call activity name',
-        bpmnElementKind: ShapeBpmnElementKind.CALL_ACTIVITY,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_call_activity_id_0',
+      bpmnElementId: 'call_activity_id_0',
+      bpmnElementName: 'call activity name',
+      bpmnElementKind: ShapeBpmnElementKind.CALL_ACTIVITY,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
-    verifyShape(
-      model.flowNodes[1],
-      {
-        shapeId: 'shape_call_activity_id_1',
-        bpmnElementId: 'call_activity_id_1',
-        bpmnElementName: undefined,
-        bpmnElementKind: ShapeBpmnElementKind.CALL_ACTIVITY,
-      },
-      {
+    });
+    verifyShape(model.flowNodes[1], {
+      shapeId: 'shape_call_activity_id_1',
+      bpmnElementId: 'call_activity_id_1',
+      bpmnElementName: undefined,
+      bpmnElementKind: ShapeBpmnElementKind.CALL_ACTIVITY,
+      bounds: {
         x: 365,
         y: 235,
         width: 35,
         height: 46,
       },
-    );
+    });
   });
 });

--- a/test/unit/component/parser/json/BpmnJsonParser.event.end.message.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.event.end.message.test.ts
@@ -42,21 +42,18 @@ describe('parse bpmn as json for Message end event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.MESSAGE, 1);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_endEvent_id_7',
-        bpmnElementId: 'event_id_7',
-        bpmnElementName: undefined,
-        bpmnElementKind: ShapeBpmnElementKind.EVENT_END,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_endEvent_id_7',
+      bpmnElementId: 'event_id_7',
+      bpmnElementName: undefined,
+      bpmnElementKind: ShapeBpmnElementKind.EVENT_END,
+      bounds: {
         x: 362,
         y: 932,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing one process with an Message end event defined as object, Message end event is present', () => {
@@ -83,21 +80,18 @@ describe('parse bpmn as json for Message end event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.MESSAGE, 1);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_endEvent_id_7',
-        bpmnElementId: 'event_id_7',
-        bpmnElementName: undefined,
-        bpmnElementKind: ShapeBpmnElementKind.EVENT_END,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_endEvent_id_7',
+      bpmnElementId: 'event_id_7',
+      bpmnElementName: undefined,
+      bpmnElementKind: ShapeBpmnElementKind.EVENT_END,
+      bounds: {
         x: 362,
         y: 932,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing one process with an end event with message definition and another definition, Message end event is NOT present', () => {

--- a/test/unit/component/parser/json/BpmnJsonParser.event.end.message.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.event.end.message.test.ts
@@ -42,16 +42,21 @@ describe('parse bpmn as json for Message end event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.MESSAGE, 1);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_endEvent_id_7',
-      bpmnElementId: 'event_id_7',
-      bpmnElementName: undefined,
-      bpmnElementKind: ShapeBpmnElementKind.EVENT_END,
-      boundsX: 362,
-      boundsY: 932,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_endEvent_id_7',
+        bpmnElementId: 'event_id_7',
+        bpmnElementName: undefined,
+        bpmnElementKind: ShapeBpmnElementKind.EVENT_END,
+      },
+      {
+        x: 362,
+        y: 932,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing one process with an Message end event defined as object, Message end event is present', () => {
@@ -78,16 +83,21 @@ describe('parse bpmn as json for Message end event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.MESSAGE, 1);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_endEvent_id_7',
-      bpmnElementId: 'event_id_7',
-      bpmnElementName: undefined,
-      bpmnElementKind: ShapeBpmnElementKind.EVENT_END,
-      boundsX: 362,
-      boundsY: 932,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_endEvent_id_7',
+        bpmnElementId: 'event_id_7',
+        bpmnElementName: undefined,
+        bpmnElementKind: ShapeBpmnElementKind.EVENT_END,
+      },
+      {
+        x: 362,
+        y: 932,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing one process with an end event with message definition and another definition, Message end event is NOT present', () => {

--- a/test/unit/component/parser/json/BpmnJsonParser.event.end.none.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.event.end.none.test.ts
@@ -42,16 +42,21 @@ describe('parse bpmn as json for end event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.NONE, 1);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_endEvent_id_0',
-      bpmnElementId: 'event_id_0',
-      bpmnElementName: 'event name',
-      bpmnElementKind: ShapeBpmnElementKind.EVENT_END,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_endEvent_id_0',
+        bpmnElementId: 'event_id_0',
+        bpmnElementName: 'event name',
+        bpmnElementKind: ShapeBpmnElementKind.EVENT_END,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing one process declared as array with a single end event', () => {
@@ -80,16 +85,21 @@ describe('parse bpmn as json for end event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.NONE, 1);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_endEvent_id_1',
-      bpmnElementId: 'event_id_1',
-      bpmnElementName: 'event name',
-      bpmnElementKind: ShapeBpmnElementKind.EVENT_END,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_endEvent_id_1',
+        bpmnElementId: 'event_id_1',
+        bpmnElementName: 'event name',
+        bpmnElementKind: ShapeBpmnElementKind.EVENT_END,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing one process with an array of end events with name & without name', () => {
@@ -126,26 +136,36 @@ describe('parse bpmn as json for end event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.NONE, 2);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_endEvent_id_0',
-      bpmnElementId: 'event_id_0',
-      bpmnElementName: 'event name',
-      bpmnElementKind: ShapeBpmnElementKind.EVENT_END,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
-    verifyShape(model.flowNodes[1], {
-      shapeId: 'shape_endEvent_id_1',
-      bpmnElementId: 'event_id_1',
-      bpmnElementName: undefined,
-      bpmnElementKind: ShapeBpmnElementKind.EVENT_END,
-      boundsX: 365,
-      boundsY: 235,
-      boundsWidth: 35,
-      boundsHeight: 46,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_endEvent_id_0',
+        bpmnElementId: 'event_id_0',
+        bpmnElementName: 'event name',
+        bpmnElementKind: ShapeBpmnElementKind.EVENT_END,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
+    verifyShape(
+      model.flowNodes[1],
+      {
+        shapeId: 'shape_endEvent_id_1',
+        bpmnElementId: 'event_id_1',
+        bpmnElementName: undefined,
+        bpmnElementKind: ShapeBpmnElementKind.EVENT_END,
+      },
+      {
+        x: 365,
+        y: 235,
+        width: 35,
+        height: 46,
+      },
+    );
   });
 
   it('json containing one process with an array of end events, some are not NONE event', () => {
@@ -207,15 +227,20 @@ describe('parse bpmn as json for end event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.NONE, 1);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_endEvent_id_0',
-      bpmnElementId: 'event_id_0',
-      bpmnElementName: 'none end event',
-      bpmnElementKind: ShapeBpmnElementKind.EVENT_END,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_endEvent_id_0',
+        bpmnElementId: 'event_id_0',
+        bpmnElementName: 'none end event',
+        bpmnElementKind: ShapeBpmnElementKind.EVENT_END,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 });

--- a/test/unit/component/parser/json/BpmnJsonParser.event.end.none.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.event.end.none.test.ts
@@ -42,21 +42,18 @@ describe('parse bpmn as json for end event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.NONE, 1);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_endEvent_id_0',
-        bpmnElementId: 'event_id_0',
-        bpmnElementName: 'event name',
-        bpmnElementKind: ShapeBpmnElementKind.EVENT_END,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_endEvent_id_0',
+      bpmnElementId: 'event_id_0',
+      bpmnElementName: 'event name',
+      bpmnElementKind: ShapeBpmnElementKind.EVENT_END,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing one process declared as array with a single end event', () => {
@@ -85,21 +82,18 @@ describe('parse bpmn as json for end event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.NONE, 1);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_endEvent_id_1',
-        bpmnElementId: 'event_id_1',
-        bpmnElementName: 'event name',
-        bpmnElementKind: ShapeBpmnElementKind.EVENT_END,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_endEvent_id_1',
+      bpmnElementId: 'event_id_1',
+      bpmnElementName: 'event name',
+      bpmnElementKind: ShapeBpmnElementKind.EVENT_END,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing one process with an array of end events with name & without name', () => {
@@ -136,36 +130,30 @@ describe('parse bpmn as json for end event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.NONE, 2);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_endEvent_id_0',
-        bpmnElementId: 'event_id_0',
-        bpmnElementName: 'event name',
-        bpmnElementKind: ShapeBpmnElementKind.EVENT_END,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_endEvent_id_0',
+      bpmnElementId: 'event_id_0',
+      bpmnElementName: 'event name',
+      bpmnElementKind: ShapeBpmnElementKind.EVENT_END,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
-    verifyShape(
-      model.flowNodes[1],
-      {
-        shapeId: 'shape_endEvent_id_1',
-        bpmnElementId: 'event_id_1',
-        bpmnElementName: undefined,
-        bpmnElementKind: ShapeBpmnElementKind.EVENT_END,
-      },
-      {
+    });
+    verifyShape(model.flowNodes[1], {
+      shapeId: 'shape_endEvent_id_1',
+      bpmnElementId: 'event_id_1',
+      bpmnElementName: undefined,
+      bpmnElementKind: ShapeBpmnElementKind.EVENT_END,
+      bounds: {
         x: 365,
         y: 235,
         width: 35,
         height: 46,
       },
-    );
+    });
   });
 
   it('json containing one process with an array of end events, some are not NONE event', () => {
@@ -227,20 +215,17 @@ describe('parse bpmn as json for end event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.NONE, 1);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_endEvent_id_0',
-        bpmnElementId: 'event_id_0',
-        bpmnElementName: 'none end event',
-        bpmnElementKind: ShapeBpmnElementKind.EVENT_END,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_endEvent_id_0',
+      bpmnElementId: 'event_id_0',
+      bpmnElementName: 'none end event',
+      bpmnElementKind: ShapeBpmnElementKind.EVENT_END,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 });

--- a/test/unit/component/parser/json/BpmnJsonParser.event.end.terminate.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.event.end.terminate.test.ts
@@ -42,16 +42,21 @@ describe('parse bpmn as json for terminate end event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.TERMINATE, 1);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_endEvent_id_7',
-      bpmnElementId: 'event_id_7',
-      bpmnElementName: undefined,
-      bpmnElementKind: ShapeBpmnElementKind.EVENT_END,
-      boundsX: 362,
-      boundsY: 932,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_endEvent_id_7',
+        bpmnElementId: 'event_id_7',
+        bpmnElementName: undefined,
+        bpmnElementKind: ShapeBpmnElementKind.EVENT_END,
+      },
+      {
+        x: 362,
+        y: 932,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing one process with an end event with terminate definition and another definition, terminate end event is NOT present', () => {

--- a/test/unit/component/parser/json/BpmnJsonParser.event.end.terminate.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.event.end.terminate.test.ts
@@ -42,21 +42,18 @@ describe('parse bpmn as json for terminate end event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.TERMINATE, 1);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_endEvent_id_7',
-        bpmnElementId: 'event_id_7',
-        bpmnElementName: undefined,
-        bpmnElementKind: ShapeBpmnElementKind.EVENT_END,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_endEvent_id_7',
+      bpmnElementId: 'event_id_7',
+      bpmnElementName: undefined,
+      bpmnElementKind: ShapeBpmnElementKind.EVENT_END,
+      bounds: {
         x: 362,
         y: 932,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing one process with an end event with terminate definition and another definition, terminate end event is NOT present', () => {

--- a/test/unit/component/parser/json/BpmnJsonParser.event.intermediate.catch.message.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.event.intermediate.catch.message.test.ts
@@ -43,16 +43,21 @@ describe('parse bpmn as json for message intermediate catch event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.MESSAGE, 1);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_intermediateCatchEvent_id_0',
-      bpmnElementId: 'event_id_0',
-      bpmnElementName: 'event name',
-      bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_intermediateCatchEvent_id_0',
+        bpmnElementId: 'event_id_0',
+        bpmnElementName: 'event name',
+        bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing one process with a message intermediate catch event defined as object, message intermediate catch event is present', () => {
@@ -80,16 +85,21 @@ describe('parse bpmn as json for message intermediate catch event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.MESSAGE, 1);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_intermediateCatchEvent_id_0',
-      bpmnElementId: 'event_id_0',
-      bpmnElementName: 'event name',
-      bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_intermediateCatchEvent_id_0',
+        bpmnElementId: 'event_id_0',
+        bpmnElementName: 'event name',
+        bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing one process with a intermediate catch event with message definition and another definition, message event is NOT present', () => {

--- a/test/unit/component/parser/json/BpmnJsonParser.event.intermediate.catch.message.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.event.intermediate.catch.message.test.ts
@@ -43,21 +43,18 @@ describe('parse bpmn as json for message intermediate catch event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.MESSAGE, 1);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_intermediateCatchEvent_id_0',
-        bpmnElementId: 'event_id_0',
-        bpmnElementName: 'event name',
-        bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_intermediateCatchEvent_id_0',
+      bpmnElementId: 'event_id_0',
+      bpmnElementName: 'event name',
+      bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing one process with a message intermediate catch event defined as object, message intermediate catch event is present', () => {
@@ -85,21 +82,18 @@ describe('parse bpmn as json for message intermediate catch event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.MESSAGE, 1);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_intermediateCatchEvent_id_0',
-        bpmnElementId: 'event_id_0',
-        bpmnElementName: 'event name',
-        bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_intermediateCatchEvent_id_0',
+      bpmnElementId: 'event_id_0',
+      bpmnElementName: 'event name',
+      bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing one process with a intermediate catch event with message definition and another definition, message event is NOT present', () => {

--- a/test/unit/component/parser/json/BpmnJsonParser.event.intermediate.catch.timer.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.event.intermediate.catch.timer.test.ts
@@ -43,16 +43,21 @@ describe('parse bpmn as json for timer intermediate catch event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.TIMER, 1);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_intermediateCatchEvent_id_0',
-      bpmnElementId: 'event_id_0',
-      bpmnElementName: 'event name',
-      bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_intermediateCatchEvent_id_0',
+        bpmnElementId: 'event_id_0',
+        bpmnElementName: 'event name',
+        bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing one process with a timer intermediate catch event defined as object, timer intermediate catch event is present', () => {
@@ -80,16 +85,21 @@ describe('parse bpmn as json for timer intermediate catch event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.TIMER, 1);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_intermediateCatchEvent_id_0',
-      bpmnElementId: 'event_id_0',
-      bpmnElementName: 'event name',
-      bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_intermediateCatchEvent_id_0',
+        bpmnElementId: 'event_id_0',
+        bpmnElementName: 'event name',
+        bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing one process with a intermediate catch event with timer definition and another definition, timer event is NOT present', () => {

--- a/test/unit/component/parser/json/BpmnJsonParser.event.intermediate.catch.timer.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.event.intermediate.catch.timer.test.ts
@@ -43,21 +43,18 @@ describe('parse bpmn as json for timer intermediate catch event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.TIMER, 1);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_intermediateCatchEvent_id_0',
-        bpmnElementId: 'event_id_0',
-        bpmnElementName: 'event name',
-        bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_intermediateCatchEvent_id_0',
+      bpmnElementId: 'event_id_0',
+      bpmnElementName: 'event name',
+      bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing one process with a timer intermediate catch event defined as object, timer intermediate catch event is present', () => {
@@ -85,21 +82,18 @@ describe('parse bpmn as json for timer intermediate catch event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.TIMER, 1);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_intermediateCatchEvent_id_0',
-        bpmnElementId: 'event_id_0',
-        bpmnElementName: 'event name',
-        bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_intermediateCatchEvent_id_0',
+      bpmnElementId: 'event_id_0',
+      bpmnElementName: 'event name',
+      bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing one process with a intermediate catch event with timer definition and another definition, timer event is NOT present', () => {

--- a/test/unit/component/parser/json/BpmnJsonParser.event.intermediate.throw.message.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.event.intermediate.throw.message.test.ts
@@ -42,16 +42,21 @@ describe('parse bpmn as json for throw Message intermediate event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.MESSAGE, 1);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_intermediateThrowEvent_id_7',
-      bpmnElementId: 'event_id_7',
-      bpmnElementName: undefined,
-      bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW,
-      boundsX: 362,
-      boundsY: 932,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_intermediateThrowEvent_id_7',
+        bpmnElementId: 'event_id_7',
+        bpmnElementName: undefined,
+        bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW,
+      },
+      {
+        x: 362,
+        y: 932,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing one process with an throw Message intermediate event defined as object, throw Message intermediate event is present', () => {
@@ -78,16 +83,21 @@ describe('parse bpmn as json for throw Message intermediate event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.MESSAGE, 1);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_intermediateThrowEvent_id_7',
-      bpmnElementId: 'event_id_7',
-      bpmnElementName: undefined,
-      bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW,
-      boundsX: 362,
-      boundsY: 932,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_intermediateThrowEvent_id_7',
+        bpmnElementId: 'event_id_7',
+        bpmnElementName: undefined,
+        bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW,
+      },
+      {
+        x: 362,
+        y: 932,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing one process with an end event with terminate definition and another definition, throw Message intermediate event is NOT present', () => {

--- a/test/unit/component/parser/json/BpmnJsonParser.event.intermediate.throw.message.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.event.intermediate.throw.message.test.ts
@@ -42,21 +42,18 @@ describe('parse bpmn as json for throw Message intermediate event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.MESSAGE, 1);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_intermediateThrowEvent_id_7',
-        bpmnElementId: 'event_id_7',
-        bpmnElementName: undefined,
-        bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_intermediateThrowEvent_id_7',
+      bpmnElementId: 'event_id_7',
+      bpmnElementName: undefined,
+      bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW,
+      bounds: {
         x: 362,
         y: 932,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing one process with an throw Message intermediate event defined as object, throw Message intermediate event is present', () => {
@@ -83,21 +80,18 @@ describe('parse bpmn as json for throw Message intermediate event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.MESSAGE, 1);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_intermediateThrowEvent_id_7',
-        bpmnElementId: 'event_id_7',
-        bpmnElementName: undefined,
-        bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_intermediateThrowEvent_id_7',
+      bpmnElementId: 'event_id_7',
+      bpmnElementName: undefined,
+      bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW,
+      bounds: {
         x: 362,
         y: 932,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing one process with an end event with terminate definition and another definition, throw Message intermediate event is NOT present', () => {

--- a/test/unit/component/parser/json/BpmnJsonParser.event.intermediate.throw.none.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.event.intermediate.throw.none.test.ts
@@ -42,21 +42,18 @@ describe('parse bpmn as json for throw None intermediate event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.NONE, 1);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_intermediateThrowEvent_id_0',
-        bpmnElementId: 'event_id_0',
-        bpmnElementName: 'event name',
-        bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_intermediateThrowEvent_id_0',
+      bpmnElementId: 'event_id_0',
+      bpmnElementName: 'event name',
+      bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing one process declared as array with a single throw None intermediate event', () => {
@@ -85,21 +82,18 @@ describe('parse bpmn as json for throw None intermediate event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.NONE, 1);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_intermediateThrowEvent_id_1',
-        bpmnElementId: 'event_id_1',
-        bpmnElementName: 'event name',
-        bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_intermediateThrowEvent_id_1',
+      bpmnElementId: 'event_id_1',
+      bpmnElementName: 'event name',
+      bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing one process with an array of throw None intermediate events with name & without name', () => {
@@ -136,37 +130,31 @@ describe('parse bpmn as json for throw None intermediate event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.NONE, 2);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_intermediateThrowEvent_id_0',
-        bpmnElementId: 'event_id_0',
-        bpmnElementName: 'event name',
-        bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_intermediateThrowEvent_id_0',
+      bpmnElementId: 'event_id_0',
+      bpmnElementName: 'event name',
+      bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
 
-    verifyShape(
-      model.flowNodes[1],
-      {
-        shapeId: 'shape_intermediateThrowEvent_id_1',
-        bpmnElementId: 'event_id_1',
-        bpmnElementName: undefined,
-        bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW,
-      },
-      {
+    verifyShape(model.flowNodes[1], {
+      shapeId: 'shape_intermediateThrowEvent_id_1',
+      bpmnElementId: 'event_id_1',
+      bpmnElementName: undefined,
+      bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW,
+      bounds: {
         x: 365,
         y: 235,
         width: 35,
         height: 46,
       },
-    );
+    });
   });
 
   it('json containing one process with an array of throw intermediate events, some are not NONE event', () => {
@@ -218,20 +206,17 @@ describe('parse bpmn as json for throw None intermediate event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.NONE, 1);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_intermediateThrowEvent_id_0',
-        bpmnElementId: 'event_id_0',
-        bpmnElementName: 'throw none intermediate event',
-        bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_intermediateThrowEvent_id_0',
+      bpmnElementId: 'event_id_0',
+      bpmnElementName: 'throw none intermediate event',
+      bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 });

--- a/test/unit/component/parser/json/BpmnJsonParser.event.intermediate.throw.none.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.event.intermediate.throw.none.test.ts
@@ -42,16 +42,21 @@ describe('parse bpmn as json for throw None intermediate event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.NONE, 1);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_intermediateThrowEvent_id_0',
-      bpmnElementId: 'event_id_0',
-      bpmnElementName: 'event name',
-      bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_intermediateThrowEvent_id_0',
+        bpmnElementId: 'event_id_0',
+        bpmnElementName: 'event name',
+        bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing one process declared as array with a single throw None intermediate event', () => {
@@ -80,16 +85,21 @@ describe('parse bpmn as json for throw None intermediate event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.NONE, 1);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_intermediateThrowEvent_id_1',
-      bpmnElementId: 'event_id_1',
-      bpmnElementName: 'event name',
-      bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_intermediateThrowEvent_id_1',
+        bpmnElementId: 'event_id_1',
+        bpmnElementName: 'event name',
+        bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing one process with an array of throw None intermediate events with name & without name', () => {
@@ -126,27 +136,37 @@ describe('parse bpmn as json for throw None intermediate event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.NONE, 2);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_intermediateThrowEvent_id_0',
-      bpmnElementId: 'event_id_0',
-      bpmnElementName: 'event name',
-      bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_intermediateThrowEvent_id_0',
+        bpmnElementId: 'event_id_0',
+        bpmnElementName: 'event name',
+        bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
 
-    verifyShape(model.flowNodes[1], {
-      shapeId: 'shape_intermediateThrowEvent_id_1',
-      bpmnElementId: 'event_id_1',
-      bpmnElementName: undefined,
-      bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW,
-      boundsX: 365,
-      boundsY: 235,
-      boundsWidth: 35,
-      boundsHeight: 46,
-    });
+    verifyShape(
+      model.flowNodes[1],
+      {
+        shapeId: 'shape_intermediateThrowEvent_id_1',
+        bpmnElementId: 'event_id_1',
+        bpmnElementName: undefined,
+        bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW,
+      },
+      {
+        x: 365,
+        y: 235,
+        width: 35,
+        height: 46,
+      },
+    );
   });
 
   it('json containing one process with an array of throw intermediate events, some are not NONE event', () => {
@@ -198,15 +218,20 @@ describe('parse bpmn as json for throw None intermediate event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.NONE, 1);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_intermediateThrowEvent_id_0',
-      bpmnElementId: 'event_id_0',
-      bpmnElementName: 'throw none intermediate event',
-      bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_intermediateThrowEvent_id_0',
+        bpmnElementId: 'event_id_0',
+        bpmnElementName: 'throw none intermediate event',
+        bpmnElementKind: ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 });

--- a/test/unit/component/parser/json/BpmnJsonParser.event.start.message.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.event.start.message.test.ts
@@ -43,16 +43,21 @@ describe('parse bpmn as json for message start event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.MESSAGE, 1);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_startEvent_id_0',
-      bpmnElementId: 'event_id_0',
-      bpmnElementName: 'event name',
-      bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_startEvent_id_0',
+        bpmnElementId: 'event_id_0',
+        bpmnElementName: 'event name',
+        bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing one process with a message start event defined as object, message start event is present', () => {
@@ -80,16 +85,21 @@ describe('parse bpmn as json for message start event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.MESSAGE, 1);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_startEvent_id_0',
-      bpmnElementId: 'event_id_0',
-      bpmnElementName: 'event name',
-      bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_startEvent_id_0',
+        bpmnElementId: 'event_id_0',
+        bpmnElementName: 'event name',
+        bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing one process with a start event with message definition and another definition, message start end event is NOT present', () => {

--- a/test/unit/component/parser/json/BpmnJsonParser.event.start.message.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.event.start.message.test.ts
@@ -43,21 +43,18 @@ describe('parse bpmn as json for message start event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.MESSAGE, 1);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_startEvent_id_0',
-        bpmnElementId: 'event_id_0',
-        bpmnElementName: 'event name',
-        bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_startEvent_id_0',
+      bpmnElementId: 'event_id_0',
+      bpmnElementName: 'event name',
+      bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing one process with a message start event defined as object, message start event is present', () => {
@@ -85,21 +82,18 @@ describe('parse bpmn as json for message start event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.MESSAGE, 1);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_startEvent_id_0',
-        bpmnElementId: 'event_id_0',
-        bpmnElementName: 'event name',
-        bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_startEvent_id_0',
+      bpmnElementId: 'event_id_0',
+      bpmnElementName: 'event name',
+      bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing one process with a start event with message definition and another definition, message start end event is NOT present', () => {

--- a/test/unit/component/parser/json/BpmnJsonParser.event.start.none.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.event.start.none.test.ts
@@ -42,16 +42,21 @@ describe('parse bpmn as json for start event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.NONE, 1);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_startEvent_id_0',
-      bpmnElementId: 'event_id_0',
-      bpmnElementName: 'event name',
-      bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_startEvent_id_0',
+        bpmnElementId: 'event_id_0',
+        bpmnElementName: 'event name',
+        bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing one process declared as array with a single start event', () => {
@@ -80,16 +85,21 @@ describe('parse bpmn as json for start event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.NONE, 1);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_startEvent_id_1',
-      bpmnElementId: 'event_id_1',
-      bpmnElementName: 'event name',
-      bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_startEvent_id_1',
+        bpmnElementId: 'event_id_1',
+        bpmnElementName: 'event name',
+        bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing one process with an array of start events with name & without name', () => {
@@ -126,27 +136,37 @@ describe('parse bpmn as json for start event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.NONE, 2);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_startEvent_id_0',
-      bpmnElementId: 'event_id_0',
-      bpmnElementName: 'event name',
-      bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_startEvent_id_0',
+        bpmnElementId: 'event_id_0',
+        bpmnElementName: 'event name',
+        bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
 
-    verifyShape(model.flowNodes[1], {
-      shapeId: 'shape_startEvent_id_1',
-      bpmnElementId: 'event_id_1',
-      bpmnElementName: undefined,
-      bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
-      boundsX: 365,
-      boundsY: 235,
-      boundsWidth: 35,
-      boundsHeight: 46,
-    });
+    verifyShape(
+      model.flowNodes[1],
+      {
+        shapeId: 'shape_startEvent_id_1',
+        bpmnElementId: 'event_id_1',
+        bpmnElementName: undefined,
+        bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
+      },
+      {
+        x: 365,
+        y: 235,
+        width: 35,
+        height: 46,
+      },
+    );
   });
 
   it('json containing one process with an array of start events, some are not NONE event', () => {
@@ -193,15 +213,20 @@ describe('parse bpmn as json for start event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.NONE, 1);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_startEvent_id_0',
-      bpmnElementId: 'event_id_0',
-      bpmnElementName: 'none start event',
-      bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_startEvent_id_0',
+        bpmnElementId: 'event_id_0',
+        bpmnElementName: 'none start event',
+        bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 });

--- a/test/unit/component/parser/json/BpmnJsonParser.event.start.none.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.event.start.none.test.ts
@@ -42,21 +42,18 @@ describe('parse bpmn as json for start event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.NONE, 1);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_startEvent_id_0',
-        bpmnElementId: 'event_id_0',
-        bpmnElementName: 'event name',
-        bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_startEvent_id_0',
+      bpmnElementId: 'event_id_0',
+      bpmnElementName: 'event name',
+      bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing one process declared as array with a single start event', () => {
@@ -85,21 +82,18 @@ describe('parse bpmn as json for start event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.NONE, 1);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_startEvent_id_1',
-        bpmnElementId: 'event_id_1',
-        bpmnElementName: 'event name',
-        bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_startEvent_id_1',
+      bpmnElementId: 'event_id_1',
+      bpmnElementName: 'event name',
+      bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing one process with an array of start events with name & without name', () => {
@@ -136,37 +130,31 @@ describe('parse bpmn as json for start event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.NONE, 2);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_startEvent_id_0',
-        bpmnElementId: 'event_id_0',
-        bpmnElementName: 'event name',
-        bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_startEvent_id_0',
+      bpmnElementId: 'event_id_0',
+      bpmnElementName: 'event name',
+      bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
 
-    verifyShape(
-      model.flowNodes[1],
-      {
-        shapeId: 'shape_startEvent_id_1',
-        bpmnElementId: 'event_id_1',
-        bpmnElementName: undefined,
-        bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
-      },
-      {
+    verifyShape(model.flowNodes[1], {
+      shapeId: 'shape_startEvent_id_1',
+      bpmnElementId: 'event_id_1',
+      bpmnElementName: undefined,
+      bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
+      bounds: {
         x: 365,
         y: 235,
         width: 35,
         height: 46,
       },
-    );
+    });
   });
 
   it('json containing one process with an array of start events, some are not NONE event', () => {
@@ -213,20 +201,17 @@ describe('parse bpmn as json for start event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.NONE, 1);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_startEvent_id_0',
-        bpmnElementId: 'event_id_0',
-        bpmnElementName: 'none start event',
-        bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_startEvent_id_0',
+      bpmnElementId: 'event_id_0',
+      bpmnElementName: 'none start event',
+      bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 });

--- a/test/unit/component/parser/json/BpmnJsonParser.event.start.timer.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.event.start.timer.test.ts
@@ -43,21 +43,18 @@ describe('parse bpmn as json for timer start event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.TIMER, 1);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_startEvent_id_0',
-        bpmnElementId: 'event_id_0',
-        bpmnElementName: 'event name',
-        bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_startEvent_id_0',
+      bpmnElementId: 'event_id_0',
+      bpmnElementName: 'event name',
+      bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing one process with a timer start event defined as object, timer start event is present', () => {
@@ -85,21 +82,18 @@ describe('parse bpmn as json for timer start event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.TIMER, 1);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_startEvent_id_0',
-        bpmnElementId: 'event_id_0',
-        bpmnElementName: 'event name',
-        bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_startEvent_id_0',
+      bpmnElementId: 'event_id_0',
+      bpmnElementName: 'event name',
+      bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing one process with a start event with timer definition and another definition, timer start end event is NOT present', () => {

--- a/test/unit/component/parser/json/BpmnJsonParser.event.start.timer.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.event.start.timer.test.ts
@@ -43,16 +43,21 @@ describe('parse bpmn as json for timer start event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.TIMER, 1);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_startEvent_id_0',
-      bpmnElementId: 'event_id_0',
-      bpmnElementName: 'event name',
-      bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_startEvent_id_0',
+        bpmnElementId: 'event_id_0',
+        bpmnElementName: 'event name',
+        bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing one process with a timer start event defined as object, timer start event is present', () => {
@@ -80,16 +85,21 @@ describe('parse bpmn as json for timer start event', () => {
 
     const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.TIMER, 1);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_startEvent_id_0',
-      bpmnElementId: 'event_id_0',
-      bpmnElementName: 'event name',
-      bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_startEvent_id_0',
+        bpmnElementId: 'event_id_0',
+        bpmnElementName: 'event name',
+        bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing one process with a start event with timer definition and another definition, timer start end event is NOT present', () => {

--- a/test/unit/component/parser/json/BpmnJsonParser.gateway.exclusive.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.gateway.exclusive.test.ts
@@ -41,21 +41,18 @@ describe('parse bpmn as json for exclusive gateway', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_exclusiveGateway_id_0',
-        bpmnElementId: 'exclusiveGateway_id_0',
-        bpmnElementName: 'exclusiveGateway name',
-        bpmnElementKind: ShapeBpmnElementKind.GATEWAY_EXCLUSIVE,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_exclusiveGateway_id_0',
+      bpmnElementId: 'exclusiveGateway_id_0',
+      bpmnElementName: 'exclusiveGateway name',
+      bpmnElementKind: ShapeBpmnElementKind.GATEWAY_EXCLUSIVE,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing one process declared as array with a single exclusive gateway', () => {
@@ -84,21 +81,18 @@ describe('parse bpmn as json for exclusive gateway', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_exclusiveGateway_id_1',
-        bpmnElementId: 'exclusiveGateway_id_1',
-        bpmnElementName: 'exclusiveGateway name',
-        bpmnElementKind: ShapeBpmnElementKind.GATEWAY_EXCLUSIVE,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_exclusiveGateway_id_1',
+      bpmnElementId: 'exclusiveGateway_id_1',
+      bpmnElementName: 'exclusiveGateway name',
+      bpmnElementKind: ShapeBpmnElementKind.GATEWAY_EXCLUSIVE,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing one process with an array of exclusive gateways with name & without name', () => {
@@ -135,35 +129,29 @@ describe('parse bpmn as json for exclusive gateway', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_exclusiveGateway_id_0',
-        bpmnElementId: 'exclusiveGateway_id_0',
-        bpmnElementName: 'exclusiveGateway name',
-        bpmnElementKind: ShapeBpmnElementKind.GATEWAY_EXCLUSIVE,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_exclusiveGateway_id_0',
+      bpmnElementId: 'exclusiveGateway_id_0',
+      bpmnElementName: 'exclusiveGateway name',
+      bpmnElementKind: ShapeBpmnElementKind.GATEWAY_EXCLUSIVE,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
-    verifyShape(
-      model.flowNodes[1],
-      {
-        shapeId: 'shape_exclusiveGateway_id_1',
-        bpmnElementId: 'exclusiveGateway_id_1',
-        bpmnElementName: undefined,
-        bpmnElementKind: ShapeBpmnElementKind.GATEWAY_EXCLUSIVE,
-      },
-      {
+    });
+    verifyShape(model.flowNodes[1], {
+      shapeId: 'shape_exclusiveGateway_id_1',
+      bpmnElementId: 'exclusiveGateway_id_1',
+      bpmnElementName: undefined,
+      bpmnElementKind: ShapeBpmnElementKind.GATEWAY_EXCLUSIVE,
+      bounds: {
         x: 365,
         y: 235,
         width: 35,
         height: 46,
       },
-    );
+    });
   });
 });

--- a/test/unit/component/parser/json/BpmnJsonParser.gateway.exclusive.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.gateway.exclusive.test.ts
@@ -41,16 +41,21 @@ describe('parse bpmn as json for exclusive gateway', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_exclusiveGateway_id_0',
-      bpmnElementId: 'exclusiveGateway_id_0',
-      bpmnElementName: 'exclusiveGateway name',
-      bpmnElementKind: ShapeBpmnElementKind.GATEWAY_EXCLUSIVE,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_exclusiveGateway_id_0',
+        bpmnElementId: 'exclusiveGateway_id_0',
+        bpmnElementName: 'exclusiveGateway name',
+        bpmnElementKind: ShapeBpmnElementKind.GATEWAY_EXCLUSIVE,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing one process declared as array with a single exclusive gateway', () => {
@@ -79,16 +84,21 @@ describe('parse bpmn as json for exclusive gateway', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_exclusiveGateway_id_1',
-      bpmnElementId: 'exclusiveGateway_id_1',
-      bpmnElementName: 'exclusiveGateway name',
-      bpmnElementKind: ShapeBpmnElementKind.GATEWAY_EXCLUSIVE,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_exclusiveGateway_id_1',
+        bpmnElementId: 'exclusiveGateway_id_1',
+        bpmnElementName: 'exclusiveGateway name',
+        bpmnElementKind: ShapeBpmnElementKind.GATEWAY_EXCLUSIVE,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing one process with an array of exclusive gateways with name & without name', () => {
@@ -125,25 +135,35 @@ describe('parse bpmn as json for exclusive gateway', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_exclusiveGateway_id_0',
-      bpmnElementId: 'exclusiveGateway_id_0',
-      bpmnElementName: 'exclusiveGateway name',
-      bpmnElementKind: ShapeBpmnElementKind.GATEWAY_EXCLUSIVE,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
-    verifyShape(model.flowNodes[1], {
-      shapeId: 'shape_exclusiveGateway_id_1',
-      bpmnElementId: 'exclusiveGateway_id_1',
-      bpmnElementName: undefined,
-      bpmnElementKind: ShapeBpmnElementKind.GATEWAY_EXCLUSIVE,
-      boundsX: 365,
-      boundsY: 235,
-      boundsWidth: 35,
-      boundsHeight: 46,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_exclusiveGateway_id_0',
+        bpmnElementId: 'exclusiveGateway_id_0',
+        bpmnElementName: 'exclusiveGateway name',
+        bpmnElementKind: ShapeBpmnElementKind.GATEWAY_EXCLUSIVE,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
+    verifyShape(
+      model.flowNodes[1],
+      {
+        shapeId: 'shape_exclusiveGateway_id_1',
+        bpmnElementId: 'exclusiveGateway_id_1',
+        bpmnElementName: undefined,
+        bpmnElementKind: ShapeBpmnElementKind.GATEWAY_EXCLUSIVE,
+      },
+      {
+        x: 365,
+        y: 235,
+        width: 35,
+        height: 46,
+      },
+    );
   });
 });

--- a/test/unit/component/parser/json/BpmnJsonParser.gateway.inclusive.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.gateway.inclusive.test.ts
@@ -41,16 +41,21 @@ describe('parse bpmn as json for inclusive gateway', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_inclusiveGateway_id_0',
-      bpmnElementId: 'inclusiveGateway_id_0',
-      bpmnElementName: 'inclusiveGateway name',
-      bpmnElementKind: ShapeBpmnElementKind.GATEWAY_INCLUSIVE,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_inclusiveGateway_id_0',
+        bpmnElementId: 'inclusiveGateway_id_0',
+        bpmnElementName: 'inclusiveGateway name',
+        bpmnElementKind: ShapeBpmnElementKind.GATEWAY_INCLUSIVE,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing one process declared as array with a single inclusive gateway', () => {
@@ -79,16 +84,21 @@ describe('parse bpmn as json for inclusive gateway', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_inclusiveGateway_id_1',
-      bpmnElementId: 'inclusiveGateway_id_1',
-      bpmnElementName: 'inclusiveGateway name',
-      bpmnElementKind: ShapeBpmnElementKind.GATEWAY_INCLUSIVE,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_inclusiveGateway_id_1',
+        bpmnElementId: 'inclusiveGateway_id_1',
+        bpmnElementName: 'inclusiveGateway name',
+        bpmnElementKind: ShapeBpmnElementKind.GATEWAY_INCLUSIVE,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing one process with an array of inclusive gateways with name & without name', () => {
@@ -125,25 +135,35 @@ describe('parse bpmn as json for inclusive gateway', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_inclusiveGateway_id_0',
-      bpmnElementId: 'inclusiveGateway_id_0',
-      bpmnElementName: 'inclusiveGateway name',
-      bpmnElementKind: ShapeBpmnElementKind.GATEWAY_INCLUSIVE,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
-    verifyShape(model.flowNodes[1], {
-      shapeId: 'shape_inclusiveGateway_id_1',
-      bpmnElementId: 'inclusiveGateway_id_1',
-      bpmnElementName: undefined,
-      bpmnElementKind: ShapeBpmnElementKind.GATEWAY_INCLUSIVE,
-      boundsX: 365,
-      boundsY: 235,
-      boundsWidth: 35,
-      boundsHeight: 46,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_inclusiveGateway_id_0',
+        bpmnElementId: 'inclusiveGateway_id_0',
+        bpmnElementName: 'inclusiveGateway name',
+        bpmnElementKind: ShapeBpmnElementKind.GATEWAY_INCLUSIVE,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
+    verifyShape(
+      model.flowNodes[1],
+      {
+        shapeId: 'shape_inclusiveGateway_id_1',
+        bpmnElementId: 'inclusiveGateway_id_1',
+        bpmnElementName: undefined,
+        bpmnElementKind: ShapeBpmnElementKind.GATEWAY_INCLUSIVE,
+      },
+      {
+        x: 365,
+        y: 235,
+        width: 35,
+        height: 46,
+      },
+    );
   });
 });

--- a/test/unit/component/parser/json/BpmnJsonParser.gateway.inclusive.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.gateway.inclusive.test.ts
@@ -41,21 +41,18 @@ describe('parse bpmn as json for inclusive gateway', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_inclusiveGateway_id_0',
-        bpmnElementId: 'inclusiveGateway_id_0',
-        bpmnElementName: 'inclusiveGateway name',
-        bpmnElementKind: ShapeBpmnElementKind.GATEWAY_INCLUSIVE,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_inclusiveGateway_id_0',
+      bpmnElementId: 'inclusiveGateway_id_0',
+      bpmnElementName: 'inclusiveGateway name',
+      bpmnElementKind: ShapeBpmnElementKind.GATEWAY_INCLUSIVE,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing one process declared as array with a single inclusive gateway', () => {
@@ -84,21 +81,18 @@ describe('parse bpmn as json for inclusive gateway', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_inclusiveGateway_id_1',
-        bpmnElementId: 'inclusiveGateway_id_1',
-        bpmnElementName: 'inclusiveGateway name',
-        bpmnElementKind: ShapeBpmnElementKind.GATEWAY_INCLUSIVE,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_inclusiveGateway_id_1',
+      bpmnElementId: 'inclusiveGateway_id_1',
+      bpmnElementName: 'inclusiveGateway name',
+      bpmnElementKind: ShapeBpmnElementKind.GATEWAY_INCLUSIVE,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing one process with an array of inclusive gateways with name & without name', () => {
@@ -135,35 +129,29 @@ describe('parse bpmn as json for inclusive gateway', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_inclusiveGateway_id_0',
-        bpmnElementId: 'inclusiveGateway_id_0',
-        bpmnElementName: 'inclusiveGateway name',
-        bpmnElementKind: ShapeBpmnElementKind.GATEWAY_INCLUSIVE,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_inclusiveGateway_id_0',
+      bpmnElementId: 'inclusiveGateway_id_0',
+      bpmnElementName: 'inclusiveGateway name',
+      bpmnElementKind: ShapeBpmnElementKind.GATEWAY_INCLUSIVE,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
-    verifyShape(
-      model.flowNodes[1],
-      {
-        shapeId: 'shape_inclusiveGateway_id_1',
-        bpmnElementId: 'inclusiveGateway_id_1',
-        bpmnElementName: undefined,
-        bpmnElementKind: ShapeBpmnElementKind.GATEWAY_INCLUSIVE,
-      },
-      {
+    });
+    verifyShape(model.flowNodes[1], {
+      shapeId: 'shape_inclusiveGateway_id_1',
+      bpmnElementId: 'inclusiveGateway_id_1',
+      bpmnElementName: undefined,
+      bpmnElementKind: ShapeBpmnElementKind.GATEWAY_INCLUSIVE,
+      bounds: {
         x: 365,
         y: 235,
         width: 35,
         height: 46,
       },
-    );
+    });
   });
 });

--- a/test/unit/component/parser/json/BpmnJsonParser.gateway.parallel.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.gateway.parallel.test.ts
@@ -41,21 +41,18 @@ describe('parse bpmn as json for parallel gateway', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_parallelGateway_id_0',
-        bpmnElementId: 'parallelGateway_id_0',
-        bpmnElementName: 'parallelGateway name',
-        bpmnElementKind: ShapeBpmnElementKind.GATEWAY_PARALLEL,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_parallelGateway_id_0',
+      bpmnElementId: 'parallelGateway_id_0',
+      bpmnElementName: 'parallelGateway name',
+      bpmnElementKind: ShapeBpmnElementKind.GATEWAY_PARALLEL,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing one process declared as array with a single parallel gateway', () => {
@@ -84,21 +81,18 @@ describe('parse bpmn as json for parallel gateway', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_parallelGateway_id_1',
-        bpmnElementId: 'parallelGateway_id_1',
-        bpmnElementName: 'parallelGateway name',
-        bpmnElementKind: ShapeBpmnElementKind.GATEWAY_PARALLEL,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_parallelGateway_id_1',
+      bpmnElementId: 'parallelGateway_id_1',
+      bpmnElementName: 'parallelGateway name',
+      bpmnElementKind: ShapeBpmnElementKind.GATEWAY_PARALLEL,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing one process with an array of parallel gateways with name & without name', () => {
@@ -135,35 +129,29 @@ describe('parse bpmn as json for parallel gateway', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_parallelGateway_id_0',
-        bpmnElementId: 'parallelGateway_id_0',
-        bpmnElementName: 'parallelGateway name',
-        bpmnElementKind: ShapeBpmnElementKind.GATEWAY_PARALLEL,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_parallelGateway_id_0',
+      bpmnElementId: 'parallelGateway_id_0',
+      bpmnElementName: 'parallelGateway name',
+      bpmnElementKind: ShapeBpmnElementKind.GATEWAY_PARALLEL,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
-    verifyShape(
-      model.flowNodes[1],
-      {
-        shapeId: 'shape_parallelGateway_id_1',
-        bpmnElementId: 'parallelGateway_id_1',
-        bpmnElementName: undefined,
-        bpmnElementKind: ShapeBpmnElementKind.GATEWAY_PARALLEL,
-      },
-      {
+    });
+    verifyShape(model.flowNodes[1], {
+      shapeId: 'shape_parallelGateway_id_1',
+      bpmnElementId: 'parallelGateway_id_1',
+      bpmnElementName: undefined,
+      bpmnElementKind: ShapeBpmnElementKind.GATEWAY_PARALLEL,
+      bounds: {
         x: 365,
         y: 235,
         width: 35,
         height: 46,
       },
-    );
+    });
   });
 });

--- a/test/unit/component/parser/json/BpmnJsonParser.gateway.parallel.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.gateway.parallel.test.ts
@@ -41,16 +41,21 @@ describe('parse bpmn as json for parallel gateway', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_parallelGateway_id_0',
-      bpmnElementId: 'parallelGateway_id_0',
-      bpmnElementName: 'parallelGateway name',
-      bpmnElementKind: ShapeBpmnElementKind.GATEWAY_PARALLEL,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_parallelGateway_id_0',
+        bpmnElementId: 'parallelGateway_id_0',
+        bpmnElementName: 'parallelGateway name',
+        bpmnElementKind: ShapeBpmnElementKind.GATEWAY_PARALLEL,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing one process declared as array with a single parallel gateway', () => {
@@ -79,16 +84,21 @@ describe('parse bpmn as json for parallel gateway', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_parallelGateway_id_1',
-      bpmnElementId: 'parallelGateway_id_1',
-      bpmnElementName: 'parallelGateway name',
-      bpmnElementKind: ShapeBpmnElementKind.GATEWAY_PARALLEL,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_parallelGateway_id_1',
+        bpmnElementId: 'parallelGateway_id_1',
+        bpmnElementName: 'parallelGateway name',
+        bpmnElementKind: ShapeBpmnElementKind.GATEWAY_PARALLEL,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing one process with an array of parallel gateways with name & without name', () => {
@@ -125,25 +135,35 @@ describe('parse bpmn as json for parallel gateway', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_parallelGateway_id_0',
-      bpmnElementId: 'parallelGateway_id_0',
-      bpmnElementName: 'parallelGateway name',
-      bpmnElementKind: ShapeBpmnElementKind.GATEWAY_PARALLEL,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
-    verifyShape(model.flowNodes[1], {
-      shapeId: 'shape_parallelGateway_id_1',
-      bpmnElementId: 'parallelGateway_id_1',
-      bpmnElementName: undefined,
-      bpmnElementKind: ShapeBpmnElementKind.GATEWAY_PARALLEL,
-      boundsX: 365,
-      boundsY: 235,
-      boundsWidth: 35,
-      boundsHeight: 46,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_parallelGateway_id_0',
+        bpmnElementId: 'parallelGateway_id_0',
+        bpmnElementName: 'parallelGateway name',
+        bpmnElementKind: ShapeBpmnElementKind.GATEWAY_PARALLEL,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
+    verifyShape(
+      model.flowNodes[1],
+      {
+        shapeId: 'shape_parallelGateway_id_1',
+        bpmnElementId: 'parallelGateway_id_1',
+        bpmnElementName: undefined,
+        bpmnElementKind: ShapeBpmnElementKind.GATEWAY_PARALLEL,
+      },
+      {
+        x: 365,
+        y: 235,
+        width: 35,
+        height: 46,
+      },
+    );
   });
 });

--- a/test/unit/component/parser/json/BpmnJsonParser.label.font.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.label.font.test.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { parseJsonAndExpectOnlyEdges, parseJsonAndExpectOnlyFlowNodes, verifyLabel } from './JsonTestUtils';
+import { parseJsonAndExpectOnlyEdges, parseJsonAndExpectOnlyFlowNodes, verifyLabelFont } from './JsonTestUtils';
 
 describe('parse bpmn as json for label font', () => {
   jest.spyOn(console, 'warn');
@@ -58,7 +58,7 @@ describe('parse bpmn as json for label font', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
-    verifyLabel(model.flowNodes[0].label, { name: 'Arial', size: 11.0 });
+    verifyLabelFont(model.flowNodes[0].label, { name: 'Arial', size: 11.0 });
   });
 
   it('json containing a BPMNEdge who references a label style with font', () => {
@@ -90,7 +90,7 @@ describe('parse bpmn as json for label font', () => {
 
     const model = parseJsonAndExpectOnlyEdges(json, 1);
 
-    verifyLabel(model.edges[0].label, { name: 'Arial', size: 11.0 });
+    verifyLabelFont(model.edges[0].label, { name: 'Arial', size: 11.0 });
   });
 
   it('json containing several BPMNShapes who reference the same label style', () => {
@@ -140,8 +140,8 @@ describe('parse bpmn as json for label font', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
 
-    verifyLabel(model.flowNodes[0].label, { name: 'Arial', size: 11.0 });
-    verifyLabel(model.flowNodes[1].label, { name: 'Arial', size: 11.0 });
+    verifyLabelFont(model.flowNodes[0].label, { name: 'Arial', size: 11.0 });
+    verifyLabelFont(model.flowNodes[1].label, { name: 'Arial', size: 11.0 });
   });
 
   it('json containing several BPMNEdges who reference the same label style', () => {
@@ -178,8 +178,8 @@ describe('parse bpmn as json for label font', () => {
 
     const model = parseJsonAndExpectOnlyEdges(json, 2);
 
-    verifyLabel(model.edges[0].label, { name: 'Arial', size: 11.0 });
-    verifyLabel(model.edges[1].label, { name: 'Arial', size: 11.0 });
+    verifyLabelFont(model.edges[0].label, { name: 'Arial', size: 11.0 });
+    verifyLabelFont(model.edges[1].label, { name: 'Arial', size: 11.0 });
   });
 
   it('json containing an array of label styles and BPMNShapes who reference a label style with font with/without all attributes', () => {
@@ -240,7 +240,7 @@ describe('parse bpmn as json for label font', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
 
-    verifyLabel(model.flowNodes[0].label, { name: 'Arial', size: 11.0, isBold: false, isItalic: false, isStrikeThrough: false, isUnderline: false });
+    verifyLabelFont(model.flowNodes[0].label, { name: 'Arial', size: 11.0, isBold: false, isItalic: false, isStrikeThrough: false, isUnderline: false });
     expect(model.flowNodes[1].label).toBeUndefined();
   });
 
@@ -289,7 +289,7 @@ describe('parse bpmn as json for label font', () => {
 
     const model = parseJsonAndExpectOnlyEdges(json, 2);
 
-    verifyLabel(model.edges[0].label, { name: 'Arial', size: 11.0, isBold: false, isItalic: false, isStrikeThrough: false, isUnderline: false });
+    verifyLabelFont(model.edges[0].label, { name: 'Arial', size: 11.0, isBold: false, isItalic: false, isStrikeThrough: false, isUnderline: false });
     expect(model.edges[1].label).toBeUndefined();
   });
 

--- a/test/unit/component/parser/json/BpmnJsonParser.lane.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.lane.test.ts
@@ -39,16 +39,21 @@ describe('parse bpmn as json for lane', () => {
 
     const model = parseJsonAndExpectOnlyLanes(json, 1);
 
-    verifyShape(model.lanes[0], {
-      shapeId: 'Lane_1h5yeu4_di',
-      bpmnElementId: 'Lane_12u5n6x',
-      bpmnElementName: undefined,
-      bpmnElementKind: ShapeBpmnElementKind.LANE,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.lanes[0],
+      {
+        shapeId: 'Lane_1h5yeu4_di',
+        bpmnElementId: 'Lane_12u5n6x',
+        bpmnElementName: undefined,
+        bpmnElementKind: ShapeBpmnElementKind.LANE,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing one process with a single lane with flowNodeRef as object & flowNode already parsed', () => {
@@ -81,16 +86,21 @@ describe('parse bpmn as json for lane', () => {
     const model = parseJson(json);
 
     expect(model.lanes).toHaveLength(1);
-    verifyShape(model.lanes[0], {
-      shapeId: 'Lane_1h5yeu4_di',
-      bpmnElementId: 'Lane_12u5n6x',
-      bpmnElementName: undefined,
-      bpmnElementKind: ShapeBpmnElementKind.LANE,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.lanes[0],
+      {
+        shapeId: 'Lane_1h5yeu4_di',
+        bpmnElementId: 'Lane_12u5n6x',
+        bpmnElementName: undefined,
+        bpmnElementKind: ShapeBpmnElementKind.LANE,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
 
     expect(model.flowNodes).toHaveLength(1);
     expect(model.flowNodes[0].bpmnElement.parentId).toEqual('Lane_12u5n6x');
@@ -118,16 +128,21 @@ describe('parse bpmn as json for lane', () => {
 
     const model = parseJsonAndExpectOnlyLanes(json, 1);
 
-    verifyShape(model.lanes[0], {
-      shapeId: 'Lane_1h5yeu4_di',
-      bpmnElementId: 'Lane_12u5n6x',
-      bpmnElementName: undefined,
-      bpmnElementKind: ShapeBpmnElementKind.LANE,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.lanes[0],
+      {
+        shapeId: 'Lane_1h5yeu4_di',
+        bpmnElementId: 'Lane_12u5n6x',
+        bpmnElementName: undefined,
+        bpmnElementKind: ShapeBpmnElementKind.LANE,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing one process with a single lane with flowNodeRef as object & flowNode not parsed', () => {
@@ -153,16 +168,21 @@ describe('parse bpmn as json for lane', () => {
     const model = parseJson(json);
 
     expect(model.lanes).toHaveLength(1);
-    verifyShape(model.lanes[0], {
-      shapeId: 'Lane_1h5yeu4_di',
-      bpmnElementId: 'Lane_12u5n6x',
-      bpmnElementName: undefined,
-      bpmnElementKind: ShapeBpmnElementKind.LANE,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.lanes[0],
+      {
+        shapeId: 'Lane_1h5yeu4_di',
+        bpmnElementId: 'Lane_12u5n6x',
+        bpmnElementName: undefined,
+        bpmnElementKind: ShapeBpmnElementKind.LANE,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing one process with a single lane with flowNodeRef as array', () => {
@@ -195,16 +215,21 @@ describe('parse bpmn as json for lane', () => {
     const model = parseJson(json);
 
     expect(model.lanes).toHaveLength(1);
-    verifyShape(model.lanes[0], {
-      shapeId: 'Lane_1h5yeu4_di',
-      bpmnElementId: 'Lane_12u5n6x',
-      bpmnElementName: undefined,
-      bpmnElementKind: ShapeBpmnElementKind.LANE,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.lanes[0],
+      {
+        shapeId: 'Lane_1h5yeu4_di',
+        bpmnElementId: 'Lane_12u5n6x',
+        bpmnElementName: undefined,
+        bpmnElementKind: ShapeBpmnElementKind.LANE,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
 
     expect(model.flowNodes).toHaveLength(1);
     expect(model.flowNodes[0].bpmnElement.parentId).toEqual('Lane_12u5n6x');
@@ -235,16 +260,21 @@ describe('parse bpmn as json for lane', () => {
 
     const model = parseJsonAndExpectOnlyLanes(json, 1);
 
-    verifyShape(model.lanes[0], {
-      shapeId: 'Lane_1h5yeu4_di',
-      bpmnElementId: 'Lane_12u5n6x',
-      bpmnElementName: undefined,
-      bpmnElementKind: ShapeBpmnElementKind.LANE,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.lanes[0],
+      {
+        shapeId: 'Lane_1h5yeu4_di',
+        bpmnElementId: 'Lane_12u5n6x',
+        bpmnElementName: undefined,
+        bpmnElementKind: ShapeBpmnElementKind.LANE,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing one process with an array of lanes with & without name', () => {
@@ -287,25 +317,35 @@ describe('parse bpmn as json for lane', () => {
 
     const model = parseJsonAndExpectOnlyLanes(json, 2);
 
-    verifyShape(model.lanes[0], {
-      shapeId: 'Lane_164yevk_di',
-      bpmnElementId: 'Lane_164yevk',
-      bpmnElementName: 'Customer',
-      bpmnElementKind: ShapeBpmnElementKind.LANE,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
-    verifyShape(model.lanes[1], {
-      shapeId: 'Lane_12u5n6x_di',
-      bpmnElementId: 'Lane_12u5n6x',
-      bpmnElementName: undefined,
-      bpmnElementKind: ShapeBpmnElementKind.LANE,
-      boundsX: 666,
-      boundsY: 222,
-      boundsWidth: 22,
-      boundsHeight: 33,
-    });
+    verifyShape(
+      model.lanes[0],
+      {
+        shapeId: 'Lane_164yevk_di',
+        bpmnElementId: 'Lane_164yevk',
+        bpmnElementName: 'Customer',
+        bpmnElementKind: ShapeBpmnElementKind.LANE,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
+    verifyShape(
+      model.lanes[1],
+      {
+        shapeId: 'Lane_12u5n6x_di',
+        bpmnElementId: 'Lane_12u5n6x',
+        bpmnElementName: undefined,
+        bpmnElementKind: ShapeBpmnElementKind.LANE,
+      },
+      {
+        x: 666,
+        y: 222,
+        width: 22,
+        height: 33,
+      },
+    );
   });
 });

--- a/test/unit/component/parser/json/BpmnJsonParser.lane.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.lane.test.ts
@@ -39,21 +39,18 @@ describe('parse bpmn as json for lane', () => {
 
     const model = parseJsonAndExpectOnlyLanes(json, 1);
 
-    verifyShape(
-      model.lanes[0],
-      {
-        shapeId: 'Lane_1h5yeu4_di',
-        bpmnElementId: 'Lane_12u5n6x',
-        bpmnElementName: undefined,
-        bpmnElementKind: ShapeBpmnElementKind.LANE,
-      },
-      {
+    verifyShape(model.lanes[0], {
+      shapeId: 'Lane_1h5yeu4_di',
+      bpmnElementId: 'Lane_12u5n6x',
+      bpmnElementName: undefined,
+      bpmnElementKind: ShapeBpmnElementKind.LANE,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing one process with a single lane with flowNodeRef as object & flowNode already parsed', () => {
@@ -86,21 +83,18 @@ describe('parse bpmn as json for lane', () => {
     const model = parseJson(json);
 
     expect(model.lanes).toHaveLength(1);
-    verifyShape(
-      model.lanes[0],
-      {
-        shapeId: 'Lane_1h5yeu4_di',
-        bpmnElementId: 'Lane_12u5n6x',
-        bpmnElementName: undefined,
-        bpmnElementKind: ShapeBpmnElementKind.LANE,
-      },
-      {
+    verifyShape(model.lanes[0], {
+      shapeId: 'Lane_1h5yeu4_di',
+      bpmnElementId: 'Lane_12u5n6x',
+      bpmnElementName: undefined,
+      bpmnElementKind: ShapeBpmnElementKind.LANE,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
 
     expect(model.flowNodes).toHaveLength(1);
     expect(model.flowNodes[0].bpmnElement.parentId).toEqual('Lane_12u5n6x');
@@ -128,21 +122,18 @@ describe('parse bpmn as json for lane', () => {
 
     const model = parseJsonAndExpectOnlyLanes(json, 1);
 
-    verifyShape(
-      model.lanes[0],
-      {
-        shapeId: 'Lane_1h5yeu4_di',
-        bpmnElementId: 'Lane_12u5n6x',
-        bpmnElementName: undefined,
-        bpmnElementKind: ShapeBpmnElementKind.LANE,
-      },
-      {
+    verifyShape(model.lanes[0], {
+      shapeId: 'Lane_1h5yeu4_di',
+      bpmnElementId: 'Lane_12u5n6x',
+      bpmnElementName: undefined,
+      bpmnElementKind: ShapeBpmnElementKind.LANE,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing one process with a single lane with flowNodeRef as object & flowNode not parsed', () => {
@@ -168,21 +159,18 @@ describe('parse bpmn as json for lane', () => {
     const model = parseJson(json);
 
     expect(model.lanes).toHaveLength(1);
-    verifyShape(
-      model.lanes[0],
-      {
-        shapeId: 'Lane_1h5yeu4_di',
-        bpmnElementId: 'Lane_12u5n6x',
-        bpmnElementName: undefined,
-        bpmnElementKind: ShapeBpmnElementKind.LANE,
-      },
-      {
+    verifyShape(model.lanes[0], {
+      shapeId: 'Lane_1h5yeu4_di',
+      bpmnElementId: 'Lane_12u5n6x',
+      bpmnElementName: undefined,
+      bpmnElementKind: ShapeBpmnElementKind.LANE,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing one process with a single lane with flowNodeRef as array', () => {
@@ -215,21 +203,18 @@ describe('parse bpmn as json for lane', () => {
     const model = parseJson(json);
 
     expect(model.lanes).toHaveLength(1);
-    verifyShape(
-      model.lanes[0],
-      {
-        shapeId: 'Lane_1h5yeu4_di',
-        bpmnElementId: 'Lane_12u5n6x',
-        bpmnElementName: undefined,
-        bpmnElementKind: ShapeBpmnElementKind.LANE,
-      },
-      {
+    verifyShape(model.lanes[0], {
+      shapeId: 'Lane_1h5yeu4_di',
+      bpmnElementId: 'Lane_12u5n6x',
+      bpmnElementName: undefined,
+      bpmnElementKind: ShapeBpmnElementKind.LANE,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
 
     expect(model.flowNodes).toHaveLength(1);
     expect(model.flowNodes[0].bpmnElement.parentId).toEqual('Lane_12u5n6x');
@@ -260,21 +245,18 @@ describe('parse bpmn as json for lane', () => {
 
     const model = parseJsonAndExpectOnlyLanes(json, 1);
 
-    verifyShape(
-      model.lanes[0],
-      {
-        shapeId: 'Lane_1h5yeu4_di',
-        bpmnElementId: 'Lane_12u5n6x',
-        bpmnElementName: undefined,
-        bpmnElementKind: ShapeBpmnElementKind.LANE,
-      },
-      {
+    verifyShape(model.lanes[0], {
+      shapeId: 'Lane_1h5yeu4_di',
+      bpmnElementId: 'Lane_12u5n6x',
+      bpmnElementName: undefined,
+      bpmnElementKind: ShapeBpmnElementKind.LANE,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing one process with an array of lanes with & without name', () => {
@@ -317,35 +299,29 @@ describe('parse bpmn as json for lane', () => {
 
     const model = parseJsonAndExpectOnlyLanes(json, 2);
 
-    verifyShape(
-      model.lanes[0],
-      {
-        shapeId: 'Lane_164yevk_di',
-        bpmnElementId: 'Lane_164yevk',
-        bpmnElementName: 'Customer',
-        bpmnElementKind: ShapeBpmnElementKind.LANE,
-      },
-      {
+    verifyShape(model.lanes[0], {
+      shapeId: 'Lane_164yevk_di',
+      bpmnElementId: 'Lane_164yevk',
+      bpmnElementName: 'Customer',
+      bpmnElementKind: ShapeBpmnElementKind.LANE,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
-    verifyShape(
-      model.lanes[1],
-      {
-        shapeId: 'Lane_12u5n6x_di',
-        bpmnElementId: 'Lane_12u5n6x',
-        bpmnElementName: undefined,
-        bpmnElementKind: ShapeBpmnElementKind.LANE,
-      },
-      {
+    });
+    verifyShape(model.lanes[1], {
+      shapeId: 'Lane_12u5n6x_di',
+      bpmnElementId: 'Lane_12u5n6x',
+      bpmnElementName: undefined,
+      bpmnElementKind: ShapeBpmnElementKind.LANE,
+      bounds: {
         x: 666,
         y: 222,
         width: 22,
         height: 33,
       },
-    );
+    });
   });
 });

--- a/test/unit/component/parser/json/BpmnJsonParser.process.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.process.test.ts
@@ -46,22 +46,19 @@ describe('parse bpmn as json for process/pool', () => {
 
     const model = parseJsonAndExpectOnlyPoolsAndLanes(json, 1, 0);
     const pool = model.pools[0];
-    verifyShape(
-      pool,
-      {
-        shapeId: 'shape_Participant_1',
-        bpmnElementId: 'Participant_1',
-        bpmnElementName: 'Process 1',
-        bpmnElementKind: ShapeBpmnElementKind.POOL,
-        parentId: undefined,
-      },
-      {
+    verifyShape(pool, {
+      shapeId: 'shape_Participant_1',
+      bpmnElementId: 'Participant_1',
+      bpmnElementName: 'Process 1',
+      bpmnElementKind: ShapeBpmnElementKind.POOL,
+      parentId: undefined,
+      bounds: {
         x: 158,
         y: 50,
         width: 1620,
         height: 430,
       },
-    );
+    });
   });
 
   it('json containing one process with a single lane without flowNodeRef', () => {
@@ -99,40 +96,34 @@ describe('parse bpmn as json for process/pool', () => {
 
     const model = parseJsonAndExpectOnlyPoolsAndLanes(json, 1, 1);
     const pool = model.pools[0];
-    verifyShape(
-      pool,
-      {
-        shapeId: 'shape_Participant_0nuvj8r',
-        bpmnElementId: 'Participant_0nuvj8r',
-        bpmnElementName: 'Pool 1',
-        bpmnElementKind: ShapeBpmnElementKind.POOL,
-        parentId: undefined,
-      },
-      {
+    verifyShape(pool, {
+      shapeId: 'shape_Participant_0nuvj8r',
+      bpmnElementId: 'Participant_0nuvj8r',
+      bpmnElementName: 'Pool 1',
+      bpmnElementKind: ShapeBpmnElementKind.POOL,
+      parentId: undefined,
+      bounds: {
         x: 158,
         y: 50,
         width: 1620,
         height: 430,
       },
-    );
+    });
 
     const lane = model.lanes[0];
-    verifyShape(
-      lane,
-      {
-        shapeId: 'shape_Lane_1h5yeu4',
-        bpmnElementId: 'Lane_12u5n6x',
-        bpmnElementName: undefined,
-        bpmnElementKind: ShapeBpmnElementKind.LANE,
-        parentId: 'Participant_0nuvj8r',
-      },
-      {
+    verifyShape(lane, {
+      shapeId: 'shape_Lane_1h5yeu4',
+      bpmnElementId: 'Lane_12u5n6x',
+      bpmnElementName: undefined,
+      bpmnElementKind: ShapeBpmnElementKind.LANE,
+      parentId: 'Participant_0nuvj8r',
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing several processes and participants (with lane or laneset)', () => {
@@ -195,71 +186,59 @@ describe('parse bpmn as json for process/pool', () => {
 }`;
 
     const model = parseJsonAndExpectOnlyPoolsAndLanes(json, 2, 2);
-    verifyShape(
-      model.pools[0],
-      {
-        shapeId: 'shape_Participant_1',
-        bpmnElementId: 'Participant_1',
-        bpmnElementName: 'Pool 1',
-        bpmnElementKind: ShapeBpmnElementKind.POOL,
-        parentId: undefined,
-      },
-      {
+    verifyShape(model.pools[0], {
+      shapeId: 'shape_Participant_1',
+      bpmnElementId: 'Participant_1',
+      bpmnElementName: 'Pool 1',
+      bpmnElementKind: ShapeBpmnElementKind.POOL,
+      parentId: undefined,
+      bounds: {
         x: 158,
         y: 50,
         width: 1620,
         height: 430,
       },
-    );
-    verifyShape(
-      model.pools[1],
-      {
-        shapeId: 'Participant_2_di',
-        bpmnElementId: 'Participant_2',
-        bpmnElementName: 'Pool 2',
-        bpmnElementKind: ShapeBpmnElementKind.POOL,
-        parentId: undefined,
-      },
-      {
+    });
+    verifyShape(model.pools[1], {
+      shapeId: 'Participant_2_di',
+      bpmnElementId: 'Participant_2',
+      bpmnElementName: 'Pool 2',
+      bpmnElementKind: ShapeBpmnElementKind.POOL,
+      parentId: undefined,
+      bounds: {
         x: 158,
         y: 1050,
         width: 1620,
         height: 430,
       },
-    );
+    });
 
-    verifyShape(
-      model.lanes[0],
-      {
-        shapeId: 'shape_Lane_1_1',
-        bpmnElementId: 'Lane_1_1',
-        bpmnElementName: undefined,
-        bpmnElementKind: ShapeBpmnElementKind.LANE,
-        parentId: 'Participant_1',
-      },
-      {
+    verifyShape(model.lanes[0], {
+      shapeId: 'shape_Lane_1_1',
+      bpmnElementId: 'Lane_1_1',
+      bpmnElementName: undefined,
+      bpmnElementKind: ShapeBpmnElementKind.LANE,
+      parentId: 'Participant_1',
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
-    verifyShape(
-      model.lanes[1],
-      {
-        shapeId: 'shape_Lane_2_1',
-        bpmnElementId: 'Lane_2_1',
-        bpmnElementName: undefined,
-        bpmnElementKind: ShapeBpmnElementKind.LANE,
-        parentId: 'Participant_2',
-      },
-      {
+    });
+    verifyShape(model.lanes[1], {
+      shapeId: 'shape_Lane_2_1',
+      bpmnElementId: 'Lane_2_1',
+      bpmnElementName: undefined,
+      bpmnElementKind: ShapeBpmnElementKind.LANE,
+      parentId: 'Participant_2',
+      bounds: {
         x: 362,
         y: 1232,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('participant without processRef are not considered as pool', () => {
@@ -293,22 +272,19 @@ describe('parse bpmn as json for process/pool', () => {
 
     const model = parseJsonAndExpectOnlyPools(json, 1);
     const pool = model.pools[0];
-    verifyShape(
-      pool,
-      {
-        shapeId: 'shape_Participant_1',
-        bpmnElementId: 'Participant_1',
-        bpmnElementName: 'Pool 1',
-        bpmnElementKind: ShapeBpmnElementKind.POOL,
-        parentId: undefined,
-      },
-      {
+    verifyShape(pool, {
+      shapeId: 'shape_Participant_1',
+      bpmnElementId: 'Participant_1',
+      bpmnElementName: 'Pool 1',
+      bpmnElementKind: ShapeBpmnElementKind.POOL,
+      parentId: undefined,
+      bounds: {
         x: 158,
         y: 50,
         width: 1620,
         height: 430,
       },
-    );
+    });
 
     // Check detected participants during json parsing
     expect(findProcessRefParticipant('Participant_2')).toBeUndefined;
@@ -351,40 +327,34 @@ describe('parse bpmn as json for process/pool', () => {
 
     const model = parseJsonAndExpectOnlyPoolsAndFlowNodes(json, 1, 1);
     const pool = model.pools[0];
-    verifyShape(
-      pool,
-      {
-        shapeId: 'shape_Participant_1',
-        bpmnElementId: 'Participant_1',
-        bpmnElementName: 'Pool 1',
-        bpmnElementKind: ShapeBpmnElementKind.POOL,
-        parentId: undefined,
-      },
-      {
+    verifyShape(pool, {
+      shapeId: 'shape_Participant_1',
+      bpmnElementId: 'Participant_1',
+      bpmnElementName: 'Pool 1',
+      bpmnElementKind: ShapeBpmnElementKind.POOL,
+      parentId: undefined,
+      bounds: {
         x: 158,
         y: 50,
         width: 1620,
         height: 630,
       },
-    );
+    });
 
     const flowNode = model.flowNodes[0];
-    verifyShape(
-      flowNode,
-      {
-        shapeId: 'shape_startEvent_id_0',
-        bpmnElementId: 'event_id_0',
-        bpmnElementName: undefined,
-        bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
-        parentId: 'Participant_1',
-      },
-      {
+    verifyShape(flowNode, {
+      shapeId: 'shape_startEvent_id_0',
+      bpmnElementId: 'event_id_0',
+      bpmnElementName: undefined,
+      bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
+      parentId: 'Participant_1',
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing one process, bpmn elements but no participant', () => {

--- a/test/unit/component/parser/json/BpmnJsonParser.process.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.process.test.ts
@@ -46,17 +46,22 @@ describe('parse bpmn as json for process/pool', () => {
 
     const model = parseJsonAndExpectOnlyPoolsAndLanes(json, 1, 0);
     const pool = model.pools[0];
-    verifyShape(pool, {
-      shapeId: 'shape_Participant_1',
-      bpmnElementId: 'Participant_1',
-      bpmnElementName: 'Process 1',
-      bpmnElementKind: ShapeBpmnElementKind.POOL,
-      boundsX: 158,
-      boundsY: 50,
-      boundsWidth: 1620,
-      boundsHeight: 430,
-      parentId: undefined,
-    });
+    verifyShape(
+      pool,
+      {
+        shapeId: 'shape_Participant_1',
+        bpmnElementId: 'Participant_1',
+        bpmnElementName: 'Process 1',
+        bpmnElementKind: ShapeBpmnElementKind.POOL,
+        parentId: undefined,
+      },
+      {
+        x: 158,
+        y: 50,
+        width: 1620,
+        height: 430,
+      },
+    );
   });
 
   it('json containing one process with a single lane without flowNodeRef', () => {
@@ -94,30 +99,40 @@ describe('parse bpmn as json for process/pool', () => {
 
     const model = parseJsonAndExpectOnlyPoolsAndLanes(json, 1, 1);
     const pool = model.pools[0];
-    verifyShape(pool, {
-      shapeId: 'shape_Participant_0nuvj8r',
-      bpmnElementId: 'Participant_0nuvj8r',
-      bpmnElementName: 'Pool 1',
-      bpmnElementKind: ShapeBpmnElementKind.POOL,
-      boundsX: 158,
-      boundsY: 50,
-      boundsWidth: 1620,
-      boundsHeight: 430,
-      parentId: undefined,
-    });
+    verifyShape(
+      pool,
+      {
+        shapeId: 'shape_Participant_0nuvj8r',
+        bpmnElementId: 'Participant_0nuvj8r',
+        bpmnElementName: 'Pool 1',
+        bpmnElementKind: ShapeBpmnElementKind.POOL,
+        parentId: undefined,
+      },
+      {
+        x: 158,
+        y: 50,
+        width: 1620,
+        height: 430,
+      },
+    );
 
     const lane = model.lanes[0];
-    verifyShape(lane, {
-      shapeId: 'shape_Lane_1h5yeu4',
-      bpmnElementId: 'Lane_12u5n6x',
-      bpmnElementName: undefined,
-      bpmnElementKind: ShapeBpmnElementKind.LANE,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-      parentId: 'Participant_0nuvj8r',
-    });
+    verifyShape(
+      lane,
+      {
+        shapeId: 'shape_Lane_1h5yeu4',
+        bpmnElementId: 'Lane_12u5n6x',
+        bpmnElementName: undefined,
+        bpmnElementKind: ShapeBpmnElementKind.LANE,
+        parentId: 'Participant_0nuvj8r',
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing several processes and participants (with lane or laneset)', () => {
@@ -180,51 +195,71 @@ describe('parse bpmn as json for process/pool', () => {
 }`;
 
     const model = parseJsonAndExpectOnlyPoolsAndLanes(json, 2, 2);
-    verifyShape(model.pools[0], {
-      shapeId: 'shape_Participant_1',
-      bpmnElementId: 'Participant_1',
-      bpmnElementName: 'Pool 1',
-      bpmnElementKind: ShapeBpmnElementKind.POOL,
-      boundsX: 158,
-      boundsY: 50,
-      boundsWidth: 1620,
-      boundsHeight: 430,
-      parentId: undefined,
-    });
-    verifyShape(model.pools[1], {
-      shapeId: 'Participant_2_di',
-      bpmnElementId: 'Participant_2',
-      bpmnElementName: 'Pool 2',
-      bpmnElementKind: ShapeBpmnElementKind.POOL,
-      boundsX: 158,
-      boundsY: 1050,
-      boundsWidth: 1620,
-      boundsHeight: 430,
-      parentId: undefined,
-    });
+    verifyShape(
+      model.pools[0],
+      {
+        shapeId: 'shape_Participant_1',
+        bpmnElementId: 'Participant_1',
+        bpmnElementName: 'Pool 1',
+        bpmnElementKind: ShapeBpmnElementKind.POOL,
+        parentId: undefined,
+      },
+      {
+        x: 158,
+        y: 50,
+        width: 1620,
+        height: 430,
+      },
+    );
+    verifyShape(
+      model.pools[1],
+      {
+        shapeId: 'Participant_2_di',
+        bpmnElementId: 'Participant_2',
+        bpmnElementName: 'Pool 2',
+        bpmnElementKind: ShapeBpmnElementKind.POOL,
+        parentId: undefined,
+      },
+      {
+        x: 158,
+        y: 1050,
+        width: 1620,
+        height: 430,
+      },
+    );
 
-    verifyShape(model.lanes[0], {
-      shapeId: 'shape_Lane_1_1',
-      bpmnElementId: 'Lane_1_1',
-      bpmnElementName: undefined,
-      bpmnElementKind: ShapeBpmnElementKind.LANE,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-      parentId: 'Participant_1',
-    });
-    verifyShape(model.lanes[1], {
-      shapeId: 'shape_Lane_2_1',
-      bpmnElementId: 'Lane_2_1',
-      bpmnElementName: undefined,
-      bpmnElementKind: ShapeBpmnElementKind.LANE,
-      boundsX: 362,
-      boundsY: 1232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-      parentId: 'Participant_2',
-    });
+    verifyShape(
+      model.lanes[0],
+      {
+        shapeId: 'shape_Lane_1_1',
+        bpmnElementId: 'Lane_1_1',
+        bpmnElementName: undefined,
+        bpmnElementKind: ShapeBpmnElementKind.LANE,
+        parentId: 'Participant_1',
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
+    verifyShape(
+      model.lanes[1],
+      {
+        shapeId: 'shape_Lane_2_1',
+        bpmnElementId: 'Lane_2_1',
+        bpmnElementName: undefined,
+        bpmnElementKind: ShapeBpmnElementKind.LANE,
+        parentId: 'Participant_2',
+      },
+      {
+        x: 362,
+        y: 1232,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('participant without processRef are not considered as pool', () => {
@@ -258,17 +293,22 @@ describe('parse bpmn as json for process/pool', () => {
 
     const model = parseJsonAndExpectOnlyPools(json, 1);
     const pool = model.pools[0];
-    verifyShape(pool, {
-      shapeId: 'shape_Participant_1',
-      bpmnElementId: 'Participant_1',
-      bpmnElementName: 'Pool 1',
-      bpmnElementKind: ShapeBpmnElementKind.POOL,
-      boundsX: 158,
-      boundsY: 50,
-      boundsWidth: 1620,
-      boundsHeight: 430,
-      parentId: undefined,
-    });
+    verifyShape(
+      pool,
+      {
+        shapeId: 'shape_Participant_1',
+        bpmnElementId: 'Participant_1',
+        bpmnElementName: 'Pool 1',
+        bpmnElementKind: ShapeBpmnElementKind.POOL,
+        parentId: undefined,
+      },
+      {
+        x: 158,
+        y: 50,
+        width: 1620,
+        height: 430,
+      },
+    );
 
     // Check detected participants during json parsing
     expect(findProcessRefParticipant('Participant_2')).toBeUndefined;
@@ -311,30 +351,40 @@ describe('parse bpmn as json for process/pool', () => {
 
     const model = parseJsonAndExpectOnlyPoolsAndFlowNodes(json, 1, 1);
     const pool = model.pools[0];
-    verifyShape(pool, {
-      shapeId: 'shape_Participant_1',
-      bpmnElementId: 'Participant_1',
-      bpmnElementName: 'Pool 1',
-      bpmnElementKind: ShapeBpmnElementKind.POOL,
-      boundsX: 158,
-      boundsY: 50,
-      boundsWidth: 1620,
-      boundsHeight: 630,
-      parentId: undefined,
-    });
+    verifyShape(
+      pool,
+      {
+        shapeId: 'shape_Participant_1',
+        bpmnElementId: 'Participant_1',
+        bpmnElementName: 'Pool 1',
+        bpmnElementKind: ShapeBpmnElementKind.POOL,
+        parentId: undefined,
+      },
+      {
+        x: 158,
+        y: 50,
+        width: 1620,
+        height: 630,
+      },
+    );
 
     const flowNode = model.flowNodes[0];
-    verifyShape(flowNode, {
-      shapeId: 'shape_startEvent_id_0',
-      bpmnElementId: 'event_id_0',
-      bpmnElementName: undefined,
-      bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-      parentId: 'Participant_1',
-    });
+    verifyShape(
+      flowNode,
+      {
+        shapeId: 'shape_startEvent_id_0',
+        bpmnElementId: 'event_id_0',
+        bpmnElementName: undefined,
+        bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
+        parentId: 'Participant_1',
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing one process, bpmn elements but no participant', () => {

--- a/test/unit/component/parser/json/BpmnJsonParser.task.abstract.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.task.abstract.test.ts
@@ -41,21 +41,18 @@ describe('parse bpmn as json for task', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_task_id_0',
-        bpmnElementId: 'task_id_0',
-        bpmnElementName: 'task name',
-        bpmnElementKind: ShapeBpmnElementKind.TASK,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_task_id_0',
+      bpmnElementId: 'task_id_0',
+      bpmnElementName: 'task name',
+      bpmnElementKind: ShapeBpmnElementKind.TASK,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing one process declared as array with a single task', () => {
@@ -84,21 +81,18 @@ describe('parse bpmn as json for task', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_task_id_1',
-        bpmnElementId: 'task_id_1',
-        bpmnElementName: 'task name',
-        bpmnElementKind: ShapeBpmnElementKind.TASK,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_task_id_1',
+      bpmnElementId: 'task_id_1',
+      bpmnElementName: 'task name',
+      bpmnElementKind: ShapeBpmnElementKind.TASK,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing one process with an array of tasks  with name & without name', () => {
@@ -136,35 +130,29 @@ describe('parse bpmn as json for task', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_task_id_0',
-        bpmnElementId: 'task_id_0',
-        bpmnElementName: 'task name',
-        bpmnElementKind: ShapeBpmnElementKind.TASK,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_task_id_0',
+      bpmnElementId: 'task_id_0',
+      bpmnElementName: 'task name',
+      bpmnElementKind: ShapeBpmnElementKind.TASK,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
-    verifyShape(
-      model.flowNodes[1],
-      {
-        shapeId: 'shape_task_id_1',
-        bpmnElementId: 'task_id_1',
-        bpmnElementName: undefined,
-        bpmnElementKind: ShapeBpmnElementKind.TASK,
-      },
-      {
+    });
+    verifyShape(model.flowNodes[1], {
+      shapeId: 'shape_task_id_1',
+      bpmnElementId: 'task_id_1',
+      bpmnElementName: undefined,
+      bpmnElementKind: ShapeBpmnElementKind.TASK,
+      bounds: {
         x: 365,
         y: 235,
         width: 35,
         height: 46,
       },
-    );
+    });
   });
 });

--- a/test/unit/component/parser/json/BpmnJsonParser.task.abstract.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.task.abstract.test.ts
@@ -41,16 +41,21 @@ describe('parse bpmn as json for task', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_task_id_0',
-      bpmnElementId: 'task_id_0',
-      bpmnElementName: 'task name',
-      bpmnElementKind: ShapeBpmnElementKind.TASK,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_task_id_0',
+        bpmnElementId: 'task_id_0',
+        bpmnElementName: 'task name',
+        bpmnElementKind: ShapeBpmnElementKind.TASK,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing one process declared as array with a single task', () => {
@@ -79,16 +84,21 @@ describe('parse bpmn as json for task', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_task_id_1',
-      bpmnElementId: 'task_id_1',
-      bpmnElementName: 'task name',
-      bpmnElementKind: ShapeBpmnElementKind.TASK,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_task_id_1',
+        bpmnElementId: 'task_id_1',
+        bpmnElementName: 'task name',
+        bpmnElementKind: ShapeBpmnElementKind.TASK,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing one process with an array of tasks  with name & without name', () => {
@@ -126,25 +136,35 @@ describe('parse bpmn as json for task', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_task_id_0',
-      bpmnElementId: 'task_id_0',
-      bpmnElementName: 'task name',
-      bpmnElementKind: ShapeBpmnElementKind.TASK,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
-    verifyShape(model.flowNodes[1], {
-      shapeId: 'shape_task_id_1',
-      bpmnElementId: 'task_id_1',
-      bpmnElementName: undefined,
-      bpmnElementKind: ShapeBpmnElementKind.TASK,
-      boundsX: 365,
-      boundsY: 235,
-      boundsWidth: 35,
-      boundsHeight: 46,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_task_id_0',
+        bpmnElementId: 'task_id_0',
+        bpmnElementName: 'task name',
+        bpmnElementKind: ShapeBpmnElementKind.TASK,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
+    verifyShape(
+      model.flowNodes[1],
+      {
+        shapeId: 'shape_task_id_1',
+        bpmnElementId: 'task_id_1',
+        bpmnElementName: undefined,
+        bpmnElementKind: ShapeBpmnElementKind.TASK,
+      },
+      {
+        x: 365,
+        y: 235,
+        width: 35,
+        height: 46,
+      },
+    );
   });
 });

--- a/test/unit/component/parser/json/BpmnJsonParser.task.receive.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.task.receive.test.ts
@@ -41,16 +41,21 @@ describe('parse bpmn as json for receive task', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_receiveTask_id_0',
-      bpmnElementId: 'receiveTask_id_0',
-      bpmnElementName: 'receiveTask name',
-      bpmnElementKind: ShapeBpmnElementKind.TASK_RECEIVE,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_receiveTask_id_0',
+        bpmnElementId: 'receiveTask_id_0',
+        bpmnElementName: 'receiveTask name',
+        bpmnElementKind: ShapeBpmnElementKind.TASK_RECEIVE,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing one process declared as array with a single receive task', () => {
@@ -79,16 +84,21 @@ describe('parse bpmn as json for receive task', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_receiveTask_id_1',
-      bpmnElementId: 'receiveTask_id_1',
-      bpmnElementName: 'receiveTask name',
-      bpmnElementKind: ShapeBpmnElementKind.TASK_RECEIVE,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_receiveTask_id_1',
+        bpmnElementId: 'receiveTask_id_1',
+        bpmnElementName: 'receiveTask name',
+        bpmnElementKind: ShapeBpmnElementKind.TASK_RECEIVE,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing one process with an array of receive tasks with/without name & instantiate', () => {
@@ -127,28 +137,38 @@ describe('parse bpmn as json for receive task', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_receiveTask_id_0',
-      bpmnElementId: 'receiveTask_id_0',
-      bpmnElementName: 'receiveTask name',
-      bpmnElementKind: ShapeBpmnElementKind.TASK_RECEIVE,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_receiveTask_id_0',
+        bpmnElementId: 'receiveTask_id_0',
+        bpmnElementName: 'receiveTask name',
+        bpmnElementKind: ShapeBpmnElementKind.TASK_RECEIVE,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
     expect(model.flowNodes[0].bpmnElement.instantiate).toBeFalsy();
 
-    verifyShape(model.flowNodes[1], {
-      shapeId: 'shape_receiveTask_id_1',
-      bpmnElementId: 'receiveTask_id_1',
-      bpmnElementName: undefined,
-      bpmnElementKind: ShapeBpmnElementKind.TASK_RECEIVE,
-      boundsX: 365,
-      boundsY: 235,
-      boundsWidth: 35,
-      boundsHeight: 46,
-    });
+    verifyShape(
+      model.flowNodes[1],
+      {
+        shapeId: 'shape_receiveTask_id_1',
+        bpmnElementId: 'receiveTask_id_1',
+        bpmnElementName: undefined,
+        bpmnElementKind: ShapeBpmnElementKind.TASK_RECEIVE,
+      },
+      {
+        x: 365,
+        y: 235,
+        width: 35,
+        height: 46,
+      },
+    );
     expect(model.flowNodes[1].bpmnElement.instantiate).toBeTruthy();
   });
 });

--- a/test/unit/component/parser/json/BpmnJsonParser.task.receive.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.task.receive.test.ts
@@ -41,21 +41,18 @@ describe('parse bpmn as json for receive task', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_receiveTask_id_0',
-        bpmnElementId: 'receiveTask_id_0',
-        bpmnElementName: 'receiveTask name',
-        bpmnElementKind: ShapeBpmnElementKind.TASK_RECEIVE,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_receiveTask_id_0',
+      bpmnElementId: 'receiveTask_id_0',
+      bpmnElementName: 'receiveTask name',
+      bpmnElementKind: ShapeBpmnElementKind.TASK_RECEIVE,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing one process declared as array with a single receive task', () => {
@@ -84,21 +81,18 @@ describe('parse bpmn as json for receive task', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_receiveTask_id_1',
-        bpmnElementId: 'receiveTask_id_1',
-        bpmnElementName: 'receiveTask name',
-        bpmnElementKind: ShapeBpmnElementKind.TASK_RECEIVE,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_receiveTask_id_1',
+      bpmnElementId: 'receiveTask_id_1',
+      bpmnElementName: 'receiveTask name',
+      bpmnElementKind: ShapeBpmnElementKind.TASK_RECEIVE,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing one process with an array of receive tasks with/without name & instantiate', () => {
@@ -137,38 +131,32 @@ describe('parse bpmn as json for receive task', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_receiveTask_id_0',
-        bpmnElementId: 'receiveTask_id_0',
-        bpmnElementName: 'receiveTask name',
-        bpmnElementKind: ShapeBpmnElementKind.TASK_RECEIVE,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_receiveTask_id_0',
+      bpmnElementId: 'receiveTask_id_0',
+      bpmnElementName: 'receiveTask name',
+      bpmnElementKind: ShapeBpmnElementKind.TASK_RECEIVE,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
     expect(model.flowNodes[0].bpmnElement.instantiate).toBeFalsy();
 
-    verifyShape(
-      model.flowNodes[1],
-      {
-        shapeId: 'shape_receiveTask_id_1',
-        bpmnElementId: 'receiveTask_id_1',
-        bpmnElementName: undefined,
-        bpmnElementKind: ShapeBpmnElementKind.TASK_RECEIVE,
-      },
-      {
+    verifyShape(model.flowNodes[1], {
+      shapeId: 'shape_receiveTask_id_1',
+      bpmnElementId: 'receiveTask_id_1',
+      bpmnElementName: undefined,
+      bpmnElementKind: ShapeBpmnElementKind.TASK_RECEIVE,
+      bounds: {
         x: 365,
         y: 235,
         width: 35,
         height: 46,
       },
-    );
+    });
     expect(model.flowNodes[1].bpmnElement.instantiate).toBeTruthy();
   });
 });

--- a/test/unit/component/parser/json/BpmnJsonParser.task.service.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.task.service.test.ts
@@ -41,21 +41,18 @@ describe('parse bpmn as json for service task', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_serviceTask_id_0',
-        bpmnElementId: 'serviceTask_id_0',
-        bpmnElementName: 'serviceTask name',
-        bpmnElementKind: ShapeBpmnElementKind.TASK_SERVICE,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_serviceTask_id_0',
+      bpmnElementId: 'serviceTask_id_0',
+      bpmnElementName: 'serviceTask name',
+      bpmnElementKind: ShapeBpmnElementKind.TASK_SERVICE,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing one process declared as array with a single service task', () => {
@@ -84,21 +81,18 @@ describe('parse bpmn as json for service task', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_serviceTask_id_1',
-        bpmnElementId: 'serviceTask_id_1',
-        bpmnElementName: 'serviceTask name',
-        bpmnElementKind: ShapeBpmnElementKind.TASK_SERVICE,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_serviceTask_id_1',
+      bpmnElementId: 'serviceTask_id_1',
+      bpmnElementName: 'serviceTask name',
+      bpmnElementKind: ShapeBpmnElementKind.TASK_SERVICE,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing one process with an array of service tasks with name & without name', () => {
@@ -136,35 +130,29 @@ describe('parse bpmn as json for service task', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_serviceTask_id_0',
-        bpmnElementId: 'serviceTask_id_0',
-        bpmnElementName: 'serviceTask name',
-        bpmnElementKind: ShapeBpmnElementKind.TASK_SERVICE,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_serviceTask_id_0',
+      bpmnElementId: 'serviceTask_id_0',
+      bpmnElementName: 'serviceTask name',
+      bpmnElementKind: ShapeBpmnElementKind.TASK_SERVICE,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
-    verifyShape(
-      model.flowNodes[1],
-      {
-        shapeId: 'shape_serviceTask_id_1',
-        bpmnElementId: 'serviceTask_id_1',
-        bpmnElementName: undefined,
-        bpmnElementKind: ShapeBpmnElementKind.TASK_SERVICE,
-      },
-      {
+    });
+    verifyShape(model.flowNodes[1], {
+      shapeId: 'shape_serviceTask_id_1',
+      bpmnElementId: 'serviceTask_id_1',
+      bpmnElementName: undefined,
+      bpmnElementKind: ShapeBpmnElementKind.TASK_SERVICE,
+      bounds: {
         x: 365,
         y: 235,
         width: 35,
         height: 46,
       },
-    );
+    });
   });
 });

--- a/test/unit/component/parser/json/BpmnJsonParser.task.service.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.task.service.test.ts
@@ -41,16 +41,21 @@ describe('parse bpmn as json for service task', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_serviceTask_id_0',
-      bpmnElementId: 'serviceTask_id_0',
-      bpmnElementName: 'serviceTask name',
-      bpmnElementKind: ShapeBpmnElementKind.TASK_SERVICE,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_serviceTask_id_0',
+        bpmnElementId: 'serviceTask_id_0',
+        bpmnElementName: 'serviceTask name',
+        bpmnElementKind: ShapeBpmnElementKind.TASK_SERVICE,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing one process declared as array with a single service task', () => {
@@ -79,16 +84,21 @@ describe('parse bpmn as json for service task', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_serviceTask_id_1',
-      bpmnElementId: 'serviceTask_id_1',
-      bpmnElementName: 'serviceTask name',
-      bpmnElementKind: ShapeBpmnElementKind.TASK_SERVICE,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_serviceTask_id_1',
+        bpmnElementId: 'serviceTask_id_1',
+        bpmnElementName: 'serviceTask name',
+        bpmnElementKind: ShapeBpmnElementKind.TASK_SERVICE,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing one process with an array of service tasks with name & without name', () => {
@@ -126,25 +136,35 @@ describe('parse bpmn as json for service task', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_serviceTask_id_0',
-      bpmnElementId: 'serviceTask_id_0',
-      bpmnElementName: 'serviceTask name',
-      bpmnElementKind: ShapeBpmnElementKind.TASK_SERVICE,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
-    verifyShape(model.flowNodes[1], {
-      shapeId: 'shape_serviceTask_id_1',
-      bpmnElementId: 'serviceTask_id_1',
-      bpmnElementName: undefined,
-      bpmnElementKind: ShapeBpmnElementKind.TASK_SERVICE,
-      boundsX: 365,
-      boundsY: 235,
-      boundsWidth: 35,
-      boundsHeight: 46,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_serviceTask_id_0',
+        bpmnElementId: 'serviceTask_id_0',
+        bpmnElementName: 'serviceTask name',
+        bpmnElementKind: ShapeBpmnElementKind.TASK_SERVICE,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
+    verifyShape(
+      model.flowNodes[1],
+      {
+        shapeId: 'shape_serviceTask_id_1',
+        bpmnElementId: 'serviceTask_id_1',
+        bpmnElementName: undefined,
+        bpmnElementKind: ShapeBpmnElementKind.TASK_SERVICE,
+      },
+      {
+        x: 365,
+        y: 235,
+        width: 35,
+        height: 46,
+      },
+    );
   });
 });

--- a/test/unit/component/parser/json/BpmnJsonParser.task.user.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.task.user.test.ts
@@ -41,21 +41,18 @@ describe('parse bpmn as json for user task', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_userTask_id_0',
-        bpmnElementId: 'userTask_id_0',
-        bpmnElementName: 'userTask name',
-        bpmnElementKind: ShapeBpmnElementKind.TASK_USER,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_userTask_id_0',
+      bpmnElementId: 'userTask_id_0',
+      bpmnElementName: 'userTask name',
+      bpmnElementKind: ShapeBpmnElementKind.TASK_USER,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing one process declared as array with a single user task', () => {
@@ -84,21 +81,18 @@ describe('parse bpmn as json for user task', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_userTask_id_1',
-        bpmnElementId: 'userTask_id_1',
-        bpmnElementName: 'userTask name',
-        bpmnElementKind: ShapeBpmnElementKind.TASK_USER,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_userTask_id_1',
+      bpmnElementId: 'userTask_id_1',
+      bpmnElementName: 'userTask name',
+      bpmnElementKind: ShapeBpmnElementKind.TASK_USER,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
+    });
   });
 
   it('json containing one process with an array of user tasks  with name & without name', () => {
@@ -136,35 +130,29 @@ describe('parse bpmn as json for user task', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
 
-    verifyShape(
-      model.flowNodes[0],
-      {
-        shapeId: 'shape_userTask_id_0',
-        bpmnElementId: 'userTask_id_0',
-        bpmnElementName: 'userTask name',
-        bpmnElementKind: ShapeBpmnElementKind.TASK_USER,
-      },
-      {
+    verifyShape(model.flowNodes[0], {
+      shapeId: 'shape_userTask_id_0',
+      bpmnElementId: 'userTask_id_0',
+      bpmnElementName: 'userTask name',
+      bpmnElementKind: ShapeBpmnElementKind.TASK_USER,
+      bounds: {
         x: 362,
         y: 232,
         width: 36,
         height: 45,
       },
-    );
-    verifyShape(
-      model.flowNodes[1],
-      {
-        shapeId: 'shape_userTask_id_1',
-        bpmnElementId: 'userTask_id_1',
-        bpmnElementName: undefined,
-        bpmnElementKind: ShapeBpmnElementKind.TASK_USER,
-      },
-      {
+    });
+    verifyShape(model.flowNodes[1], {
+      shapeId: 'shape_userTask_id_1',
+      bpmnElementId: 'userTask_id_1',
+      bpmnElementName: undefined,
+      bpmnElementKind: ShapeBpmnElementKind.TASK_USER,
+      bounds: {
         x: 365,
         y: 235,
         width: 35,
         height: 46,
       },
-    );
+    });
   });
 });

--- a/test/unit/component/parser/json/BpmnJsonParser.task.user.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.task.user.test.ts
@@ -41,16 +41,21 @@ describe('parse bpmn as json for user task', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_userTask_id_0',
-      bpmnElementId: 'userTask_id_0',
-      bpmnElementName: 'userTask name',
-      bpmnElementKind: ShapeBpmnElementKind.TASK_USER,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_userTask_id_0',
+        bpmnElementId: 'userTask_id_0',
+        bpmnElementName: 'userTask name',
+        bpmnElementKind: ShapeBpmnElementKind.TASK_USER,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing one process declared as array with a single user task', () => {
@@ -79,16 +84,21 @@ describe('parse bpmn as json for user task', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_userTask_id_1',
-      bpmnElementId: 'userTask_id_1',
-      bpmnElementName: 'userTask name',
-      bpmnElementKind: ShapeBpmnElementKind.TASK_USER,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_userTask_id_1',
+        bpmnElementId: 'userTask_id_1',
+        bpmnElementName: 'userTask name',
+        bpmnElementKind: ShapeBpmnElementKind.TASK_USER,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
   });
 
   it('json containing one process with an array of user tasks  with name & without name', () => {
@@ -126,25 +136,35 @@ describe('parse bpmn as json for user task', () => {
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: 'shape_userTask_id_0',
-      bpmnElementId: 'userTask_id_0',
-      bpmnElementName: 'userTask name',
-      bpmnElementKind: ShapeBpmnElementKind.TASK_USER,
-      boundsX: 362,
-      boundsY: 232,
-      boundsWidth: 36,
-      boundsHeight: 45,
-    });
-    verifyShape(model.flowNodes[1], {
-      shapeId: 'shape_userTask_id_1',
-      bpmnElementId: 'userTask_id_1',
-      bpmnElementName: undefined,
-      bpmnElementKind: ShapeBpmnElementKind.TASK_USER,
-      boundsX: 365,
-      boundsY: 235,
-      boundsWidth: 35,
-      boundsHeight: 46,
-    });
+    verifyShape(
+      model.flowNodes[0],
+      {
+        shapeId: 'shape_userTask_id_0',
+        bpmnElementId: 'userTask_id_0',
+        bpmnElementName: 'userTask name',
+        bpmnElementKind: ShapeBpmnElementKind.TASK_USER,
+      },
+      {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    );
+    verifyShape(
+      model.flowNodes[1],
+      {
+        shapeId: 'shape_userTask_id_1',
+        bpmnElementId: 'userTask_id_1',
+        bpmnElementName: undefined,
+        bpmnElementKind: ShapeBpmnElementKind.TASK_USER,
+      },
+      {
+        x: 365,
+        y: 235,
+        width: 35,
+        height: 46,
+      },
+    );
   });
 });

--- a/test/unit/component/parser/json/JsonTestUtils.ts
+++ b/test/unit/component/parser/json/JsonTestUtils.ts
@@ -29,10 +29,6 @@ export interface ExpectedShape {
   bpmnElementId: string;
   bpmnElementName: string;
   bpmnElementKind: ShapeBpmnElementKind;
-  boundsX: number;
-  boundsY: number;
-  boundsWidth: number;
-  boundsHeight: number;
   parentId?: string;
 }
 
@@ -58,6 +54,13 @@ export interface ExpectedFont {
   isItalic?: boolean;
   isUnderline?: boolean;
   isStrikeThrough?: boolean;
+}
+
+export interface ExpectedBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
 }
 
 export function parseJson(json: string): BpmnModel {
@@ -107,20 +110,20 @@ export function parseJsonAndExpectOnlyEdgesAndFlowNodes(json: string, numberOfEx
   return parseJsonAndExpect(json, 0, 0, numberOfExpectedFlowNodes, numberOfExpectedEdges);
 }
 
-export function verifyShape(shape: Shape, expectedValue: ExpectedShape): void {
-  expect(shape.id).toEqual(expectedValue.shapeId);
+export function verifyShape(shape: Shape, expectedShape: ExpectedShape, expectedBounds: ExpectedBounds): void {
+  expect(shape.id).toEqual(expectedShape.shapeId);
 
   const bpmnElement = shape.bpmnElement;
-  expect(bpmnElement.id).toEqual(expectedValue.bpmnElementId);
-  expect(bpmnElement.name).toEqual(expectedValue.bpmnElementName);
-  expect(bpmnElement.kind).toEqual(expectedValue.bpmnElementKind);
-  expect(bpmnElement.parentId).toEqual(expectedValue.parentId);
+  expect(bpmnElement.id).toEqual(expectedShape.bpmnElementId);
+  expect(bpmnElement.name).toEqual(expectedShape.bpmnElementName);
+  expect(bpmnElement.kind).toEqual(expectedShape.bpmnElementKind);
+  expect(bpmnElement.parentId).toEqual(expectedShape.parentId);
 
   const bounds = shape.bounds;
-  expect(bounds.x).toEqual(expectedValue.boundsX);
-  expect(bounds.y).toEqual(expectedValue.boundsY);
-  expect(bounds.width).toEqual(expectedValue.boundsWidth);
-  expect(bounds.height).toEqual(expectedValue.boundsHeight);
+  expect(bounds.x).toEqual(expectedBounds.x);
+  expect(bounds.y).toEqual(expectedBounds.y);
+  expect(bounds.width).toEqual(expectedBounds.width);
+  expect(bounds.height).toEqual(expectedBounds.height);
 }
 
 export function verifyEdge(edge: Edge, expectedValue: ExpectedEdge): void {
@@ -154,7 +157,7 @@ export function verifyEvents(model: BpmnModel, expectedEvents: ExpectedEvent[]):
   });
 }
 
-export function verifyLabel(label: Label, expectedFont?: ExpectedFont): void {
+export function verifyLabelFont(label: Label, expectedFont?: ExpectedFont): void {
   expect(label).toBeDefined();
 
   const font = label.font;

--- a/test/unit/component/parser/json/JsonTestUtils.ts
+++ b/test/unit/component/parser/json/JsonTestUtils.ts
@@ -30,6 +30,7 @@ export interface ExpectedShape {
   bpmnElementName: string;
   bpmnElementKind: ShapeBpmnElementKind;
   parentId?: string;
+  bounds?: ExpectedBounds;
 }
 
 export interface ExpectedEdge {
@@ -105,7 +106,7 @@ export function parseJsonAndExpectOnlyEdgesAndFlowNodes(json: string, numberOfEx
   return parseJsonAndExpect(json, 0, 0, numberOfExpectedFlowNodes, numberOfExpectedEdges);
 }
 
-export function verifyShape(shape: Shape, expectedShape: ExpectedShape, expectedBounds: ExpectedBounds): void {
+export function verifyShape(shape: Shape, expectedShape: ExpectedShape): void {
   expect(shape.id).toEqual(expectedShape.shapeId);
 
   const bpmnElement = shape.bpmnElement;
@@ -115,6 +116,7 @@ export function verifyShape(shape: Shape, expectedShape: ExpectedShape, expected
   expect(bpmnElement.parentId).toEqual(expectedShape.parentId);
 
   const bounds = shape.bounds;
+  const expectedBounds = expectedShape.bounds;
   expect(bounds.x).toEqual(expectedBounds.x);
   expect(bounds.y).toEqual(expectedBounds.y);
   expect(bounds.width).toEqual(expectedBounds.width);

--- a/test/unit/component/parser/json/JsonTestUtils.ts
+++ b/test/unit/component/parser/json/JsonTestUtils.ts
@@ -32,11 +32,6 @@ export interface ExpectedShape {
   parentId?: string;
 }
 
-export interface ExpectedEvent {
-  kind: ShapeBpmnEventKind;
-  expectedNumber: number;
-}
-
 export interface ExpectedEdge {
   edgeId: string;
   bpmnElementId: string;
@@ -149,12 +144,6 @@ export function verifyEvent(model: BpmnModel, kind: ShapeBpmnEventKind, expected
     return bpmnElement instanceof ShapeBpmnEvent && (bpmnElement as ShapeBpmnEvent).eventKind === kind;
   });
   expect(events).toHaveLength(expectedNumber);
-}
-
-export function verifyEvents(model: BpmnModel, expectedEvents: ExpectedEvent[]): void {
-  expectedEvents.forEach(expectedEvent => {
-    verifyEvent(model, expectedEvent.kind, expectedEvent.expectedNumber);
-  });
 }
 
 export function verifyLabelFont(label: Label, expectedFont?: ExpectedFont): void {


### PR DESCRIPTION
Extract `ExpectedBounds` from `ExpectedShape` to prepare code sharing with the upcoming `Label Bounds` parsing
Introduce minor refactoring:
  - rename label verification method to prepare the `Label Bounds` parsing
  - remove unused code about Events verification