### PR TITLE
[POC] experiment label bounds with mxgraph dedicated label mxCell

### DIFF
--- a/src/component/mxgraph/MxGraphConfigurator.ts
+++ b/src/component/mxgraph/MxGraphConfigurator.ts
@@ -47,7 +47,7 @@ export default class MxGraphConfigurator {
   private configureGraph(): void {
     this.graph.setCellsLocked(true);
     this.graph.setCellsSelectable(false);
-    // this.graph.htmlLabels = true; // required for wrapping and clipping
+    this.graph.htmlLabels = true; // required for wrapping and clipping
 
     // TODO see if this changes something
     this.graph.setEdgeLabelsMovable(false);

--- a/src/component/mxgraph/MxGraphConfigurator.ts
+++ b/src/component/mxgraph/MxGraphConfigurator.ts
@@ -20,10 +20,11 @@ import ShapeConfigurator from './ShapeConfigurator';
 import MarkerConfigurator from './MarkerConfigurator';
 
 /**
- * Configure mxgraph
+ * Configure the mxGraph graph that can be used by the lib
  * <ul>
  *     <li>styles
  *     <li>shapes
+ *     <li>markers
  */
 export default class MxGraphConfigurator {
   private mxGraph: typeof mxgraph.mxGraph = MxGraphFactoryService.getMxGraphProperty('mxGraph');
@@ -32,8 +33,8 @@ export default class MxGraphConfigurator {
   private readonly graph: mxgraph.mxGraph;
 
   constructor(container: Element) {
-    this.initMxGraphPrototype();
     this.graph = new this.mxGraph(container, new this.mxGraphModel());
+    this.configureGraph();
     new StyleConfigurator(this.graph).configureStyles();
     new ShapeConfigurator().configureShapes();
     new MarkerConfigurator().configureMarkers();
@@ -43,9 +44,13 @@ export default class MxGraphConfigurator {
     return this.graph;
   }
 
-  private initMxGraphPrototype(): void {
-    this.mxGraph.prototype.edgeLabelsMovable = false;
-    this.mxGraph.prototype.cellsLocked = true;
-    this.mxGraph.prototype.cellsSelectable = false;
+  private configureGraph(): void {
+    this.graph.setCellsLocked(true);
+    this.graph.setCellsSelectable(false);
+    // this.graph.htmlLabels = true; // required for wrapping and clipping
+
+    // TODO see if this changes something
+    this.graph.setEdgeLabelsMovable(false);
+    this.graph.setVertexLabelsMovable(false);
   }
 }

--- a/src/component/mxgraph/MxGraphRenderer.ts
+++ b/src/component/mxgraph/MxGraphRenderer.ts
@@ -159,7 +159,7 @@ export default class MxGraphRenderer {
             labelRelativeCoordinate.y,
             labelBounds.width,
             labelBounds.height,
-            this.computeLabelStyle('bpmn.label.vertex', edge.label),
+            this.computeLabelStyle(StyleConstant.BPMN_STYLE_LABEL, edge.label),
           );
         }
       }
@@ -193,7 +193,7 @@ export default class MxGraphRenderer {
       // const labelRelativeCoordinate = this.getRelativeCoordinates(vertex, { x: labelBounds.x, y: labelBounds.y });
       // this.graph.insertVertex(vertex, null, labelText, labelRelativeCoordinate.x, labelRelativeCoordinate.y, labelBounds.width, labelBounds.height);
       const labelRelativeCoordinate = this.getRelativeCoordinates(parent, { x: labelBounds.x, y: labelBounds.y });
-      this.graph.insertVertex(parent, null, labelText, labelRelativeCoordinate.x, labelRelativeCoordinate.y, labelBounds.width, labelBounds.height, 'bpmn.label.vertex');
+      this.graph.insertVertex(parent, null, labelText, labelRelativeCoordinate.x, labelRelativeCoordinate.y, labelBounds.width, labelBounds.height, StyleConstant.BPMN_STYLE_LABEL);
     }
     return vertex;
   }

--- a/src/component/mxgraph/MxGraphRenderer.ts
+++ b/src/component/mxgraph/MxGraphRenderer.ts
@@ -193,6 +193,7 @@ export default class MxGraphRenderer {
       // const labelRelativeCoordinate = this.getRelativeCoordinates(vertex, { x: labelBounds.x, y: labelBounds.y });
       // this.graph.insertVertex(vertex, null, labelText, labelRelativeCoordinate.x, labelRelativeCoordinate.y, labelBounds.width, labelBounds.height);
       const labelRelativeCoordinate = this.getRelativeCoordinates(parent, { x: labelBounds.x, y: labelBounds.y });
+      // TODO label style should contains font configuration (as done for edge)
       this.graph.insertVertex(parent, null, labelText, labelRelativeCoordinate.x, labelRelativeCoordinate.y, labelBounds.width, labelBounds.height, StyleConstant.BPMN_STYLE_LABEL);
     }
     return vertex;

--- a/src/component/mxgraph/MxGraphRenderer.ts
+++ b/src/component/mxgraph/MxGraphRenderer.ts
@@ -157,7 +157,7 @@ export default class MxGraphRenderer {
             labelText,
             labelRelativeCoordinate.x,
             labelRelativeCoordinate.y,
-            labelBounds.width,
+            labelBounds.width + 1, // increase arbitrarily to relax too small bounds (ref miwg-test-suite)
             labelBounds.height,
             this.computeLabelStyle(StyleConstant.BPMN_STYLE_LABEL, edge.label),
           );

--- a/src/component/mxgraph/MxGraphRenderer.ts
+++ b/src/component/mxgraph/MxGraphRenderer.ts
@@ -22,6 +22,7 @@ import { MxGraphFactoryService } from '../../service/MxGraphFactoryService';
 import Waypoint from '../../model/bpmn/edge/Waypoint';
 import { StyleConstant } from './StyleConfigurator';
 import { Font } from '../../model/bpmn/Label';
+import Bounds from '../../model/bpmn/Bounds';
 
 interface Coordinate {
   x: number;
@@ -29,8 +30,8 @@ interface Coordinate {
 }
 
 export default class MxGraphRenderer {
-  private mxPoint: typeof mxgraph.mxPoint = MxGraphFactoryService.getMxGraphProperty('mxPoint');
   private mxConstants: typeof mxgraph.mxConstants = MxGraphFactoryService.getMxGraphProperty('mxConstants');
+  private mxPoint: typeof mxgraph.mxPoint = MxGraphFactoryService.getMxGraphProperty('mxPoint');
   constructor(readonly graph: mxgraph.mxGraph) {}
 
   public render(bpmnModel: BpmnModel): void {
@@ -64,11 +65,13 @@ export default class MxGraphRenderer {
   private insertShape(shape: Shape): void {
     const bpmnElement = shape.bpmnElement;
     if (bpmnElement) {
-      const bounds = shape.bounds;
       const parent = this.getParent(bpmnElement);
-      const absoluteCoordinate = { x: bounds.x, y: bounds.y };
       const style = this.computeStyle(shape);
-      this.insertVertexGivenAbsoluteCoordinates(parent, bpmnElement.id, bpmnElement.name, absoluteCoordinate, bounds.width, bounds.height, style);
+
+      const bounds = shape.bounds;
+      const labelBounds = shape.label?.bounds;
+
+      this.insertVertex(parent, bpmnElement.id, bpmnElement.name, bounds, labelBounds, style);
     }
   }
 
@@ -136,17 +139,18 @@ export default class MxGraphRenderer {
     return this.graph.getModel().getCell(id);
   }
 
-  private insertVertexGivenAbsoluteCoordinates(
-    parent: mxgraph.mxCell,
-    id: string | null,
-    value: string,
-    absoluteCoordinate: Coordinate,
-    width: number,
-    height: number,
-    style?: string,
-  ): mxgraph.mxCell {
-    const relativeCoordinate = this.getRelativeCoordinates(parent, absoluteCoordinate);
-    return this.graph.insertVertex(parent, id, value, relativeCoordinate.x, relativeCoordinate.y, width, height, style);
+  private insertVertex(parent: mxgraph.mxCell, id: string | null, label: string, bounds: Bounds, labelBounds: Bounds, style?: string): mxgraph.mxCell {
+    const relativeCoordinate = this.getRelativeCoordinates(parent, { x: bounds.x, y: bounds.y });
+    const mxCell = this.graph.insertVertex(parent, id, label, relativeCoordinate.x, relativeCoordinate.y, bounds.width, bounds.height, style);
+
+    // demonstrate how to set label position using the cell geometry offset
+    // label relative coordinates to the cell
+    // if (labelBounds) {
+    //   const relativeLabelX = labelBounds.x - bounds.x;
+    //   const relativeLabelY = labelBounds.y - bounds.y;
+    //   mxCell.geometry.offset = new this.mxPoint(relativeLabelX, relativeLabelY);
+    // }
+    return mxCell;
   }
 
   private getRelativeCoordinates(parent: mxgraph.mxCell, absoluteCoordinate: Coordinate): Coordinate {

--- a/src/component/mxgraph/StyleConfigurator.ts
+++ b/src/component/mxgraph/StyleConfigurator.ts
@@ -218,7 +218,6 @@ export default class StyleConfigurator {
   }
 
   private configureLabelStyles(): void {
-    // for vertex
     const style = this.cloneDefaultVertexStyle();
     style[this.mxConstants.STYLE_SHAPE] = this.mxConstants.SHAPE_RECTANGLE;
     style[this.mxConstants.STYLE_PERIMETER] = this.mxPerimeter.RectanglePerimeter;
@@ -229,10 +228,8 @@ export default class StyleConfigurator {
     style[this.mxConstants.STYLE_STROKECOLOR] = 'orange'; // TODO temp for identification
     // style[this.mxConstants.STYLE_STROKEWIDTH] = 0; // TODO hide stroke
 
-    // style[this.mxConstants.STYLE_FILL_OPACITY] = 0;
-    style[this.mxConstants.STYLE_FILLCOLOR] = this.mxConstants.NONE;
+    style[this.mxConstants.STYLE_FILLCOLOR] = this.mxConstants.NONE; // ensure we do note see the label shape
 
-    // label bounds are provided from the top left
     style[this.mxConstants.STYLE_VERTICAL_ALIGN] = this.mxConstants.ALIGN_TOP;
     style[this.mxConstants.STYLE_ALIGN] = this.mxConstants.ALIGN_MIDDLE;
 

--- a/src/component/mxgraph/StyleConfigurator.ts
+++ b/src/component/mxgraph/StyleConfigurator.ts
@@ -95,6 +95,10 @@ export default class StyleConfigurator {
   private configureDefaultVertexStyle(): void {
     const style = this.getDefaultVertexStyle();
     this.configureCommonDefaultStyle(style);
+
+    // only works with html labels (see MxGraphConfigurator to enable html labels)
+    // style[this.mxConstants.STYLE_OVERFLOW] = 'hidden'; // enable clipping
+    // style[this.mxConstants.STYLE_WHITE_SPACE] = 'wrap'; // wrap for html labels
   }
 
   private configurePoolStyle(): void {

--- a/src/component/mxgraph/StyleConfigurator.ts
+++ b/src/component/mxgraph/StyleConfigurator.ts
@@ -24,6 +24,7 @@ export enum StyleConstant {
   STROKE_WIDTH_THIN = 2,
   STROKE_WIDTH_THICK = 5,
   BPMN_STYLE_EVENT_KIND = 'bpmn.eventKind',
+  BPMN_STYLE_LABEL = 'bpmn.label',
 }
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -236,6 +237,6 @@ export default class StyleConfigurator {
     // STYLE_SPACING to relax too small bounds (ref mgiw
     // Defines the key for the spacing.  The value represents the spacing, in pixels, added to each side of a label in a vertex (style applies to vertices only).  Value is “spacing”.
 
-    this.graph.getStylesheet().putCellStyle('bpmn.label.vertex', style);
+    this.graph.getStylesheet().putCellStyle(StyleConstant.BPMN_STYLE_LABEL, style);
   }
 }

--- a/src/component/mxgraph/StyleConfigurator.ts
+++ b/src/component/mxgraph/StyleConfigurator.ts
@@ -197,7 +197,7 @@ export default class StyleConfigurator {
   }
 
   private configureCommonDefaultStyle(style: any): void {
-    style[this.mxConstants.STYLE_FONTSIZE] = 12;
+    style[this.mxConstants.STYLE_FONTSIZE] = 11; // 11px to better render miwg-test-suite diagrams
     style[this.mxConstants.STYLE_FONTCOLOR] = 'Black';
     style[this.mxConstants.STYLE_FILLCOLOR] = 'White';
     style[this.mxConstants.STYLE_STROKECOLOR] = 'Black';

--- a/src/component/mxgraph/StyleConfigurator.ts
+++ b/src/component/mxgraph/StyleConfigurator.ts
@@ -104,7 +104,8 @@ export default class StyleConfigurator {
   private configurePoolStyle(): void {
     const style = this.cloneDefaultVertexStyle();
     style[this.mxConstants.STYLE_SHAPE] = this.mxConstants.SHAPE_SWIMLANE;
-    style[this.mxConstants.STYLE_VERTICAL_ALIGN] = 'middle';
+    style[this.mxConstants.STYLE_VERTICAL_ALIGN] = this.mxConstants.ALIGN_MIDDLE;
+    style[this.mxConstants.STYLE_ALIGN] = this.mxConstants.ALIGN_CENTER;
     style[this.mxConstants.STYLE_HORIZONTAL] = false;
     style[this.mxConstants.STYLE_FILLCOLOR] = '#d3d2d1';
 
@@ -118,7 +119,8 @@ export default class StyleConfigurator {
   private configureLaneStyle(): void {
     const style = this.cloneDefaultVertexStyle();
     style[this.mxConstants.STYLE_SHAPE] = this.mxConstants.SHAPE_SWIMLANE;
-    style[this.mxConstants.STYLE_VERTICAL_ALIGN] = 'middle';
+    style[this.mxConstants.STYLE_VERTICAL_ALIGN] = this.mxConstants.ALIGN_MIDDLE;
+    style[this.mxConstants.STYLE_ALIGN] = this.mxConstants.ALIGN_CENTER;
     style[this.mxConstants.STYLE_HORIZONTAL] = false;
     style[this.mxConstants.STYLE_SWIMLANE_LINE] = 0; // hide the line between the title region and the content area
 
@@ -130,7 +132,7 @@ export default class StyleConfigurator {
       const style = this.cloneDefaultVertexStyle();
       style[this.mxConstants.STYLE_SHAPE] = kind;
       style[this.mxConstants.STYLE_PERIMETER] = this.mxPerimeter.EllipsePerimeter;
-      style[this.mxConstants.STYLE_VERTICAL_LABEL_POSITION] = 'bottom';
+      style[this.mxConstants.STYLE_VERTICAL_LABEL_POSITION] = this.mxConstants.ALIGN_BOTTOM;
       this.putCellStyle(kind, style);
     });
   }
@@ -144,7 +146,7 @@ export default class StyleConfigurator {
     ShapeUtil.taskKinds().forEach(kind => {
       const style = this.cloneDefaultVertexStyle();
       style[this.mxConstants.STYLE_SHAPE] = kind;
-      style[this.mxConstants.STYLE_VERTICAL_ALIGN] = 'middle';
+      style[this.mxConstants.STYLE_VERTICAL_ALIGN] = this.mxConstants.ALIGN_MIDDLE;
       this.putCellStyle(kind, style);
     });
   }
@@ -153,7 +155,7 @@ export default class StyleConfigurator {
     const style = this.cloneDefaultVertexStyle();
     style[this.mxConstants.STYLE_SHAPE] = this.mxConstants.SHAPE_RECTANGLE;
     style[this.mxConstants.STYLE_PERIMETER] = this.mxPerimeter.RectanglePerimeter;
-    style[this.mxConstants.STYLE_VERTICAL_ALIGN] = 'middle';
+    style[this.mxConstants.STYLE_VERTICAL_ALIGN] = this.mxConstants.ALIGN_MIDDLE;
     style[this.mxConstants.STYLE_STROKECOLOR] = '#2C6DA3';
     style[this.mxConstants.STYLE_STROKEWIDTH] = 4;
     style[this.mxConstants.STYLE_ROUNDED] = true;
@@ -165,7 +167,8 @@ export default class StyleConfigurator {
       const style = this.cloneDefaultVertexStyle();
       style[this.mxConstants.STYLE_SHAPE] = kind;
       style[this.mxConstants.STYLE_PERIMETER] = this.mxPerimeter.RhombusPerimeter;
-      style[this.mxConstants.STYLE_VERTICAL_ALIGN] = 'top';
+      // TODO try 'label position' config to remove the spacing config
+      style[this.mxConstants.STYLE_VERTICAL_ALIGN] = this.mxConstants.ALIGN_TOP;
 
       // TODO to be removed when supporting label position
       // left just to not break current rendering
@@ -184,7 +187,7 @@ export default class StyleConfigurator {
     style[this.mxConstants.STYLE_STROKEWIDTH] = 1.5;
     style[this.mxConstants.STYLE_ROUNDED] = 1;
     style[this.mxConstants.STYLE_ARCSIZE] = 5;
-    style[this.mxConstants.STYLE_VERTICAL_ALIGN] = 'bottom';
+    style[this.mxConstants.STYLE_VERTICAL_ALIGN] = this.mxConstants.ALIGN_BOTTOM;
 
     this.configureCommonDefaultStyle(style);
   }
@@ -194,7 +197,7 @@ export default class StyleConfigurator {
     style[this.mxConstants.STYLE_FONTCOLOR] = 'Black';
     style[this.mxConstants.STYLE_FILLCOLOR] = 'White';
     style[this.mxConstants.STYLE_STROKECOLOR] = 'Black';
-    style[this.mxConstants.STYLE_LABEL_BACKGROUNDCOLOR] = 'none';
+    style[this.mxConstants.STYLE_LABEL_BACKGROUNDCOLOR] = this.mxConstants.NONE;
   }
 
   private configureSequenceFlowsStyle(): void {

--- a/src/component/mxgraph/StyleConfigurator.ts
+++ b/src/component/mxgraph/StyleConfigurator.ts
@@ -198,6 +198,7 @@ export default class StyleConfigurator {
   }
 
   private configureCommonDefaultStyle(style: any): void {
+    style[this.mxConstants.STYLE_FONTFAMILY] = 'Arial, sans-serif';
     style[this.mxConstants.STYLE_FONTSIZE] = 11; // 11px to better render miwg-test-suite diagrams
     style[this.mxConstants.STYLE_FONTCOLOR] = 'Black';
     style[this.mxConstants.STYLE_FILLCOLOR] = 'White';
@@ -223,19 +224,23 @@ export default class StyleConfigurator {
     style[this.mxConstants.STYLE_SHAPE] = this.mxConstants.SHAPE_RECTANGLE;
     style[this.mxConstants.STYLE_PERIMETER] = this.mxPerimeter.RectanglePerimeter;
 
-    style[this.mxConstants.STYLE_ROUNDED] = 0; // non rounded rectangle if possible
-    style[this.mxConstants.STYLE_DASHED] = this.mxPerimeter.RectanglePerimeter;
+    style[this.mxConstants.STYLE_ROUNDED] = false; // non rounded rectangle if possible
+    style[this.mxConstants.STYLE_DASHED] = true;
 
     style[this.mxConstants.STYLE_STROKECOLOR] = 'orange'; // TODO temp for identification
-    // style[this.mxConstants.STYLE_STROKEWIDTH] = 0; // TODO hide stroke
+    // style[this.mxConstants.STYLE_STROKEWIDTH] = false; // TODO hide stroke
 
-    style[this.mxConstants.STYLE_FILLCOLOR] = this.mxConstants.NONE; // ensure we do note see the label shape
+    style[this.mxConstants.STYLE_FILLCOLOR] = this.mxConstants.NONE; // ensure we do not see the label shape
 
     style[this.mxConstants.STYLE_VERTICAL_ALIGN] = this.mxConstants.ALIGN_TOP;
     style[this.mxConstants.STYLE_ALIGN] = this.mxConstants.ALIGN_MIDDLE;
 
-    // STYLE_SPACING to relax too small bounds (ref mgiw
-    // Defines the key for the spacing.  The value represents the spacing, in pixels, added to each side of a label in a vertex (style applies to vertices only).  Value is “spacing”.
+    // add negative STYLE_SPACING to relax too small bounds (ref miwg-test-suite)
+    // Defines the key for the spacing.  The value represents the spacing, in pixels, added to each side of a label in a
+    // vertex (style applies to vertices only).  Value is “spacing”.
+    // TODO adjust the value
+    style[this.mxConstants.STYLE_SPACING_LEFT] = -5;
+    style[this.mxConstants.STYLE_SPACING_RIGHT] = -5;
 
     this.graph.getStylesheet().putCellStyle(StyleConstant.BPMN_STYLE_LABEL, style);
   }

--- a/src/component/mxgraph/StyleConfigurator.ts
+++ b/src/component/mxgraph/StyleConfigurator.ts
@@ -64,6 +64,8 @@ export default class StyleConfigurator {
 
     this.configureDefaultEdgeStyle();
     this.configureSequenceFlowsStyle();
+
+    this.configureLabelStyles();
   }
 
   private getStylesheet(): any {
@@ -96,9 +98,11 @@ export default class StyleConfigurator {
     const style = this.getDefaultVertexStyle();
     this.configureCommonDefaultStyle(style);
 
+    // TODO decide if we want this for the label shape or also for the label manage directly by the shape (no label bounds)
+    // if configured here, it applies to both
     // only works with html labels (see MxGraphConfigurator to enable html labels)
     // style[this.mxConstants.STYLE_OVERFLOW] = 'hidden'; // enable clipping
-    // style[this.mxConstants.STYLE_WHITE_SPACE] = 'wrap'; // wrap for html labels
+    style[this.mxConstants.STYLE_WHITE_SPACE] = 'wrap'; // wrap for html labels
   }
 
   private configurePoolStyle(): void {
@@ -211,5 +215,30 @@ export default class StyleConfigurator {
       updateEdgeStyle(style);
       this.graph.getStylesheet().putCellStyle(kind, style);
     });
+  }
+
+  private configureLabelStyles(): void {
+    // for vertex
+    const style = this.cloneDefaultVertexStyle();
+    style[this.mxConstants.STYLE_SHAPE] = this.mxConstants.SHAPE_RECTANGLE;
+    style[this.mxConstants.STYLE_PERIMETER] = this.mxPerimeter.RectanglePerimeter;
+
+    style[this.mxConstants.STYLE_ROUNDED] = 0; // non rounded rectangle if possible
+    style[this.mxConstants.STYLE_DASHED] = this.mxPerimeter.RectanglePerimeter;
+
+    style[this.mxConstants.STYLE_STROKECOLOR] = 'orange'; // TODO temp for identification
+    // style[this.mxConstants.STYLE_STROKEWIDTH] = 0; // TODO hide stroke
+
+    // style[this.mxConstants.STYLE_FILL_OPACITY] = 0;
+    style[this.mxConstants.STYLE_FILLCOLOR] = this.mxConstants.NONE;
+
+    // label bounds are provided from the top left
+    style[this.mxConstants.STYLE_VERTICAL_ALIGN] = this.mxConstants.ALIGN_TOP;
+    style[this.mxConstants.STYLE_ALIGN] = this.mxConstants.ALIGN_MIDDLE;
+
+    // STYLE_SPACING to relax too small bounds (ref mgiw
+    // Defines the key for the spacing.  The value represents the spacing, in pixels, added to each side of a label in a vertex (style applies to vertices only).  Value is “spacing”.
+
+    this.graph.getStylesheet().putCellStyle('bpmn.label.vertex', style);
   }
 }

--- a/src/component/mxgraph/StyleConfigurator.ts
+++ b/src/component/mxgraph/StyleConfigurator.ts
@@ -239,8 +239,8 @@ export default class StyleConfigurator {
     // Defines the key for the spacing.  The value represents the spacing, in pixels, added to each side of a label in a
     // vertex (style applies to vertices only).  Value is “spacing”.
     // TODO adjust the value
-    style[this.mxConstants.STYLE_SPACING_LEFT] = -5;
-    style[this.mxConstants.STYLE_SPACING_RIGHT] = -5;
+    // style[this.mxConstants.STYLE_SPACING_LEFT] = -5;
+    // style[this.mxConstants.STYLE_SPACING_RIGHT] = -5;
 
     this.graph.getStylesheet().putCellStyle(StyleConstant.BPMN_STYLE_LABEL, style);
   }


### PR DESCRIPTION
:heavy_check_mark: POC completed

This POC experiments a way to implement label position. As it has some drawbacks, another poc is in progress using mxgraph label offset (see ##291).
It is freely inspired from https://github.com/jgraph/mxgraph2/blob/mxgraph-4_1_1/javascript/examples/labels.html

**Main idea**
If bpmn label is available, do not set the label text to the current vertex, leave it empty
Add another vertex containing only the label. That way, we can fully control bounds in particular height and width

Relates to #279 and #280 


## Implementation notes

- the label cell displays a dashed orange stroke to let visualize its rendered bounds (only needed for this POC)
- this POC does not handle position for pool/lane which are generally vertical. It should be done in a dedicated PR and probably extra work will be required to support #127. The same would apply to BPMN element with vertical orientation (currently not supported at all by the lib)
- the default font and font size has been adjusted to better render bpmn files of the [bpmn-miwg-test-suite repository](https://github.com/bpmn-miwg/bpmn-miwg-test-suite). Switch from `Arial, Helvetica 12px` to `Arial,sans-sherif 11px`
- notice that for labels without font, the rendering may not be accurate as the default font used by the original modeller may differ from the one we use and the bounds set in the BPMN file may be too small. So the resulting wrapping can not be the same as with the original modeler.
- to improve the wrapping, margin of the label are slightly put outside of the label bounds or the width of label is increased a little to avoid extra break line. The value should be adjusted. Notice that is a workaround and we won't be able to support all cases especially for label without font (see above)

### Potential issue with text wrapping
**Note**: this is not specific to this implementation but to the fact we want to use wrapping which seems not supported by default when using svg labels (could be done with svg text/tspan)

Text wrapping has been activated. This requires to activate `htmlLabels` on the graph. 
As mention in the [mxGraph documentation](https://jgraph.github.io/mxgraph/docs/js-api/files/view/mxGraph-js.html): `Enabling HTML labels carries a possible security risk (see the section on security in the manual).`


This could also cause issue if we want to export the graph in svg (mixed svg with html??), as requested for #133 
Clipping (i.e truncating the label) is not activated has we want to display everything that has been modeled within the diagram by default.
If clipping with ellipse is needed (i.e truncating the label and ends it with '...'), have a look at https://github.com/jgraph/mxgraph2/blob/mxgraph-4_1_1/javascript/examples/labels.html


### Possible issue with relationship between the label and its cell
There is currently no link between a mxCell and its label mxCell except they are associated to the same parent.

This may prevent future features to be easily implemented, for instance 'hide a bpmn path so label of elements associated to this path'. We currently has no way to find the label of mxCell

We may
- at least try to group the cells. But remember that for mxGraph, grouping means creating a new mxCell which is the parent of cells to be grouped
- also make the bpmn cell the parent of the label cell. This would require extra config to avoid cell resize, especially for `gateway` and `event` whose label is generally display out of the cell
Notice that we may have the same need to render `boundary events`
- set a dedicated id to the label mxCell. Currently, we do not use the eventual id from the BPMN source, we always delegate the id creation to mxGraph. We should use it or generate one that can be easily be rebuilt from the mxCell id (for instance `<mxCell_id>_label`). This would at least let us easily search for label mxCell knowning the original mxCell

A side effect of this non relationship is that the label may now be displayed whereas its edge is invisible. An edge may not be displayed if its terminal points are not displayed (bpmn elements not supported for instance). In previous implementation, both the element and its label were hidden. 

### BPMN element without BPMN label
This implementation can display a text at an arbitrary position when no BPMN label is associated. Each BPMN style configures default positioning which is used in this case (the configuration used prior this PR has been kept untouched). No special code is need to handle that: just skip the part that renders the dedicated cell for the label and use the text has label of the mxGraph bpmn vertex/edge.



## Rendering of the [B.1.0.bpmn file from BPMN-MIWG](https://github.com/bpmn-miwg/bpmn-miwg-test-suite/blob/9e8416f04db90c25d93a39d34719c9cdc62848c2/Reference/B.1.0.bpmn)

### prior change
![bpmn-visualization_B 1 0_01_prior_change](https://user-images.githubusercontent.com/27200110/84049171-67d98880-a9ac-11ea-82e8-2184dc1f59a9.png)

### with change 8f5ea14
![bpmn-visualization_B 1 0_02_with_change](https://user-images.githubusercontent.com/27200110/84049186-6b6d0f80-a9ac-11ea-858e-d0c8a0f3d558.png)


## Rendering of the the [sequence flow example](https://github.com/process-analytics/bpmn-visualization-examples/blob/7848b9873e47ed2b6617a9b2be3897a99540ccdb/bpmn-files/all_sequence_flow_types.bpmn)

### prior change
![bpmn-visualization_flow_nodes_examples_01_prior_change](https://user-images.githubusercontent.com/27200110/84049450-c272e480-a9ac-11ea-87b9-c37e054f3475.png)

### with change 8f5ea14
![bpmn-visualization_flow_nodes_examples_02_with_change](https://user-images.githubusercontent.com/27200110/84049476-c7d02f00-a9ac-11ea-80d7-e8abb70aa482.png)
