### PR TITLE
[POC] experiment label bounds with mxgraph mxCell geometry offset

### DIFF
--- a/src/component/mxgraph/MxGraphConfigurator.ts
+++ b/src/component/mxgraph/MxGraphConfigurator.ts
@@ -47,7 +47,7 @@ export default class MxGraphConfigurator {
   private configureGraph(): void {
     this.graph.setCellsLocked(true);
     this.graph.setCellsSelectable(false);
-    // this.graph.htmlLabels = true; // required for wrapping and clipping
+    this.graph.htmlLabels = true; // required for wrapping and clipping
 
     // TODO see if this changes something
     this.graph.setEdgeLabelsMovable(false);

--- a/src/component/mxgraph/MxGraphConfigurator.ts
+++ b/src/component/mxgraph/MxGraphConfigurator.ts
@@ -49,8 +49,8 @@ export default class MxGraphConfigurator {
     this.graph.setCellsSelectable(true);
     this.graph.htmlLabels = true; // required for wrapping and clipping
 
-    // TODO see if this changes something
+    // TODO this is to see the label offset point (in yellow by default)
     this.graph.setEdgeLabelsMovable(true);
-    this.graph.setVertexLabelsMovable(false);
+    this.graph.setVertexLabelsMovable(true);
   }
 }

--- a/src/component/mxgraph/MxGraphConfigurator.ts
+++ b/src/component/mxgraph/MxGraphConfigurator.ts
@@ -20,10 +20,11 @@ import ShapeConfigurator from './ShapeConfigurator';
 import MarkerConfigurator from './MarkerConfigurator';
 
 /**
- * Configure mxgraph
+ * Configure the mxGraph graph that can be used by the lib
  * <ul>
  *     <li>styles
  *     <li>shapes
+ *     <li>markers
  */
 export default class MxGraphConfigurator {
   private mxGraph: typeof mxgraph.mxGraph = MxGraphFactoryService.getMxGraphProperty('mxGraph');
@@ -32,8 +33,8 @@ export default class MxGraphConfigurator {
   private readonly graph: mxgraph.mxGraph;
 
   constructor(container: Element) {
-    this.initMxGraphPrototype();
     this.graph = new this.mxGraph(container, new this.mxGraphModel());
+    this.configureGraph();
     new StyleConfigurator(this.graph).configureStyles();
     new ShapeConfigurator().configureShapes();
     new MarkerConfigurator().configureMarkers();
@@ -43,9 +44,13 @@ export default class MxGraphConfigurator {
     return this.graph;
   }
 
-  private initMxGraphPrototype(): void {
-    this.mxGraph.prototype.edgeLabelsMovable = false;
-    this.mxGraph.prototype.cellsLocked = true;
-    this.mxGraph.prototype.cellsSelectable = false;
+  private configureGraph(): void {
+    this.graph.setCellsLocked(true);
+    this.graph.setCellsSelectable(false);
+    // this.graph.htmlLabels = true; // required for wrapping and clipping
+
+    // TODO see if this changes something
+    this.graph.setEdgeLabelsMovable(false);
+    this.graph.setVertexLabelsMovable(false);
   }
 }

--- a/src/component/mxgraph/MxGraphConfigurator.ts
+++ b/src/component/mxgraph/MxGraphConfigurator.ts
@@ -45,12 +45,12 @@ export default class MxGraphConfigurator {
   }
 
   private configureGraph(): void {
-    this.graph.setCellsLocked(true);
-    this.graph.setCellsSelectable(false);
+    this.graph.setCellsLocked(false);
+    this.graph.setCellsSelectable(true);
     this.graph.htmlLabels = true; // required for wrapping and clipping
 
     // TODO see if this changes something
-    this.graph.setEdgeLabelsMovable(false);
+    this.graph.setEdgeLabelsMovable(true);
     this.graph.setVertexLabelsMovable(false);
   }
 }

--- a/src/component/mxgraph/MxGraphRenderer.ts
+++ b/src/component/mxgraph/MxGraphRenderer.ts
@@ -141,9 +141,39 @@ export default class MxGraphRenderer {
         const parent = this.graph.getDefaultParent();
         const source = this.getCell(bpmnElement.sourceRefId);
         const target = this.getCell(bpmnElement.targetRefId);
-        const style = this.computeStyle(edge);
+
+        const labelBounds = edge.label?.bounds;
+        const style = this.computeStyle(edge, labelBounds);
+
         const mxEdge = this.graph.insertEdge(parent, bpmnElement.id, bpmnElement.name, source, target, style);
         this.insertWaypoints(edge.waypoints, mxEdge);
+
+        // eslint-disable-next-line no-console
+        console.info('###Rendering edge, geometry prior applying info from label bounds:');
+        // eslint-disable-next-line no-console
+        console.info(mxEdge.geometry);
+
+        // demonstrate how to set label position using the cell geometry offset
+        // label relative coordinates to the cell
+        if (labelBounds) {
+          mxEdge.geometry.relative = false;
+          const relativeCoordinate = this.getRelativeCoordinates(mxEdge.parent, { x: labelBounds.x, y: labelBounds.y });
+          mxEdge.geometry.x = relativeCoordinate.x;
+          mxEdge.geometry.y = relativeCoordinate.y;
+          // as described in the doc,
+          // "The width and height parameter for edge geometries can be used to set the label width and height (eg. for word wrapping)."
+          mxEdge.geometry.width = labelBounds.width;
+          mxEdge.geometry.height = labelBounds.height;
+
+          // const relativeLabelX = labelBounds.x - bounds.x;
+          // const relativeLabelY = labelBounds.y - bounds.y;
+          // mxEdge.geometry.offset = new this.mxPoint(relativeLabelX, relativeLabelY);
+
+          // eslint-disable-next-line no-console
+          console.info('###Rendering edge, geometry AFTER applying info from label bounds:');
+          // eslint-disable-next-line no-console
+          console.info(mxEdge.geometry);
+        }
       }
     });
   }

--- a/src/component/mxgraph/MxGraphRenderer.ts
+++ b/src/component/mxgraph/MxGraphRenderer.ts
@@ -29,8 +29,8 @@ interface Coordinate {
 }
 
 export default class MxGraphRenderer {
-  private mxPoint: typeof mxgraph.mxPoint = MxGraphFactoryService.getMxGraphProperty('mxPoint');
   private mxConstants: typeof mxgraph.mxConstants = MxGraphFactoryService.getMxGraphProperty('mxConstants');
+  private mxPoint: typeof mxgraph.mxPoint = MxGraphFactoryService.getMxGraphProperty('mxPoint');
   constructor(readonly graph: mxgraph.mxGraph) {}
 
   public render(bpmnModel: BpmnModel): void {
@@ -146,7 +146,9 @@ export default class MxGraphRenderer {
     style?: string,
   ): mxgraph.mxCell {
     const relativeCoordinate = this.getRelativeCoordinates(parent, absoluteCoordinate);
-    return this.graph.insertVertex(parent, id, value, relativeCoordinate.x, relativeCoordinate.y, width, height, style);
+    const mxCell = this.graph.insertVertex(parent, id, value, relativeCoordinate.x, relativeCoordinate.y, width, height, style);
+    mxCell.geometry.offset = new this.mxPoint(30, 30); // demonstrate how to set label position
+    return mxCell;
   }
 
   private getRelativeCoordinates(parent: mxgraph.mxCell, absoluteCoordinate: Coordinate): Coordinate {

--- a/src/component/mxgraph/MxGraphRenderer.ts
+++ b/src/component/mxgraph/MxGraphRenderer.ts
@@ -147,24 +147,25 @@ export default class MxGraphRenderer {
         const style = this.computeStyle(edge, labelBounds);
 
         const labelText = bpmnElement.name;
-        // eslint-disable-next-line no-console
-        console.info('###Processing edge with label:', labelText);
         const mxEdge = this.graph.insertEdge(parent, bpmnElement.id, labelText, source, target, style);
         this.insertWaypoints(edge.waypoints, mxEdge);
 
-        // eslint-disable-next-line no-console
-        console.info('###geometry prior applying info from label bounds');
-        const geometry = mxEdge.geometry;
-        // eslint-disable-next-line no-console
-        console.info(geometry);
-        // eslint-disable-next-line no-console
-        console.info('###center: %s / %s', geometry.getCenterX(), geometry.getCenterY());
-
-        // demonstrate how to set label position using the cell geometry offset
-        // label relative coordinates to the cell
         if (labelBounds) {
-          // mxEdge.geometry.relative = false;
-          const relativeCoordinate = this.getRelativeCoordinates(mxEdge.parent, { x: labelBounds.x, y: labelBounds.y });
+          // eslint-disable-next-line no-console
+          console.info('###Processing edge label bounds with label:', labelText);
+          // eslint-disable-next-line no-console
+          console.info('###geometry BEFORE applying info from label bounds');
+          // eslint-disable-next-line no-console
+          console.info(mxEdge.geometry);
+
+          // only if we have waypoints to compute the center of the edge
+          mxEdge.geometry.relative = true;
+          const labelBoundsRelativeCoordinateFromParent = this.getRelativeCoordinates(mxEdge.parent, { x: labelBounds.x, y: labelBounds.y });
+          // eslint-disable-next-line no-console
+          console.info('labelBoundsRelativeCoordinateFromParent:');
+          // eslint-disable-next-line no-console
+          console.info(labelBoundsRelativeCoordinateFromParent);
+
           // mxEdge.geometry.x = relativeCoordinate.x;
           // mxEdge.geometry.y = relativeCoordinate.y;
 
@@ -178,6 +179,14 @@ export default class MxGraphRenderer {
           // const relativeLabelX = labelBounds.x - bounds.x;
           // const relativeLabelY = labelBounds.y - bounds.y;
           // mxEdge.geometry.offset = new this.mxPoint(relativeLabelX, relativeLabelY);
+
+          const edgeCenterCoordinate = this.computeEgeCenter(mxEdge);
+          // eslint-disable-next-line no-console
+          console.info('Computed edgeCenterCoordinate');
+          // eslint-disable-next-line no-console
+          console.info(edgeCenterCoordinate);
+          if (edgeCenterCoordinate) {
+          }
 
           // eslint-disable-next-line no-console
           console.info('###geometry AFTER applying info from label bounds');
@@ -232,12 +241,53 @@ export default class MxGraphRenderer {
   //
   // The width and height parameter for edge geometries can be used to set the label width and height (eg. for word wrapping).
 
+  // mxGraphView.prototype.updateEdgeLabelOffset = function(	state	)
+  // Updates mxCellState.absoluteOffset for the given state.
+  // The absolute offset is normally used for the position of the edge label.
+  // Is is calculated from the geometry as an absolute offset from the center between the two endpoints if the
+  // geometry is absolute, or as the relative distance between the center along the line and the absolute orthogonal
+  // distance if the geometry is relative.
+  //
+  // 			var p0 = points[0];
+  // 			var pe = points[points.length - 1];
+  //
+  // 			if (p0 != null && pe != null)
+  // 			{
+  // 				var dx = pe.x - p0.x;
+  // 				var dy = pe.y - p0.y;
+  // 				var x0 = 0;
+  // 				var y0 = 0;
+  //
+  // 				var off = geometry.offset;
+  //
+  // 				if (off != null)
+  // 				{
+  // 					x0 = off.x;
+  // 					y0 = off.y;
+  // 				}
+  //
+  // 				var x = p0.x + dx / 2 + x0 * this.scale;
+  // 				var y = p0.y + dy / 2 + y0 * this.scale;
+  //
+  // 				state.absoluteOffset.x = x;
+  // 				state.absoluteOffset.y = y;
+  // 			}
+
   // coordinate in the same referential as the mxCell, so here, relative to its parent
   private computeEgeCenter(mxEdge: mxgraph.mxCell): Coordinate {
     // TODO final impl should ensure we have an edge
-    const wayPoints = mxEdge.geometry.points;
+    const points: mxgraph.mxPoint[] = mxEdge.geometry.points;
 
-    return null;
+    const p0 = points[0];
+    const pe = points[points.length - 1];
+
+    if (p0 != null && pe != null) {
+      const dx = pe.x - p0.x;
+      const dy = pe.y - p0.y;
+      return { x: p0.x + dx / 2, y: p0.y + dy / 2 };
+    }
+
+    return undefined;
   }
 
   private getRelativeCoordinates(parent: mxgraph.mxCell, absoluteCoordinate: Coordinate): Coordinate {

--- a/src/component/mxgraph/MxGraphRenderer.ts
+++ b/src/component/mxgraph/MxGraphRenderer.ts
@@ -105,6 +105,11 @@ export default class MxGraphRenderer {
       // only apply to vertex
       // style[this.mxConstants.STYLE_SPACING_TOP] = 55;
       // style[this.mxConstants.STYLE_SPACING_RIGHT] = 110;
+      // add negative STYLE_SPACING to relax too small bounds (ref miwg-test-suite)
+      // TODO adjust the value
+      // TODO warn apply only to vertex, not edge
+      styleValues.set(this.mxConstants.STYLE_SPACING_LEFT, -5);
+      styleValues.set(this.mxConstants.STYLE_SPACING_RIGHT, -5);
     }
 
     return [bpmnElement.kind as string] //

--- a/src/component/mxgraph/MxGraphRenderer.ts
+++ b/src/component/mxgraph/MxGraphRenderer.ts
@@ -145,32 +145,41 @@ export default class MxGraphRenderer {
         const labelBounds = edge.label?.bounds;
         const style = this.computeStyle(edge, labelBounds);
 
-        const mxEdge = this.graph.insertEdge(parent, bpmnElement.id, bpmnElement.name, source, target, style);
+        const labelText = bpmnElement.name;
+        // eslint-disable-next-line no-console
+        console.info('###Processing edge with label:', labelText);
+        const mxEdge = this.graph.insertEdge(parent, bpmnElement.id, labelText, source, target, style);
         this.insertWaypoints(edge.waypoints, mxEdge);
 
         // eslint-disable-next-line no-console
-        console.info('###Rendering edge, geometry prior applying info from label bounds:');
+        console.info('###geometry prior applying info from label bounds');
+        const geometry = mxEdge.geometry;
         // eslint-disable-next-line no-console
-        console.info(mxEdge.geometry);
+        console.info(geometry);
+        // eslint-disable-next-line no-console
+        console.info('###center: %s / %s', geometry.getCenterX(), geometry.getCenterY());
 
         // demonstrate how to set label position using the cell geometry offset
         // label relative coordinates to the cell
         if (labelBounds) {
-          mxEdge.geometry.relative = false;
+          // mxEdge.geometry.relative = false;
           const relativeCoordinate = this.getRelativeCoordinates(mxEdge.parent, { x: labelBounds.x, y: labelBounds.y });
-          mxEdge.geometry.x = relativeCoordinate.x;
-          mxEdge.geometry.y = relativeCoordinate.y;
-          // as described in the doc,
-          // "The width and height parameter for edge geometries can be used to set the label width and height (eg. for word wrapping)."
+          // mxEdge.geometry.x = relativeCoordinate.x;
+          // mxEdge.geometry.y = relativeCoordinate.y;
+
+          // described in the doc
+          // "The width and height parameter for edge geometries can be used to set the label width and height
+          // (eg. for word wrapping)."
           mxEdge.geometry.width = labelBounds.width;
           mxEdge.geometry.height = labelBounds.height;
 
+          // TODO ensure we do not need offset here
           // const relativeLabelX = labelBounds.x - bounds.x;
           // const relativeLabelY = labelBounds.y - bounds.y;
           // mxEdge.geometry.offset = new this.mxPoint(relativeLabelX, relativeLabelY);
 
           // eslint-disable-next-line no-console
-          console.info('###Rendering edge, geometry AFTER applying info from label bounds:');
+          console.info('###geometry AFTER applying info from label bounds');
           // eslint-disable-next-line no-console
           console.info(mxEdge.geometry);
         }
@@ -203,6 +212,31 @@ export default class MxGraphRenderer {
       mxCell.geometry.offset = new this.mxPoint(relativeLabelX, relativeLabelY);
     }
     return mxCell;
+  }
+
+  // ===================================================================================================================
+  // TODO move to a dedicated class
+  // ===================================================================================================================
+  //
+  // https://jgraph.github.io/mxgraph/docs/js-api/files/model/mxGeometry-js.html#mxGeometry
+  // Edge Labels
+  //
+  // Using the x- and y-coordinates of a cell’s geometry, it is possible to position the label on edges on a specific
+  // location on the actual edge shape as it appears on the screen.  The x-coordinate of an edge’s geometry is used to
+  // describe the distance from the center of the edge from -1 to 1 with 0 being the center of the edge and the default value.
+  // The y-coordinate of an edge’s geometry is used to describe the absolute, orthogonal distance in pixels from that point.
+  // In addition, the mxGeometry.offset is used as an absolute offset vector from the resulting point.
+  //
+  // This coordinate system is applied if relative is true, otherwise the offset defines the absolute vector from the edge’s center point to the label and the values for <x> and <y> are ignored.
+  //
+  // The width and height parameter for edge geometries can be used to set the label width and height (eg. for word wrapping).
+
+  // coordinate in the same referential as the mxCell, so here, relative to its parent
+  private computeEgeCenter(mxEdge: mxgraph.mxCell): Coordinate {
+    // TODO final impl should ensure we have an edge
+    const wayPoints = mxEdge.geometry.points;
+
+    return null;
   }
 
   private getRelativeCoordinates(parent: mxgraph.mxCell, absoluteCoordinate: Coordinate): Coordinate {

--- a/src/component/mxgraph/MxGraphRenderer.ts
+++ b/src/component/mxgraph/MxGraphRenderer.ts
@@ -69,17 +69,16 @@ export default class MxGraphRenderer {
       const parent = this.getParent(bpmnElement);
 
       const bounds = shape.bounds;
-      const labelBounds = shape.label?.bounds;
-
+      let labelBounds = shape.label?.bounds;
       // TODO pool/lane not managed for now
-      const isSupportLabelBounds = !ShapeUtil.isPoolOrLane(bpmnElement.kind) && !!labelBounds;
-      const style = this.computeStyle(shape, isSupportLabelBounds);
+      labelBounds = ShapeUtil.isPoolOrLane(bpmnElement.kind) ? undefined : labelBounds;
+      const style = this.computeStyle(shape, labelBounds);
 
       this.insertVertex(parent, bpmnElement.id, bpmnElement.name, bounds, labelBounds, style);
     }
   }
 
-  computeStyle(bpmnCell: Shape | Edge, isSupportLabelBounds = false): string {
+  computeStyle(bpmnCell: Shape | Edge, labelBounds?: Bounds): string {
     const styleValues = new Map<string, string | number>();
 
     const font = bpmnCell.label?.font;
@@ -94,15 +93,14 @@ export default class MxGraphRenderer {
       styleValues.set(StyleConstant.BPMN_STYLE_EVENT_KIND, bpmnElement.eventKind);
     }
 
-    if (isSupportLabelBounds) {
+    if (labelBounds) {
       styleValues.set(this.mxConstants.STYLE_VERTICAL_ALIGN, this.mxConstants.ALIGN_TOP);
-      styleValues.set(this.mxConstants.STYLE_ALIGN, this.mxConstants.ALIGN_LEFT);
-      styleValues.set(this.mxConstants.STYLE_LABEL_BORDERCOLOR, 'green'); // TODO only for detection in this POC
+      styleValues.set(this.mxConstants.STYLE_ALIGN, this.mxConstants.ALIGN_MIDDLE);
+      styleValues.set(this.mxConstants.STYLE_LABEL_BORDERCOLOR, 'red'); // TODO only for detection in this POC
       // erase eventual style configuration for BPMN element
       styleValues.set(this.mxConstants.STYLE_LABEL_POSITION, this.mxConstants.NONE);
       styleValues.set(this.mxConstants.STYLE_VERTICAL_LABEL_POSITION, this.mxConstants.NONE);
-      // TODO to add
-      //styleValues.set(this.mxConstants.STYLE_LABEL_WIDTH, 100); // todo taken from label bounds
+      styleValues.set(this.mxConstants.STYLE_LABEL_WIDTH, labelBounds.width); // TODO how do we manage height constraints?
       //styleValues.set(this.mxConstants.STYLE_LABEL_PADDING, 0); // todo adjust
       // only apply to vertex
       // style[this.mxConstants.STYLE_SPACING_TOP] = 55;

--- a/src/component/mxgraph/MxGraphRenderer.ts
+++ b/src/component/mxgraph/MxGraphRenderer.ts
@@ -100,7 +100,8 @@ export default class MxGraphRenderer {
       // erase eventual style configuration for BPMN element
       styleValues.set(this.mxConstants.STYLE_LABEL_POSITION, this.mxConstants.NONE);
       styleValues.set(this.mxConstants.STYLE_VERTICAL_LABEL_POSITION, this.mxConstants.NONE);
-      styleValues.set(this.mxConstants.STYLE_LABEL_WIDTH, labelBounds.width); // TODO how do we manage height constraints?
+      // arbitrarily increase width to relax too small bounds (for instance for reference diagrams from miwg-test-suite)
+      styleValues.set(this.mxConstants.STYLE_LABEL_WIDTH, labelBounds.width + 1); // TODO how do we manage height constraints?
       //styleValues.set(this.mxConstants.STYLE_LABEL_PADDING, 0); // todo adjust
       // only apply to vertex
       // style[this.mxConstants.STYLE_SPACING_TOP] = 55;
@@ -108,8 +109,8 @@ export default class MxGraphRenderer {
       // add negative STYLE_SPACING to relax too small bounds (ref miwg-test-suite)
       // TODO adjust the value
       // TODO warn apply only to vertex, not edge
-      styleValues.set(this.mxConstants.STYLE_SPACING_LEFT, -5);
-      styleValues.set(this.mxConstants.STYLE_SPACING_RIGHT, -5);
+      // styleValues.set(this.mxConstants.STYLE_SPACING_LEFT, -5);
+      // styleValues.set(this.mxConstants.STYLE_SPACING_RIGHT, -5);
     }
 
     return [bpmnElement.kind as string] //

--- a/src/component/mxgraph/StyleConfigurator.ts
+++ b/src/component/mxgraph/StyleConfigurator.ts
@@ -99,7 +99,7 @@ export default class StyleConfigurator {
     // TODO move this to also support wrapping for edge labels
     // only works with html labels (see MxGraphConfigurator to enable html labels)
     // style[this.mxConstants.STYLE_OVERFLOW] = 'hidden'; // enable clipping
-    // style[this.mxConstants.STYLE_WHITE_SPACE] = 'wrap'; // wrap for html labels
+    style[this.mxConstants.STYLE_WHITE_SPACE] = 'wrap'; // wrap for html labels
   }
 
   private configurePoolStyle(): void {

--- a/src/component/mxgraph/StyleConfigurator.ts
+++ b/src/component/mxgraph/StyleConfigurator.ts
@@ -193,7 +193,8 @@ export default class StyleConfigurator {
   }
 
   private configureCommonDefaultStyle(style: any): void {
-    style[this.mxConstants.STYLE_FONTSIZE] = 12;
+    style[this.mxConstants.STYLE_FONTFAMILY] = 'Arial, sans-serif';
+    style[this.mxConstants.STYLE_FONTSIZE] = 11; // 11px to better render miwg-test-suite diagrams
     style[this.mxConstants.STYLE_FONTCOLOR] = 'Black';
     style[this.mxConstants.STYLE_FILLCOLOR] = 'White';
     style[this.mxConstants.STYLE_STROKECOLOR] = 'Black';

--- a/src/component/mxgraph/StyleConfigurator.ts
+++ b/src/component/mxgraph/StyleConfigurator.ts
@@ -95,6 +95,10 @@ export default class StyleConfigurator {
   private configureDefaultVertexStyle(): void {
     const style = this.getDefaultVertexStyle();
     this.configureCommonDefaultStyle(style);
+
+    // only works with html labels (see MxGraphConfigurator to enable html labels)
+    // style[this.mxConstants.STYLE_OVERFLOW] = 'hidden'; // enable clipping
+    // style[this.mxConstants.STYLE_WHITE_SPACE] = 'wrap'; // wrap for html labels
   }
 
   private configurePoolStyle(): void {

--- a/src/component/mxgraph/StyleConfigurator.ts
+++ b/src/component/mxgraph/StyleConfigurator.ts
@@ -96,10 +96,7 @@ export default class StyleConfigurator {
     const style = this.getDefaultVertexStyle();
     this.configureCommonDefaultStyle(style);
 
-    // label bounds are provided from the top left
-    style[this.mxConstants.STYLE_VERTICAL_ALIGN] = this.mxConstants.ALIGN_TOP;
-    style[this.mxConstants.STYLE_ALIGN] = this.mxConstants.ALIGN_LEFT;
-
+    // TODO move this to also support wrapping for edge labels
     // only works with html labels (see MxGraphConfigurator to enable html labels)
     // style[this.mxConstants.STYLE_OVERFLOW] = 'hidden'; // enable clipping
     // style[this.mxConstants.STYLE_WHITE_SPACE] = 'wrap'; // wrap for html labels
@@ -108,7 +105,7 @@ export default class StyleConfigurator {
   private configurePoolStyle(): void {
     const style = this.cloneDefaultVertexStyle();
     style[this.mxConstants.STYLE_SHAPE] = this.mxConstants.SHAPE_SWIMLANE;
-    style[this.mxConstants.STYLE_VERTICAL_ALIGN] = 'middle'; // TODO use constant
+    style[this.mxConstants.STYLE_VERTICAL_ALIGN] = this.mxConstants.ALIGN_MIDDLE;
     style[this.mxConstants.STYLE_ALIGN] = this.mxConstants.ALIGN_CENTER;
     style[this.mxConstants.STYLE_HORIZONTAL] = false;
     style[this.mxConstants.STYLE_FILLCOLOR] = '#d3d2d1';
@@ -123,7 +120,7 @@ export default class StyleConfigurator {
   private configureLaneStyle(): void {
     const style = this.cloneDefaultVertexStyle();
     style[this.mxConstants.STYLE_SHAPE] = this.mxConstants.SHAPE_SWIMLANE;
-    style[this.mxConstants.STYLE_VERTICAL_ALIGN] = 'middle'; // TODO use constant
+    style[this.mxConstants.STYLE_VERTICAL_ALIGN] = this.mxConstants.ALIGN_MIDDLE;
     style[this.mxConstants.STYLE_ALIGN] = this.mxConstants.ALIGN_CENTER;
     style[this.mxConstants.STYLE_HORIZONTAL] = false;
     style[this.mxConstants.STYLE_SWIMLANE_LINE] = 0; // hide the line between the title region and the content area
@@ -136,7 +133,7 @@ export default class StyleConfigurator {
       const style = this.cloneDefaultVertexStyle();
       style[this.mxConstants.STYLE_SHAPE] = kind;
       style[this.mxConstants.STYLE_PERIMETER] = this.mxPerimeter.EllipsePerimeter;
-      // style[this.mxConstants.STYLE_VERTICAL_LABEL_POSITION] = 'bottom';
+      style[this.mxConstants.STYLE_VERTICAL_LABEL_POSITION] = this.mxConstants.ALIGN_BOTTOM;
       this.putCellStyle(kind, style);
     });
   }
@@ -150,7 +147,7 @@ export default class StyleConfigurator {
     ShapeUtil.taskKinds().forEach(kind => {
       const style = this.cloneDefaultVertexStyle();
       style[this.mxConstants.STYLE_SHAPE] = kind;
-      // style[this.mxConstants.STYLE_VERTICAL_ALIGN] = 'middle';
+      style[this.mxConstants.STYLE_VERTICAL_ALIGN] = this.mxConstants.ALIGN_MIDDLE;
       this.putCellStyle(kind, style);
     });
   }
@@ -159,7 +156,7 @@ export default class StyleConfigurator {
     const style = this.cloneDefaultVertexStyle();
     style[this.mxConstants.STYLE_SHAPE] = this.mxConstants.SHAPE_RECTANGLE;
     style[this.mxConstants.STYLE_PERIMETER] = this.mxPerimeter.RectanglePerimeter;
-    // style[this.mxConstants.STYLE_VERTICAL_ALIGN] = 'middle';
+    style[this.mxConstants.STYLE_VERTICAL_ALIGN] = this.mxConstants.ALIGN_MIDDLE;
     style[this.mxConstants.STYLE_STROKECOLOR] = '#2C6DA3';
     style[this.mxConstants.STYLE_STROKEWIDTH] = 4;
     style[this.mxConstants.STYLE_ROUNDED] = true;
@@ -171,9 +168,9 @@ export default class StyleConfigurator {
       const style = this.cloneDefaultVertexStyle();
       style[this.mxConstants.STYLE_SHAPE] = kind;
       style[this.mxConstants.STYLE_PERIMETER] = this.mxPerimeter.RhombusPerimeter;
-      // style[this.mxConstants.STYLE_VERTICAL_ALIGN] = 'top';
+      style[this.mxConstants.STYLE_VERTICAL_ALIGN] = this.mxConstants.ALIGN_TOP;
 
-      // // TODO to be removed when supporting label position
+      // TODO find a better way with label position that can be easily overridden when label bounds are available in BPMN
       // // left just to not break current rendering
       // style[this.mxConstants.STYLE_SPACING_TOP] = 55;
       // style[this.mxConstants.STYLE_SPACING_RIGHT] = 110;
@@ -190,7 +187,7 @@ export default class StyleConfigurator {
     style[this.mxConstants.STYLE_STROKEWIDTH] = 1.5;
     style[this.mxConstants.STYLE_ROUNDED] = 1;
     style[this.mxConstants.STYLE_ARCSIZE] = 5;
-    style[this.mxConstants.STYLE_VERTICAL_ALIGN] = 'bottom';
+    style[this.mxConstants.STYLE_VERTICAL_ALIGN] = this.mxConstants.ALIGN_BOTTOM;
 
     this.configureCommonDefaultStyle(style);
   }
@@ -200,7 +197,7 @@ export default class StyleConfigurator {
     style[this.mxConstants.STYLE_FONTCOLOR] = 'Black';
     style[this.mxConstants.STYLE_FILLCOLOR] = 'White';
     style[this.mxConstants.STYLE_STROKECOLOR] = 'Black';
-    style[this.mxConstants.STYLE_LABEL_BACKGROUNDCOLOR] = 'none';
+    style[this.mxConstants.STYLE_LABEL_BACKGROUNDCOLOR] = this.mxConstants.NONE;
   }
 
   private configureSequenceFlowsStyle(): void {

--- a/src/component/mxgraph/StyleConfigurator.ts
+++ b/src/component/mxgraph/StyleConfigurator.ts
@@ -95,11 +95,6 @@ export default class StyleConfigurator {
   private configureDefaultVertexStyle(): void {
     const style = this.getDefaultVertexStyle();
     this.configureCommonDefaultStyle(style);
-
-    // TODO move this to also support wrapping for edge labels
-    // only works with html labels (see MxGraphConfigurator to enable html labels)
-    // style[this.mxConstants.STYLE_OVERFLOW] = 'hidden'; // enable clipping
-    style[this.mxConstants.STYLE_WHITE_SPACE] = 'wrap'; // wrap for html labels
   }
 
   private configurePoolStyle(): void {
@@ -199,6 +194,11 @@ export default class StyleConfigurator {
     style[this.mxConstants.STYLE_FILLCOLOR] = 'White';
     style[this.mxConstants.STYLE_STROKECOLOR] = 'Black';
     style[this.mxConstants.STYLE_LABEL_BACKGROUNDCOLOR] = this.mxConstants.NONE;
+
+    // TODO decide if we want this to apply to default label (configure here = always apply)
+    // only works with html labels (see MxGraphConfigurator to enable html labels)
+    // style[this.mxConstants.STYLE_OVERFLOW] = 'hidden'; // enable clipping
+    style[this.mxConstants.STYLE_WHITE_SPACE] = 'wrap'; // wrap for html labels
   }
 
   private configureSequenceFlowsStyle(): void {

--- a/src/component/mxgraph/StyleConfigurator.ts
+++ b/src/component/mxgraph/StyleConfigurator.ts
@@ -96,6 +96,10 @@ export default class StyleConfigurator {
     const style = this.getDefaultVertexStyle();
     this.configureCommonDefaultStyle(style);
 
+    // label bounds are provided from the top left
+    style[this.mxConstants.STYLE_VERTICAL_ALIGN] = this.mxConstants.ALIGN_TOP;
+    style[this.mxConstants.STYLE_ALIGN] = this.mxConstants.ALIGN_LEFT;
+
     // only works with html labels (see MxGraphConfigurator to enable html labels)
     // style[this.mxConstants.STYLE_OVERFLOW] = 'hidden'; // enable clipping
     // style[this.mxConstants.STYLE_WHITE_SPACE] = 'wrap'; // wrap for html labels
@@ -104,7 +108,8 @@ export default class StyleConfigurator {
   private configurePoolStyle(): void {
     const style = this.cloneDefaultVertexStyle();
     style[this.mxConstants.STYLE_SHAPE] = this.mxConstants.SHAPE_SWIMLANE;
-    style[this.mxConstants.STYLE_VERTICAL_ALIGN] = 'middle';
+    style[this.mxConstants.STYLE_VERTICAL_ALIGN] = 'middle'; // TODO use constant
+    style[this.mxConstants.STYLE_ALIGN] = this.mxConstants.ALIGN_CENTER;
     style[this.mxConstants.STYLE_HORIZONTAL] = false;
     style[this.mxConstants.STYLE_FILLCOLOR] = '#d3d2d1';
 
@@ -118,7 +123,8 @@ export default class StyleConfigurator {
   private configureLaneStyle(): void {
     const style = this.cloneDefaultVertexStyle();
     style[this.mxConstants.STYLE_SHAPE] = this.mxConstants.SHAPE_SWIMLANE;
-    style[this.mxConstants.STYLE_VERTICAL_ALIGN] = 'middle';
+    style[this.mxConstants.STYLE_VERTICAL_ALIGN] = 'middle'; // TODO use constant
+    style[this.mxConstants.STYLE_ALIGN] = this.mxConstants.ALIGN_CENTER;
     style[this.mxConstants.STYLE_HORIZONTAL] = false;
     style[this.mxConstants.STYLE_SWIMLANE_LINE] = 0; // hide the line between the title region and the content area
 
@@ -130,7 +136,7 @@ export default class StyleConfigurator {
       const style = this.cloneDefaultVertexStyle();
       style[this.mxConstants.STYLE_SHAPE] = kind;
       style[this.mxConstants.STYLE_PERIMETER] = this.mxPerimeter.EllipsePerimeter;
-      style[this.mxConstants.STYLE_VERTICAL_LABEL_POSITION] = 'bottom';
+      // style[this.mxConstants.STYLE_VERTICAL_LABEL_POSITION] = 'bottom';
       this.putCellStyle(kind, style);
     });
   }
@@ -144,7 +150,7 @@ export default class StyleConfigurator {
     ShapeUtil.taskKinds().forEach(kind => {
       const style = this.cloneDefaultVertexStyle();
       style[this.mxConstants.STYLE_SHAPE] = kind;
-      style[this.mxConstants.STYLE_VERTICAL_ALIGN] = 'middle';
+      // style[this.mxConstants.STYLE_VERTICAL_ALIGN] = 'middle';
       this.putCellStyle(kind, style);
     });
   }
@@ -153,7 +159,7 @@ export default class StyleConfigurator {
     const style = this.cloneDefaultVertexStyle();
     style[this.mxConstants.STYLE_SHAPE] = this.mxConstants.SHAPE_RECTANGLE;
     style[this.mxConstants.STYLE_PERIMETER] = this.mxPerimeter.RectanglePerimeter;
-    style[this.mxConstants.STYLE_VERTICAL_ALIGN] = 'middle';
+    // style[this.mxConstants.STYLE_VERTICAL_ALIGN] = 'middle';
     style[this.mxConstants.STYLE_STROKECOLOR] = '#2C6DA3';
     style[this.mxConstants.STYLE_STROKEWIDTH] = 4;
     style[this.mxConstants.STYLE_ROUNDED] = true;
@@ -165,12 +171,12 @@ export default class StyleConfigurator {
       const style = this.cloneDefaultVertexStyle();
       style[this.mxConstants.STYLE_SHAPE] = kind;
       style[this.mxConstants.STYLE_PERIMETER] = this.mxPerimeter.RhombusPerimeter;
-      style[this.mxConstants.STYLE_VERTICAL_ALIGN] = 'top';
+      // style[this.mxConstants.STYLE_VERTICAL_ALIGN] = 'top';
 
-      // TODO to be removed when supporting label position
-      // left just to not break current rendering
-      style[this.mxConstants.STYLE_SPACING_TOP] = 55;
-      style[this.mxConstants.STYLE_SPACING_RIGHT] = 110;
+      // // TODO to be removed when supporting label position
+      // // left just to not break current rendering
+      // style[this.mxConstants.STYLE_SPACING_TOP] = 55;
+      // style[this.mxConstants.STYLE_SPACING_RIGHT] = 110;
 
       this.putCellStyle(kind, style);
     });

--- a/src/model/bpmn/shape/ShapeUtil.ts
+++ b/src/model/bpmn/shape/ShapeUtil.ts
@@ -80,4 +80,8 @@ export default class ShapeUtil {
       return kind != ShapeBpmnElementKind.LANE;
     });
   }
+
+  public static isPoolOrLane(kind: ShapeBpmnElementKind): boolean {
+    return kind == ShapeBpmnElementKind.POOL || kind == ShapeBpmnElementKind.LANE;
+  }
 }


### PR DESCRIPTION
:heavy_check_mark: POC completed

Relates to #279 and #280 
Depends on #286 

**Done**
- vertex label: position with mxgraph mxgeometry offset, using BPMN label
- edge label: position with mxgraph mxgeometry set to absolute, offset computed from the 'center' of the edge, see https://github.com/process-analytics/bpmn-visualization-js/pull/291#issuecomment-642024601
- all labels: default position (as in previous implementation) when no BPMN label
- like for #290, label rendering adjustments for migw test suite diagrams


**Limitations**
- how to configure the vertex label bounds height? But is this an issue? would only be required for clipping
- currently, labels are not placed exactly at the rigth place: https://github.com/process-analytics/bpmn-visualization-js/pull/291#issuecomment-644059011
- as for #290
  - does not manage pool/lane nor vertical elements
  - html labels activated for wrapping

**Notes**
- some experiments done here are derived from https://github.com/jgraph/mxgraph2/blob/mxgraph-4_1_1/javascript/examples/labels.html available live at https://jgraph.github.io/mxgraph/javascript/examples/labels.html
