### PR TITLE
[FEAT] Display Interrupting Message Intermediate Event Attached to an Activity Boundary

### DIFF
--- a/docs/bpmn-support.adoc
+++ b/docs/bpmn-support.adoc
@@ -144,7 +144,7 @@ The default rendering uses `white` as fill color and `black` as stroke color.
 |Rendering
 |Comments
 
-|
+|Timer Interrupting Boundary Event
 |
 |
 

--- a/docs/bpmn-support.adoc
+++ b/docs/bpmn-support.adoc
@@ -135,6 +135,26 @@ The default rendering uses `white` as fill color and `black` as stroke color.
 |The stroke & icon width may be adjusted
 |===
 
+[cols="1,1,4", options="header"]
+.Boundary Events
+|===
+|Name
+|Rendering
+|Comments
+
+|Timer Non-interrupting Boundary Event
+|
+|
+
+|Message Interrupting Boundary Event
+|
+|
+
+|Message Non-interrupting Boundary Event
+|
+|
+|===
+
 
 [cols="1,1,4", options="header"]
 .End Events

--- a/docs/bpmn-support.adoc
+++ b/docs/bpmn-support.adoc
@@ -119,6 +119,7 @@ The default rendering uses `white` as fill color and `black` as stroke color.
 |The stroke & icon width may be adjusted
 |===
 
+
 [cols="1,1,4", options="header"]
 .Intermediate Throw Events
 |===
@@ -135,18 +136,32 @@ The default rendering uses `white` as fill color and `black` as stroke color.
 |The stroke & icon width may be adjusted
 |===
 
+
 [cols="1,1,4", options="header"]
-.Boundary Events
+.Interrupting Boundary Events
+|===
+|Name
+|Rendering
+|Comments
+
+|
+|
+|
+
+|Message Interrupting Boundary Event
+|
+|
+|===
+
+
+[cols="1,1,4", options="header"]
+.Non-interrupting Boundary Events
 |===
 |Name
 |Rendering
 |Comments
 
 |Timer Non-interrupting Boundary Event
-|
-|
-
-|Message Interrupting Boundary Event
 |
 |
 

--- a/src/component/mxgraph/MxGraphConfigurator.ts
+++ b/src/component/mxgraph/MxGraphConfigurator.ts
@@ -50,5 +50,9 @@ export default class MxGraphConfigurator {
     this.graph.setEdgeLabelsMovable(false);
 
     this.graph.setHtmlLabels(true); // required for wrapping
+
+    // To have the boundary event on the border of a task
+    this.graph.setConstrainChildren(false);
+    this.graph.setExtendParents(false);
   }
 }

--- a/src/component/mxgraph/MxGraphRenderer.ts
+++ b/src/component/mxgraph/MxGraphRenderer.ts
@@ -95,7 +95,7 @@ export default class MxGraphRenderer {
     }
 
     const bpmnElement = bpmnCell.bpmnElement;
-    if (bpmnElement instanceof ShapeBpmnEvent || bpmnElement instanceof ShapeBpmnBoundaryEvent) {
+    if (bpmnElement instanceof ShapeBpmnEvent) {
       styleValues.set(StyleConstant.BPMN_STYLE_EVENT_KIND, bpmnElement.eventKind);
     }
 

--- a/src/component/mxgraph/MxGraphRenderer.ts
+++ b/src/component/mxgraph/MxGraphRenderer.ts
@@ -25,7 +25,6 @@ import { Font } from '../../model/bpmn/Label';
 import Bounds from '../../model/bpmn/Bounds';
 import ShapeUtil from '../../model/bpmn/shape/ShapeUtil';
 import CoordinatesTranslator from './extension/CoordinatesTranslator';
-import { ShapeBpmnElementKind } from '../../model/bpmn/shape/ShapeBpmnElementKind';
 
 export default class MxGraphRenderer {
   private mxConstants: typeof mxgraph.mxConstants = MxGraphFactoryService.getMxGraphProperty('mxConstants');
@@ -60,7 +59,7 @@ export default class MxGraphRenderer {
       return bpmnElementParent;
     }
 
-    if (bpmnElement.kind !== ShapeBpmnElementKind.EVENT_BOUNDARY) {
+    if (!ShapeUtil.isBoundaryEvent(bpmnElement.kind)) {
       return this.graph.getDefaultParent();
     }
   }

--- a/src/component/mxgraph/MxGraphRenderer.ts
+++ b/src/component/mxgraph/MxGraphRenderer.ts
@@ -90,6 +90,10 @@ export default class MxGraphRenderer {
       styleValues.set(StyleConstant.BPMN_STYLE_EVENT_KIND, bpmnElement.eventKind);
     }
 
+    if (bpmnElement instanceof ShapeBpmnBoundaryEvent) {
+      styleValues.set(StyleConstant.BPMN_STYLE_IS_INTERRUPTING, bpmnElement.isInterrupting);
+    }
+
     if (bpmnCell instanceof Shape && labelBounds) {
       // arbitrarily increase width to relax too small bounds (for instance for reference diagrams from miwg-test-suite)
       styleValues.set(this.mxConstants.STYLE_LABEL_WIDTH, labelBounds.width + 1);

--- a/src/component/mxgraph/MxGraphRenderer.ts
+++ b/src/component/mxgraph/MxGraphRenderer.ts
@@ -85,7 +85,7 @@ export default class MxGraphRenderer {
   }
 
   computeStyle(bpmnCell: Shape | Edge, labelBounds?: Bounds): string {
-    const styleValues = new Map<string, string | number>();
+    const styleValues = new Map<string, string | number | boolean>();
 
     const font = bpmnCell.label?.font;
     if (font) {

--- a/src/component/mxgraph/MxGraphRenderer.ts
+++ b/src/component/mxgraph/MxGraphRenderer.ts
@@ -85,7 +85,7 @@ export default class MxGraphRenderer {
   }
 
   computeStyle(bpmnCell: Shape | Edge, labelBounds?: Bounds): string {
-    const styleValues = new Map<string, string | number | boolean>();
+    const styleValues = new Map<string, string | number>();
 
     const font = bpmnCell.label?.font;
     if (font) {
@@ -100,7 +100,7 @@ export default class MxGraphRenderer {
     }
 
     if (bpmnElement instanceof ShapeBpmnBoundaryEvent) {
-      styleValues.set(StyleConstant.BPMN_STYLE_IS_INTERRUPTING, bpmnElement.isInterrupting);
+      styleValues.set(StyleConstant.BPMN_STYLE_IS_INTERRUPTING, String(bpmnElement.isInterrupting));
     }
 
     if (bpmnCell instanceof Shape && labelBounds) {

--- a/src/component/mxgraph/MxGraphRenderer.ts
+++ b/src/component/mxgraph/MxGraphRenderer.ts
@@ -17,7 +17,7 @@ import { mxgraph } from 'ts-mxgraph';
 import Shape from '../../model/bpmn/shape/Shape';
 import Edge from '../../model/bpmn/edge/Edge';
 import BpmnModel from '../../model/bpmn/BpmnModel';
-import ShapeBpmnElement, { ShapeBpmnEvent } from '../../model/bpmn/shape/ShapeBpmnElement';
+import ShapeBpmnElement, { ShapeBpmnBoundaryEvent, ShapeBpmnEvent } from '../../model/bpmn/shape/ShapeBpmnElement';
 import { MxGraphFactoryService } from '../../service/MxGraphFactoryService';
 import Waypoint from '../../model/bpmn/edge/Waypoint';
 import { StyleConstant } from './StyleUtils';
@@ -86,7 +86,7 @@ export default class MxGraphRenderer {
     }
 
     const bpmnElement = bpmnCell.bpmnElement;
-    if (bpmnElement instanceof ShapeBpmnEvent) {
+    if (bpmnElement instanceof ShapeBpmnEvent || bpmnElement instanceof ShapeBpmnBoundaryEvent) {
       styleValues.set(StyleConstant.BPMN_STYLE_EVENT_KIND, bpmnElement.eventKind);
     }
 

--- a/src/component/mxgraph/MxGraphRenderer.ts
+++ b/src/component/mxgraph/MxGraphRenderer.ts
@@ -69,18 +69,18 @@ export default class MxGraphRenderer {
     const bpmnElement = shape.bpmnElement;
     if (bpmnElement) {
       const parent = this.getParent(bpmnElement);
-      if (parent) {
-        const bounds = shape.bounds;
-        let labelBounds = shape.label?.bounds;
-        // pool/lane label bounds are not managed for now (use hard coded values)
-        labelBounds = ShapeUtil.isPoolOrLane(bpmnElement.kind) ? undefined : labelBounds;
-        const style = this.computeStyle(shape, labelBounds);
-
-        this.insertVertex(parent, bpmnElement.id, bpmnElement.name, bounds, labelBounds, style);
-      } else {
+      if (!parent) {
         // TODO error management
         console.warn('Not possible to insert shape %s: parent cell %s is not found', bpmnElement.id, bpmnElement.parentId);
+        return;
       }
+      const bounds = shape.bounds;
+      let labelBounds = shape.label?.bounds;
+      // pool/lane label bounds are not managed for now (use hard coded values)
+      labelBounds = ShapeUtil.isPoolOrLane(bpmnElement.kind) ? undefined : labelBounds;
+      const style = this.computeStyle(shape, labelBounds);
+
+      this.insertVertex(parent, bpmnElement.id, bpmnElement.name, bounds, labelBounds, style);
     }
   }
 

--- a/src/component/mxgraph/ShapeConfigurator.ts
+++ b/src/component/mxgraph/ShapeConfigurator.ts
@@ -16,7 +16,7 @@
 import { MxGraphFactoryService } from '../../service/MxGraphFactoryService';
 import { mxgraph } from 'ts-mxgraph';
 import { ShapeBpmnElementKind } from '../../model/bpmn/shape/ShapeBpmnElementKind';
-import { EndEventShape, StartEventShape, ThrowIntermediateEventShape, CatchIntermediateEventShape } from './shape/event-shapes';
+import { EndEventShape, StartEventShape, ThrowIntermediateEventShape, CatchIntermediateEventShape, BoundaryEventShape } from './shape/event-shapes';
 import { ExclusiveGatewayShape, ParallelGatewayShape, InclusiveGatewayShape } from './shape/gateway-shapes';
 import { ReceiveTaskShape, ServiceTaskShape, TaskShape, UserTaskShape } from './shape/task-shapes';
 
@@ -36,6 +36,7 @@ export default class ShapeConfigurator {
     this.mxCellRenderer.registerShape(ShapeBpmnElementKind.EVENT_START, StartEventShape);
     this.mxCellRenderer.registerShape(ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW, ThrowIntermediateEventShape);
     this.mxCellRenderer.registerShape(ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH, CatchIntermediateEventShape);
+    this.mxCellRenderer.registerShape(ShapeBpmnElementKind.EVENT_BOUNDARY, BoundaryEventShape);
     // gateways
     this.mxCellRenderer.registerShape(ShapeBpmnElementKind.GATEWAY_EXCLUSIVE, ExclusiveGatewayShape);
     this.mxCellRenderer.registerShape(ShapeBpmnElementKind.GATEWAY_INCLUSIVE, InclusiveGatewayShape);

--- a/src/component/mxgraph/StyleUtils.ts
+++ b/src/component/mxgraph/StyleUtils.ts
@@ -53,4 +53,8 @@ export default class StyleUtils {
   public static getBpmnEventKind(style: any): ShapeBpmnEventKind {
     return mxUtils.getValue(style, StyleConstant.BPMN_STYLE_EVENT_KIND, ShapeBpmnEventKind.NONE);
   }
+
+  public static getBpmnIsInterrupting(style: any): string {
+    return mxUtils.getValue(style, StyleConstant.BPMN_STYLE_IS_INTERRUPTING, undefined);
+  }
 }

--- a/src/component/mxgraph/StyleUtils.ts
+++ b/src/component/mxgraph/StyleUtils.ts
@@ -24,6 +24,7 @@ export enum StyleConstant {
   STROKE_WIDTH_THIN = 2,
   STROKE_WIDTH_THICK = 5,
   BPMN_STYLE_EVENT_KIND = 'bpmn.eventKind',
+  BPMN_STYLE_IS_INTERRUPTING = 'bpmn.isInterrupting',
   DEFAULT_FILL_COLOR = 'White',
   DEFAULT_STROKE_COLOR = 'Black',
   DEFAULT_FONT_FAMILY = 'Arial, Helvetica, sans-serif', // define our own to not depend on eventual mxGraph default change

--- a/src/component/mxgraph/shape/event-shapes.ts
+++ b/src/component/mxgraph/shape/event-shapes.ts
@@ -105,3 +105,20 @@ export class ThrowIntermediateEventShape extends IntermediateEventShape {
     this.withFilledIcon = true;
   }
 }
+
+export class BoundaryEventShape extends IntermediateEventShape {
+  public constructor(bounds: mxgraph.mxRectangle, fill: string, stroke: string, strokewidth?: number) {
+    super(bounds, fill, stroke, strokewidth);
+  }
+
+  protected paintOuterShape(paintParameter: PaintParameter): void {
+    const isInterrupting = StyleUtils.getBpmnIsInterrupting(this.style);
+    if (isInterrupting === 'true' || isInterrupting === undefined) {
+      paintParameter.c.setFillColor('yellow');
+    } else if (isInterrupting === 'false') {
+      paintParameter.c.setFillColor('LightPink');
+    }
+
+    super.paintOuterShape(paintParameter);
+  }
+}

--- a/src/component/parser/json/converter/ProcessConverter.ts
+++ b/src/component/parser/json/converter/ProcessConverter.ts
@@ -15,12 +15,12 @@
  */
 import { JsonConverter } from 'json2typescript';
 import { AbstractConverter, ensureIsArray } from './AbstractConverter';
-import ShapeBpmnElement, { BpmnEventKind, ShapeBpmnBoundaryEvent, ShapeBpmnEvent } from '../../../../model/bpmn/shape/ShapeBpmnElement';
+import ShapeBpmnElement, { ShapeBpmnBoundaryEvent, ShapeBpmnEvent } from '../../../../model/bpmn/shape/ShapeBpmnElement';
 import { ShapeBpmnElementKind } from '../../../../model/bpmn/shape/ShapeBpmnElementKind';
 import { Process } from '../Definitions';
 import SequenceFlow from '../../../../model/bpmn/edge/SequenceFlow';
 import { ShapeBpmnEventKind, supportedBpmnEventKinds } from '../../../../model/bpmn/shape/ShapeBpmnEventKind';
-import ShapeUtil from '../../../../model/bpmn/shape/ShapeUtil';
+import ShapeUtil, { BpmnEventKind } from '../../../../model/bpmn/shape/ShapeUtil';
 import { SequenceFlowKind } from '../../../../model/bpmn/edge/SequenceFlowKind';
 
 const convertedFlowNodeBpmnElements: ShapeBpmnElement[] = [];

--- a/src/component/parser/json/converter/ProcessConverter.ts
+++ b/src/component/parser/json/converter/ProcessConverter.ts
@@ -15,7 +15,7 @@
  */
 import { JsonConverter } from 'json2typescript';
 import { AbstractConverter, ensureIsArray } from './AbstractConverter';
-import ShapeBpmnElement, { ShapeBpmnBoundaryEvent, ShapeBpmnEvent } from '../../../../model/bpmn/shape/ShapeBpmnElement';
+import ShapeBpmnElement, { BpmnEventKind, ShapeBpmnBoundaryEvent, ShapeBpmnEvent } from '../../../../model/bpmn/shape/ShapeBpmnElement';
 import { ShapeBpmnElementKind } from '../../../../model/bpmn/shape/ShapeBpmnElementKind';
 import { Process } from '../Definitions';
 import SequenceFlow from '../../../../model/bpmn/edge/SequenceFlow';
@@ -97,7 +97,7 @@ export default class ProcessConverter extends AbstractConverter<Process> {
       let shapeBpmnElement;
 
       if (ShapeUtil.isEvent(kind)) {
-        shapeBpmnElement = this.buildShapeBpmnEvent(bpmnElement, kind, processId);
+        shapeBpmnElement = this.buildShapeBpmnEvent(bpmnElement, kind as BpmnEventKind, processId);
       } else {
         shapeBpmnElement = new ShapeBpmnElement(bpmnElement.id, bpmnElement.name, kind, processId, bpmnElement.instantiate);
 
@@ -113,7 +113,7 @@ export default class ProcessConverter extends AbstractConverter<Process> {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private buildShapeBpmnEvent(bpmnElement: any, elementKind: ShapeBpmnElementKind, processId: string): ShapeBpmnEvent {
+  private buildShapeBpmnEvent(bpmnElement: any, elementKind: BpmnEventKind, processId: string): ShapeBpmnEvent {
     const eventDefinitions = this.getEventDefinitions(bpmnElement);
     const numberOfEventDefinitions = eventDefinitions.map(eventDefinition => eventDefinition.counter).reduce((counter, it) => counter + it, 0);
 

--- a/src/component/parser/json/converter/ProcessConverter.ts
+++ b/src/component/parser/json/converter/ProcessConverter.ts
@@ -118,7 +118,7 @@ export default class ProcessConverter extends AbstractConverter<Process> {
     const numberOfEventDefinitions = eventDefinitions.map(eventDefinition => eventDefinition.counter).reduce((counter, it) => counter + it, 0);
 
     // do we have a None Event?
-    if (numberOfEventDefinitions == 0 && ShapeUtil.isWithNoneEvent(elementKind)) {
+    if (numberOfEventDefinitions == 0 && ShapeUtil.canHaveNoneEvent(elementKind)) {
       return new ShapeBpmnEvent(bpmnElement.id, bpmnElement.name, elementKind, ShapeBpmnEventKind.NONE, processId);
     }
 
@@ -126,7 +126,7 @@ export default class ProcessConverter extends AbstractConverter<Process> {
       const eventKind = eventDefinitions[0].kind;
       if (supportedBpmnEventKinds.includes(eventKind)) {
         if (ShapeUtil.isBoundaryEvent(elementKind)) {
-          return new ShapeBpmnBoundaryEvent(bpmnElement.id, bpmnElement.name, eventKind, bpmnElement.attachedToRef, bpmnElement.cancelActivity, processId);
+          return new ShapeBpmnBoundaryEvent(bpmnElement.id, bpmnElement.name, eventKind, bpmnElement.attachedToRef, bpmnElement.cancelActivity);
         }
         return new ShapeBpmnEvent(bpmnElement.id, bpmnElement.name, elementKind, eventKind, processId);
       }
@@ -173,7 +173,9 @@ export default class ProcessConverter extends AbstractConverter<Process> {
       const shapeBpmnElement = findFlowNodeBpmnElement(flowNodeRef);
       const laneId = lane.id;
       if (shapeBpmnElement) {
-        shapeBpmnElement.parentId = laneId;
+        if (!ShapeUtil.isBoundaryEvent(shapeBpmnElement.kind)) {
+          shapeBpmnElement.parentId = laneId;
+        }
       } else {
         // TODO error management
         console.warn('Unable to assign lane %s as parent: flow node %s is not found', laneId, flowNodeRef);

--- a/src/component/parser/json/converter/ProcessConverter.ts
+++ b/src/component/parser/json/converter/ProcessConverter.ts
@@ -126,7 +126,7 @@ export default class ProcessConverter extends AbstractConverter<Process> {
       const eventKind = eventDefinitions[0].kind;
       if (supportedBpmnEventKinds.includes(eventKind)) {
         if (ShapeUtil.isBoundaryEvent(elementKind)) {
-          return new ShapeBpmnBoundaryEvent(bpmnElement.id, bpmnElement.name, elementKind, eventKind, bpmnElement.attachedToRef, bpmnElement.cancelActivity, processId);
+          return new ShapeBpmnBoundaryEvent(bpmnElement.id, bpmnElement.name, eventKind, bpmnElement.attachedToRef, bpmnElement.cancelActivity, processId);
         }
         return new ShapeBpmnEvent(bpmnElement.id, bpmnElement.name, elementKind, eventKind, processId);
       }

--- a/src/model/bpmn/shape/ShapeBpmnElement.ts
+++ b/src/model/bpmn/shape/ShapeBpmnElement.ts
@@ -30,13 +30,12 @@ export class ShapeBpmnBoundaryEvent extends ShapeBpmnEvent {
   constructor(
     readonly id: string,
     readonly name: string,
-    readonly elementKind: ShapeBpmnElementKind,
     readonly eventKind: ShapeBpmnEventKind,
     readonly attachedToRef: string,
     readonly isInterrupting: boolean = true,
     parentId?: string,
   ) {
-    super(id, name, elementKind, eventKind, parentId);
+    super(id, name, ShapeBpmnElementKind.EVENT_BOUNDARY, eventKind, parentId);
   }
 }
 

--- a/src/model/bpmn/shape/ShapeBpmnElement.ts
+++ b/src/model/bpmn/shape/ShapeBpmnElement.ts
@@ -21,19 +21,13 @@ export default class ShapeBpmnElement {
 }
 
 export class ShapeBpmnEvent extends ShapeBpmnElement {
-  constructor(readonly id: string, readonly name: string, readonly elementKind: ShapeBpmnElementKind, readonly eventKind: ShapeBpmnEventKind, parentId?: string) {
+  constructor(id: string, name: string, elementKind: ShapeBpmnElementKind, readonly eventKind: ShapeBpmnEventKind, parentId: string) {
     super(id, name, elementKind, parentId);
   }
 }
 
 export class ShapeBpmnBoundaryEvent extends ShapeBpmnEvent {
-  constructor(
-    readonly id: string,
-    readonly name: string,
-    readonly eventKind: ShapeBpmnEventKind,
-    readonly parentId: string,
-    readonly isInterrupting: boolean = true,
-  ) {
+  constructor(id: string, name: string, eventKind: ShapeBpmnEventKind, parentId: string, readonly isInterrupting: boolean = true) {
     super(id, name, ShapeBpmnElementKind.EVENT_BOUNDARY, eventKind, parentId);
   }
 }

--- a/src/model/bpmn/shape/ShapeBpmnElement.ts
+++ b/src/model/bpmn/shape/ShapeBpmnElement.ts
@@ -20,8 +20,14 @@ export default class ShapeBpmnElement {
   constructor(readonly id: string, readonly name: string, readonly kind: ShapeBpmnElementKind, public parentId?: string, readonly instantiate: boolean = false) {}
 }
 
+export type BpmnEventKind =
+  | ShapeBpmnElementKind.EVENT_BOUNDARY
+  | ShapeBpmnElementKind.EVENT_START
+  | ShapeBpmnElementKind.EVENT_END
+  | ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW
+  | ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH;
 export class ShapeBpmnEvent extends ShapeBpmnElement {
-  constructor(id: string, name: string, elementKind: ShapeBpmnElementKind, readonly eventKind: ShapeBpmnEventKind, parentId: string) {
+  constructor(id: string, name: string, elementKind: BpmnEventKind, readonly eventKind: ShapeBpmnEventKind, parentId: string) {
     super(id, name, elementKind, parentId);
   }
 }

--- a/src/model/bpmn/shape/ShapeBpmnElement.ts
+++ b/src/model/bpmn/shape/ShapeBpmnElement.ts
@@ -31,9 +31,8 @@ export class ShapeBpmnBoundaryEvent extends ShapeBpmnEvent {
     readonly id: string,
     readonly name: string,
     readonly eventKind: ShapeBpmnEventKind,
-    readonly attachedToRef: string,
+    readonly parentId: string,
     readonly isInterrupting: boolean = true,
-    parentId?: string,
   ) {
     super(id, name, ShapeBpmnElementKind.EVENT_BOUNDARY, eventKind, parentId);
   }

--- a/src/model/bpmn/shape/ShapeBpmnElement.ts
+++ b/src/model/bpmn/shape/ShapeBpmnElement.ts
@@ -15,17 +15,12 @@
  */
 import { ShapeBpmnElementKind } from './ShapeBpmnElementKind';
 import { ShapeBpmnEventKind } from './ShapeBpmnEventKind';
+import { BpmnEventKind } from './ShapeUtil';
 
 export default class ShapeBpmnElement {
   constructor(readonly id: string, readonly name: string, readonly kind: ShapeBpmnElementKind, public parentId?: string, readonly instantiate: boolean = false) {}
 }
 
-export type BpmnEventKind =
-  | ShapeBpmnElementKind.EVENT_BOUNDARY
-  | ShapeBpmnElementKind.EVENT_START
-  | ShapeBpmnElementKind.EVENT_END
-  | ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW
-  | ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH;
 export class ShapeBpmnEvent extends ShapeBpmnElement {
   constructor(id: string, name: string, elementKind: BpmnEventKind, readonly eventKind: ShapeBpmnEventKind, parentId: string) {
     super(id, name, elementKind, parentId);

--- a/src/model/bpmn/shape/ShapeBpmnElement.ts
+++ b/src/model/bpmn/shape/ShapeBpmnElement.ts
@@ -21,8 +21,22 @@ export default class ShapeBpmnElement {
 }
 
 export class ShapeBpmnEvent extends ShapeBpmnElement {
-  constructor(id: string, name: string, elementKind: ShapeBpmnElementKind, readonly eventKind: ShapeBpmnEventKind, parentId?: string) {
+  constructor(readonly id: string, readonly name: string, readonly elementKind: ShapeBpmnElementKind, readonly eventKind: ShapeBpmnEventKind, parentId?: string) {
     super(id, name, elementKind, parentId);
+  }
+}
+
+export class ShapeBpmnBoundaryEvent extends ShapeBpmnEvent {
+  constructor(
+    readonly id: string,
+    readonly name: string,
+    readonly elementKind: ShapeBpmnElementKind,
+    readonly eventKind: ShapeBpmnEventKind,
+    readonly attachedToRef: string,
+    readonly isInterrupting: boolean = true,
+    parentId?: string,
+  ) {
+    super(id, name, elementKind, eventKind, parentId);
   }
 }
 

--- a/src/model/bpmn/shape/ShapeBpmnElementKind.ts
+++ b/src/model/bpmn/shape/ShapeBpmnElementKind.ts
@@ -53,6 +53,7 @@ export enum ShapeBpmnElementKind {
   EVENT_END = 'endEvent',
   EVENT_INTERMEDIATE_CATCH = 'intermediateCatchEvent',
   EVENT_INTERMEDIATE_THROW = 'intermediateThrowEvent',
+  EVENT_BOUNDARY = 'boundaryEvent',
 
   CALL_ACTIVITY = 'callActivity',
 

--- a/src/model/bpmn/shape/ShapeUtil.ts
+++ b/src/model/bpmn/shape/ShapeUtil.ts
@@ -53,6 +53,14 @@ export default class ShapeUtil {
     return this.EVENT_KINDS.includes(kind);
   }
 
+  public static isBoundaryEvent(kind: ShapeBpmnElementKind): boolean {
+    return ShapeBpmnElementKind.EVENT_BOUNDARY === kind;
+  }
+
+  public static isWithNoneEvent(kind: ShapeBpmnElementKind): boolean {
+    return ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW === kind || ShapeBpmnElementKind.EVENT_END === kind || ShapeBpmnElementKind.EVENT_START === kind;
+  }
+
   public static isActivity(kind: ShapeBpmnElementKind): boolean {
     return this.ACTIVITY_KINDS.includes(kind);
   }

--- a/src/model/bpmn/shape/ShapeUtil.ts
+++ b/src/model/bpmn/shape/ShapeUtil.ts
@@ -57,7 +57,7 @@ export default class ShapeUtil {
     return ShapeBpmnElementKind.EVENT_BOUNDARY === kind;
   }
 
-  public static isWithNoneEvent(kind: ShapeBpmnElementKind): boolean {
+  public static canHaveNoneEvent(kind: ShapeBpmnElementKind): boolean {
     return ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW === kind || ShapeBpmnElementKind.EVENT_END === kind || ShapeBpmnElementKind.EVENT_START === kind;
   }
 

--- a/src/model/bpmn/shape/ShapeUtil.ts
+++ b/src/model/bpmn/shape/ShapeUtil.ts
@@ -15,6 +15,13 @@
  */
 import { ShapeBpmnElementKind } from './ShapeBpmnElementKind';
 
+export type BpmnEventKind =
+  | ShapeBpmnElementKind.EVENT_BOUNDARY
+  | ShapeBpmnElementKind.EVENT_START
+  | ShapeBpmnElementKind.EVENT_END
+  | ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW
+  | ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH;
+
 // TODO move to ShapeBpmnElementKind? and rename into ShapeBpmnElementKindUtil?
 // TODO bpmnEventKinds currently hosted in ProcessConverter may be hosted here
 export default class ShapeUtil {

--- a/test/e2e/mxGraph.model.test.ts
+++ b/test/e2e/mxGraph.model.test.ts
@@ -260,6 +260,11 @@ describe('mxGraph model', () => {
     }
   }
 
+  function expectModelNotContainCell(cellId: string): void {
+    const cell = bpmnVisu.graph.model.getCell(cellId);
+    expect(cell).toBeUndefined();
+  }
+
   function expectModelContainsCell(cellId: string): mxgraph.mxCell {
     const cell = bpmnVisu.graph.model.getCell(cellId);
     expect(cell).not.toBeUndefined();
@@ -371,6 +376,32 @@ describe('mxGraph model', () => {
     expectModelContainsEdge('normal_sequence_flow_id', SequenceFlowKind.NORMAL);
     expectModelContainsEdge('conditional_sequence_flow_from_activity_id', SequenceFlowKind.CONDITIONAL_FROM_ACTIVITY, mxConstants.ARROW_DIAMOND_THIN);
     expectModelContainsEdge('conditional_sequence_flow_from_gateway_id', SequenceFlowKind.CONDITIONAL_FROM_GATEWAY);
+  });
+
+  it('bpmn elements should not be available in the mxGraph model, if they are attached to not existing elements', async () => {
+    // load BPMN
+    const xmlContent = `
+<?xml version="1.0" encoding="ISO-8859-1" standalone="yes"?>
+<semantic:definitions id="_1373649849716" name="A.1.0" targetNamespace="http://www.trisotech.com/definitions/_1373649849716" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:semantic="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <semantic:process isExecutable="false" id="WFP-6-">
+        <semantic:boundaryEvent attachedToRef="nothing" cancelActivity="true" name="Boundary Intermediate Event Interrupting Message" id="boundary_event_interrupting_message_id">
+            <semantic:messageEventDefinition/>
+        </semantic:boundaryEvent>
+    </semantic:process>
+    <bpmndi:BPMNDiagram documentation="" id="Trisotech_Visio-_6" name="A.1.0" resolution="96.00000267028808">
+        <bpmndi:BPMNPlane bpmnElement="WFP-6-">
+            <bpmndi:BPMNShape bpmnElement="boundary_event_interrupting_message_id" id="S1373649849862_boundary_event_interrupting_message_id">
+	           <dc:Bounds height="32.0" width="32.0" x="98.0" y="335.0" />
+	        </bpmndi:BPMNShape>
+        </bpmndi:BPMNPlane>
+    </bpmndi:BPMNDiagram>
+</semantic:definitions>
+`;
+    bpmnVisu.load(xmlContent);
+
+    // model is OK
+    // boundary event
+    expectModelNotContainCell('boundary_event_interrupting_message_id');
   });
 
   function expectModelContainsCellWithGeometry(cellId: string, parentId: string, geometry: mxgraph.mxGeometry): void {

--- a/test/e2e/mxGraph.model.test.ts
+++ b/test/e2e/mxGraph.model.test.ts
@@ -67,6 +67,9 @@ describe('mxGraph model', () => {
             <semantic:incoming>conditional_sequence_flow_from_activity_id</semantic:incoming>
             <semantic:outgoing>_8e8fe679-eb3b-4c43-a4d6-891e7087ff80</semantic:outgoing>
         </semantic:userTask>
+        <semantic:boundaryEvent attachedToRef="userTask_3" cancelActivity="true" name="Boundary Intermediate Event Interrupting Message" id="boundary_event_interrupting_message_id">
+            <semantic:messageEventDefinition/>
+        </semantic:boundaryEvent>
         <semantic:intermediateThrowEvent name="Throw None Intermediate Event" id="noneIntermediateThrowEvent" />
         <semantic:intermediateThrowEvent name="Throw Message Intermediate Event" id="messageIntermediateThrowEvent">
             <semantic:messageEventDefinition />
@@ -134,6 +137,9 @@ describe('mxGraph model', () => {
                     <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="527.3333333333334" y="344.5818763825664"/>
                 </bpmndi:BPMNLabel>
             </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="boundary_event_interrupting_message_id" id="S1373649849862_boundary_event_interrupting_message_id">
+	           <dc:Bounds height="32.0" width="32.0" x="98.0" y="335.0" />
+	        </bpmndi:BPMNShape>
             <bpmndi:BPMNShape bpmnElement="noneIntermediateThrowEvent" id="S1373649849862_noneIntermediateThrowEvent">
 	           <dc:Bounds height="32.0" width="32.0" x="648.0" y="336.0" />
 	           <bpmndi:BPMNLabel labelStyle="strike_through_font_id">
@@ -283,9 +289,15 @@ describe('mxGraph model', () => {
     return cell;
   }
 
-  function expectModelContainsBpmnEvent(cellId: string, shapeKind: ShapeBpmnElementKind, bpmnEventKind: ShapeBpmnEventKind, expectedFont?: ExpectedFont): void {
+  function expectModelContainsBpmnEvent(cellId: string, shapeKind: ShapeBpmnElementKind, bpmnEventKind: ShapeBpmnEventKind, expectedFont?: ExpectedFont): mxgraph.mxCell {
     const cell = expectModelContainsShape(cellId, shapeKind, expectedFont);
     expect(cell.style).toContain(`bpmn.eventKind=${bpmnEventKind}`);
+    return cell;
+  }
+
+  function expectModelContainsBpmnBoundaryEvent(cellId: string, bpmnEventKind: ShapeBpmnEventKind, isInterrupting?: boolean, expectedFont?: ExpectedFont): void {
+    const cell = expectModelContainsBpmnEvent(cellId, ShapeBpmnElementKind.EVENT_BOUNDARY, bpmnEventKind, expectedFont);
+    expect(cell.style).toContain(`bpmn.isInterrupting=${isInterrupting}`);
   }
 
   it('bpmn elements should be available in the mxGraph model', async () => {
@@ -332,6 +344,9 @@ describe('mxGraph model', () => {
     // catch intermediate event
     expectModelContainsBpmnEvent('messageIntermediateCatchEvent', ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH, ShapeBpmnEventKind.MESSAGE);
     expectModelContainsBpmnEvent('IntermediateCatchEvent_Timer_01', ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH, ShapeBpmnEventKind.TIMER);
+
+    // boundary event
+    expectModelContainsBpmnBoundaryEvent('boundary_event_interrupting_message_id', ShapeBpmnEventKind.MESSAGE, true);
 
     // activity
     expectModelContainsShape('task_1', ShapeBpmnElementKind.TASK, {

--- a/test/unit/component/mxgraph/MxGraphRenderer.test.ts
+++ b/test/unit/component/mxgraph/MxGraphRenderer.test.ts
@@ -16,7 +16,7 @@
 
 import { defaultMxGraphRenderer } from '../../../../src/component/mxgraph/MxGraphRenderer';
 import Shape from '../../../../src/model/bpmn/shape/Shape';
-import ShapeBpmnElement, { BpmnEventKind, ShapeBpmnBoundaryEvent, ShapeBpmnEvent } from '../../../../src/model/bpmn/shape/ShapeBpmnElement';
+import ShapeBpmnElement, { ShapeBpmnBoundaryEvent, ShapeBpmnEvent } from '../../../../src/model/bpmn/shape/ShapeBpmnElement';
 import { ShapeBpmnElementKind } from '../../../../src/model/bpmn/shape/ShapeBpmnElementKind';
 import Label, { Font } from '../../../../src/model/bpmn/Label';
 import { ExpectedFont } from '../parser/json/JsonTestUtils';
@@ -25,6 +25,7 @@ import SequenceFlow from '../../../../src/model/bpmn/edge/SequenceFlow';
 import { SequenceFlowKind } from '../../../../src/model/bpmn/edge/SequenceFlowKind';
 import Bounds from '../../../../src/model/bpmn/Bounds';
 import { ShapeBpmnEventKind } from '../../../../src/model/bpmn/shape/ShapeBpmnEventKind';
+import { BpmnEventKind } from '../../../../src/model/bpmn/shape/ShapeUtil';
 
 function toFont(font: ExpectedFont): Font {
   return new Font(font.name, font.size, font.isBold, font.isItalic, font.isUnderline, font.isStrikeThrough);

--- a/test/unit/component/mxgraph/MxGraphRenderer.test.ts
+++ b/test/unit/component/mxgraph/MxGraphRenderer.test.ts
@@ -16,7 +16,7 @@
 
 import { defaultMxGraphRenderer } from '../../../../src/component/mxgraph/MxGraphRenderer';
 import Shape from '../../../../src/model/bpmn/shape/Shape';
-import ShapeBpmnElement, { ShapeBpmnBoundaryEvent, ShapeBpmnEvent } from '../../../../src/model/bpmn/shape/ShapeBpmnElement';
+import ShapeBpmnElement, { BpmnEventKind, ShapeBpmnBoundaryEvent, ShapeBpmnEvent } from '../../../../src/model/bpmn/shape/ShapeBpmnElement';
 import { ShapeBpmnElementKind } from '../../../../src/model/bpmn/shape/ShapeBpmnElementKind';
 import Label, { Font } from '../../../../src/model/bpmn/Label';
 import { ExpectedFont } from '../parser/json/JsonTestUtils';
@@ -50,7 +50,7 @@ function newShapeBpmnElement(kind: ShapeBpmnElementKind): ShapeBpmnElement {
   return new ShapeBpmnElement('id', 'name', kind);
 }
 
-function newShapeBpmnEvent(bpmnElementKind: ShapeBpmnElementKind, eventKind: ShapeBpmnEventKind): ShapeBpmnEvent {
+function newShapeBpmnEvent(bpmnElementKind: BpmnEventKind, eventKind: ShapeBpmnEventKind): ShapeBpmnEvent {
   return new ShapeBpmnEvent('id', 'name', bpmnElementKind, eventKind, null);
 }
 

--- a/test/unit/component/mxgraph/MxGraphRenderer.test.ts
+++ b/test/unit/component/mxgraph/MxGraphRenderer.test.ts
@@ -16,7 +16,7 @@
 
 import { defaultMxGraphRenderer } from '../../../../src/component/mxgraph/MxGraphRenderer';
 import Shape from '../../../../src/model/bpmn/shape/Shape';
-import ShapeBpmnElement from '../../../../src/model/bpmn/shape/ShapeBpmnElement';
+import ShapeBpmnElement, { ShapeBpmnBoundaryEvent, ShapeBpmnEvent } from '../../../../src/model/bpmn/shape/ShapeBpmnElement';
 import { ShapeBpmnElementKind } from '../../../../src/model/bpmn/shape/ShapeBpmnElementKind';
 import Label, { Font } from '../../../../src/model/bpmn/Label';
 import { ExpectedFont } from '../parser/json/JsonTestUtils';
@@ -24,9 +24,22 @@ import Edge from '../../../../src/model/bpmn/edge/Edge';
 import SequenceFlow from '../../../../src/model/bpmn/edge/SequenceFlow';
 import { SequenceFlowKind } from '../../../../src/model/bpmn/edge/SequenceFlowKind';
 import Bounds from '../../../../src/model/bpmn/Bounds';
+import { ShapeBpmnEventKind } from '../../../../src/model/bpmn/shape/ShapeBpmnEventKind';
 
 function toFont(font: ExpectedFont): Font {
   return new Font(font.name, font.size, font.isBold, font.isItalic, font.isUnderline, font.isStrikeThrough);
+}
+
+function newLabel(font: ExpectedFont, bounds?: Bounds): Label {
+  return new Label(toFont(font), bounds);
+}
+
+/**
+ * Returns a new `Shape` instance with arbitrary id and `undefined` bounds.
+ * @param kind the `ShapeBpmnElementKind` to set in the new `ShapeBpmnElement` instance
+ */
+function newShape(bpmnElement: ShapeBpmnElement, label?: Label): Shape {
+  return new Shape('id', bpmnElement, undefined, label);
 }
 
 /**
@@ -35,6 +48,14 @@ function toFont(font: ExpectedFont): Font {
  */
 function newShapeBpmnElement(kind: ShapeBpmnElementKind): ShapeBpmnElement {
   return new ShapeBpmnElement('id', 'name', kind);
+}
+
+function newShapeBpmnEvent(bpmnElementKind: ShapeBpmnElementKind, eventKind: ShapeBpmnEventKind): ShapeBpmnEvent {
+  return new ShapeBpmnEvent('id', 'name', bpmnElementKind, eventKind, null);
+}
+
+function newShapeBpmnBoundaryEvent(eventKind: ShapeBpmnEventKind, isInterrupting: boolean): ShapeBpmnBoundaryEvent {
+  return new ShapeBpmnBoundaryEvent('id', 'name', eventKind, null, isInterrupting);
 }
 
 /**
@@ -116,5 +137,33 @@ describe('mxgraph renderer', () => {
   it('compute style of edge with label bounds: style kept unchanged', () => {
     const edge = new Edge('id', newSequenceFlow(SequenceFlowKind.NORMAL), undefined, new Label(toFont({ name: 'Helvetica' }), new Bounds(20, 20, 30, 120)));
     expect(computeStyle(edge)).toEqual('normal;fontFamily=Helvetica');
+  });
+
+  describe('compute style - events kind', () => {
+    it('intermediate catch conditional', () => {
+      const shape = newShape(newShapeBpmnEvent(ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH, ShapeBpmnEventKind.CONDITIONAL), newLabel({ name: 'Ubuntu' }));
+      expect(computeStyle(shape)).toEqual('intermediateCatchEvent;fontFamily=Ubuntu;bpmn.eventKind=conditional');
+    });
+
+    it('start signal', () => {
+      const shape = newShape(newShapeBpmnEvent(ShapeBpmnElementKind.EVENT_START, ShapeBpmnEventKind.SIGNAL), newLabel({ isBold: true }));
+      expect(computeStyle(shape)).toEqual('startEvent;fontStyle=1;bpmn.eventKind=signal');
+    });
+  });
+  describe('compute style - boundary events', () => {
+    it('interrupting message', () => {
+      const shape = newShape(newShapeBpmnBoundaryEvent(ShapeBpmnEventKind.MESSAGE, true), newLabel({ name: 'Arial' }));
+      expect(computeStyle(shape)).toEqual('boundaryEvent;fontFamily=Arial;bpmn.eventKind=message;bpmn.isInterrupting=true');
+    });
+
+    it('non interrupting timer', () => {
+      const shape = newShape(newShapeBpmnBoundaryEvent(ShapeBpmnEventKind.TIMER, false), newLabel({ isItalic: true }));
+      expect(computeStyle(shape)).toEqual('boundaryEvent;fontStyle=2;bpmn.eventKind=timer;bpmn.isInterrupting=false');
+    });
+
+    it('cancel with undefined interrupting value', () => {
+      const shape = newShape(newShapeBpmnBoundaryEvent(ShapeBpmnEventKind.CANCEL, undefined), newLabel({ isStrikeThrough: true }));
+      expect(computeStyle(shape)).toEqual('boundaryEvent;fontStyle=8;bpmn.eventKind=cancel;bpmn.isInterrupting=true');
+    });
   });
 });

--- a/test/unit/component/parser/json/BpmnJsonParser.event.boundary.interrupting.message.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.event.boundary.interrupting.message.test.ts
@@ -54,10 +54,11 @@ describe('parse bpmn as json for message interrupting boundary event', () => {
                 }
             }`;
 
-    const model = parseJsonAndExpectOnlyBoundaryEvent(json, ShapeBpmnEventKind.MESSAGE, 1, 'task_id_0', true);
+    const model = parseJsonAndExpectOnlyBoundaryEvent(json, ShapeBpmnEventKind.MESSAGE, 1, true);
 
     verifyShape(model.flowNodes[1], {
       shapeId: 'shape_boundaryEvent_id_0',
+      parentId: 'task_id_0',
       bpmnElementId: 'event_id_0',
       bpmnElementName: 'event name',
       bpmnElementKind: ShapeBpmnElementKind.EVENT_BOUNDARY,
@@ -106,10 +107,11 @@ describe('parse bpmn as json for message interrupting boundary event', () => {
                 }
             }`;
 
-    const model = parseJsonAndExpectOnlyBoundaryEvent(json, ShapeBpmnEventKind.MESSAGE, 1, 'task_id_0', true);
+    const model = parseJsonAndExpectOnlyBoundaryEvent(json, ShapeBpmnEventKind.MESSAGE, 1, true);
 
     verifyShape(model.flowNodes[1], {
       shapeId: 'shape_boundaryEvent_id_0',
+      parentId: 'task_id_0',
       bpmnElementId: 'event_id_0',
       bpmnElementName: 'event name',
       bpmnElementKind: ShapeBpmnElementKind.EVENT_BOUNDARY,
@@ -157,10 +159,11 @@ describe('parse bpmn as json for message interrupting boundary event', () => {
                 }
             }`;
 
-    const model = parseJsonAndExpectOnlyBoundaryEvent(json, ShapeBpmnEventKind.MESSAGE, 1, 'task_id_0', true);
+    const model = parseJsonAndExpectOnlyBoundaryEvent(json, ShapeBpmnEventKind.MESSAGE, 1, true);
 
     verifyShape(model.flowNodes[1], {
       shapeId: 'shape_boundaryEvent_id_0',
+      parentId: 'task_id_0',
       bpmnElementId: 'event_id_0',
       bpmnElementName: 'event name',
       bpmnElementKind: ShapeBpmnElementKind.EVENT_BOUNDARY,

--- a/test/unit/component/parser/json/BpmnJsonParser.event.boundary.interrupting.message.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.event.boundary.interrupting.message.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ShapeBpmnElementKind } from '../../../../../src/model/bpmn/shape/ShapeBpmnElementKind';
+import { parseJsonAndExpectOnlyBoundaryEvent, verifyShape } from './JsonTestUtils';
+import { ShapeBpmnEventKind } from '../../../../../src/model/bpmn/shape/ShapeBpmnEventKind';
+
+describe('parse bpmn as json for message interrupting boundary event', () => {
+  it('json containing one process with a message interrupting boundary event, attached to an activity, defined as empty string, message interrupting boundary event is present', () => {
+    const json = `{
+                "definitions" : {
+                    "process": {
+                        "task": {
+                            "id":"task_id_0",
+                            "name":"task name"
+                        },
+                        "boundaryEvent": {
+                            "id":"event_id_0",
+                            "name":"event name",
+                            "attachedToRef":"task_id_0",
+                            "cancelActivity":true,
+                            "messageEventDefinition": ""
+                        }
+                    },
+                    "BPMNDiagram": {
+                        "name":"process 0",
+                        "BPMNPlane": {
+                            "BPMNShape": [
+                              {
+                                  "id":"shape_task_id_0",
+                                  "bpmnElement":"task_id_0",
+                                  "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 }
+                              },
+                              {
+                                  "id":"shape_boundaryEvent_id_0",
+                                  "bpmnElement":"event_id_0",
+                                  "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 }
+                              }
+                            ]
+                        }
+                    }
+                }
+            }`;
+
+    const model = parseJsonAndExpectOnlyBoundaryEvent(json, ShapeBpmnEventKind.MESSAGE, 1, 'task_id_0', true);
+
+    verifyShape(model.flowNodes[1], {
+      shapeId: 'shape_boundaryEvent_id_0',
+      bpmnElementId: 'event_id_0',
+      bpmnElementName: 'event name',
+      bpmnElementKind: ShapeBpmnElementKind.EVENT_BOUNDARY,
+      bounds: {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    });
+  });
+
+  it('json containing one process with a message interrupting boundary event, attached to an activity, defined as object, message interrupting boundary event is present', () => {
+    const json = `{
+                "definitions" : {
+                    "process": {
+                        "task": {
+                            "id":"task_id_0",
+                            "name":"task name"
+                        },
+                        "boundaryEvent": {
+                            "id":"event_id_0",
+                            "name":"event name",
+                            "attachedToRef":"task_id_0",
+                            "cancelActivity":true,
+                            "messageEventDefinition": { "id": "messageEventDefinition_1" }
+                        }
+                    },
+                    "BPMNDiagram": {
+                        "name":"process 0",
+                        "BPMNPlane": {
+                            "BPMNShape": [
+                              {
+                                  "id":"shape_task_id_0",
+                                  "bpmnElement":"task_id_0",
+                                  "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 }
+                              },
+                              {
+                                  "id":"shape_boundaryEvent_id_0",
+                                  "bpmnElement":"event_id_0",
+                                  "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 }
+                              }
+                            ]
+                        }
+                    }
+                }
+            }`;
+
+    const model = parseJsonAndExpectOnlyBoundaryEvent(json, ShapeBpmnEventKind.MESSAGE, 1, 'task_id_0', true);
+
+    verifyShape(model.flowNodes[1], {
+      shapeId: 'shape_boundaryEvent_id_0',
+      bpmnElementId: 'event_id_0',
+      bpmnElementName: 'event name',
+      bpmnElementKind: ShapeBpmnElementKind.EVENT_BOUNDARY,
+      bounds: {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    });
+  });
+
+  it('json containing one process with a message interrupting boundary event, attached to an activity, without cancelActivity attribute, message interrupting boundary event is present', () => {
+    const json = `{
+                "definitions" : {
+                    "process": {
+                        "task": {
+                            "id":"task_id_0",
+                            "name":"task name"
+                        },
+                        "boundaryEvent": {
+                            "id":"event_id_0",
+                            "name":"event name",
+                            "attachedToRef":"task_id_0",
+                            "messageEventDefinition": ""
+                        }
+                    },
+                    "BPMNDiagram": {
+                        "name":"process 0",
+                        "BPMNPlane": {
+                            "BPMNShape": [
+                              {
+                                  "id":"shape_task_id_0",
+                                  "bpmnElement":"task_id_0",
+                                  "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 }
+                              },
+                              {
+                                  "id":"shape_boundaryEvent_id_0",
+                                  "bpmnElement":"event_id_0",
+                                  "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 }
+                              }
+                            ]
+                        }
+                    }
+                }
+            }`;
+
+    const model = parseJsonAndExpectOnlyBoundaryEvent(json, ShapeBpmnEventKind.MESSAGE, 1, 'task_id_0', true);
+
+    verifyShape(model.flowNodes[1], {
+      shapeId: 'shape_boundaryEvent_id_0',
+      bpmnElementId: 'event_id_0',
+      bpmnElementName: 'event name',
+      bpmnElementKind: ShapeBpmnElementKind.EVENT_BOUNDARY,
+      bounds: {
+        x: 362,
+        y: 232,
+        width: 36,
+        height: 45,
+      },
+    });
+  });
+
+  it('json containing one process with a interrupting boundary event, attached to an activity, with message definition and another definition, message event is NOT present', () => {
+    const json = `{
+    "definitions" : {
+        "process": {
+            "task": { "id":"task_id_0", "name":"task name" },
+            "boundaryEvent": { 
+                "id":"event_id_0", 
+                "attachedToRef":"task_id_0",
+                "cancelActivity":true,
+                "messageEventDefinition": "", 
+                "timerEventDefinition": "" 
+            }
+        },
+        "BPMNDiagram": {
+            "name":"process 0",
+            "BPMNPlane": {
+                "BPMNShape": [
+                    {
+                        "id":"shape_task_id_0",
+                        "bpmnElement":"task_id_0",
+                        "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 }
+                    },
+                    {
+                         "id":"shape_boundaryEvent_id_0",
+                         "bpmnElement":"event_id_0",
+                         "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 }
+                    }
+                ]
+            }
+        }
+    }
+}`;
+
+    parseJsonAndExpectOnlyBoundaryEvent(json, ShapeBpmnEventKind.MESSAGE, 0);
+  });
+
+  it('json containing one process with a interrupting boundary event, attached to an activity, with several message definitions, message event is NOT present', () => {
+    const json = `{
+    "definitions" : {
+        "process": {
+            "task": { "id":"task_id_0", "name":"task name" },
+            "boundaryEvent": { 
+                "id":"event_id_0", 
+                "attachedToRef":"task_id_0",
+                "cancelActivity":true,
+                "messageEventDefinition": ["", ""] 
+            }
+        },
+        "BPMNDiagram": {
+            "name":"process 0",
+            "BPMNPlane": {
+                "BPMNShape": [
+                    {
+                        "id":"shape_task_id_0",
+                        "bpmnElement":"task_id_0",
+                        "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 }
+                    },
+                    {
+                         "id":"shape_boundaryEvent_id_0",
+                         "bpmnElement":"event_id_0",
+                         "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 }
+                    }
+                ]
+            }
+        }
+    }
+}`;
+
+    parseJsonAndExpectOnlyBoundaryEvent(json, ShapeBpmnEventKind.MESSAGE, 0);
+  });
+
+  it('message interrupting boundary event cannot be attached to anything than an activity', () => {
+    const json = `{
+                "definitions" : {
+                    "process": {
+                        "startEvent": {
+                            "id":"not_task_id_0"
+                        },
+                        "boundaryEvent": {
+                            "id":"event_id_0",
+                            "name":"event name",
+                            "attachedToRef":"not_task_id_0",
+                            "messageEventDefinition": ""
+                        }
+                    },
+                    "BPMNDiagram": {
+                        "name":"process 0",
+                        "BPMNPlane": {
+                            "BPMNShape": [
+                              {
+                                  "id":"shape_task_id_0",
+                                  "bpmnElement":"task_id_0",
+                                  "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 }
+                              },
+                              {
+                                  "id":"shape_boundaryEvent_id_0",
+                                  "bpmnElement":"event_id_0",
+                                  "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 }
+                              }
+                            ]
+                        }
+                    }
+                }
+            }`;
+
+    parseJsonAndExpectOnlyBoundaryEvent(json, ShapeBpmnEventKind.MESSAGE, 0);
+  });
+});

--- a/test/unit/component/parser/json/JsonTestUtils.ts
+++ b/test/unit/component/parser/json/JsonTestUtils.ts
@@ -148,13 +148,12 @@ export function verifyEvent(model: BpmnModel, kind: ShapeBpmnEventKind, expected
   expect(events).toHaveLength(expectedNumber);
 }
 
-export function verifyBoundaryEvent(model: BpmnModel, kind: ShapeBpmnEventKind, expectedNumber: number, attachedTo: string, isInterrupting?: boolean): void {
+export function verifyBoundaryEvent(model: BpmnModel, kind: ShapeBpmnEventKind, expectedNumber: number, isInterrupting?: boolean): void {
   const events = model.flowNodes.filter(shape => {
     const bpmnElement = shape.bpmnElement;
     return (
       bpmnElement instanceof ShapeBpmnBoundaryEvent &&
       (bpmnElement as ShapeBpmnBoundaryEvent).eventKind === kind &&
-      (bpmnElement as ShapeBpmnBoundaryEvent).attachedToRef === attachedTo &&
       (bpmnElement as ShapeBpmnBoundaryEvent).isInterrupting === isInterrupting
     );
   });
@@ -203,14 +202,14 @@ export function parseJsonAndExpectOnlyEvent(json: string, kind: ShapeBpmnEventKi
   return model;
 }
 
-export function parseJsonAndExpectOnlyBoundaryEvent(json: string, kind: ShapeBpmnEventKind, expectedNumber: number, attachedTo?: string, isInterrupting?: boolean): BpmnModel {
+export function parseJsonAndExpectOnlyBoundaryEvent(json: string, kind: ShapeBpmnEventKind, expectedNumber: number, isInterrupting?: boolean): BpmnModel {
   const model = parseJson(json);
 
   expect(model.lanes).toHaveLength(0);
   expect(model.pools).toHaveLength(0);
   expect(model.edges).toHaveLength(0);
 
-  verifyBoundaryEvent(model, kind, expectedNumber, attachedTo, isInterrupting);
+  verifyBoundaryEvent(model, kind, expectedNumber, isInterrupting);
 
   return model;
 }

--- a/test/unit/component/parser/json/JsonTestUtils.ts
+++ b/test/unit/component/parser/json/JsonTestUtils.ts
@@ -19,7 +19,7 @@ import { defaultBpmnJsonParser } from '../../../../../src/component/parser/json/
 import Edge from '../../../../../src/model/bpmn/edge/Edge';
 import BpmnModel from '../../../../../src/model/bpmn/BpmnModel';
 import Waypoint from '../../../../../src/model/bpmn/edge/Waypoint';
-import { ShapeBpmnEvent } from '../../../../../src/model/bpmn/shape/ShapeBpmnElement';
+import { ShapeBpmnBoundaryEvent, ShapeBpmnEvent } from '../../../../../src/model/bpmn/shape/ShapeBpmnElement';
 import { ShapeBpmnEventKind } from '../../../../../src/model/bpmn/shape/ShapeBpmnEventKind';
 import { SequenceFlowKind } from '../../../../../src/model/bpmn/edge/SequenceFlowKind';
 import Label from '../../../../../src/model/bpmn/Label';
@@ -148,6 +148,19 @@ export function verifyEvent(model: BpmnModel, kind: ShapeBpmnEventKind, expected
   expect(events).toHaveLength(expectedNumber);
 }
 
+export function verifyBoundaryEvent(model: BpmnModel, kind: ShapeBpmnEventKind, expectedNumber: number, attachedTo: string, isInterrupting?: boolean): void {
+  const events = model.flowNodes.filter(shape => {
+    const bpmnElement = shape.bpmnElement;
+    return (
+      bpmnElement instanceof ShapeBpmnBoundaryEvent &&
+      (bpmnElement as ShapeBpmnBoundaryEvent).eventKind === kind &&
+      (bpmnElement as ShapeBpmnBoundaryEvent).attachedToRef === attachedTo &&
+      (bpmnElement as ShapeBpmnBoundaryEvent).isInterrupting === isInterrupting
+    );
+  });
+  expect(events).toHaveLength(expectedNumber);
+}
+
 export function verifyLabelFont(label: Label, expectedFont?: ExpectedFont): void {
   expect(label).toBeDefined();
 
@@ -186,6 +199,18 @@ export function parseJsonAndExpectOnlyEvent(json: string, kind: ShapeBpmnEventKi
   expect(model.edges).toHaveLength(0);
 
   verifyEvent(model, kind, expectedNumber);
+
+  return model;
+}
+
+export function parseJsonAndExpectOnlyBoundaryEvent(json: string, kind: ShapeBpmnEventKind, expectedNumber: number, attachedTo?: string, isInterrupting?: boolean): BpmnModel {
+  const model = parseJson(json);
+
+  expect(model.lanes).toHaveLength(0);
+  expect(model.pools).toHaveLength(0);
+  expect(model.edges).toHaveLength(0);
+
+  verifyBoundaryEvent(model, kind, expectedNumber, attachedTo, isInterrupting);
 
   return model;
 }


### PR DESCRIPTION
Closes #309 

### Render at 45bdc1fc7ef49a6b16a0bb10d9ca072c534e1bfd
The parent mxCell of the mxCell of the boundary event is the pool/lane.
Example with B.2.0.bpmn, the timer boundary event in the middle of the screnshot belongs to a subprocess, currently not supported. As the boundary event is attached to the parent graph, it is displayed.
<img width="1336" alt="image" src="https://user-images.githubusercontent.com/4921914/85049387-e4324f80-b194-11ea-8af5-28cbc5f91926.png">


### Render at baa079d236ea6486106d93108573cf0d3b2d6182
The parent mxCell of the mxCell of the boundary event is the activity.
<img width="1336" alt="image" src="https://user-images.githubusercontent.com/4921914/85049044-7dad3180-b194-11ea-827b-58a5222ffc45.png">


As I use the same mechanism of event to calculte the kind of boundary events, we see all supported event kind (timer, message) as boundary.
I'll create in 2 next PRs the tests for the non-interrupting message & for interrupting timer.

The render is temporary. 
The color & the lines of the shape border will change later.