### PR TITLE
[INFRA] use a tagged version of ts-mxgraph

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11651,8 +11651,8 @@
       }
     },
     "ts-mxgraph": {
-      "version": "git+https://github.com/process-analytics/ts-mxgraph.git#50ee481f67d64ac31e45f1814b536d6d0ad7dc",
-      "from": "git+https://github.com/process-analytics/ts-mxgraph.git"
+      "version": "git+https://github.com/process-analytics/ts-mxgraph.git#50ee481f67d64ac31e45f1814b536d6d0ad7dc5d",
+      "from": "git+https://github.com/process-analytics/ts-mxgraph.git#v1.0.1"
     },
     "tslib": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,6 @@
     "entities": "^2.0.0",
     "fast-xml-parser": "^3.16.0",
     "json2typescript": "^1.2.5",
-    "ts-mxgraph": "git+https://github.com/process-analytics/ts-mxgraph.git"
+    "ts-mxgraph": "git+https://github.com/process-analytics/ts-mxgraph.git#v1.0.1"
   }
 }


### PR DESCRIPTION
Use fixed tagged version of ts-mxgraph instead of the last master commit