### PR TITLE
[FEAT] Render Interrupting Timer Intermediate Event Attached to an Activity Boundary

### DIFF
--- a/docs/bpmn-support.adoc
+++ b/docs/bpmn-support.adoc
@@ -145,8 +145,8 @@ The default rendering uses `white` as fill color and `black` as stroke color.
 |Comments
 
 |Timer Interrupting Boundary Event
-|
-|
+|icon:check-circle-o[]
+|The stroke & icon width may be adjusted
 
 |Message Interrupting Boundary Event
 |icon:check-circle-o[]

--- a/src/component/mxgraph/shape/event-shapes.ts
+++ b/src/component/mxgraph/shape/event-shapes.ts
@@ -111,9 +111,7 @@ export class BoundaryEventShape extends IntermediateEventShape {
 
   protected paintOuterShape(paintParameter: PaintParameter): void {
     const isInterrupting = StyleUtils.getBpmnIsInterrupting(this.style);
-    if ((isInterrupting === 'true' || isInterrupting === undefined) && StyleUtils.getBpmnEventKind(this.style) === ShapeBpmnEventKind.TIMER) {
-      paintParameter.c.setFillColor('yellow');
-    } else if (isInterrupting === 'false') {
+    if (isInterrupting === 'false') {
       paintParameter.c.setFillColor('LightPink');
     }
 

--- a/test/e2e/mxGraph.model.test.ts
+++ b/test/e2e/mxGraph.model.test.ts
@@ -69,6 +69,9 @@ describe('mxGraph model', () => {
         <semantic:boundaryEvent attachedToRef="userTask_3" cancelActivity="true" name="Boundary Intermediate Event Interrupting Message" id="boundary_event_interrupting_message_id">
             <semantic:messageEventDefinition/>
         </semantic:boundaryEvent>
+        <semantic:boundaryEvent attachedToRef="userTask_3" cancelActivity="true" name="Boundary Intermediate Event Interrupting Message" id="boundary_event_interrupting_timer_id">
+            <semantic:timerEventDefinition/>
+        </semantic:boundaryEvent>
         <semantic:intermediateThrowEvent name="Throw None Intermediate Event" id="noneIntermediateThrowEvent" />
         <semantic:intermediateThrowEvent name="Throw Message Intermediate Event" id="messageIntermediateThrowEvent">
             <semantic:messageEventDefinition />
@@ -138,7 +141,10 @@ describe('mxGraph model', () => {
             </bpmndi:BPMNShape>
             <bpmndi:BPMNShape bpmnElement="boundary_event_interrupting_message_id" id="S1373649849862_boundary_event_interrupting_message_id">
 	           <dc:Bounds height="32.0" width="32.0" x="98.0" y="335.0" />
-	        </bpmndi:BPMNShape>
+	          </bpmndi:BPMNShape>
+	          <bpmndi:BPMNShape bpmnElement="boundary_event_interrupting_timer_id" id="S1373649849862_boundary_event_interrupting_timer_id">
+	           <dc:Bounds height="32.0" width="32.0" x="98.0" y="335.0" />
+	          </bpmndi:BPMNShape>
             <bpmndi:BPMNShape bpmnElement="noneIntermediateThrowEvent" id="S1373649849862_noneIntermediateThrowEvent">
 	           <dc:Bounds height="32.0" width="32.0" x="648.0" y="336.0" />
 	           <bpmndi:BPMNLabel labelStyle="strike_through_font_id">
@@ -351,6 +357,7 @@ describe('mxGraph model', () => {
 
     // boundary event
     expectModelContainsBpmnBoundaryEvent('boundary_event_interrupting_message_id', ShapeBpmnEventKind.MESSAGE, true);
+    expectModelContainsBpmnBoundaryEvent('boundary_event_interrupting_timer_id', ShapeBpmnEventKind.TIMER, true);
 
     // activity
     expectModelContainsShape('task_1', ShapeBpmnElementKind.TASK, {
@@ -386,6 +393,9 @@ describe('mxGraph model', () => {
         <semantic:boundaryEvent attachedToRef="nothing" cancelActivity="true" name="Boundary Intermediate Event Interrupting Message" id="boundary_event_interrupting_message_id">
             <semantic:messageEventDefinition/>
         </semantic:boundaryEvent>
+        <semantic:boundaryEvent attachedToRef="nothing" cancelActivity="true" name="Boundary Intermediate Event Interrupting Timer" id="boundary_event_interrupting_timer_id">
+            <semantic:timerEventDefinition/>
+        </semantic:boundaryEvent>
     </semantic:process>
     <bpmndi:BPMNDiagram documentation="" id="Trisotech_Visio-_6" name="A.1.0" resolution="96.00000267028808">
         <bpmndi:BPMNPlane bpmnElement="WFP-6-">
@@ -401,6 +411,7 @@ describe('mxGraph model', () => {
     // model is OK
     // boundary event
     expectModelNotContainCell('boundary_event_interrupting_message_id');
+    expectModelNotContainCell('boundary_event_interrupting_timer_id');
   });
 
   function expectModelContainsCellWithGeometry(cellId: string, parentId: string, geometry: mxgraph.mxGeometry): void {


### PR DESCRIPTION
Closes #333 

### With [B.2.0](https://github.com/bpmn-miwg/bpmn-miwg-test-suite/blob/master/Reference/B.2.0.bpmn)
<img width="1414" alt="image" src="https://user-images.githubusercontent.com/4921914/85561241-aff2df00-b62b-11ea-929b-f052f05d1824.png">
