### PR TITLE
[FEAT] Render Non-interrupting Message Intermediate Event Attached to an Activity Boundary 

### DIFF
--- a/docs/bpmn-support.adoc
+++ b/docs/bpmn-support.adoc
@@ -145,8 +145,8 @@ The default rendering uses `white` as fill color and `black` as stroke color.
 |Comments
 
 |Timer Interrupting Boundary Event
-|
-|
+|icon:check-circle-o[]
+|The stroke & icon width may be adjusted
 
 |Message Interrupting Boundary Event
 |icon:check-circle-o[]

--- a/docs/bpmn-support.adoc
+++ b/docs/bpmn-support.adoc
@@ -166,8 +166,8 @@ The default rendering uses `white` as fill color and `black` as stroke color.
 |
 
 |Message Non-interrupting Boundary Event
-|
-|
+|icon:check-circle-o[]
+|The stroke & icon width may be adjusted
 |===
 
 

--- a/src/component/mxgraph/StyleUtils.ts
+++ b/src/component/mxgraph/StyleUtils.ts
@@ -30,6 +30,9 @@ export enum StyleConstant {
   DEFAULT_FONT_SIZE = 11,
   DEFAULT_FONT_COLOR = 'Black',
   DEFAULT_MARGIN = 0,
+  DEFAULT_DASHED = 0,
+  DEFAULT_FIX_DASH = 0,
+  DEFAULT_DASH_PATTERN = '3 3',
 }
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -48,6 +51,18 @@ export default class StyleUtils {
 
   public static getMargin(style: any): number {
     return mxUtils.getValue(style, mxConstants.STYLE_MARGIN, StyleConstant.DEFAULT_MARGIN);
+  }
+
+  public static isDashed(style: any): number {
+    return mxUtils.getValue(style, mxConstants.STYLE_DASHED, StyleConstant.DEFAULT_DASHED);
+  }
+
+  public static getFixDash(style: any): number {
+    return mxUtils.getValue(style, mxConstants.STYLE_FIX_DASH, StyleConstant.DEFAULT_FIX_DASH);
+  }
+
+  public static getDashPattern(style: any): string {
+    return mxUtils.getValue(style, mxConstants.STYLE_DASH_PATTERN, StyleConstant.DEFAULT_DASH_PATTERN);
   }
 
   public static getBpmnEventKind(style: any): ShapeBpmnEventKind {

--- a/src/component/mxgraph/shape/event-shapes.ts
+++ b/src/component/mxgraph/shape/event-shapes.ts
@@ -109,16 +109,17 @@ export class BoundaryEventShape extends IntermediateEventShape {
     super(bounds, fill, stroke, strokewidth);
   }
 
-  public configureCanvas(c: mxgraph.mxXmlCanvas2D, x: number, y: number, w: number, h: number): void {
-    super.configureCanvas(c, x, y, w, h);
-
+  protected paintOuterShape(paintParameter: PaintParameter): void {
     const isInterrupting = StyleUtils.getBpmnIsInterrupting(this.style);
     if (isInterrupting === 'false') {
       if (StyleUtils.getBpmnEventKind(this.style) === ShapeBpmnEventKind.TIMER) {
-        c.setFillColor('LightPink');
+        paintParameter.c.setFillColor('LightPink');
       } else {
-        c.setDashed(1, null);
+        paintParameter.c.setDashed(1, 0);
       }
     }
+
+    super.paintOuterShape(paintParameter);
+    paintParameter.c.setDashed(0, 0);
   }
 }

--- a/src/component/mxgraph/shape/event-shapes.ts
+++ b/src/component/mxgraph/shape/event-shapes.ts
@@ -116,10 +116,12 @@ export class BoundaryEventShape extends IntermediateEventShape {
         paintParameter.c.setFillColor('LightPink');
       } else {
         paintParameter.c.setDashed(1, 0);
+        paintParameter.c.setDashPattern('3 2');
       }
     }
 
     super.paintOuterShape(paintParameter);
-    paintParameter.c.setDashed(0, 0);
+    paintParameter.c.setDashed(StyleUtils.isDashed(this.style), StyleUtils.getFixDash(this.style));
+    paintParameter.c.setDashPattern(StyleUtils.getDashPattern(this.style));
   }
 }

--- a/src/component/mxgraph/shape/event-shapes.ts
+++ b/src/component/mxgraph/shape/event-shapes.ts
@@ -111,9 +111,7 @@ export class BoundaryEventShape extends IntermediateEventShape {
 
   protected paintOuterShape(paintParameter: PaintParameter): void {
     const isInterrupting = StyleUtils.getBpmnIsInterrupting(this.style);
-    if ((isInterrupting === 'true' || isInterrupting === undefined) && StyleUtils.getBpmnEventKind(this.style) === ShapeBpmnEventKind.TIMER) {
-      paintParameter.c.setFillColor('yellow');
-    } else if (isInterrupting === 'false') {
+    if (isInterrupting === 'false') {
       paintParameter.c.setFillColor('LightPink');
     }
 

--- a/src/component/mxgraph/shape/event-shapes.ts
+++ b/src/component/mxgraph/shape/event-shapes.ts
@@ -109,12 +109,16 @@ export class BoundaryEventShape extends IntermediateEventShape {
     super(bounds, fill, stroke, strokewidth);
   }
 
-  protected paintOuterShape(paintParameter: PaintParameter): void {
+  public configureCanvas(c: mxgraph.mxXmlCanvas2D, x: number, y: number, w: number, h: number): void {
+    super.configureCanvas(c, x, y, w, h);
+
     const isInterrupting = StyleUtils.getBpmnIsInterrupting(this.style);
     if (isInterrupting === 'false') {
-      paintParameter.c.setFillColor('LightPink');
+      if (StyleUtils.getBpmnEventKind(this.style) === ShapeBpmnEventKind.TIMER) {
+        c.setFillColor('LightPink');
+      } else {
+        c.setDashed(1, null);
+      }
     }
-
-    super.paintOuterShape(paintParameter);
   }
 }

--- a/test/e2e/mxGraph.model.test.ts
+++ b/test/e2e/mxGraph.model.test.ts
@@ -69,6 +69,9 @@ describe('mxGraph model', () => {
         <semantic:boundaryEvent attachedToRef="userTask_3" cancelActivity="true" name="Boundary Intermediate Event Interrupting Message" id="boundary_event_interrupting_message_id">
             <semantic:messageEventDefinition/>
         </semantic:boundaryEvent>
+        <semantic:boundaryEvent attachedToRef="userTask_3" cancelActivity="true" name="Boundary Intermediate Event Interrupting Message" id="boundary_event_interrupting_timer_id">
+            <semantic:timerEventDefinition/>
+        </semantic:boundaryEvent>
         <semantic:intermediateThrowEvent name="Throw None Intermediate Event" id="noneIntermediateThrowEvent" />
         <semantic:intermediateThrowEvent name="Throw Message Intermediate Event" id="messageIntermediateThrowEvent">
             <semantic:messageEventDefinition />
@@ -138,7 +141,10 @@ describe('mxGraph model', () => {
             </bpmndi:BPMNShape>
             <bpmndi:BPMNShape bpmnElement="boundary_event_interrupting_message_id" id="S1373649849862_boundary_event_interrupting_message_id">
 	           <dc:Bounds height="32.0" width="32.0" x="98.0" y="335.0" />
-	        </bpmndi:BPMNShape>
+	          </bpmndi:BPMNShape>
+	          <bpmndi:BPMNShape bpmnElement="boundary_event_interrupting_timer_id" id="S1373649849862_boundary_event_interrupting_timer_id">
+	           <dc:Bounds height="32.0" width="32.0" x="98.0" y="335.0" />
+	          </bpmndi:BPMNShape>
             <bpmndi:BPMNShape bpmnElement="noneIntermediateThrowEvent" id="S1373649849862_noneIntermediateThrowEvent">
 	           <dc:Bounds height="32.0" width="32.0" x="648.0" y="336.0" />
 	           <bpmndi:BPMNLabel labelStyle="strike_through_font_id">
@@ -351,6 +357,7 @@ describe('mxGraph model', () => {
 
     // boundary event
     expectModelContainsBpmnBoundaryEvent('boundary_event_interrupting_message_id', ShapeBpmnEventKind.MESSAGE, true);
+    expectModelContainsBpmnBoundaryEvent('boundary_event_interrupting_timer_id', ShapeBpmnEventKind.TIMER, true);
 
     // activity
     expectModelContainsShape('task_1', ShapeBpmnElementKind.TASK, {
@@ -386,6 +393,9 @@ describe('mxGraph model', () => {
         <semantic:boundaryEvent attachedToRef="nothing" cancelActivity="true" name="Boundary Intermediate Event Interrupting Message" id="boundary_event_interrupting_message_id">
             <semantic:messageEventDefinition/>
         </semantic:boundaryEvent>
+        <semantic:boundaryEvent attachedToRef="nothing" cancelActivity="true" name="Boundary Intermediate Event Interrupting Timer" id="boundary_event_interrupting_timer_id">
+            <semantic:timerEventDefinition/>
+        </semantic:boundaryEvent>
     </semantic:process>
     <bpmndi:BPMNDiagram documentation="" id="Trisotech_Visio-_6" name="A.1.0" resolution="96.00000267028808">
         <bpmndi:BPMNPlane bpmnElement="WFP-6-">
@@ -401,6 +411,7 @@ describe('mxGraph model', () => {
     // model is OK
     // boundary event
     expectModelNotContainCell('boundary_event_interrupting_message_id');
+    expectModelNotContainCell('boundary_event_interrupting_timer_id');
   });
 
   function expectModelContainsCellWithGeometry(cellId: string, parentId: string, geometry: mxgraph.mxGeometry): void {

--- a/test/e2e/mxGraph.model.test.ts
+++ b/test/e2e/mxGraph.model.test.ts
@@ -69,6 +69,9 @@ describe('mxGraph model', () => {
         <semantic:boundaryEvent attachedToRef="userTask_3" cancelActivity="true" name="Boundary Intermediate Event Interrupting Message" id="boundary_event_interrupting_message_id">
             <semantic:messageEventDefinition/>
         </semantic:boundaryEvent>
+        <semantic:boundaryEvent attachedToRef="userTask_3" cancelActivity="false" name="Boundary Intermediate Event Non-interrupting Message" id="boundary_event_non_interrupting_message_id">
+            <semantic:messageEventDefinition/>
+        </semantic:boundaryEvent>
         <semantic:boundaryEvent attachedToRef="userTask_3" cancelActivity="true" name="Boundary Intermediate Event Interrupting Message" id="boundary_event_interrupting_timer_id">
             <semantic:timerEventDefinition/>
         </semantic:boundaryEvent>
@@ -140,6 +143,9 @@ describe('mxGraph model', () => {
                 </bpmndi:BPMNLabel>
             </bpmndi:BPMNShape>
             <bpmndi:BPMNShape bpmnElement="boundary_event_interrupting_message_id" id="S1373649849862_boundary_event_interrupting_message_id">
+	           <dc:Bounds height="32.0" width="32.0" x="98.0" y="335.0" />
+	          </bpmndi:BPMNShape>
+	           <bpmndi:BPMNShape bpmnElement="boundary_event_non_interrupting_message_id" id="S1373649849862_boundary_event_non_interrupting_message_id">
 	           <dc:Bounds height="32.0" width="32.0" x="98.0" y="335.0" />
 	          </bpmndi:BPMNShape>
 	          <bpmndi:BPMNShape bpmnElement="boundary_event_interrupting_timer_id" id="S1373649849862_boundary_event_interrupting_timer_id">
@@ -355,9 +361,12 @@ describe('mxGraph model', () => {
     expectModelContainsBpmnEvent('messageIntermediateCatchEvent', ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH, ShapeBpmnEventKind.MESSAGE);
     expectModelContainsBpmnEvent('IntermediateCatchEvent_Timer_01', ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH, ShapeBpmnEventKind.TIMER);
 
-    // boundary event
+    // boundary event: interrupting
     expectModelContainsBpmnBoundaryEvent('boundary_event_interrupting_message_id', ShapeBpmnEventKind.MESSAGE, true);
     expectModelContainsBpmnBoundaryEvent('boundary_event_interrupting_timer_id', ShapeBpmnEventKind.TIMER, true);
+
+    // boundary event: non-interrupting
+    expectModelContainsBpmnBoundaryEvent('boundary_event_non_interrupting_message_id', ShapeBpmnEventKind.MESSAGE, false);
 
     // activity
     expectModelContainsShape('task_1', ShapeBpmnElementKind.TASK, {
@@ -393,6 +402,9 @@ describe('mxGraph model', () => {
         <semantic:boundaryEvent attachedToRef="nothing" cancelActivity="true" name="Boundary Intermediate Event Interrupting Message" id="boundary_event_interrupting_message_id">
             <semantic:messageEventDefinition/>
         </semantic:boundaryEvent>
+        <semantic:boundaryEvent attachedToRef="nothing" cancelActivity="false" name="Boundary Intermediate Event Non-nterrupting Message" id="boundary_event_non_interrupting_message_id">
+            <semantic:messageEventDefinition/>
+        </semantic:boundaryEvent>
         <semantic:boundaryEvent attachedToRef="nothing" cancelActivity="true" name="Boundary Intermediate Event Interrupting Timer" id="boundary_event_interrupting_timer_id">
             <semantic:timerEventDefinition/>
         </semantic:boundaryEvent>
@@ -409,9 +421,12 @@ describe('mxGraph model', () => {
     bpmnVisu.load(xmlContent);
 
     // model is OK
-    // boundary event
+    // boundary event: interrupting
     expectModelNotContainCell('boundary_event_interrupting_message_id');
     expectModelNotContainCell('boundary_event_interrupting_timer_id');
+
+    // boundary event: non-interrupting
+    expectModelNotContainCell('boundary_event_non_interrupting_message_id');
   });
 
   function expectModelContainsCellWithGeometry(cellId: string, parentId: string, geometry: mxgraph.mxGeometry): void {


### PR DESCRIPTION
Closes #332 

### With [B.2.0](https://github.com/bpmn-miwg/bpmn-miwg-test-suite/blob/master/Reference/B.2.0.bpmn)
<img width="1414" alt="image" src="https://user-images.githubusercontent.com/4921914/85564848-e5e59280-b62e-11ea-9dfa-533b19749333.png">
