### PR TITLE
[FIX] do not force usage orthogonal edge segments

### DIFF
--- a/src/component/mxgraph/config/StyleConfigurator.ts
+++ b/src/component/mxgraph/config/StyleConfigurator.ts
@@ -182,7 +182,6 @@ export default class StyleConfigurator {
 
   private configureDefaultEdgeStyle(): void {
     const style = this.getDefaultEdgeStyle();
-    style[mxConstants.STYLE_EDGE] = mxConstants.EDGESTYLE_SEGMENT;
     style[mxConstants.STYLE_ENDARROW] = mxConstants.ARROW_BLOCK_THIN;
     style[mxConstants.STYLE_ENDSIZE] = 12;
     style[mxConstants.STYLE_STROKEWIDTH] = 1.5;


### PR DESCRIPTION
In a conform BPMN file, segments are defined by waypoints, so forcing orthogonal
segments prevent rendering edges correctly when the waypoints don't defined such
orthogonality.

closes #295