### PR TITLE
[DOC] remove reference to 'JS' in library name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-You are here to help on BPMN Visualization JS? Awesome, feel welcome and read the following guidelines in order to know how to contribute, to ask questions and to make BPMN Visualization JS such a great tool.
+You are here to help on `bpmn-visualization`? Awesome, feel welcome and read the following guidelines in order to know how to contribute, to ask questions and to make `bpmn-visualization` such a great tool.
 
 All members of our community are expected to follow our [Code of Conduct](CODE_OF_CONDUCT.md). Please make sure you are welcoming and friendly in all of our spaces.
 
@@ -10,9 +10,9 @@ There are many ways to contribute:
 
 - help people with the questions they ask on the [Github Issues](https://github.com/process-analytics/bpmn-visualization-js/issues )
 - submitting bug reports and feature requests in the [Github Issues](https://github.com/process-analytics/bpmn-visualization-js/issues/new )
-- [writing code](CONTRIBUTING.md#code-and-documentation-changes) which can be incorporated into BPMN Visualization JS itself
+- [writing code](CONTRIBUTING.md#code-and-documentation-changes) which can be incorporated into `bpmn-visualization` itself
 - [improving](CONTRIBUTING.md#code-and-documentation-changes) the documentation
-- improve the existing example applications to demonstrate features in BPMN Visualization JS
+- improve the existing example applications to demonstrate features in `bpmn-visualization`
 
 ## Code and documentation changes
 
@@ -42,7 +42,7 @@ test everything)
 
 ### Fork & create a branch
 
-[Fork BPMN Visualization JS](https://help.github.com/articles/fork-a-repo) and create a branch with a descriptive name. 
+[Fork bpmn-visualization](https://help.github.com/articles/fork-a-repo) and create a branch with a descriptive name. 
 
 A good branch name would be (where issue #25 is the ticket you're working on): **25_add-annotations-to-tasks**
 
@@ -182,7 +182,8 @@ You only need to sign the CLA once or when the CLA terms have changed.
 
 ### Open a Pull Request
 
-At this point, you should switch back to your master branch and make sure it's up to date with BPMN Visualization JS's master branch:
+At this point, you should switch back to your master branch and make sure it's up to date with `bpmn-visualization`
+`master` branch:
 
 ```sh
 git remote add upstream git@github.com:process-analytics/bpmn-visualization-js.git

--- a/README.md
+++ b/README.md
@@ -1,16 +1,19 @@
-# BPMN Visualization JS
-A JavaScript library to visualize process execution data. Diagrams are displayed from [BPMN](https://www.omg.org/spec/BPMN/2.0.2/PDF) files. With additional display
-options for execution data (highlight some transitions, counters, and more). With interactive capacities (mouse hover,
-click).
+# bpmn-visualization
+
 
 [![Build](https://github.com/process-analytics/bpmn-visualization-js/workflows/Build/badge.svg)](https://github.com/process-analytics/bpmn-visualization-js/actions)
-[![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/bonitasoft-labs/bpmn-visu-js?color=orange&include_prereleases)](https://github.com/process-analytics/bpmn-visualization-js/releases)
+[![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/process-analytics/bpmn-visualization-js?color=orange&include_prereleases)](https://github.com/process-analytics/bpmn-visualization-js/releases)
 
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
 
+`bpmn-visualization` is a TypeScript library to visualize process execution data on [BPMN](https://www.omg.org/spec/BPMN/2.0.2/)
+diagrams with
+- additional display options for execution data (highlight some transitions, counters, and more)
+- with interactive capacities (mouse hover, click)
 
-**Supported Browsers**: Chrome, Firefox, Safari, Edge
+
+**Supported Browsers**: Chrome, Firefox, Safari, Edge.
 
 
 # Demos
@@ -25,12 +28,15 @@ If you need BPMN examples, you can use resources of the [BPMN Model Interchange 
 
 # Roadmap
 
-`BPMN Visualization JS` is in early development stages and is subject to changes until the `1.0.0` version is released.
+`bpmn-visualization` is in early development stages and is subject to changes prior to the `1.0.0` release.
 
 We are currently focusing on the [BPMN support](https://github.com/process-analytics/bpmn-visualization-js/milestone/6)
-to be able to render most of the BPMN elements.
+to be able to render most of the BPMN elements. Notice that there is currently no plan to support `Conversation` and
+`Choreography`.
 
-Then, we will work on BPMN extensions, library extension points.
+Then, we will work on BPMN extensions, library extension points, display options for execution data with interactive
+capacities.
+
 
 # Development
 
@@ -39,9 +45,9 @@ To build the project, see the [Contributing guide](CONTRIBUTING.md#Build) :sligh
 
 # License
 
-`bpmn-visualization-js` is released under the Apache 2.0 license.
+`bpmn-visualization` is released under the `Apache 2.0` license.
 
-Some BPMN icons used by `bpmn-visualization-js` are derived from existing projects. See the [BPMN Support page](docs/bpmn-support.adoc)
+Some BPMN icons used by `bpmn-visualization` are derived from existing projects. See the [BPMN Support page](docs/bpmn-support.adoc)
 for more details:
 - [draw.io](https://github.com/jgraph/drawio) (Apache-2.0)
 - [flaticon](https://www.flaticon.com) ([freepikcompany license](https://www.freepikcompany.com/legal#nav-flaticon))

--- a/docs/bpmn-support.adoc
+++ b/docs/bpmn-support.adoc
@@ -17,7 +17,7 @@ The default rendering uses `white` as fill color and `black` as stroke color.
 * icon:check-circle[] considered as stable (only minor changes may occurred)
 * icon:check-circle-o[] early access (1st attempt)
 * icon:flask[] experimental (subject to change)
-* no status means that are arbitrary rendering is used (not following BPMNN), generally using a dedicated color to identify the shape among other
+* no status means that are arbitrary rendering is used (i.e. not following the BPMN specification requirements), generally using a dedicated color to identify the shape among others
 ====
 
 

--- a/docs/build-doc.bash
+++ b/docs/build-doc.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-echo "Building bpmn-visualization-js html documentation with Docker"
+echo "Building bpmn-visualization html documentation with Docker"
 
 doc_input="$(pwd)/docs"
 doc_output="$(pwd)/build/docs"
@@ -9,7 +9,7 @@ rm -rf ${doc_output}
 mkdir -p ${doc_output}
 
 docker run --rm -v "${doc_input}:/documents/" -v "${doc_output}:/documents-generated/" \
-    --name bpmn-visu-js-asciidoc \
+    --name bpmn-visualization-asciidoc \
     asciidoctor/docker-asciidoctor:1.1.0 \
     asciidoctor -D /documents-generated index.adoc
 

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -1,4 +1,4 @@
-= BPMN Visualization JS
+= bpmn-visualization
 :toc: left
 // see: https://asciidoctor.org/docs/user-manual/#table-of-contents-summary
 :toc-title: Table of Contents

--- a/docs/intro.adoc
+++ b/docs/intro.adoc
@@ -1,13 +1,13 @@
 == Introduction
 
-`BPMN Visualization JS` is JavaScript library relying on https://www.omg.org/spec/BPMN/2.0.2/PDF[BPMN] to
-visualize process execution data. It is in early development stages and is subject to changes prior to the `1.0.0`
-release.
+`bpmn-visualization` is a TypeScript library to visualize process execution data on https://www.omg.org/spec/BPMN/2.0.2/[BPMN]
+diagrams. It is in early development stages and is subject to changes prior to the `1.0.0` release.
 
 We are currently focusing on the <<supported-bpmn-elements,BPMN support>> to be able to render most of the BPMN
-elements. Then, we will work on BPMN extensions, library extension points.
+elements. Then, we will work on BPMN extensions, library extension points, display options for execution data with interactive
+capacities.
 
-**Supported Browsers**: Chrome, Firefox, Safari, Edge
+**Supported Browsers**: Chrome, Firefox, Safari, Edge.
 
 
 == Demo environment

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "bpmn-visu-js",
+  "name": "bpmn-visualization",
   "version": "0.1.5",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "bpmn-visu-js",
+  "name": "bpmn-visualization",
   "version": "0.1.5",
-  "description": "Javascript lib to visualize BPMN diagrams",
+  "description": "A TypeScript library to visualize process execution data on BPMN diagrams",
   "repository": "https://github.com/process-analytics/bpmn-visualization-js",
   "license": "Apache-2.0",
   "module": "dist/index.es.js",

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>BPMN Visualization JS</title>
+    <title>BPMN Visualization Demo</title>
     <link href="./static/css/main.css" rel="stylesheet">
 </head>
 <body>
@@ -17,7 +17,7 @@
     <script src="./static/js/configureMxGraphGlobals.js"></script>
     <!-- load mxGraph client library -->
     <script src="./static/js/mxClient.js"></script>
-    <!-- load BPMN Visualization library -->
+    <!-- load bpmn-visualization library -->
     <script src="./index.es.js"></script>
 </body>
 </html>

--- a/test/e2e/mxGraph.view.test.ts
+++ b/test/e2e/mxGraph.view.test.ts
@@ -55,7 +55,7 @@ describe('BpmnVisu view', () => {
   it('should display page title', async () => {
     await page.goto('http://localhost:10001');
     await page.waitForSelector(`#${graphContainerId}`);
-    await expect(page.title()).resolves.toMatch('BPMN Visualization JS');
+    await expect(page.title()).resolves.toMatch('BPMN Visualization Demo');
   });
 
   it('should display graph in page', async () => {


### PR DESCRIPTION
We are developing a TypeScript library no we should not mention JavaScript or JS
in its name.
In addition, use the current repository url for the GitHub release badge.