### PR TITLE
[FEAT] Render Message Flow with no message

### DIFF
--- a/docs/bpmn-support.adoc
+++ b/docs/bpmn-support.adoc
@@ -227,9 +227,10 @@ The default rendering uses `white` as fill color and `black` as stroke color.
 |Subject to change: arrow size/form and position endpoint
 
 |message flow
-|
-|
-
+|icon:check-circle-o[]
+|- No message: Subject to change: arrow size/form and position endpoint +
+- Initiating message: To do
+- Non-initiating message: To do
 
 |way points
 |icon:flask[]

--- a/src/component/mxgraph/config/StyleConfigurator.ts
+++ b/src/component/mxgraph/config/StyleConfigurator.ts
@@ -36,10 +36,12 @@ export default class StyleConfigurator {
     [
       FlowKind.MESSAGE_FLOW,
       (style: any) => {
+        style[mxConstants.STYLE_DASHED] = true;
+        style[mxConstants.STYLE_DASH_PATTERN] = '8 5';
         style[mxConstants.STYLE_STARTARROW] = mxConstants.ARROW_OVAL;
-        style[mxConstants.STYLE_STARTSIZE] = 7;
+        style[mxConstants.STYLE_STARTSIZE] = 8;
         style[mxConstants.STYLE_STARTFILL] = false;
-        style[mxConstants.STYLE_STROKECOLOR] = 'DeepPink';
+        style[mxConstants.STYLE_ENDFILL] = false;
       },
     ],
   ]);


### PR DESCRIPTION
Closes #389

<img width="1232" alt="image" src="https://user-images.githubusercontent.com/4921914/86616923-ce0af880-bfb6-11ea-8709-ce1fc1d781c8.png">


The position of the edge will be fixed with #351 and/or #349
