### PR TITLE
[REFACTOR] use `BpmnCanvas` in `IconPainter`

### DIFF
--- a/src/component/mxgraph/StyleUtils.ts
+++ b/src/component/mxgraph/StyleUtils.ts
@@ -23,7 +23,7 @@ export enum MarkerIdentifier {
 export enum StyleDefault {
   STROKE_WIDTH_THIN = 2,
   STROKE_WIDTH_THICK = 5,
-  TASK_SHAPE_BOTTOM_MARGIN = 7,
+  SHAPE_ACTIVITY_BOTTOM_MARGIN = 7,
   DEFAULT_FILL_COLOR = 'White',
   DEFAULT_STROKE_COLOR = 'Black',
   DEFAULT_FONT_FAMILY = 'Arial, Helvetica, sans-serif', // define our own to not depend on eventual mxGraph default change

--- a/src/component/mxgraph/shape/render/render-types.ts
+++ b/src/component/mxgraph/shape/render/render-types.ts
@@ -29,6 +29,7 @@ export interface Size {
 
 export interface IconConfiguration {
   originalSize: Size;
-  ratioFromShape: number;
+  /** If `undefined`, no scaling will be done in {@link BpmnCanvas}. */
+  ratioFromShape?: number;
   style: IconStyleConfiguration;
 }


### PR DESCRIPTION
Move all methods that set icon origin to `BpmnCanvas`
Remove `MxCanvasUtil` static utility
`IconPainter` additional refactoring: method signatures and rename

Covers #247