### PR TITLE
[INFRA] Bump mxgraph-type-definitions from 1.0.2 to 1.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9419,9 +9419,9 @@
       "integrity": "sha512-w/KQfK1vbvswvpkidg5gUxg3XFlY2M5El4juD5vKwIfCkN+eT1FonaGK479C8dasi+NWAzzh0X15GwuklRWPMA=="
     },
     "mxgraph-type-definitions": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/mxgraph-type-definitions/-/mxgraph-type-definitions-1.0.2.tgz",
-      "integrity": "sha512-Bkw1KsrvzOoHcpcjfxvPMU96vCvrjsxbWqKxeBNcCiwJ7Uwe4zKQRLa7/MyKLEM++CmgIEwiKN/YSDa+B734mw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/mxgraph-type-definitions/-/mxgraph-type-definitions-1.0.3.tgz",
+      "integrity": "sha512-zM56TQ8hkeetq/aOLf2RArqrSNoVhEmc8m/YYeziEJObtZFWLKOacVJr4Rty4tQPVG0bXcxZAyKH9kVSyTwXXw==",
       "dev": true
     },
     "nan": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "jest-puppeteer": "^4.4.0",
     "lint-staged": "^10.0.8",
     "minimist": "^0.2.1",
-    "mxgraph-type-definitions": "1.0.2",
+    "mxgraph-type-definitions": "^1.0.3",
     "npm-run-all": "^4.1.5",
     "prettier": "^1.19.1",
     "puppeteer": "^3.0.4",

--- a/src/component/mxgraph/StyleUtils.ts
+++ b/src/component/mxgraph/StyleUtils.ts
@@ -30,8 +30,8 @@ export enum StyleDefault {
   DEFAULT_FONT_SIZE = 11,
   DEFAULT_FONT_COLOR = 'Black',
   DEFAULT_MARGIN = 0,
-  DEFAULT_DASHED = 0,
-  DEFAULT_FIX_DASH = 0,
+  DEFAULT_DASHED = 0, // it means 'false'
+  DEFAULT_FIX_DASH = 0, // it means 'false'
   DEFAULT_DASH_PATTERN = '3 3',
 }
 
@@ -60,11 +60,11 @@ export default class StyleUtils {
     return mxUtils.getValue(style, mxConstants.STYLE_MARGIN, StyleDefault.DEFAULT_MARGIN);
   }
 
-  public static isDashed(style: any): number {
+  public static isDashed(style: any): boolean {
     return mxUtils.getValue(style, mxConstants.STYLE_DASHED, StyleDefault.DEFAULT_DASHED);
   }
 
-  public static getFixDash(style: any): number {
+  public static isFixDash(style: any): boolean {
     return mxUtils.getValue(style, mxConstants.STYLE_FIX_DASH, StyleDefault.DEFAULT_FIX_DASH);
   }
 

--- a/src/component/mxgraph/config/MarkerConfigurator.ts
+++ b/src/component/mxgraph/config/MarkerConfigurator.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { mxgraph } from 'ts-mxgraph';
 import { MarkerIdentifier } from '../StyleUtils';
 
 export default class MarkerConfigurator {
@@ -26,8 +25,7 @@ export default class MarkerConfigurator {
     // https://github.com/jgraph/drawio/blob/f539f1ff362e76127dcc7e68b5a9d83dd7d4965c/src/main/webapp/js/mxgraph/Shapes.js#L2796
 
     const createMarker = (
-      // TODO should be mxAbstractCanvas2D, but it is missing the 'stroke' method in mxgraph-type-definitions@1.0.2
-      c: mxgraph.mxXmlCanvas2D,
+      c: mxAbstractCanvas2D,
       shape: mxShape,
       type: string,
       pe: mxPoint,

--- a/src/component/mxgraph/config/ShapeConfigurator.ts
+++ b/src/component/mxgraph/config/ShapeConfigurator.ts
@@ -60,7 +60,9 @@ export default class ShapeConfigurator {
       const canvas = new mxSvgCanvas2D(this.node, false);
       canvas.strokeTolerance = this.pointerEvents ? this.svgStrokeTolerance : 0;
       canvas.pointerEventsValue = this.svgPointerEvents;
-      canvas.blockImagePointerEvents = isFF;
+      // TODO existed in mxgraph-type-definitions@1.0.2, no more in mxgraph-type-definitions@1.0.3
+      // this is probably because mxSvgCanvas2D definition matches mxgraph@4.1.1 and we are using  mxgraph@4.1.0
+      ((canvas as unknown) as mxgraph.mxSvgCanvas2D).blockImagePointerEvents = isFF;
       const off = this.getSvgScreenOffset();
 
       if (off != 0) {

--- a/src/component/mxgraph/shape/IconPainter.ts
+++ b/src/component/mxgraph/shape/IconPainter.ts
@@ -20,7 +20,7 @@ import StyleUtils from '../StyleUtils';
 import { IconStyleConfiguration, Size } from './render/render-types';
 
 export interface PaintParameter {
-  c: mxgraph.mxXmlCanvas2D;
+  c: mxAbstractCanvas2D;
   shape: ShapeConfiguration;
   icon: IconStyleConfiguration;
   ratioFromParent?: number;
@@ -36,12 +36,12 @@ export interface ShapeConfiguration {
 
 export default class IconPainter {
   public static buildPaintParameter(
-    c: mxgraph.mxXmlCanvas2D,
+    c: mxAbstractCanvas2D,
     x: number,
     y: number,
     width: number,
     height: number,
-    shape: mxgraph.mxShape,
+    shape: mxgraph.mxShape, // TODO use mxShape from mxgraph-type-definitions (missing fill and stroke properties)
     ratioFromParent = 0.25,
     isFilled = false,
     iconStrokeWidth = 0,

--- a/src/component/mxgraph/shape/activity-shapes.ts
+++ b/src/component/mxgraph/shape/activity-shapes.ts
@@ -19,9 +19,9 @@ import IconPainter, { PaintParameter } from './IconPainter';
 import { ShapeBpmnSubProcessKind } from '../../../model/bpmn/shape/ShapeBpmnSubProcessKind';
 
 export abstract class BaseActivityShape extends mxRectangleShape {
-  // TODO missing in mxgraph-type-definitions@1.0.2 mxShape
+  // TODO missing in mxgraph-type-definitions mxShape
   isRounded: boolean;
-  // TODO missing in mxgraph-type-definitions@1.0.2 mxShape
+  // TODO missing in mxgraph-type-definitions mxShape
   gradient: string;
 
   protected constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number = StyleDefault.STROKE_WIDTH_THIN) {
@@ -39,8 +39,7 @@ abstract class BaseTaskShape extends BaseActivityShape {
   public paintForeground(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): void {
     super.paintForeground(c, x, y, w, h);
 
-    // TODO temp before removing ts-mxgraph (xxx as unknown as mxgraph.yyy)
-    const paintParameter = IconPainter.buildPaintParameter((c as unknown) as mxgraph.mxXmlCanvas2D, x, y, w, h, (this as unknown) as mxgraph.mxShape);
+    const paintParameter = IconPainter.buildPaintParameter(c, x, y, w, h, (this as unknown) as mxgraph.mxShape);
     this.paintTaskIcon(paintParameter);
   }
 
@@ -109,29 +108,24 @@ export class SubProcessShape extends BaseActivityShape {
 
   public paintBackground(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): void {
     const subProcessKind = StyleUtils.getBpmnSubProcessKind(this.style);
-
-    // TODO temp. Wrong type for setDashPattern
-    const xmlCanvas = (c as unknown) as mxgraph.mxXmlCanvas2D;
-
     if (subProcessKind === ShapeBpmnSubProcessKind.EVENT) {
       c.setDashed(true, false);
-
-      xmlCanvas.setDashPattern('1 2');
+      c.setDashPattern('1 2');
     }
 
     super.paintBackground(c, x, y, w, h);
 
-    // TODO temp. missing in mxgraph-type-definitions@1.0.2 mxShape
+    // TODO temp. missing in mxgraph-type-definitions mxShape
     // this.configureCanvas(c, x, y, w, h);
-    xmlCanvas.setDashed(StyleUtils.isDashed(this.style), StyleUtils.getFixDash(this.style));
-    xmlCanvas.setDashPattern(StyleUtils.getDashPattern(this.style));
+    c.setDashed(StyleUtils.isDashed(this.style), StyleUtils.isFixDash(this.style));
+    c.setDashPattern(StyleUtils.getDashPattern(this.style));
   }
 
   public paintForeground(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): void {
     super.paintForeground(c, x, y, w, h);
 
     if (StyleUtils.getBpmnIsExpanded(this.style) === 'false') {
-      const paintParameter = IconPainter.buildPaintParameter((c as unknown) as mxgraph.mxXmlCanvas2D, x, y, w, h, (this as unknown) as mxgraph.mxShape, 0.17, false, 1.5);
+      const paintParameter = IconPainter.buildPaintParameter(c, x, y, w, h, (this as unknown) as mxgraph.mxShape, 0.17, false, 1.5);
       IconPainter.paintExpandIcon(paintParameter);
     }
   }

--- a/src/component/mxgraph/shape/event-shapes.ts
+++ b/src/component/mxgraph/shape/event-shapes.ts
@@ -36,7 +36,7 @@ abstract class EventShape extends mxEllipse {
     // TODO: This will be removed after implementation of all supported events
     this.markNonFullyRenderedEvents(c);
     // TODO temp before removing ts-mxgraph (xxx as unknown as mxgraph.yyy)
-    const paintParameter = IconPainter.buildPaintParameter((c as unknown) as mxgraph.mxXmlCanvas2D, x, y, w, h, (this as unknown) as mxgraph.mxShape, 0.25, this.withFilledIcon);
+    const paintParameter = IconPainter.buildPaintParameter(c, x, y, w, h, (this as unknown) as mxgraph.mxShape, 0.25, this.withFilledIcon);
     this.paintOuterShape(paintParameter);
     this.paintInnerShape(paintParameter);
   }
@@ -51,8 +51,7 @@ abstract class EventShape extends mxEllipse {
   }
 
   protected paintOuterShape({ c, shape: { x, y, w, h } }: PaintParameter): void {
-    // TODO temp before removing ts-mxgraph (xxx as unknown as mxgraph.yyy)
-    super.paintVertexShape((c as unknown) as mxAbstractCanvas2D, x, y, w, h);
+    super.paintVertexShape(c, x, y, w, h);
   }
 
   protected paintInnerShape(paintParameter: PaintParameter): void {
@@ -112,15 +111,16 @@ export class BoundaryEventShape extends IntermediateEventShape {
   protected paintOuterShape(paintParameter: PaintParameter): void {
     const isInterrupting = StyleUtils.getBpmnIsInterrupting(this.style);
     if (isInterrupting === 'false') {
-      paintParameter.c.setDashed(1, 0);
+      paintParameter.c.setDashed(true, false);
       paintParameter.c.setDashPattern('3 2');
     }
 
     super.paintOuterShape(paintParameter);
 
-    // TODO temp. missing in mxgraph-type-definitions@1.0.2 mxShape
+    // Restore original configuration
+    // TODO missing mxShape.configureCanvas in mxgraph-type-definitions (this will replace explicit function calls)
     // this.configureCanvas(c, x, y, w, h);
-    paintParameter.c.setDashed(StyleUtils.isDashed(this.style), StyleUtils.getFixDash(this.style));
+    paintParameter.c.setDashed(StyleUtils.isDashed(this.style), StyleUtils.isFixDash(this.style));
     paintParameter.c.setDashPattern(StyleUtils.getDashPattern(this.style));
   }
 }

--- a/src/component/mxgraph/shape/gateway-shapes.ts
+++ b/src/component/mxgraph/shape/gateway-shapes.ts
@@ -25,15 +25,13 @@ abstract class GatewayShape extends mxRhombus {
   protected abstract paintInnerShape(paintParameter: PaintParameter): void;
 
   public paintVertexShape(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): void {
-    // TODO temp before removing ts-mxgraph (xxx as unknown as mxgraph.yyy)
-    const paintParameter = IconPainter.buildPaintParameter((c as unknown) as mxgraph.mxXmlCanvas2D, x, y, w, h, (this as unknown) as mxgraph.mxShape);
+    const paintParameter = IconPainter.buildPaintParameter(c, x, y, w, h, (this as unknown) as mxgraph.mxShape);
     this.paintOuterShape(paintParameter);
     this.paintInnerShape(paintParameter);
   }
 
   protected paintOuterShape({ c, shape: { x, y, w, h } }: PaintParameter): void {
-    // TODO temp before removing ts-mxgraph (xxx as unknown as mxgraph.yyy)
-    super.paintVertexShape((c as unknown) as mxAbstractCanvas2D, x, y, w, h);
+    super.paintVertexShape(c, x, y, w, h);
   }
 }
 

--- a/src/component/mxgraph/shape/render/BpmnCanvas.ts
+++ b/src/component/mxgraph/shape/render/BpmnCanvas.ts
@@ -13,13 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { mxgraph } from 'ts-mxgraph';
 import { ShapeConfiguration } from '../IconPainter';
 import { StyleDefault } from '../../StyleUtils';
 import { IconConfiguration, IconStyleConfiguration, Size } from './render-types';
 
 export interface BpmnCanvasConfiguration {
-  mxCanvas: mxgraph.mxXmlCanvas2D; // TODO use mxAbstractCanvas2D when fully available in mxgraph-type-definitions
+  mxCanvas: mxAbstractCanvas2D;
   shapeConfiguration: ShapeConfiguration;
   iconConfiguration: IconConfiguration;
 }
@@ -27,7 +26,7 @@ export interface BpmnCanvasConfiguration {
 /**
  * Wrapper of {@link mxAbstractCanvas2D} to simplify method calls when painting icons/markers of BPMN shapes.
  *
- * It can scale dimensions passed to the method of the original {@link mxgraph.mxXmlCanvas2D}
+ * It can scale dimensions passed to the method of the original {@link mxAbstractCanvas2D}
  *
  * @example vanilla canvas calls when a scale factor must be applied to positions
  * const scaleX = 0.26;
@@ -41,7 +40,7 @@ export interface BpmnCanvasConfiguration {
  * canvas.lineTo(12, 25);
  */
 export default class BpmnCanvas {
-  private c: mxgraph.mxXmlCanvas2D; // TODO use mxAbstractCanvas2D when fully available in mxgraph-type-definitions
+  private c: mxAbstractCanvas2D;
 
   private readonly iconOriginalSize: Size;
   private readonly scaleX: number;

--- a/src/component/mxgraph/shape/text-annotation-shapes.ts
+++ b/src/component/mxgraph/shape/text-annotation-shapes.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { mxgraph } from 'ts-mxgraph';
 import { StyleDefault } from '../StyleUtils';
 
 export class TextAnnotationShape extends mxRectangleShape {
@@ -23,16 +22,13 @@ export class TextAnnotationShape extends mxRectangleShape {
   }
 
   public paintBackground(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): void {
-    // TODO temp. Missing fillAndStroke on mxAbstractCanvas2D
-    const xmlCanvas = (c as unknown) as mxgraph.mxXmlCanvas2D;
-
     // paint sort of left square bracket shape - for text annotation
-    xmlCanvas.begin();
-    xmlCanvas.moveTo(x + this.TEXT_ANNOTATION_BORDER_LENGTH, y);
-    xmlCanvas.lineTo(x, y);
-    xmlCanvas.lineTo(x, y + h);
-    xmlCanvas.lineTo(x + this.TEXT_ANNOTATION_BORDER_LENGTH, y + h);
+    c.begin();
+    c.moveTo(x + this.TEXT_ANNOTATION_BORDER_LENGTH, y);
+    c.lineTo(x, y);
+    c.lineTo(x, y + h);
+    c.lineTo(x + this.TEXT_ANNOTATION_BORDER_LENGTH, y + h);
 
-    xmlCanvas.fillAndStroke();
+    c.fillAndStroke();
   }
 }


### PR DESCRIPTION
More `mxgraph-type-definitions` usages in production code
  - replace ts-mxgraph canvas2D types by mxAbstractCanvas2D when possible
  - keep integer values for DEFAULT_DASHED and DEFAULT_FIX_DASH: the mxUtils
  code isn't able to correctly convert the string into boolean
  - update some TODO for remaining ts-mxgraph usages

covers #368 
