### PR TITLE
[REFACTOR] restore temporary commented mxShape createCanvas code

### DIFF
--- a/src/component/mxgraph/config/ShapeConfigurator.ts
+++ b/src/component/mxgraph/config/ShapeConfigurator.ts
@@ -79,13 +79,12 @@ export default class ShapeConfigurator {
       //
       canvas.minStrokeWidth = this.minSvgStrokeWidth;
 
-      // TODO mxgraph-definitions 1.0.2 wrong value arg type in the format function (should be 'string', but is 'number')
-      // if (!this.antiAlias) {
-      //   // Rounds all numbers in the SVG output to integers
-      //   canvas.format = function(value: string) {
-      //     return Math.round(parseFloat(value));
-      //   };
-      // }
+      if (!this.antiAlias) {
+        // Rounds all numbers in the SVG output to integers
+        canvas.format = function(value: string) {
+          return Math.round(parseFloat(value));
+        };
+      }
 
       return canvas;
     };


### PR DESCRIPTION
This was due to wrong definitions of the canvas format method in
mxgraph-type-definitions@1.0.2. As we now use 1.0.3 which fixes this problem, we
can restore the code.