### PR TITLE
[REFACTOR] add a way to inject and extend IconPainter

### DIFF
--- a/src/component/mxgraph/shape/activity-shapes.ts
+++ b/src/component/mxgraph/shape/activity-shapes.ts
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 import StyleUtils, { StyleDefault } from '../StyleUtils';
-import IconPainter, { buildPaintParameter, PaintParameter } from './render/IconPainter';
+import { buildPaintParameter, IconPainterProvider, PaintParameter } from './render/IconPainter';
 import { ShapeBpmnSubProcessKind } from '../../../model/bpmn/shape/ShapeBpmnSubProcessKind';
 
 export abstract class BaseActivityShape extends mxRectangleShape {
+  protected iconPainter = IconPainterProvider.get();
+
   // TODO missing in mxgraph-type-definitions mxShape
   isRounded: boolean;
   // TODO missing in mxgraph-type-definitions mxShape
@@ -51,7 +53,7 @@ export class TaskShape extends BaseTaskShape {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   protected paintTaskIcon(paintParameter: PaintParameter): void {
     // No symbol for the BPMN Task
-    IconPainter.paintEmptyIcon();
+    this.iconPainter.paintEmptyIcon();
   }
 }
 
@@ -61,7 +63,7 @@ export class ServiceTaskShape extends BaseTaskShape {
   }
 
   protected paintTaskIcon(paintParameter: PaintParameter): void {
-    IconPainter.paintGearIcon(paintParameter);
+    this.iconPainter.paintGearIcon(paintParameter);
   }
 }
 
@@ -71,7 +73,7 @@ export class UserTaskShape extends BaseTaskShape {
   }
 
   protected paintTaskIcon(paintParameter: PaintParameter): void {
-    IconPainter.paintWomanIcon(paintParameter);
+    this.iconPainter.paintWomanIcon(paintParameter);
   }
 }
 
@@ -122,7 +124,7 @@ export class SubProcessShape extends BaseActivityShape {
     super.paintForeground(c, x, y, w, h);
 
     if (StyleUtils.getBpmnIsExpanded(this.style) === 'false') {
-      IconPainter.paintExpandIcon(buildPaintParameter(c, x, y, w, h, this, 0.17, false, 1.5));
+      this.iconPainter.paintExpandIcon(buildPaintParameter(c, x, y, w, h, this, 0.17, false, 1.5));
     }
   }
 }

--- a/src/component/mxgraph/shape/event-shapes.ts
+++ b/src/component/mxgraph/shape/event-shapes.ts
@@ -14,15 +14,17 @@
  * limitations under the License.
  */
 import { ShapeBpmnEventKind } from '../../../model/bpmn/shape/ShapeBpmnEventKind';
-import IconPainter, { PaintParameter, buildPaintParameter } from './render/IconPainter';
+import { PaintParameter, buildPaintParameter, IconPainterProvider } from './render/IconPainter';
 import StyleUtils, { StyleDefault } from '../StyleUtils';
 
 abstract class EventShape extends mxEllipse {
+  protected iconPainter = IconPainterProvider.get();
+
   // TODO: when all/more event types will be supported, we could move to a Record/MappedType
   private iconPainters: Map<ShapeBpmnEventKind, (paintParameter: PaintParameter) => void> = new Map([
-    [ShapeBpmnEventKind.MESSAGE, (paintParameter: PaintParameter) => IconPainter.paintEnvelopeIcon({ ...paintParameter, ratioFromParent: 0.5 })],
-    [ShapeBpmnEventKind.TERMINATE, (paintParameter: PaintParameter) => IconPainter.paintCircleIcon({ ...paintParameter, ratioFromParent: 0.6 })],
-    [ShapeBpmnEventKind.TIMER, (paintParameter: PaintParameter) => IconPainter.paintClockIcon(paintParameter)],
+    [ShapeBpmnEventKind.MESSAGE, (paintParameter: PaintParameter) => this.iconPainter.paintEnvelopeIcon({ ...paintParameter, ratioFromParent: 0.5 })],
+    [ShapeBpmnEventKind.TERMINATE, (paintParameter: PaintParameter) => this.iconPainter.paintCircleIcon({ ...paintParameter, ratioFromParent: 0.6 })],
+    [ShapeBpmnEventKind.TIMER, (paintParameter: PaintParameter) => this.iconPainter.paintClockIcon(paintParameter)],
   ]);
 
   protected withFilledIcon = false;
@@ -54,7 +56,7 @@ abstract class EventShape extends mxEllipse {
   }
 
   protected paintInnerShape(paintParameter: PaintParameter): void {
-    const paintIcon = this.iconPainters.get(StyleUtils.getBpmnEventKind(this.style)) || (() => IconPainter.paintEmptyIcon());
+    const paintIcon = this.iconPainters.get(StyleUtils.getBpmnEventKind(this.style)) || (() => this.iconPainter.paintEmptyIcon());
     paintIcon(paintParameter);
   }
 }

--- a/src/component/mxgraph/shape/gateway-shapes.ts
+++ b/src/component/mxgraph/shape/gateway-shapes.ts
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 import { StyleDefault } from '../StyleUtils';
-import IconPainter, { PaintParameter, buildPaintParameter } from './render/IconPainter';
+import { PaintParameter, buildPaintParameter, IconPainterProvider } from './render/IconPainter';
 
 abstract class GatewayShape extends mxRhombus {
+  protected iconPainter = IconPainterProvider.get();
+
   protected constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number) {
     super(bounds, fill, stroke, strokewidth);
   }
@@ -40,7 +42,7 @@ export class ExclusiveGatewayShape extends GatewayShape {
   }
 
   protected paintInnerShape(paintParameter: PaintParameter): void {
-    IconPainter.paintXCrossIcon(paintParameter);
+    this.iconPainter.paintXCrossIcon(paintParameter);
   }
 }
 
@@ -50,7 +52,7 @@ export class ParallelGatewayShape extends GatewayShape {
   }
 
   protected paintInnerShape(paintParameter: PaintParameter): void {
-    IconPainter.paintPlusCrossIcon(paintParameter);
+    this.iconPainter.paintPlusCrossIcon(paintParameter);
   }
 }
 
@@ -60,7 +62,7 @@ export class InclusiveGatewayShape extends GatewayShape {
   }
 
   protected paintInnerShape(paintParameter: PaintParameter): void {
-    IconPainter.paintCircleIcon({
+    this.iconPainter.paintCircleIcon({
       ...paintParameter,
       ratioFromParent: 0.62,
       icon: { ...paintParameter.icon, isFilled: false, strokeWidth: StyleDefault.STROKE_WIDTH_THICK.valueOf() },

--- a/src/component/mxgraph/shape/render/IconPainter.ts
+++ b/src/component/mxgraph/shape/render/IconPainter.ts
@@ -53,13 +53,13 @@ export function buildPaintParameter(
 }
 
 export default class IconPainter {
-  public static paintEmptyIcon(): void {
+  public paintEmptyIcon(): void {
     // empty by nature
   }
 
   // this implementation is adapted from the draw.io BPMN 'message' symbol
   // https://github.com/jgraph/drawio/blob/0e19be6b42755790a749af30450c78c0d83be765/src/main/webapp/shapes/bpmn/mxBpmnShape2.js#L465
-  public static paintEnvelopeIcon({ c, ratioFromParent, shape, icon }: PaintParameter): void {
+  public paintEnvelopeIcon({ c, ratioFromParent, shape, icon }: PaintParameter): void {
     const originalIconSize = { width: 485.41, height: 321.76 };
     const canvas = new BpmnCanvas({
       mxCanvas: c,
@@ -105,7 +105,7 @@ export default class IconPainter {
   }
 
   // highly inspired from mxDoubleEllipse
-  public static paintCircleIcon({ c, ratioFromParent, shape, icon }: PaintParameter): void {
+  public paintCircleIcon({ c, ratioFromParent, shape, icon }: PaintParameter): void {
     const originalIconSize = { width: shape.w, height: shape.h };
     const canvas = new BpmnCanvas({
       mxCanvas: c,
@@ -133,7 +133,7 @@ export default class IconPainter {
   }
 
   // implementation adapted from https://www.flaticon.com/free-icon/clock_223404
-  public static paintClockIcon({ c, ratioFromParent, shape, icon }: PaintParameter): void {
+  public paintClockIcon({ c, ratioFromParent, shape, icon }: PaintParameter): void {
     const canvas = new BpmnCanvas({
       mxCanvas: c,
       shapeConfiguration: shape,
@@ -235,7 +235,7 @@ export default class IconPainter {
     canvas.fillAndStroke();
   }
 
-  public static paintXCrossIcon({ c, ratioFromParent, shape, icon }: PaintParameter): void {
+  public paintXCrossIcon({ c, ratioFromParent, shape, icon }: PaintParameter): void {
     const canvas = new BpmnCanvas({
       mxCanvas: c,
       shapeConfiguration: shape,
@@ -247,14 +247,14 @@ export default class IconPainter {
     });
     canvas.setIconOriginPosition(4);
 
-    this.drawCrossIcon(canvas);
+    IconPainter.drawCrossIcon(canvas);
     const rotationCenterX = shape.w / 4;
     const rotationCenterY = shape.h / 4;
     canvas.rotate(45, false, false, rotationCenterX, rotationCenterY);
     canvas.fillAndStroke();
   }
 
-  public static paintPlusCrossIcon({ c, ratioFromParent, shape, icon }: PaintParameter): void {
+  public paintPlusCrossIcon({ c, ratioFromParent, shape, icon }: PaintParameter): void {
     const canvas = new BpmnCanvas({
       mxCanvas: c,
       shapeConfiguration: shape,
@@ -266,7 +266,7 @@ export default class IconPainter {
     });
     canvas.setIconOriginPosition(4);
 
-    this.drawCrossIcon(canvas);
+    IconPainter.drawCrossIcon(canvas);
     canvas.fillAndStroke();
   }
 
@@ -289,7 +289,7 @@ export default class IconPainter {
 
   // implementation adapted from https://www.flaticon.com/free-icon/employees_554768
   // use https://github.com/process-analytics/mxgraph-svg2shape to generate the xml stencil and port it to code
-  public static paintWomanIcon({ c, ratioFromParent, shape, icon }: PaintParameter): void {
+  public paintWomanIcon({ c, ratioFromParent, shape, icon }: PaintParameter): void {
     const canvas = new BpmnCanvas({
       mxCanvas: c,
       shapeConfiguration: shape,
@@ -382,7 +382,7 @@ export default class IconPainter {
 
   // this implementation is adapted from the draw.io BPMN 'Service Task' stencil
   // https://github.com/jgraph/drawio/blob/9394fb0f1430d2c869865827b2bbef5639f63478/src/main/webapp/stencils/bpmn.xml#L898
-  public static paintGearIcon({ c, ratioFromParent, shape, icon }: PaintParameter): void {
+  public paintGearIcon({ c, ratioFromParent, shape, icon }: PaintParameter): void {
     const canvas = new BpmnCanvas({
       mxCanvas: c,
       shapeConfiguration: shape,
@@ -396,11 +396,11 @@ export default class IconPainter {
     canvas.setIconOriginPosition(20);
 
     // background
-    this.paintGearIconBackground(canvas);
+    IconPainter.paintGearIconBackground(canvas);
 
     // foreground
     canvas.translateIconOrigin(14, 14);
-    this.paintGearIconForeground(canvas);
+    IconPainter.paintGearIconForeground(canvas);
   }
 
   private static paintGearIconBackground(canvas: BpmnCanvas): void {
@@ -441,7 +441,7 @@ export default class IconPainter {
 
     const arcStartX = 24.8;
     const arcStartY = 39;
-    this.paintGearInnerCircle(canvas, arcStartX, arcStartY);
+    IconPainter.paintGearInnerCircle(canvas, arcStartX, arcStartY);
   }
 
   private static paintGearIconForeground(canvas: BpmnCanvas): void {
@@ -482,11 +482,11 @@ export default class IconPainter {
 
     const arcStartX = 39.2;
     const arcStartY = 55.8;
-    this.paintGearInnerCircle(canvas, arcStartX, arcStartY);
+    IconPainter.paintGearInnerCircle(canvas, arcStartX, arcStartY);
 
     // fill the inner circle to mask the background
     canvas.begin();
-    this.paintGearInnerCircle(canvas, arcStartX, arcStartY);
+    IconPainter.paintGearInnerCircle(canvas, arcStartX, arcStartY);
   }
 
   private static paintGearInnerCircle(canvas: BpmnCanvas, arcStartX: number, arcStartY: number): void {
@@ -498,7 +498,7 @@ export default class IconPainter {
     canvas.fillAndStroke();
   }
 
-  public static paintExpandIcon({ c, ratioFromParent, shape, icon }: PaintParameter): void {
+  public paintExpandIcon({ c, ratioFromParent, shape, icon }: PaintParameter): void {
     const originalIconSize = { width: 16, height: 16 };
     const canvas = new BpmnCanvas({
       mxCanvas: c,
@@ -528,5 +528,16 @@ export default class IconPainter {
     canvas.lineTo((w * 3) / 4, h / 2);
     canvas.close();
     canvas.fillAndStroke();
+  }
+}
+
+export class IconPainterProvider {
+  private static instance = new IconPainter();
+
+  static get(): IconPainter {
+    return this.instance;
+  }
+  static set(painter: IconPainter): void {
+    this.instance = painter;
   }
 }


### PR DESCRIPTION
Remove static calls to IconPainter which prevented to use alternate
implementation (by injection and for extension).
Introduce `IconPainterProvider` that returned an instance of `IconPainter` that
can be injected by configuration code. The new `IconPainterProvider` is now used
in all BPMN shapes when an `IconPainter` is needed.

Covers #247