### PR TITLE
[REFACTOR] Replace string content for BPMN content by json object, in unit json tests

### DIFF
--- a/src/component/mxgraph/shape/event-shapes.ts
+++ b/src/component/mxgraph/shape/event-shapes.ts
@@ -25,7 +25,11 @@ abstract class EventShape extends mxEllipse {
     [ShapeBpmnEventKind.MESSAGE, (paintParameter: PaintParameter) => this.iconPainter.paintEnvelopeIcon({ ...paintParameter, ratioFromParent: 0.5 })],
     [ShapeBpmnEventKind.TERMINATE, (paintParameter: PaintParameter) => this.iconPainter.paintCircleIcon({ ...paintParameter, ratioFromParent: 0.6 })],
     [ShapeBpmnEventKind.TIMER, (paintParameter: PaintParameter) => this.iconPainter.paintClockIcon(paintParameter)],
-    [ShapeBpmnEventKind.SIGNAL, (paintParameter: PaintParameter) => this.iconPainter.paintTriangleIcon({ ...paintParameter, ratioFromParent: 0.55, icon: { ...paintParameter.icon, strokeWidth: StyleDefault.STROKE_WIDTH_THIN.valueOf() } })],
+    [
+      ShapeBpmnEventKind.SIGNAL,
+      (paintParameter: PaintParameter) =>
+        this.iconPainter.paintTriangleIcon({ ...paintParameter, ratioFromParent: 0.55, icon: { ...paintParameter.icon, strokeWidth: StyleDefault.STROKE_WIDTH_THIN.valueOf() } }),
+    ],
   ]);
 
   protected withFilledIcon = false;

--- a/src/component/mxgraph/shape/render/IconPainter.ts
+++ b/src/component/mxgraph/shape/render/IconPainter.ts
@@ -16,7 +16,7 @@
 
 import { mxgraph } from 'ts-mxgraph';
 import BpmnCanvas from './BpmnCanvas';
-import StyleUtils, { StyleDefault } from '../../StyleUtils';
+import StyleUtils from '../../StyleUtils';
 import { IconStyleConfiguration, ShapeConfiguration } from './render-types';
 
 export interface PaintParameter {

--- a/src/component/parser/json/BpmnJsonParser.ts
+++ b/src/component/parser/json/BpmnJsonParser.ts
@@ -17,11 +17,12 @@ import { Definitions } from './Definitions';
 import BpmnModel from '../../../model/bpmn/BpmnModel';
 import JsonConvertConfig from './converter/JsonConvertConfig';
 import { JsonConvert } from 'json2typescript';
+import { BpmnJsonModel } from '../xml/bpmn-json-model/BPMN20';
 
 export default class BpmnJsonParser {
   constructor(readonly jsonConvert: JsonConvert) {}
 
-  public parse(json: { definitions: Definitions }): BpmnModel {
+  public parse(json: BpmnJsonModel): BpmnModel {
     const definitions = this.jsonConvert.deserializeObject(json.definitions, Definitions);
     return definitions.bpmnModel;
   }

--- a/src/component/parser/json/converter/CollaborationConverter.ts
+++ b/src/component/parser/json/converter/CollaborationConverter.ts
@@ -19,6 +19,9 @@ import { Participant } from '../../../../model/bpmn/shape/ShapeBpmnElement';
 import { Collaboration } from '../Definitions';
 import { MessageFlow } from '../../../../model/bpmn/edge/Flow';
 import { FlowKind } from '../../../../model/bpmn/edge/FlowKind';
+import { TCollaboration } from '../../xml/bpmn-json-model/baseElement/rootElement/collaboration';
+import { TParticipant } from '../../xml/bpmn-json-model/baseElement/participant';
+import { TMessageFlow } from '../../xml/bpmn-json-model/baseElement/baseElement';
 
 const convertedProcessRefParticipants: Participant[] = [];
 const convertedMessageFlows: MessageFlow[] = [];
@@ -37,8 +40,7 @@ export function findMessageFlow(id: string): MessageFlow {
 
 @JsonConverter
 export default class CollaborationConverter extends AbstractConverter<Collaboration> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  deserialize(collaboration: any): Collaboration {
+  deserialize(collaboration: TCollaboration): Collaboration {
     try {
       // Deletes everything in the array, which does hit other references. For better performance.
       convertedProcessRefParticipants.length = 0;
@@ -54,8 +56,7 @@ export default class CollaborationConverter extends AbstractConverter<Collaborat
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private buildParticipant(bpmnElements: Array<any> | any): void {
+  private buildParticipant(bpmnElements: Array<TParticipant> | TParticipant): void {
     ensureIsArray(bpmnElements).forEach(participant => {
       if (participant.processRef) {
         convertedProcessRefParticipants.push(new Participant(participant.id, participant.name, participant.processRef));
@@ -63,8 +64,7 @@ export default class CollaborationConverter extends AbstractConverter<Collaborat
     });
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private buildMessageFlows(bpmnElements: Array<any> | any): void {
+  private buildMessageFlows(bpmnElements: Array<TMessageFlow> | TMessageFlow): void {
     ensureIsArray(bpmnElements).forEach(messageFlow => {
       const convertedMessageFlow = new MessageFlow(messageFlow.id, messageFlow.name, messageFlow.sourceRef, messageFlow.targetRef);
       convertedMessageFlows.push(convertedMessageFlow);

--- a/src/component/parser/xml/BpmnXmlParser.ts
+++ b/src/component/parser/xml/BpmnXmlParser.ts
@@ -15,6 +15,7 @@
  */
 import { parse } from 'fast-xml-parser/src/parser';
 import * as entities from 'entities';
+import { BpmnJsonModel } from './bpmn-json-model/BPMN20';
 
 /**
  * Parse bpmn xml source
@@ -31,8 +32,7 @@ export default class BpmnXmlParser {
   };
 
   // disable eslint as it comes from 3rd party
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public parse(xml: string): any {
+  public parse(xml: string): BpmnJsonModel {
     return parse(xml, this.options);
   }
 }

--- a/src/component/parser/xml/bpmn-json-model/BPMN20.ts
+++ b/src/component/parser/xml/bpmn-json-model/BPMN20.ts
@@ -49,6 +49,10 @@ import {
   TTimerEventDefinition,
 } from './baseElement/rootElement/eventDefinition';
 
+export interface BpmnJsonModel {
+  definitions: TDefinitions;
+}
+
 // <xsd:anyAttribute namespace="##other" processContents="lax"/>
 export interface TDefinitions {
   import?: TImport | TImport[];

--- a/src/component/parser/xml/bpmn-json-model/BPMN20.ts
+++ b/src/component/parser/xml/bpmn-json-model/BPMN20.ts
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { BPMNDiagram } from './BPMNDI';
+import { TRelationship } from './baseElement/baseElement';
+import { TExtension } from './Semantic';
+import { TGlobalBusinessRuleTask, TGlobalManualTask, TGlobalScriptTask, TGlobalTask, TGlobalUserTask } from './baseElement/rootElement/globalTask';
+import { TCorrelationProperty } from './baseElement/correlation';
+import { TDataStore } from './baseElement/data';
+import {
+  TCategory,
+  TEndPoint,
+  TError,
+  TEscalation,
+  TInterface,
+  TItemDefinition,
+  TMessage,
+  TPartnerEntity,
+  TPartnerRole,
+  TProcess,
+  TResource,
+  TRootElement,
+  TSignal,
+} from './baseElement/rootElement/rootElement';
+import { TChoreography, TCollaboration, TGlobalChoreographyTask, TGlobalConversation } from './baseElement/rootElement/collaboration';
+import {
+  TCancelEventDefinition,
+  TCompensateEventDefinition,
+  TConditionalEventDefinition,
+  TErrorEventDefinition,
+  TEscalationEventDefinition,
+  TEventDefinition,
+  TLinkEventDefinition,
+  TMessageEventDefinition,
+  TSignalEventDefinition,
+  TTerminateEventDefinition,
+  TTimerEventDefinition,
+} from './baseElement/rootElement/eventDefinition';
+
+// <xsd:anyAttribute namespace="##other" processContents="lax"/>
+export interface TDefinitions {
+  import?: TImport | TImport[];
+  extension?: TExtension | TExtension[];
+
+  // rootElement
+  category?: TCategory | TCategory[];
+  choreography?: TChoreography | TChoreography[];
+  collaboration?: TCollaboration | TCollaboration[];
+  correlationProperty?: TCorrelationProperty | TCorrelationProperty[];
+  dataStore?: TDataStore | TDataStore[];
+  endPoint?: TEndPoint | TEndPoint[];
+  error?: TError | TError[];
+  escalation?: TEscalation | TEscalation[];
+  globalBusinessRuleTask?: TGlobalBusinessRuleTask | TGlobalBusinessRuleTask[];
+  globalChoreographyTask?: TGlobalChoreographyTask | TGlobalChoreographyTask[];
+  globalConversation?: TGlobalConversation | TGlobalConversation[];
+  globalManualTask?: TGlobalManualTask | TGlobalManualTask[];
+  globalScriptTask?: TGlobalScriptTask | TGlobalScriptTask[];
+  globalTask?: TGlobalTask | TGlobalTask[];
+  globalUserTask?: TGlobalUserTask | TGlobalUserTask[];
+  interface?: TInterface | TInterface[];
+  itemDefinition?: TItemDefinition | TItemDefinition[];
+  message?: TMessage | TMessage[];
+  partnerEntity?: TPartnerEntity | TPartnerEntity[];
+  partnerRole?: TPartnerRole | TPartnerRole[];
+  process?: string | TProcess | TProcess[];
+  resource?: TResource | TResource[];
+  rootElement?: TRootElement | TRootElement[];
+  signal?: TSignal | TSignal[];
+
+  // eventDefinition
+  eventDefinition?: string | TEventDefinition | TEventDefinition[];
+  cancelEventDefinition?: string | TCancelEventDefinition | TCancelEventDefinition[];
+  compensateEventDefinition?: string | TCompensateEventDefinition | TCompensateEventDefinition[];
+  conditionalEventDefinition?: string | TConditionalEventDefinition | TConditionalEventDefinition[];
+  errorEventDefinition?: string | TErrorEventDefinition | TErrorEventDefinition[];
+  escalationEventDefinition?: string | TEscalationEventDefinition | TEscalationEventDefinition[];
+  linkEventDefinition?: string | TLinkEventDefinition | TLinkEventDefinition[];
+  messageEventDefinition?: string | TMessageEventDefinition | TMessageEventDefinition[];
+  signalEventDefinition?: string | TSignalEventDefinition | TSignalEventDefinition[];
+  terminateEventDefinition?: string | TTerminateEventDefinition | TTerminateEventDefinition[];
+  timerEventDefinition?: string | TTimerEventDefinition | TTimerEventDefinition[];
+
+  BPMNDiagram?: BPMNDiagram | BPMNDiagram[];
+  relationship?: TRelationship | TRelationship[];
+  id?: string;
+  name?: string;
+  targetNamespace: string;
+  expressionLanguage?: string; // default="http://www.w3.org/1999/XPath"
+  typeLanguage?: string; // default="http://www.w3.org/2001/XMLSchema"
+  exporter?: string;
+  exporterVersion?: string;
+}
+
+export interface TImport {
+  namespace: string;
+  location: string;
+  importType: string;
+}

--- a/src/component/parser/xml/bpmn-json-model/BPMNDI.ts
+++ b/src/component/parser/xml/bpmn-json-model/BPMNDI.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Diagram, Label, LabeledEdge, LabeledShape, Plane, Style } from './DI';
+import { Font } from './DC';
+
+export interface BPMNDiagram extends Diagram {
+  BPMNPlane: BPMNPlane;
+  BPMNLabelStyle?: BPMNLabelStyle | BPMNLabelStyle[];
+}
+
+export interface BPMNPlane extends Plane {
+  bpmnElement?: string;
+}
+
+export interface BPMNEdge extends LabeledEdge {
+  BPMNLabel?: string | BPMNLabel;
+  bpmnElement?: string;
+  sourceElement?: string;
+  targetElement?: string;
+  messageVisibleKind?: MessageVisibleKind;
+}
+
+export interface BPMNShape extends LabeledShape {
+  BPMNLabel?: string | BPMNLabel;
+  bpmnElement?: string;
+  isHorizontal?: boolean;
+  isExpanded?: boolean;
+  isMarkerVisible?: boolean;
+  isMessageVisible?: boolean;
+  participantBandKind?: ParticipantBandKind;
+  choreographyActivityShape?: string;
+}
+
+export interface BPMNLabel extends Label {
+  labelStyle?: string;
+}
+
+export interface BPMNLabelStyle extends Style {
+  Font?: string | Font | Font[];
+}
+
+export enum ParticipantBandKind {
+  topInitiating = 'top_initiating',
+  middleInitiating = 'middle_initiating',
+  bottomInitiating = 'bottom_initiating',
+  topNonInitiating = 'top_non_initiating',
+  middleNonInitiating = 'middle_non_initiating',
+  bottomNonInitiating = 'bottom_non_initiating',
+}
+
+export enum MessageVisibleKind {
+  initiating = 'initiating',
+  nonInitiating = 'non_initiating',
+}

--- a/src/component/parser/xml/bpmn-json-model/DC.ts
+++ b/src/component/parser/xml/bpmn-json-model/DC.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export interface Font {
+  name?: string;
+  size?: number;
+  isBold?: boolean;
+  isItalic?: boolean;
+  isUnderline?: boolean;
+  isStrikeThrough?: boolean;
+}
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export interface Bounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}

--- a/src/component/parser/xml/bpmn-json-model/DI.ts
+++ b/src/component/parser/xml/bpmn-json-model/DI.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Bounds, Point } from './DC';
+import { BPMNEdge, BPMNLabel, BPMNShape } from './BPMNDI';
+import { TExtension } from './Semantic';
+
+// <xsd:any namespace="##other" minOccurs="0" maxOccurs="unbounded" />
+export interface DiagramElement {
+  id?: string;
+  extension?: TExtension | TExtension[];
+}
+
+export interface Diagram {
+  name?: string;
+  documentation?: string;
+  resolution?: number;
+  id?: string;
+}
+
+export type Node = DiagramElement;
+
+export interface Edge extends DiagramElement {
+  waypoint: Point[];
+}
+
+export type LabeledEdge = Edge;
+
+export interface Shape extends Node {
+  Bounds: Bounds;
+}
+
+export type LabeledShape = Shape;
+
+export interface Label extends Node {
+  Bounds?: Bounds;
+}
+
+export interface Plane extends Node {
+  BPMNEdge?: BPMNEdge | BPMNEdge[];
+  BPMNShape?: BPMNShape | BPMNShape[];
+  BPMNLabel?: BPMNLabel | BPMNLabel[];
+}
+
+export interface Style {
+  id: string;
+}

--- a/src/component/parser/xml/bpmn-json-model/Semantic.ts
+++ b/src/component/parser/xml/bpmn-json-model/Semantic.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// mixed="true"
+// <xsd:any namespace="##any" processContents="lax" minOccurs="0"/>
+export interface TDocumentation {
+  id?: string;
+  textFormat?: string; // default="text/plain"
+}
+
+export interface TExtension {
+  documentation?: TDocumentation | TDocumentation[];
+  definition?: string;
+  mustUnderstand?: boolean; // default="false"
+}
+
+// <xsd:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded" />
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface TExtensionElements {}
+
+// mixed="true"
+// <xsd:any namespace="##any" processContents="lax" minOccurs="0"/>
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface TScript {}
+
+// mixed="true"
+// <xsd:any namespace="##any" processContents="lax" minOccurs="0"/>
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface TText {}

--- a/src/component/parser/xml/bpmn-json-model/baseElement/artifact.ts
+++ b/src/component/parser/xml/bpmn-json-model/baseElement/artifact.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TBaseElement } from './baseElement';
+
+// abstract="true"
+export type TArtifact = TBaseElement;
+
+export interface TAssociation extends TArtifact {
+  sourceRef: string;
+  targetRef: string;
+  associationDirection?: tAssociationDirection; // default="None"
+}
+
+export interface TGroup extends TArtifact {
+  categoryValueRef?: string;
+}
+
+export interface TTextAnnotation extends TArtifact {
+  text?: string | Text;
+  textFormat?: string; // default="text/plain"
+}
+
+export enum tAssociationDirection {
+  None = 'None',
+  One = 'One',
+  Both = 'Both',
+}

--- a/src/component/parser/xml/bpmn-json-model/baseElement/baseElement.ts
+++ b/src/component/parser/xml/bpmn-json-model/baseElement/baseElement.ts
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TImplicitThrowEvent } from './flowNode/event';
+import { TDocumentation, TExtensionElements } from '../Semantic';
+import { TDataState } from './data';
+import { TExpression, TFormalExpression } from './expression';
+
+// abstract="true"
+// <xsd:anyAttribute namespace="##other" processContents="lax"/>
+export interface TBaseElement {
+  documentation?: TDocumentation | TDocumentation[];
+  extensionElements?: TExtensionElements;
+  id?: string;
+}
+
+// abstract="true" mixed="true"
+// <xsd:anyAttribute namespace="##other" processContents="lax"/>
+export interface TBaseElementWithMixedContent {
+  documentation?: TDocumentation | TDocumentation[];
+  extensionElements?: TExtensionElements;
+  id?: string;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+}
+
+export interface TCategoryValue extends TBaseElement {
+  value?: string;
+}
+
+export interface TAssignment extends TBaseElement {
+  from: TExpression;
+  to: TExpression;
+}
+
+export type TAuditing = TBaseElement;
+
+export interface TMessageFlow extends TBaseElement {
+  name?: string;
+  sourceRef: string;
+  targetRef: string;
+  messageRef?: string;
+}
+
+export interface TMessageFlowAssociation extends TBaseElement {
+  innerMessageFlowRef: string;
+  outerMessageFlowRef: string;
+}
+
+export type TMonitoring = TBaseElement;
+
+export interface TProperty extends TBaseElement {
+  dataState?: TDataState;
+  name?: string;
+  itemSubjectRef?: string;
+}
+
+export interface TRelationship extends TBaseElement {
+  source: string | string[];
+  target: string | string[];
+  type: string;
+  direction?: tRelationshipDirection;
+}
+
+enum tRelationshipDirection {
+  None = 'None',
+  Forward = 'Forward',
+  Backward = 'Backward',
+  Both = 'Both',
+}
+
+export interface TComplexBehaviorDefinition extends TBaseElement {
+  condition: TFormalExpression;
+  event?: TImplicitThrowEvent;
+}
+
+export interface TLane extends TBaseElement {
+  partitionElement?: TBaseElement;
+  flowNodeRef?: string | string[];
+  childLaneSet?: TLaneSet;
+  name?: string;
+  partitionElementRef?: string;
+}
+
+export interface TLaneSet extends TBaseElement {
+  lane?: TLane | TLane[];
+  name?: string;
+}
+
+export interface TOperation extends TBaseElement {
+  inMessageRef: string;
+  outMessageRef?: string;
+  errorRef?: string | string[];
+  name: string;
+  implementationRef?: string;
+}
+
+export type TRendering = TBaseElement;

--- a/src/component/parser/xml/bpmn-json-model/baseElement/conversation.ts
+++ b/src/component/parser/xml/bpmn-json-model/baseElement/conversation.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TBaseElement } from './baseElement';
+import { TCorrelationKey } from './correlation';
+import { TParticipantAssociation } from './participant';
+
+// abstract="true"
+export interface TConversationNode extends TBaseElement {
+  correlationKey?: TCorrelationKey[];
+  participantRef?: string | string[];
+  messageFlowRef?: string | string[];
+  name?: string;
+}
+
+export interface TCallConversation extends TConversationNode {
+  participantAssociation?: TParticipantAssociation | TParticipantAssociation[];
+  calledCollaborationRef?: string;
+}
+
+export interface TSubConversation extends TConversationNode {
+  // conversationNode
+  conversationNode?: TConversationNode | TConversationNode[];
+  callConversation?: TCallConversation | TCallConversation[];
+  conversation?: TConversation[];
+}
+
+export type TConversation = TConversationNode;
+
+export interface TConversationAssociation extends TBaseElement {
+  innerConversationNodeRef: string;
+  outerConversationNodeRef: string;
+}
+
+export interface TConversationLink extends TBaseElement {
+  name?: string;
+  sourceRef: string;
+  targetRef: string;
+}

--- a/src/component/parser/xml/bpmn-json-model/baseElement/correlation.ts
+++ b/src/component/parser/xml/bpmn-json-model/baseElement/correlation.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TBaseElement } from './baseElement';
+import { TRootElement } from './rootElement/rootElement';
+import { TFormalExpression } from './expression';
+
+export interface TCorrelationProperty extends TRootElement {
+  correlationPropertyRetrievalExpression: TCorrelationPropertyRetrievalExpression | TCorrelationPropertyRetrievalExpression[];
+  name?: string;
+  type?: string;
+}
+
+export interface TCorrelationKey extends TBaseElement {
+  correlationPropertyRef?: string | string[];
+  name?: string;
+}
+
+export interface TCorrelationPropertyBinding extends TBaseElement {
+  dataPath: TFormalExpression;
+  correlationPropertyRef: string;
+}
+
+export interface TCorrelationPropertyRetrievalExpression extends TBaseElement {
+  messagePath: TFormalExpression;
+  messageRef: string;
+}
+
+export interface TCorrelationSubscription extends TBaseElement {
+  correlationPropertyBinding?: TCorrelationPropertyBinding | TCorrelationPropertyBinding[];
+  correlationKeyRef: string;
+}

--- a/src/component/parser/xml/bpmn-json-model/baseElement/data.ts
+++ b/src/component/parser/xml/bpmn-json-model/baseElement/data.ts
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TAssignment, TBaseElement } from './baseElement';
+import { TRootElement } from './rootElement/rootElement';
+import { TFormalExpression } from './expression';
+import { TFlowElement } from './flowElement';
+
+export type TDataInputAssociation = TDataAssociation;
+
+export type TDataOutputAssociation = TDataAssociation;
+
+export interface TDataState {
+  name?: string;
+}
+
+export interface TDataObject extends TFlowElement {
+  dataState?: TDataState;
+  itemSubjectRef?: string;
+  isCollection?: boolean; // default="false"
+}
+
+export interface TDataObjectReference extends TFlowElement {
+  dataState?: TDataState;
+  itemSubjectRef?: string;
+  dataObjectRef?: string;
+}
+
+export interface TDataStoreReference extends TFlowElement {
+  dataState?: TDataState;
+  itemSubjectRef?: string;
+  dataStoreRef?: string;
+}
+
+export interface TDataAssociation extends TBaseElement {
+  assignment?: TAssignment | TAssignment[];
+  sourceRef?: string | string[];
+  targetRef: string;
+  transformation?: TFormalExpression;
+}
+
+export interface TDataInput extends TBaseElement {
+  dataState?: TDataState;
+  name?: string;
+  itemSubjectRef?: string;
+  isCollection?: boolean; // default="false"
+}
+
+export interface TDataOutput extends TBaseElement {
+  dataState?: TDataState;
+  name?: string;
+  itemSubjectRef?: string;
+  isCollection?: boolean; // default="false"
+}
+
+export interface TDataStore extends TRootElement {
+  dataState?: TDataState;
+  name?: string;
+  capacity?: number;
+  isUnlimited?: boolean; // default="true"
+  itemSubjectRef?: string;
+}

--- a/src/component/parser/xml/bpmn-json-model/baseElement/expression.ts
+++ b/src/component/parser/xml/bpmn-json-model/baseElement/expression.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TBaseElementWithMixedContent } from './baseElement';
+
+export type TExpression = TBaseElementWithMixedContent;
+
+export interface TFormalExpression extends TExpression {
+  language?: string;
+  evaluatesToTypeRef?: string;
+}

--- a/src/component/parser/xml/bpmn-json-model/baseElement/flowElement.ts
+++ b/src/component/parser/xml/bpmn-json-model/baseElement/flowElement.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TExpression } from './expression';
+import { TAuditing, TBaseElement, TMonitoring } from './baseElement';
+
+export interface TFlowElement extends TBaseElement {
+  auditing?: TAuditing;
+  monitoring?: TMonitoring;
+  categoryValueRef?: string | string[];
+  name?: string;
+}
+
+// abstract="true"
+export interface TFlowNode extends TFlowElement {
+  incoming?: string | string[];
+  outgoing?: string | string[];
+}
+
+export interface TSequenceFlow extends TFlowElement {
+  conditionExpression?: TExpression;
+  sourceRef: string;
+  targetRef: string;
+  isImmediate?: boolean;
+}

--- a/src/component/parser/xml/bpmn-json-model/baseElement/flowNode/activity/activity.ts
+++ b/src/component/parser/xml/bpmn-json-model/baseElement/flowNode/activity/activity.ts
@@ -1,0 +1,132 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TInputOutputSpecification } from '../../input-output';
+import { TLaneSet, TProperty } from '../../baseElement';
+import { TDataInputAssociation, TDataObject, TDataObjectReference, TDataOutputAssociation, TDataStoreReference } from '../../data';
+import { THumanPerformer, TPerformer, TPotentialOwner, TResourceRole } from '../../resource';
+import { TLoopCharacteristics, TMultiInstanceLoopCharacteristics, TStandardLoopCharacteristics } from '../../loopCharacteristics';
+import { TExpression } from '../../expression';
+import { TArtifact, TAssociation, TGroup, TTextAnnotation } from '../../artifact';
+import { TFlowElement, TFlowNode, TSequenceFlow } from '../../flowElement';
+import { TCallChoreography, TChoreographyTask, TSubChoreography } from '../choreographyActivity';
+import { TBoundaryEvent, TEndEvent, TEvent, TImplicitThrowEvent, TIntermediateCatchEvent, TIntermediateThrowEvent, TStartEvent } from '../event';
+import { TComplexGateway, TEventBasedGateway, TExclusiveGateway, TInclusiveGateway, TParallelGateway } from '../gateway';
+import { TBusinessRuleTask, TManualTask, TReceiveTask, TScriptTask, TSendTask, TServiceTask, TTask, TUserTask } from './task';
+
+// abstract="true"
+export interface TActivity extends TFlowNode {
+  ioSpecification?: TInputOutputSpecification;
+  property?: TProperty | TProperty[];
+  dataInputAssociation?: TDataInputAssociation | TDataInputAssociation[];
+  dataOutputAssociation?: TDataOutputAssociation | TDataOutputAssociation[];
+
+  // resourceRole
+  resourceRole?: TResourceRole | TResourceRole[];
+  performer?: TPerformer | TPerformer[];
+  humanPerformer?: THumanPerformer | THumanPerformer[];
+  potentialOwner?: TPotentialOwner | TPotentialOwner[];
+
+  // loopCharacteristics
+  loopCharacteristics?: TLoopCharacteristics | TLoopCharacteristics[];
+  multiInstanceLoopCharacteristics?: TMultiInstanceLoopCharacteristics | TMultiInstanceLoopCharacteristics[];
+  standardLoopCharacteristics?: TStandardLoopCharacteristics | TStandardLoopCharacteristics[];
+
+  isForCompensation?: boolean; // default="false"
+  startQuantity?: number; // default="1"
+  completionQuantity?: number; // default="1"
+  default?: string;
+}
+
+export interface TCallActivity extends TActivity {
+  calledElement?: string;
+}
+
+export interface TSubProcess extends TActivity {
+  laneSet?: TLaneSet | TLaneSet[];
+
+  // flowElement
+  flowElement?: TFlowElement | TFlowElement[];
+  sequenceFlow?: TSequenceFlow | TSequenceFlow[];
+  callChoreography?: TCallChoreography | TCallChoreography[];
+  choreographyTask?: TChoreographyTask | TChoreographyTask[];
+  subChoreography?: TSubChoreography | TSubChoreography[];
+  callActivity?: TCallActivity | TCallActivity[];
+
+  // dataObject
+  dataObject?: TDataObject | TDataObject[];
+  dataObjectReference?: TDataObjectReference | TDataObjectReference[];
+  dataStoreReference?: TDataStoreReference | TDataStoreReference[];
+
+  // event
+  event?: TEvent | TEvent[];
+  intermediateCatchEvent?: TIntermediateCatchEvent | TIntermediateCatchEvent[];
+  boundaryEvent?: TBoundaryEvent | TBoundaryEvent[];
+  startEvent?: TStartEvent | TStartEvent[];
+  implicitThrowEvent?: TImplicitThrowEvent | TImplicitThrowEvent[];
+  intermediateThrowEvent?: TIntermediateThrowEvent | TIntermediateThrowEvent[];
+  endEvent?: TEndEvent | TEndEvent[];
+
+  // sub process
+  subProcess?: TSubProcess | TSubProcess[];
+  adHocSubProcess?: TAdHocSubProcess | TAdHocSubProcess[];
+  transaction?: TTransaction | TTransaction[];
+
+  // gateway
+  complexGateway?: TComplexGateway | TComplexGateway[];
+  eventBasedGateway?: TEventBasedGateway | TEventBasedGateway[];
+  exclusiveGateway?: TExclusiveGateway | TExclusiveGateway[];
+  inclusiveGateway?: TInclusiveGateway | TInclusiveGateway[];
+  parallelGateway?: TParallelGateway | TParallelGateway[];
+
+  // task
+  task?: TTask | TTask[];
+  businessRuleTask?: TBusinessRuleTask | TBusinessRuleTask[];
+  manualTask?: TManualTask | TManualTask[];
+  receiveTask?: TReceiveTask | TReceiveTask[];
+  sendTask?: TSendTask | TSendTask[];
+  serviceTask?: TServiceTask | TServiceTask[];
+  scriptTask?: TScriptTask | TScriptTask[];
+  userTask?: TUserTask | TUserTask[];
+
+  // artifact
+  artifact?: TArtifact | TArtifact[];
+  association?: TAssociation | TAssociation[];
+  group?: TGroup | TGroup[];
+  textAnnotation?: TTextAnnotation | TTextAnnotation[];
+
+  triggeredByEvent?: boolean; // default="false"
+}
+
+export interface TAdHocSubProcess extends TSubProcess {
+  completionCondition?: TExpression;
+  cancelRemainingInstances?: boolean; // default="true"
+  ordering?: tAdHocOrdering;
+}
+
+enum tAdHocOrdering {
+  Parallel = 'Parallel',
+  Sequential = 'Sequential',
+}
+
+export interface TTransaction extends TSubProcess {
+  method?: tTransactionMethod; //default="##Compensate"
+}
+
+enum tTransactionMethod {
+  Compensate = '##Compensate',
+  Image = '##Image',
+  Store = '##Store',
+}

--- a/src/component/parser/xml/bpmn-json-model/baseElement/flowNode/activity/task.ts
+++ b/src/component/parser/xml/bpmn-json-model/baseElement/flowNode/activity/task.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TScript } from '../../../Semantic';
+import { TActivity } from './activity';
+import { tImplementation } from '../../rootElement/globalTask';
+import { TRendering } from '../../baseElement';
+
+export type TTask = TActivity;
+
+export interface TBusinessRuleTask extends TTask {
+  implementation?: tImplementation; // default="##unspecified"
+}
+
+export type TManualTask = TTask;
+
+export interface TReceiveTask extends TTask {
+  implementation?: tImplementation; // default="##WebService"
+  instantiate?: boolean; // default="##false"
+  messageRef?: string;
+  operationRef?: string;
+}
+
+export interface TSendTask extends TTask {
+  implementation?: tImplementation; // default="##WebService"
+  messageRef?: string;
+  operationRef?: string;
+}
+
+export interface TServiceTask extends TTask {
+  implementation?: tImplementation; // default="##WebService"
+  operationRef?: string;
+}
+
+export interface TScriptTask extends TTask {
+  script?: TScript;
+  scriptFormat?: string;
+}
+
+export interface TUserTask extends TTask {
+  rendering?: TRendering | TRendering[];
+  implementation?: tImplementation; // default="##unspecified"
+}

--- a/src/component/parser/xml/bpmn-json-model/baseElement/flowNode/choreographyActivity.ts
+++ b/src/component/parser/xml/bpmn-json-model/baseElement/flowNode/choreographyActivity.ts
@@ -1,0 +1,100 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TCorrelationKey } from '../correlation';
+import { TParticipantAssociation } from '../participant';
+import { TArtifact, TAssociation, TGroup, TTextAnnotation } from '../artifact';
+import { TFlowElement, TFlowNode, TSequenceFlow } from '../flowElement';
+import { TAdHocSubProcess, TCallActivity, TSubProcess, TTransaction } from './activity/activity';
+import { TDataObject, TDataObjectReference, TDataStoreReference } from '../data';
+import { TBoundaryEvent, TEndEvent, TEvent, TImplicitThrowEvent, TIntermediateCatchEvent, TIntermediateThrowEvent, TStartEvent } from './event';
+import { TComplexGateway, TEventBasedGateway, TExclusiveGateway, TInclusiveGateway, TParallelGateway } from './gateway';
+import { TBusinessRuleTask, TManualTask, TReceiveTask, TScriptTask, TSendTask, TServiceTask, TTask, TUserTask } from './activity/task';
+
+// abstract="true"
+export interface TChoreographyActivity extends TFlowNode {
+  correlationKey?: TCorrelationKey | TCorrelationKey[];
+  participantRef: string | string[];
+  initiatingParticipantRef: string;
+  loopType?: tChoreographyLoopType; // default="None"
+}
+
+export interface TCallChoreography extends TChoreographyActivity {
+  participantAssociation?: TParticipantAssociation | TParticipantAssociation[];
+  calledChoreographyRef?: string;
+}
+
+export interface TChoreographyTask extends TChoreographyActivity {
+  messageFlowRef: string | string[];
+}
+
+export interface TSubChoreography extends TChoreographyActivity {
+  // flowElement
+  flowElement?: TFlowElement | TFlowElement[];
+  sequenceFlow?: TSequenceFlow | TSequenceFlow[];
+  callChoreography?: TCallChoreography | TCallChoreography[];
+  choreographyTask?: TChoreographyTask | TChoreographyTask[];
+  subChoreography?: TSubChoreography | TSubChoreography[];
+  callActivity?: TCallActivity | TCallActivity[];
+
+  // dataObject
+  dataObject?: TDataObject | TDataObject[];
+  dataObjectReference?: TDataObjectReference | TDataObjectReference[];
+  dataStoreReference?: TDataStoreReference | TDataStoreReference[];
+
+  // event
+  event?: TEvent | TEvent[];
+  intermediateCatchEvent?: TIntermediateCatchEvent | TIntermediateCatchEvent[];
+  boundaryEvent?: TBoundaryEvent | TBoundaryEvent[];
+  startEvent?: TStartEvent | TStartEvent[];
+  implicitThrowEvent?: TImplicitThrowEvent | TImplicitThrowEvent[];
+  intermediateThrowEvent?: TIntermediateThrowEvent | TIntermediateThrowEvent[];
+  endEvent?: TEndEvent | TEndEvent[];
+
+  // sub process
+  subProcess?: TSubProcess | TSubProcess[];
+  adHocSubProcess?: TAdHocSubProcess | TAdHocSubProcess[];
+  transaction?: TTransaction | TTransaction[];
+
+  // gateway
+  complexGateway?: TComplexGateway | TComplexGateway[];
+  eventBasedGateway?: TEventBasedGateway | TEventBasedGateway[];
+  exclusiveGateway?: TExclusiveGateway | TExclusiveGateway[];
+  inclusiveGateway?: TInclusiveGateway | TInclusiveGateway[];
+  parallelGateway?: TParallelGateway | TParallelGateway[];
+
+  // task
+  task?: TTask | TTask[];
+  businessRuleTask?: TBusinessRuleTask | TBusinessRuleTask[];
+  manualTask?: TManualTask | TManualTask[];
+  receiveTask?: TReceiveTask | TReceiveTask[];
+  sendTask?: TSendTask | TSendTask[];
+  serviceTask?: TServiceTask | TServiceTask[];
+  scriptTask?: TScriptTask | TScriptTask[];
+  userTask?: TUserTask | TUserTask[];
+
+  // artifact
+  artifact?: TArtifact | TArtifact[];
+  association?: TAssociation | TAssociation[];
+  group?: TGroup | TGroup[];
+  textAnnotation?: TTextAnnotation | TTextAnnotation[];
+}
+
+enum tChoreographyLoopType {
+  None = 'None',
+  Standard = 'Standard',
+  MultiInstanceSequential = 'MultiInstanceSequential',
+  MultiInstanceParallel = 'MultiInstanceParallel',
+}

--- a/src/component/parser/xml/bpmn-json-model/baseElement/flowNode/event.ts
+++ b/src/component/parser/xml/bpmn-json-model/baseElement/flowNode/event.ts
@@ -1,0 +1,118 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TProperty } from '../baseElement';
+import { TDataInput, TDataInputAssociation, TDataOutput, TDataOutputAssociation } from '../data';
+import { TInputSet, TOutputSet } from '../input-output';
+import {
+  TCancelEventDefinition,
+  TCompensateEventDefinition,
+  TConditionalEventDefinition,
+  TErrorEventDefinition,
+  TEscalationEventDefinition,
+  TEventDefinition,
+  TLinkEventDefinition,
+  TMessageEventDefinition,
+  TSignalEventDefinition,
+  TTerminateEventDefinition,
+  TTimerEventDefinition,
+} from '../rootElement/eventDefinition';
+import { TFlowNode } from '../flowElement';
+
+// abstract="true"
+export interface TEvent extends TFlowNode {
+  property?: TProperty | TProperty[];
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+}
+// ======================== Catch event ========================
+// abstract="true"
+export interface TCatchEvent extends TEvent {
+  dataOutput?: TDataOutput | TDataOutput[];
+  dataOutputAssociation?: TDataOutputAssociation | TDataOutputAssociation[];
+  outputSet?: TOutputSet;
+
+  // eventDefinition
+  eventDefinition?: string | TEventDefinition | TEventDefinition[];
+  cancelEventDefinition?: string | TCancelEventDefinition | TCancelEventDefinition[];
+  compensateEventDefinition?: string | TCompensateEventDefinition | TCompensateEventDefinition[];
+  conditionalEventDefinition?: string | TConditionalEventDefinition | TConditionalEventDefinition[];
+  errorEventDefinition?: string | TErrorEventDefinition | TErrorEventDefinition[];
+  escalationEventDefinition?: string | TEscalationEventDefinition | TEscalationEventDefinition[];
+  linkEventDefinition?: string | TLinkEventDefinition | TLinkEventDefinition[];
+  messageEventDefinition?: string | TMessageEventDefinition | TMessageEventDefinition[];
+  signalEventDefinition?: string | TSignalEventDefinition | TSignalEventDefinition[];
+  terminateEventDefinition?: string | TTerminateEventDefinition | TTerminateEventDefinition[];
+  timerEventDefinition?: string | TTimerEventDefinition | TTimerEventDefinition[];
+
+  eventDefinitionRef?: string | string[];
+  parallelMultiple?: boolean; // default="false"
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+}
+
+export type TIntermediateCatchEvent = TCatchEvent;
+
+export interface TBoundaryEvent extends TCatchEvent {
+  cancelActivity?: boolean; // default="true"
+  attachedToRef: string;
+}
+
+export interface TStartEvent extends TCatchEvent {
+  isInterrupting?: boolean; // default="true"
+}
+
+// ======================== Throw event ========================
+// abstract="true"
+export interface TThrowEvent extends TEvent {
+  dataInput?: TDataInput | TDataInput[];
+  dataInputAssociation?: TDataInputAssociation | TDataInputAssociation[];
+  inputSet?: TInputSet;
+
+  // eventDefinition
+  eventDefinition?: string | TEventDefinition | TEventDefinition[];
+  cancelEventDefinition?: string | TCancelEventDefinition | TCancelEventDefinition[];
+  compensateEventDefinition?: string | TCompensateEventDefinition | TCompensateEventDefinition[];
+  conditionalEventDefinition?: string | TConditionalEventDefinition | TConditionalEventDefinition[];
+  errorEventDefinition?: string | TErrorEventDefinition | TErrorEventDefinition[];
+  escalationEventDefinition?: string | TEscalationEventDefinition | TEscalationEventDefinition[];
+  linkEventDefinition?: string | TLinkEventDefinition | TLinkEventDefinition[];
+  messageEventDefinition?: string | TMessageEventDefinition | TMessageEventDefinition[];
+  signalEventDefinition?: string | TSignalEventDefinition | TSignalEventDefinition[];
+  terminateEventDefinition?: string | TTerminateEventDefinition | TTerminateEventDefinition[];
+  timerEventDefinition?: string | TTimerEventDefinition | TTimerEventDefinition[];
+
+  eventDefinitionRef?: string | string[];
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+}
+
+export interface TImplicitThrowEvent extends TThrowEvent {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+}
+
+export interface TIntermediateThrowEvent extends TThrowEvent {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+}
+
+export interface TEndEvent extends TThrowEvent {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+}

--- a/src/component/parser/xml/bpmn-json-model/baseElement/flowNode/gateway.ts
+++ b/src/component/parser/xml/bpmn-json-model/baseElement/flowNode/gateway.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TExpression } from '../expression';
+import { TFlowNode } from '../flowElement';
+
+// abstract="true"
+export interface TGateway extends TFlowNode {
+  gatewayDirection?: tGatewayDirection; // default="Unspecified"
+}
+
+export interface TComplexGateway extends TGateway {
+  activationCondition?: TExpression;
+  default?: string;
+}
+
+export interface TEventBasedGateway extends TGateway {
+  instantiate?: boolean; // default="false"
+  eventGatewayType?: tEventBasedGatewayType; // default="Exclusive"
+}
+
+export interface TExclusiveGateway extends TGateway {
+  default?: string;
+}
+
+export interface TInclusiveGateway extends TGateway {
+  default?: string;
+}
+
+export type TParallelGateway = TGateway;
+
+enum tEventBasedGatewayType {
+  Exclusive = 'Exclusive',
+  Parallel = 'Parallel',
+}
+
+enum tGatewayDirection {
+  Unspecified = 'Unspecified',
+  Converging = 'Converging',
+  Diverging = 'Diverging',
+  Mixed = 'Mixed',
+}

--- a/src/component/parser/xml/bpmn-json-model/baseElement/input-output.ts
+++ b/src/component/parser/xml/bpmn-json-model/baseElement/input-output.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TBaseElement } from './baseElement';
+import { TDataInput, TDataOutput } from './data';
+
+export interface TInputOutputBinding extends TBaseElement {
+  operationRef: string;
+  inputDataRef: string;
+  outputDataRef: string;
+}
+
+export interface TInputOutputSpecification extends TBaseElement {
+  dataInput?: TDataInput | TDataInput[];
+  dataOutput?: TDataOutput | TDataOutput[];
+  inputSet: TInputSet | TInputSet[];
+  outputSet: TOutputSet | TOutputSet[];
+}
+
+export interface TInputSet extends TBaseElement {
+  dataInputRefs?: string | string[];
+  optionalInputRefs?: string | string[];
+  whileExecutingInputRefs?: string | string[];
+  outputSetRefs?: string | string[];
+  name?: string;
+}
+
+export interface TOutputSet extends TBaseElement {
+  dataOutputRefs?: string | string[];
+  optionalOutputRefs?: string | string[];
+  whileExecutingOutputRefs?: string | string[];
+  inputSetRefs?: string | string[];
+  name?: string;
+}

--- a/src/component/parser/xml/bpmn-json-model/baseElement/loopCharacteristics.ts
+++ b/src/component/parser/xml/bpmn-json-model/baseElement/loopCharacteristics.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TExpression } from './expression';
+import { TDataInput, TDataOutput } from './data';
+import { TBaseElement, TComplexBehaviorDefinition } from './baseElement';
+
+// abstract="true"
+export type TLoopCharacteristics = TBaseElement;
+
+export interface TMultiInstanceLoopCharacteristics extends TLoopCharacteristics {
+  complexBehaviorDefinition?: TComplexBehaviorDefinition | TComplexBehaviorDefinition[];
+  loopCardinality?: TExpression;
+  loopDataInputRef?: string;
+  loopDataOutputRef?: string;
+  inputDataItem?: TDataInput;
+  outputDataItem?: TDataOutput;
+  completionCondition?: TExpression;
+  isSequential?: boolean; // default="false"
+  behavior?: tMultiInstanceFlowCondition; // default="All"
+  oneBehaviorEventRef?: string;
+  noneBehaviorEventRef?: string;
+}
+
+export interface TStandardLoopCharacteristics extends TLoopCharacteristics {
+  loopCondition?: TExpression;
+  testBefore?: boolean; // default="false"
+  loopMaximum?: number;
+}
+
+export enum tMultiInstanceFlowCondition {
+  None = 'None',
+  One = 'One',
+  All = 'All',
+  Complex = 'Complex',
+}

--- a/src/component/parser/xml/bpmn-json-model/baseElement/participant.ts
+++ b/src/component/parser/xml/bpmn-json-model/baseElement/participant.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TBaseElement } from './baseElement';
+
+export interface TParticipant extends TBaseElement {
+  participantMultiplicity?: TParticipantMultiplicity;
+  interfaceRef?: string | string[];
+  endPointRef?: string | string[];
+  name?: string;
+  processRef?: string;
+}
+
+export interface TParticipantAssociation extends TBaseElement {
+  innerParticipantRef: string;
+  outerParticipantRef: string;
+}
+
+export interface TParticipantMultiplicity extends TBaseElement {
+  minimum?: number; // default="0"
+  maximum?: number; // default="1"
+}

--- a/src/component/parser/xml/bpmn-json-model/baseElement/resource.ts
+++ b/src/component/parser/xml/bpmn-json-model/baseElement/resource.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TBaseElement } from './baseElement';
+import { TExpression, TFormalExpression } from './expression';
+
+export interface TResourceAssignmentExpression extends TBaseElement {
+  // expression
+  expression: TExpression;
+  formalExpression: TFormalExpression;
+}
+
+export interface TResourceParameter extends TBaseElement {
+  name?: string;
+  type?: string;
+  isRequired?: boolean;
+}
+
+export interface TResourceParameterBinding extends TBaseElement {
+  // expression
+  expression: TExpression;
+  formalExpression: TFormalExpression;
+
+  parameterRef: string;
+}
+
+export interface TResourceRole extends TBaseElement {
+  resourceRef?: string;
+  resourceParameterBinding?: TResourceParameterBinding | TResourceParameterBinding[];
+  resourceAssignmentExpression?: TResourceAssignmentExpression | TResourceAssignmentExpression;
+  name?: string;
+}
+
+// ======================== Performer ========================
+export type TPerformer = TResourceRole;
+
+export type THumanPerformer = TPerformer;
+
+export type TPotentialOwner = THumanPerformer;

--- a/src/component/parser/xml/bpmn-json-model/baseElement/rootElement/collaboration.ts
+++ b/src/component/parser/xml/bpmn-json-model/baseElement/rootElement/collaboration.ts
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TRootElement } from './rootElement';
+import { TCallConversation, TConversation, TConversationAssociation, TConversationLink, TConversationNode, TSubConversation } from '../conversation';
+import { TMessageFlow, TMessageFlowAssociation } from '../baseElement';
+import { TParticipant, TParticipantAssociation } from '../participant';
+import { TArtifact, TAssociation, TGroup, TTextAnnotation } from '../artifact';
+import { TCorrelationKey } from '../correlation';
+import { TFlowElement, TSequenceFlow } from '../flowElement';
+import { TCallChoreography, TChoreographyTask, TSubChoreography } from '../flowNode/choreographyActivity';
+import { TAdHocSubProcess, TCallActivity, TSubProcess, TTransaction } from '../flowNode/activity/activity';
+import { TDataObject, TDataObjectReference, TDataStoreReference } from '../data';
+import { TBoundaryEvent, TEndEvent, TEvent, TImplicitThrowEvent, TIntermediateCatchEvent, TIntermediateThrowEvent, TStartEvent } from '../flowNode/event';
+import { TComplexGateway, TEventBasedGateway, TExclusiveGateway, TInclusiveGateway, TParallelGateway } from '../flowNode/gateway';
+import { TBusinessRuleTask, TManualTask, TReceiveTask, TScriptTask, TSendTask, TServiceTask, TTask, TUserTask } from '../flowNode/activity/task';
+
+export interface TCollaboration extends TRootElement {
+  participant?: TParticipant | TParticipant[];
+  messageFlow?: TMessageFlow | TMessageFlow[];
+
+  // artifact
+  artifact?: TArtifact | TArtifact[];
+  association?: TAssociation | TAssociation[];
+  group?: TGroup | TGroup[];
+  textAnnotation?: TTextAnnotation | TTextAnnotation[];
+
+  // conversationNode
+  conversationNode?: TConversationNode | TConversationNode[];
+  callConversation?: TCallConversation | TCallConversation[];
+  conversation?: TConversation | TConversation[];
+  subConversation?: TSubConversation | TSubConversation[];
+
+  conversationAssociation?: TConversationAssociation | TConversationAssociation[];
+  participantAssociation?: TParticipantAssociation | TParticipantAssociation[];
+  messageFlowAssociation?: TMessageFlowAssociation | TMessageFlowAssociation[];
+  correlationKey?: TCorrelationKey | TCorrelationKey[];
+  choreographyRef?: string | string[];
+  conversationLink?: TConversationLink | TConversationLink[];
+  name?: string;
+  isClosed?: boolean; // default="false"
+}
+
+export type TGlobalConversation = TCollaboration;
+
+export interface TChoreography extends TCollaboration {
+  // flowElement
+  flowElement?: TFlowElement | TFlowElement[];
+  sequenceFlow?: TSequenceFlow | TSequenceFlow[];
+  callChoreography?: TCallChoreography | TCallChoreography[];
+  choreographyTask?: TChoreographyTask | TChoreographyTask[];
+  subChoreography?: TSubChoreography | TSubChoreography[];
+  callActivity?: TCallActivity | TCallActivity[];
+
+  // dataObject
+  dataObject?: TDataObject | TDataObject[];
+  dataObjectReference?: TDataObjectReference | TDataObjectReference[];
+  dataStoreReference?: TDataStoreReference | TDataStoreReference[];
+
+  // event
+  event?: TEvent | TEvent[];
+  intermediateCatchEvent?: TIntermediateCatchEvent | TIntermediateCatchEvent[];
+  boundaryEvent?: TBoundaryEvent | TBoundaryEvent[];
+  startEvent?: TStartEvent | TStartEvent[];
+  implicitThrowEvent?: TImplicitThrowEvent | TImplicitThrowEvent[];
+  intermediateThrowEvent?: TIntermediateThrowEvent | TIntermediateThrowEvent[];
+  endEvent?: TEndEvent | TEndEvent[];
+
+  // sub process
+  subProcess?: TSubProcess | TSubProcess[];
+  adHocSubProcess?: TAdHocSubProcess | TAdHocSubProcess[];
+  transaction?: TTransaction | TTransaction[];
+
+  // gateway
+  complexGateway?: TComplexGateway | TComplexGateway[];
+  eventBasedGateway?: TEventBasedGateway | TEventBasedGateway[];
+  exclusiveGateway?: TExclusiveGateway | TExclusiveGateway[];
+  inclusiveGateway?: TInclusiveGateway | TInclusiveGateway[];
+  parallelGateway?: TParallelGateway | TParallelGateway[];
+
+  // task
+  task?: TTask | TTask[];
+  businessRuleTask?: TBusinessRuleTask | TBusinessRuleTask[];
+  manualTask?: TManualTask | TManualTask[];
+  receiveTask?: TReceiveTask | TReceiveTask[];
+  sendTask?: TSendTask | TSendTask[];
+  serviceTask?: TServiceTask | TServiceTask[];
+  scriptTask?: TScriptTask | TScriptTask[];
+  userTask?: TUserTask | TUserTask[];
+}
+
+export interface TGlobalChoreographyTask extends TChoreography {
+  initiatingParticipantRef?: string;
+}

--- a/src/component/parser/xml/bpmn-json-model/baseElement/rootElement/eventDefinition.ts
+++ b/src/component/parser/xml/bpmn-json-model/baseElement/rootElement/eventDefinition.ts
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TRootElement } from './rootElement';
+import { TExpression } from '../expression';
+
+// abstract="true"
+export type TEventDefinition = TRootElement;
+
+export interface TConditionalEventDefinition extends TEventDefinition {
+  condition?: TExpression;
+}
+
+export interface TLinkEventDefinition extends TEventDefinition {
+  source?: string | string[];
+  target?: string;
+  name: string;
+}
+
+export interface TMessageEventDefinition extends TEventDefinition {
+  operationRef?: string;
+  messageRef?: string;
+}
+
+export type TCancelEventDefinition = TEventDefinition;
+
+export interface TCompensateEventDefinition extends TEventDefinition {
+  waitForCompletion?: boolean;
+  activityRef?: string;
+}
+
+export interface TErrorEventDefinition extends TEventDefinition {
+  errorRef?: string;
+}
+
+export interface TEscalationEventDefinition extends TEventDefinition {
+  escalationRef?: string;
+}
+
+export interface TSignalEventDefinition extends TEventDefinition {
+  signalRef?: string;
+}
+
+export type TTerminateEventDefinition = TEventDefinition;
+
+export interface TTimerEventDefinition extends TEventDefinition {
+  timeDate?: TExpression;
+  timeDuration?: TExpression;
+  timeCycle?: TExpression;
+}

--- a/src/component/parser/xml/bpmn-json-model/baseElement/rootElement/globalTask.ts
+++ b/src/component/parser/xml/bpmn-json-model/baseElement/rootElement/globalTask.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TCallableElement } from './rootElement';
+import { THumanPerformer, TPerformer, TPotentialOwner, TResourceRole } from '../resource';
+import { TScript } from '../../Semantic';
+import { TRendering } from '../baseElement';
+
+export interface TGlobalTask extends TCallableElement {
+  // resourceRole
+  resourceRole?: TResourceRole | TResourceRole[];
+  performer?: TPerformer | TPerformer[];
+  humanPerformer?: THumanPerformer | THumanPerformer[];
+  potentialOwner?: TPotentialOwner | TPotentialOwner[];
+}
+
+export interface TGlobalBusinessRuleTask extends TGlobalTask {
+  implementation?: tImplementation; // default="##unspecified"
+}
+
+export type TGlobalManualTask = TGlobalTask;
+
+export interface TGlobalScriptTask extends TGlobalTask {
+  script?: TScript;
+  scriptLanguage?: string;
+}
+
+export interface TGlobalUserTask extends TGlobalTask {
+  rendering?: TRendering | TRendering[];
+  implementation?: tImplementation; // default="##unspecified"
+}
+
+export enum tImplementation {
+  Unspecified = '##unspecified',
+  WebService = '##WebService',
+}

--- a/src/component/parser/xml/bpmn-json-model/baseElement/rootElement/rootElement.ts
+++ b/src/component/parser/xml/bpmn-json-model/baseElement/rootElement/rootElement.ts
@@ -1,0 +1,177 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TInputOutputBinding, TInputOutputSpecification } from '../input-output';
+import { TAuditing, TBaseElement, TCategoryValue, TLaneSet, TMonitoring, TOperation, TProperty } from '../baseElement';
+import { THumanPerformer, TPerformer, TPotentialOwner, TResourceParameter, TResourceRole } from '../resource';
+import { TCorrelationSubscription } from '../correlation';
+import { TArtifact, TAssociation, TGroup, TTextAnnotation } from '../artifact';
+import { TFlowElement, TSequenceFlow } from '../flowElement';
+import { TBoundaryEvent, TEndEvent, TEvent, TImplicitThrowEvent, TIntermediateCatchEvent, TIntermediateThrowEvent, TStartEvent } from '../flowNode/event';
+import { TCallChoreography, TChoreographyTask, TSubChoreography } from '../flowNode/choreographyActivity';
+import { TAdHocSubProcess, TCallActivity, TSubProcess, TTransaction } from '../flowNode/activity/activity';
+import { TComplexGateway, TEventBasedGateway, TExclusiveGateway, TInclusiveGateway, TParallelGateway } from '../flowNode/gateway';
+import { TDataObject, TDataObjectReference, TDataStoreReference } from '../data';
+import { TBusinessRuleTask, TManualTask, TReceiveTask, TScriptTask, TSendTask, TServiceTask, TTask, TUserTask } from '../flowNode/activity/task';
+
+// abstract="true"
+export type TRootElement = TBaseElement;
+
+export interface TCallableElement extends TRootElement {
+  ioSpecification?: TInputOutputSpecification;
+  ioBinding?: TInputOutputBinding[];
+  supportedInterfaceRef?: string[];
+  name?: string;
+}
+
+export interface TCategory extends TRootElement {
+  categoryValue?: TCategoryValue[];
+  name?: string;
+}
+
+export type TEndPoint = TRootElement;
+
+export interface TError extends TRootElement {
+  name?: string;
+  errorCode?: string;
+  structureRef?: string;
+}
+
+export interface TEscalation extends TRootElement {
+  name?: string;
+  escalationCode?: string;
+  structureRef?: string;
+}
+
+export interface TItemDefinition extends TRootElement {
+  structureRef?: string;
+  isCollection?: boolean; // default="false"
+  itemKind?: tItemKind; // default="Information"
+}
+
+enum tItemKind {
+  Information = 'Information',
+  Physical = 'Physical',
+}
+
+export interface TMessage extends TRootElement {
+  name?: string;
+  itemRef?: string;
+}
+
+export interface TInterface extends TRootElement {
+  operation: TOperation[];
+  name: string;
+  implementationRef?: string;
+}
+
+export interface TPartnerEntity extends TRootElement {
+  participantRef?: string[];
+  name?: string;
+}
+
+export interface TPartnerRole extends TRootElement {
+  participantRef?: string[];
+  name?: string;
+}
+
+export interface TResource extends TRootElement {
+  resourceParameter?: TResourceParameter[];
+  name: string;
+}
+
+export interface TSignal extends TRootElement {
+  name?: string;
+  structureRef?: string;
+}
+
+export interface TProcess extends TCallableElement {
+  auditing?: TAuditing;
+  monitoring?: TMonitoring;
+  property?: TProperty | TProperty[];
+  laneSet?: TLaneSet | TLaneSet[];
+
+  // flowElement
+  flowElement?: TFlowElement | TFlowElement[];
+  sequenceFlow?: TSequenceFlow | TSequenceFlow[];
+  callChoreography?: TCallChoreography | TCallChoreography[];
+  choreographyTask?: TChoreographyTask | TChoreographyTask[];
+  subChoreography?: TSubChoreography | TSubChoreography[];
+  callActivity?: TCallActivity | TCallActivity[];
+
+  // dataObject
+  dataObject?: TDataObject | TDataObject[];
+  dataObjectReference?: TDataObjectReference | TDataObjectReference[];
+  dataStoreReference?: TDataStoreReference | TDataStoreReference[];
+
+  // event
+  event?: TEvent | TEvent[];
+  intermediateCatchEvent?: TIntermediateCatchEvent | TIntermediateCatchEvent[];
+  boundaryEvent?: TBoundaryEvent | TBoundaryEvent[];
+  startEvent?: TStartEvent | TStartEvent[];
+  implicitThrowEvent?: TImplicitThrowEvent | TImplicitThrowEvent[];
+  intermediateThrowEvent?: TIntermediateThrowEvent | TIntermediateThrowEvent[];
+  endEvent?: TEndEvent | TEndEvent[];
+
+  // sub process
+  subProcess?: TSubProcess | TSubProcess[];
+  adHocSubProcess?: TAdHocSubProcess | TAdHocSubProcess[];
+  transaction?: TTransaction | TTransaction[];
+
+  // gateway
+  complexGateway?: TComplexGateway | TComplexGateway[];
+  eventBasedGateway?: TEventBasedGateway | TEventBasedGateway[];
+  exclusiveGateway?: TExclusiveGateway | TExclusiveGateway[];
+  inclusiveGateway?: TInclusiveGateway | TInclusiveGateway[];
+  parallelGateway?: TParallelGateway | TParallelGateway[];
+
+  // task
+  task?: TTask | TTask[];
+  businessRuleTask?: TBusinessRuleTask | TBusinessRuleTask[];
+  manualTask?: TManualTask | TManualTask[];
+  receiveTask?: TReceiveTask | TReceiveTask[];
+  sendTask?: TSendTask | TSendTask[];
+  serviceTask?: TServiceTask | TServiceTask[];
+  scriptTask?: TScriptTask | TScriptTask[];
+  userTask?: TUserTask | TUserTask[];
+
+  // artifact
+  artifact?: TArtifact | TArtifact[];
+  association?: TAssociation | TAssociation[];
+  group?: TGroup | TGroup[];
+  textAnnotation?: TTextAnnotation | TTextAnnotation[];
+
+  // resourceRole
+  resourceRole?: TResourceRole | TResourceRole[];
+  performer?: TPerformer | TPerformer[];
+  humanPerformer?: THumanPerformer | THumanPerformer[];
+  potentialOwner?: TPotentialOwner | TPotentialOwner[];
+
+  correlationSubscription?: TCorrelationSubscription | TCorrelationSubscription[];
+  supports?: string | string[];
+  processType?: tProcessType; // default="None"
+  isClosed?: boolean; // default="false"
+  isExecutable?: boolean;
+  definitionalCollaborationRef?: string;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+}
+
+export enum tProcessType {
+  None = 'None',
+  Public = 'Public',
+  Private = 'Private',
+}

--- a/test/unit/component/parser/json/BpmnJsonParser.association.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.association.test.ts
@@ -13,8 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// import { parseJsonAndExpectOnlyEdges, verifyEdge } from './JsonTestUtils';
-import { verifyEdge } from './JsonTestUtils';
+import { parseJsonAndExpectOnlyEdges, verifyEdge } from './JsonTestUtils';
 import { defaultBpmnJsonParser } from '../../../../../src/component/parser/json/BpmnJsonParser';
 import Waypoint from '../../../../../src/model/bpmn/edge/Waypoint';
 import { TProcess } from '../../../../../src/component/parser/xml/bpmn-json-model/baseElement/rootElement/rootElement';
@@ -50,13 +49,7 @@ describe('parse bpmn as json for association', () => {
       },
     };
 
-    // const model = parseJsonAndExpectOnlyEdges(json, 1);
-
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(0);
-    expect(model.edges).toHaveLength(1);
+    const model = parseJsonAndExpectOnlyEdges(json, 1);
 
     verifyEdge(model.edges[0], {
       edgeId: 'edge_association_id_0',

--- a/test/unit/component/parser/json/BpmnJsonParser.association.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.association.test.ts
@@ -13,128 +13,163 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { parseJsonAndExpectOnlyEdges, verifyEdge } from './JsonTestUtils';
+// import { parseJsonAndExpectOnlyEdges, verifyEdge } from './JsonTestUtils';
+import { verifyEdge } from './JsonTestUtils';
+import { defaultBpmnJsonParser } from '../../../../../src/component/parser/json/BpmnJsonParser';
+import Waypoint from '../../../../../src/model/bpmn/edge/Waypoint';
+import { TProcess } from '../../../../../src/component/parser/xml/bpmn-json-model/baseElement/rootElement/rootElement';
 
-describe('parse bpmn as json for text annotation', () => {
-  it('json containing one process with an association', () => {
-    const json = `{
-                "definitions" : {
-                    "process": {
-                        "association": {
-                            "id": "TextAssociation_01",
-                            "sourceRef": "Activity_01",
-                            "targetRef": "Annotation_01"
-                          }
-                    },
-                    "BPMNDiagram": {
-                        "name":"process 0",
-                        "BPMNPlane": {
-                            "BPMNEdge": {
-                              "id": "edge_TextAssociation_01",
-                              "bpmnElement": "TextAssociation_01"
-                            }
-                        }
-                    }
-                }
-            }`;
+describe('parse bpmn as json for association', () => {
+  const processJsonAsObjectWithAssociationJsonAsObject = {
+    association: {
+      id: 'association_id_0',
+      name: 'association name',
+      sourceRef: 'Activity_01',
+      targetRef: 'Annotation_01',
+    },
+  };
 
-    const model = parseJsonAndExpectOnlyEdges(json, 1);
+  it.each([
+    ['object', processJsonAsObjectWithAssociationJsonAsObject],
+    ['array', [processJsonAsObjectWithAssociationJsonAsObject]],
+  ])(`should convert as Edge, when a association is an attribute (as object) of 'process' (as %s)`, (title: string, processJson: TProcess | TProcess[]) => {
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: processJson,
+        BPMNDiagram: {
+          name: 'process 0',
+          BPMNPlane: {
+            BPMNEdge: {
+              id: 'edge_association_id_0',
+              bpmnElement: 'association_id_0',
+              waypoint: [{ x: 362, y: 232 }],
+            },
+          },
+        },
+      },
+    };
+
+    // const model = parseJsonAndExpectOnlyEdges(json, 1);
+
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(0);
+    expect(model.edges).toHaveLength(1);
 
     verifyEdge(model.edges[0], {
-      edgeId: 'edge_TextAssociation_01',
-      bpmnElementId: 'TextAssociation_01',
-      bpmnElementName: undefined,
+      edgeId: 'edge_association_id_0',
+      bpmnElementId: 'association_id_0',
+      bpmnElementName: `association name`,
       bpmnElementSourceRefId: 'Activity_01',
       bpmnElementTargetRefId: 'Annotation_01',
-      bpmnElementSequenceFlowKind: undefined,
+      waypoints: [new Waypoint(362, 232)],
     });
   });
 
-  it('json containing  one process declared as array with an association', () => {
-    const json = `{
-                "definitions" : {
-                    "process": {
-                        "association": {
-                            "id": "TextAssociation_01",
-                            "sourceRef": "Activity_01",
-                            "targetRef": "Annotation_01"
-                          }
-                    },
-                    "BPMNDiagram": {
-                        "name":"process 0",
-                        "BPMNPlane": {
-                            "BPMNEdge": {
-                              "id": "edge_TextAssociation_01",
-                              "bpmnElement": "TextAssociation_01"
-                            }
-                        }
-                    }
-                }
-            }`;
+  it('json containing one process with an array of associations with/without name', () => {
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: {
+          association: [
+            {
+              id: 'association_id_0',
+              name: 'association name',
+              sourceRef: 'Activity_01',
+              targetRef: 'Annotation_01',
+            },
+            {
+              id: 'association_id_1',
+              instantiate: true,
+              sourceRef: 'Activity_02',
+              targetRef: 'Annotation_02',
+            },
+          ],
+        },
+        BPMNDiagram: {
+          name: 'process 0',
+          BPMNPlane: {
+            BPMNEdge: [
+              {
+                id: 'edge_association_id_0',
+                bpmnElement: 'association_id_0',
+                waypoint: [{ x: 362, y: 232 }],
+              },
+              {
+                id: 'edge_association_id_1',
+                bpmnElement: 'association_id_1',
+                waypoint: [{ x: 362, y: 232 }],
+              },
+            ],
+          },
+        },
+      },
+    };
 
-    const model = parseJsonAndExpectOnlyEdges(json, 1);
+    //const model = parseJsonAndExpectOnlyEdges(json, 2);
 
-    verifyEdge(model.edges[0], {
-      edgeId: 'edge_TextAssociation_01',
-      bpmnElementId: 'TextAssociation_01',
-      bpmnElementName: undefined,
-      bpmnElementSourceRefId: 'Activity_01',
-      bpmnElementTargetRefId: 'Annotation_01',
-      bpmnElementSequenceFlowKind: undefined,
-    });
-  });
-
-  it('json containing one process with an array of associations', () => {
-    const json = `{
-                "definitions" : {
-                    "process": {
-                        "association": [{
-                              "id": "TextAssociation_01",
-                              "sourceRef": "Activity_01",
-                              "targetRef": "Annotation_01"
-                            },
-                            {
-                              "id": "TextAssociation_02",
-                              "sourceRef": "Activity_02",
-                              "targetRef": "Annotation_02"
-                            }
-                        ]
-                    },
-                    "BPMNDiagram": {
-                        "name":"process 0",
-                        "BPMNPlane": {
-                            "BPMNEdge": [{
-                                  "id": "edge_TextAssociation_01",
-                                  "bpmnElement": "TextAssociation_01"
-                                },
-                                {
-                                  "id": "edge_TextAssociation_02",
-                                  "bpmnElement": "TextAssociation_02"
-                                }
-                            ]
-                        }
-                    }
-                }
-            }`;
-
-    const model = parseJsonAndExpectOnlyEdges(json, 2);
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(0);
+    expect(model.edges).toHaveLength(2);
 
     verifyEdge(model.edges[0], {
-      edgeId: 'edge_TextAssociation_01',
-      bpmnElementId: 'TextAssociation_01',
-      bpmnElementName: undefined,
+      edgeId: 'edge_association_id_0',
+      bpmnElementId: 'association_id_0',
+      bpmnElementName: 'association name',
       bpmnElementSourceRefId: 'Activity_01',
       bpmnElementTargetRefId: 'Annotation_01',
-      bpmnElementSequenceFlowKind: undefined,
+      waypoints: [new Waypoint(362, 232)],
     });
 
     verifyEdge(model.edges[1], {
-      edgeId: 'edge_TextAssociation_02',
-      bpmnElementId: 'TextAssociation_02',
+      edgeId: 'edge_association_id_1',
+      bpmnElementId: 'association_id_1',
       bpmnElementName: undefined,
       bpmnElementSourceRefId: 'Activity_02',
       bpmnElementTargetRefId: 'Annotation_02',
-      bpmnElementSequenceFlowKind: undefined,
+      waypoints: [new Waypoint(362, 232)],
+    });
+  });
+
+  it('should convert as Edge, when BPMNDiagram is an array', () => {
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: processJsonAsObjectWithAssociationJsonAsObject,
+        BPMNDiagram: [
+          {
+            name: 'process 0',
+            BPMNPlane: {
+              BPMNEdge: {
+                id: 'edge_association_id_0',
+                bpmnElement: 'association_id_0',
+                waypoint: [{ x: 362, y: 232 }],
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    //const model = parseJsonAndExpectOnlyEdges(json, 1);
+
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(0);
+    expect(model.edges).toHaveLength(1);
+
+    verifyEdge(model.edges[0], {
+      edgeId: `edge_association_id_0`,
+      bpmnElementId: `association_id_0`,
+      bpmnElementName: `association name`,
+      bpmnElementSourceRefId: 'Activity_01',
+      bpmnElementTargetRefId: 'Annotation_01',
+      waypoints: [new Waypoint(362, 232)],
     });
   });
 });

--- a/test/unit/component/parser/json/BpmnJsonParser.call.activity.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.call.activity.test.ts
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 import { ShapeBpmnElementKind } from '../../../../../src/model/bpmn/shape/ShapeBpmnElementKind';
-// import { parseJsonAndExpectOnlyFlowNodes, verifyShape } from './JsonTestUtils';
-import { verifyShape } from './JsonTestUtils';
-import { defaultBpmnJsonParser } from '../../../../../src/component/parser/json/BpmnJsonParser';
+import { parseJsonAndExpectOnlyFlowNodes, verifyShape } from './JsonTestUtils';
 import { TProcess } from '../../../../../src/component/parser/xml/bpmn-json-model/baseElement/rootElement/rootElement';
 
 describe('parse bpmn as json for call activity', () => {
@@ -48,13 +46,7 @@ describe('parse bpmn as json for call activity', () => {
       },
     };
 
-    //const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
-
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(1);
-    expect(model.edges).toHaveLength(0);
+    const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
     verifyShape(model.flowNodes[0], {
       shapeId: `shape_callActivity_id_0`,
@@ -106,13 +98,7 @@ describe('parse bpmn as json for call activity', () => {
       },
     };
 
-    //const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
-
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(2);
-    expect(model.edges).toHaveLength(0);
+    const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
 
     verifyShape(model.flowNodes[0], {
       shapeId: 'shape_callActivity_id_0',
@@ -161,13 +147,7 @@ describe('parse bpmn as json for call activity', () => {
       },
     };
 
-    //const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
-
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(1);
-    expect(model.edges).toHaveLength(0);
+    const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
     verifyShape(model.flowNodes[0], {
       shapeId: `shape_callActivity_id_0`,

--- a/test/unit/component/parser/json/BpmnJsonParser.event.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.event.test.ts
@@ -14,13 +14,11 @@
  * limitations under the License.
  */
 import { ShapeBpmnElementKind } from '../../../../../src/model/bpmn/shape/ShapeBpmnElementKind';
-import { parseJsonAndExpectOnlyBoundaryEvent, parseJsonAndExpectOnlyEvent, verifyShape } from './JsonTestUtils';
-// import { parseJsonAndExpectOnlyBoundaryEvent, parseJsonAndExpectOnlyEvent, parseJsonAndExpectOnlyFlowNodes, verifyShape } from './JsonTestUtils';
+import { parseJsonAndExpectOnlyBoundaryEvent, parseJsonAndExpectOnlyEvent, parseJsonAndExpectOnlyFlowNodes, verifyShape } from './JsonTestUtils';
 import { ShapeBpmnEventKind } from '../../../../../src/model/bpmn/shape/ShapeBpmnEventKind';
 import { TProcess } from '../../../../../src/component/parser/xml/bpmn-json-model/baseElement/rootElement/rootElement';
 import { TEventDefinition } from '../../../../../src/component/parser/xml/bpmn-json-model/baseElement/rootElement/eventDefinition';
 import { TBoundaryEvent, TCatchEvent, TEvent, TThrowEvent } from '../../../../../src/component/parser/xml/bpmn-json-model/baseElement/flowNode/event';
-import { defaultBpmnJsonParser } from '../../../../../src/component/parser/json/BpmnJsonParser';
 import { BPMNShape } from '../../../../../src/component/parser/xml/bpmn-json-model/BPMNDI';
 
 const eventDefinitionParameters = [
@@ -260,12 +258,7 @@ describe('parse bpmn as json for all events', () => {
           };
           (json.definitions.process as TProcess)[`${bpmnKind}`] = eventJson;
 
-          //  parseJsonAndExpectOnlyFlowNodes(json, 0);
-          const model = defaultBpmnJsonParser().parse(json);
-          expect(model.lanes).toHaveLength(0);
-          expect(model.pools).toHaveLength(0);
-          expect(model.flowNodes).toHaveLength(0);
-          expect(model.edges).toHaveLength(0);
+          parseJsonAndExpectOnlyFlowNodes(json, 0);
         });
       }
     });

--- a/test/unit/component/parser/json/BpmnJsonParser.gateway.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.gateway.test.ts
@@ -14,10 +14,8 @@
  * limitations under the License.
  */
 import { ShapeBpmnElementKind } from '../../../../../src/model/bpmn/shape/ShapeBpmnElementKind';
-// import { parseJsonAndExpectOnlyFlowNodes, verifyShape } from './JsonTestUtils';
-import { verifyShape } from './JsonTestUtils';
+import { parseJsonAndExpectOnlyFlowNodes, verifyShape } from './JsonTestUtils';
 import { TProcess } from '../../../../../src/component/parser/xml/bpmn-json-model/baseElement/rootElement/rootElement';
-import { defaultBpmnJsonParser } from '../../../../../src/component/parser/json/BpmnJsonParser';
 import { BpmnJsonModel } from '../../../../../src/component/parser/xml/bpmn-json-model/BPMN20';
 
 describe.each([
@@ -52,13 +50,7 @@ describe.each([
       },
     };
 
-    //const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
-
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(1);
-    expect(model.edges).toHaveLength(0);
+    const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
     verifyShape(model.flowNodes[0], {
       shapeId: `shape_${bpmnKind}Gateway_id_0`,
@@ -108,13 +100,7 @@ describe.each([
       },
     ];
 
-    //const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
-
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(2);
-    expect(model.edges).toHaveLength(0);
+    const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
 
     verifyShape(model.flowNodes[0], {
       shapeId: `shape_${bpmnKind}Gateway_id_0`,

--- a/test/unit/component/parser/json/BpmnJsonParser.gateway.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.gateway.test.ts
@@ -14,41 +14,51 @@
  * limitations under the License.
  */
 import { ShapeBpmnElementKind } from '../../../../../src/model/bpmn/shape/ShapeBpmnElementKind';
-import { parseJsonAndExpectOnlyFlowNodes, verifyShape } from './JsonTestUtils';
+// import { parseJsonAndExpectOnlyFlowNodes, verifyShape } from './JsonTestUtils';
+import { verifyShape } from './JsonTestUtils';
+import { TProcess } from '../../../../../src/component/parser/xml/bpmn-json-model/baseElement/rootElement/rootElement';
+import { defaultBpmnJsonParser } from '../../../../../src/component/parser/json/BpmnJsonParser';
+import { BpmnJsonModel } from '../../../../../src/component/parser/xml/bpmn-json-model/BPMN20';
 
 describe.each([
   ['exclusive', ShapeBpmnElementKind.GATEWAY_EXCLUSIVE],
   ['inclusive', ShapeBpmnElementKind.GATEWAY_INCLUSIVE],
   ['parallel', ShapeBpmnElementKind.GATEWAY_PARALLEL],
 ])('parse bpmn as json for %s gateway', (bpmnKind: string, expectedShapeBpmnElementKind: ShapeBpmnElementKind) => {
-  const processJsonAsObjectWithGatewayJsonAsObject = `{
-                        "${bpmnKind}Gateway": {
-                            "id":"${bpmnKind}Gateway_id_0",
-                            "name":"${bpmnKind}Gateway name"
-                        }
-                    }`;
+  const processJsonAsObjectWithGatewayJsonAsObject = {} as TProcess;
+  processJsonAsObjectWithGatewayJsonAsObject[`${bpmnKind}Gateway`] = {
+    id: `${bpmnKind}Gateway_id_0`,
+    name: `${bpmnKind}Gateway name`,
+  };
 
   it.each([
-    ['object', `${processJsonAsObjectWithGatewayJsonAsObject}`],
-    ['array', `[${processJsonAsObjectWithGatewayJsonAsObject}]`],
-  ])(`should convert as Shape, when a ${bpmnKind} gateway is an attribute (as object) of 'process' (as %s)`, (title: string, processJson: string) => {
-    const json = `{
-                "definitions" : {
-                    "process": ${processJson},
-                    "BPMNDiagram": {
-                        "name":"process 0",
-                        "BPMNPlane": {
-                            "BPMNShape": {
-                                "id":"shape_${bpmnKind}Gateway_id_0",
-                                "bpmnElement":"${bpmnKind}Gateway_id_0",
-                                "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 }
-                            }
-                        }
-                    }
-                }
-            }`;
+    ['object', processJsonAsObjectWithGatewayJsonAsObject],
+    ['array', [processJsonAsObjectWithGatewayJsonAsObject]],
+  ])(`should convert as Shape, when a ${bpmnKind} gateway is an attribute (as object) of 'process' (as %s)`, (title: string, processJson: TProcess | TProcess[]) => {
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: processJson,
+        BPMNDiagram: {
+          name: 'process 0',
+          BPMNPlane: {
+            BPMNShape: {
+              id: `shape_${bpmnKind}Gateway_id_0`,
+              bpmnElement: `${bpmnKind}Gateway_id_0`,
+              Bounds: { x: 362, y: 232, width: 36, height: 45 },
+            },
+          },
+        },
+      },
+    };
 
-    const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
+    //const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
+
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(1);
+    expect(model.edges).toHaveLength(0);
 
     verifyShape(model.flowNodes[0], {
       shapeId: `shape_${bpmnKind}Gateway_id_0`,
@@ -65,38 +75,46 @@ describe.each([
   });
 
   it(`should convert as Shape, when a ${bpmnKind} gateway (with/without name) is an attribute (as array) of 'process'`, () => {
-    const json = `{
-                "definitions" : {
-                    "process": {
-                        "${bpmnKind}Gateway": [
-                          {
-                              "id":"${bpmnKind}Gateway_id_0",
-                              "name":"${bpmnKind}Gateway name"
-                          }, {
-                              "id":"${bpmnKind}Gateway_id_1"
-                          }
-                        ]
-                    },
-                    "BPMNDiagram": {
-                        "name":"process 0",
-                        "BPMNPlane": {
-                            "BPMNShape": [
-                              {
-                                "id":"shape_${bpmnKind}Gateway_id_0",
-                                "bpmnElement":"${bpmnKind}Gateway_id_0",
-                                "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 }
-                              }, {
-                                "id":"shape_${bpmnKind}Gateway_id_1",
-                                "bpmnElement":"${bpmnKind}Gateway_id_1",
-                                "Bounds": { "x": 365, "y": 235, "width": 35, "height": 46 }
-                              }
-                            ]
-                        }
-                    }
-                }
-            }`;
+    const json: BpmnJsonModel = {
+      definitions: {
+        targetNamespace: '',
+        process: {},
+        BPMNDiagram: {
+          name: 'process 0',
+          BPMNPlane: {
+            BPMNShape: [
+              {
+                id: `shape_${bpmnKind}Gateway_id_0`,
+                bpmnElement: `${bpmnKind}Gateway_id_0`,
+                Bounds: { x: 362, y: 232, width: 36, height: 45 },
+              },
+              {
+                id: `shape_${bpmnKind}Gateway_id_1`,
+                bpmnElement: `${bpmnKind}Gateway_id_1`,
+                Bounds: { x: 365, y: 235, width: 35, height: 46 },
+              },
+            ],
+          },
+        },
+      },
+    };
+    (json.definitions.process as TProcess)[`${bpmnKind}Gateway`] = [
+      {
+        id: `${bpmnKind}Gateway_id_0`,
+        name: `${bpmnKind}Gateway name`,
+      },
+      {
+        id: `${bpmnKind}Gateway_id_1`,
+      },
+    ];
 
-    const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
+    //const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
+
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(2);
+    expect(model.edges).toHaveLength(0);
 
     verifyShape(model.flowNodes[0], {
       shapeId: `shape_${bpmnKind}Gateway_id_0`,

--- a/test/unit/component/parser/json/BpmnJsonParser.label.bounds.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.label.bounds.test.ts
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { parseJsonAndExpectOnlyEdges, parseJsonAndExpectOnlyFlowNodes, verifyLabelBounds } from './JsonTestUtils';
+// import { parseJsonAndExpectOnlyEdges, parseJsonAndExpectOnlyFlowNodes, verifyLabelBounds } from './JsonTestUtils';
+import { verifyLabelBounds } from './JsonTestUtils';
 import each from 'jest-each';
+import { defaultBpmnJsonParser } from '../../../../../src/component/parser/json/BpmnJsonParser';
+import { TProcess } from '../../../../../src/component/parser/xml/bpmn-json-model/baseElement/rootElement/rootElement';
 
 describe('parse bpmn as json for label bounds', () => {
   each([
@@ -38,168 +41,141 @@ describe('parse bpmn as json for label bounds', () => {
     // TODO: To uncomment when we support businessRuleTask
     //['businessRuleTask'],
   ]).it('json containing a BPMNShape which has a label with bounds with all attributes in a %s', sourceKind => {
-    const json = `{
-          "definitions": {
-              "process": {
-                  "id": "Process_1",
-                  "${sourceKind}": { "id": "source_id_0", "name": "${sourceKind}_id_0"}
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: {
+          id: 'Process_1',
+        },
+        BPMNDiagram: {
+          id: 'BpmnDiagram_1',
+          BPMNPlane: {
+            id: 'BpmnPlane_1',
+            BPMNShape: {
+              id: 'shape_source_id_0',
+              bpmnElement: 'source_id_0',
+              Bounds: { x: 362, y: 232, width: 36, height: 45 },
+              BPMNLabel: {
+                id: 'label_id',
+                Bounds: { x: 25, y: 26, width: 27, height: 28 },
               },
-              "BPMNDiagram": {
-                  "id": "BpmnDiagram_1",
-                  "BPMNPlane": {
-                      "id": "BpmnPlane_1",
-                      "BPMNShape": {
-                          "id": "shape_source_id_0",
-                          "bpmnElement": "source_id_0",
-                          "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 },
-                          "BPMNLabel": {
-                             "id": "label_id",
-                             "Bounds": { "x": 25, "y": 26, "width": 27, "height": 28 }
-                          }
-                      }
-                  }
-              }
-          }
-      }`;
+            },
+          },
+        },
+      },
+    };
+    (json.definitions.process as TProcess)[`${sourceKind}`] = { id: 'source_id_0', name: `${sourceKind}_id_0` };
 
-    const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
+    //const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
+
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(1);
+    expect(model.edges).toHaveLength(0);
 
     verifyLabelBounds(model.flowNodes[0].label, { x: 25, y: 26, width: 27, height: 28 });
   });
 
   it('json containing a BPMNEdge which has a label with bounds with all attributes', () => {
-    const json = `{
-       "definitions": {
-          "process": "",
-          "BPMNDiagram": {
-             "id": "BpmnDiagram_1",
-             "BPMNPlane": {
-                "id": "BpmnPlane_1",
-                "BPMNEdge": {
-                   "id": "BPMNEdge_id_0",
-                   "BPMNLabel": {
-                      "id": "label_id",
-                      "Bounds": { "x": 25, "y": 26, "width": 27, "height": 28 }
-                   }
-                }
-             }
-          }
-       }
-    }`;
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: '',
+        BPMNDiagram: {
+          id: 'BpmnDiagram_1',
+          BPMNPlane: {
+            id: 'BpmnPlane_1',
+            BPMNEdge: {
+              id: 'BPMNEdge_id_0',
+              waypoint: [{ x: 10, y: 10 }],
+              BPMNLabel: {
+                id: 'label_id',
+                Bounds: { x: 25, y: 26, width: 27, height: 28 },
+              },
+            },
+          },
+        },
+      },
+    };
 
-    const model = parseJsonAndExpectOnlyEdges(json, 1);
+    // const model = parseJsonAndExpectOnlyEdges(json, 1);
+
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(0);
+    expect(model.edges).toHaveLength(1);
 
     verifyLabelBounds(model.edges[0].label, { x: 25, y: 26, width: 27, height: 28 });
   });
 
-  it('json containing a BPMNShape which has a label with bounds without attribute', () => {
-    const json = `{
-       "definitions": {
-          "process": {
-             "task": {
-                "id": "task_id_0",
-                "name": "task name"
-             }
-          },
-          "BPMNDiagram": {
-             "id": "BpmnDiagram_1",
-             "BPMNPlane": {
-                "id": "BpmnPlane_1",
-                "BPMNShape": {
-                   "id": "BPMNShape_id_0",
-                   "bpmnElement": "task_id_0",
-                   "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 },
-                   "BPMNLabel": {
-                      "id": "label_id",
-                      "Bounds": ""
-                   }
-                }
-             }
-          }
-       }
-    }`;
-
-    const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
-
-    expect(model.flowNodes[0].label).toBeUndefined();
-  });
-
-  it('json containing a BPMNEdge which has a label with bounds without attribute', () => {
-    const json = `{
-       "definitions": {
-          "process": "",
-          "BPMNDiagram": {
-             "id": "BpmnDiagram_1",
-             "BPMNPlane": {
-                "id": "BpmnPlane_1",
-                "BPMNEdge": {
-                   "id": "BPMNEdge_id_0",
-                   "BPMNLabel": {
-                      "id": "label_id",
-                      "Bounds": ""
-                   }
-                }
-             }
-          }
-       }
-    }`;
-
-    const model = parseJsonAndExpectOnlyEdges(json, 1);
-
-    expect(model.edges[0].label).toBeUndefined();
-  });
-
   it('json containing a BPMNShape which has a label without bounds', () => {
-    const json = `{
-       "definitions": {
-          "process": {
-             "task": {
-                "id": "task_id_0",
-                "name": "task name"
-             }
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: {
+          task: {
+            id: 'task_id_0',
+            name: 'task name',
           },
-          "BPMNDiagram": {
-             "id": "BpmnDiagram_1",
-             "BPMNPlane": {
-                "id": "BpmnPlane_1",
-                "BPMNShape": {
-                   "id": "BPMNShape_id_0",
-                   "bpmnElement": "task_id_0",
-                   "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 },
-                   "BPMNLabel": {
-                      "id": "label_id"
-                   }
-                }
-             }
-          }
-       }
-    }`;
+        },
+        BPMNDiagram: {
+          id: 'BpmnDiagram_1',
+          BPMNPlane: {
+            id: 'BpmnPlane_1',
+            BPMNShape: {
+              id: 'BPMNShape_id_0',
+              bpmnElement: 'task_id_0',
+              Bounds: { x: 362, y: 232, width: 36, height: 45 },
+              BPMNLabel: {
+                id: 'label_id',
+              },
+            },
+          },
+        },
+      },
+    };
 
-    const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
+    //const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
+
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(1);
+    expect(model.edges).toHaveLength(0);
 
     expect(model.flowNodes[0].label).toBeUndefined();
   });
 
   it('json containing a BPMNEdge which has a label without bounds', () => {
-    const json = `{
-       "definitions": {
-          "process": "",
-          "BPMNDiagram": {
-             "id": "BpmnDiagram_1",
-             "BPMNPlane": {
-                "id": "BpmnPlane_1",
-                "BPMNEdge": {
-                   "id": "BPMNEdge_id_0",
-                   "BPMNLabel": {
-                      "id": "label_id"
-                   }
-                }
-             }
-          }
-       }
-    }`;
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: '',
+        BPMNDiagram: {
+          id: 'BpmnDiagram_1',
+          BPMNPlane: {
+            id: 'BpmnPlane_1',
+            BPMNEdge: {
+              id: 'BPMNEdge_id_0',
+              waypoint: [{ x: 10, y: 10 }],
+              BPMNLabel: {
+                id: 'label_id',
+              },
+            },
+          },
+        },
+      },
+    };
 
-    const model = parseJsonAndExpectOnlyEdges(json, 1);
+    // const model = parseJsonAndExpectOnlyEdges(json, 1);
+
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(0);
+    expect(model.edges).toHaveLength(1);
 
     expect(model.edges[0].label).toBeUndefined();
   });

--- a/test/unit/component/parser/json/BpmnJsonParser.label.bounds.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.label.bounds.test.ts
@@ -13,10 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// import { parseJsonAndExpectOnlyEdges, parseJsonAndExpectOnlyFlowNodes, verifyLabelBounds } from './JsonTestUtils';
-import { verifyLabelBounds } from './JsonTestUtils';
+import { parseJsonAndExpectOnlyEdges, parseJsonAndExpectOnlyFlowNodes, verifyLabelBounds } from './JsonTestUtils';
 import each from 'jest-each';
-import { defaultBpmnJsonParser } from '../../../../../src/component/parser/json/BpmnJsonParser';
 import { TProcess } from '../../../../../src/component/parser/xml/bpmn-json-model/baseElement/rootElement/rootElement';
 
 describe('parse bpmn as json for label bounds', () => {
@@ -66,13 +64,7 @@ describe('parse bpmn as json for label bounds', () => {
     };
     (json.definitions.process as TProcess)[`${sourceKind}`] = { id: 'source_id_0', name: `${sourceKind}_id_0` };
 
-    //const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
-
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(1);
-    expect(model.edges).toHaveLength(0);
+    const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
     verifyLabelBounds(model.flowNodes[0].label, { x: 25, y: 26, width: 27, height: 28 });
   });
@@ -99,13 +91,7 @@ describe('parse bpmn as json for label bounds', () => {
       },
     };
 
-    // const model = parseJsonAndExpectOnlyEdges(json, 1);
-
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(0);
-    expect(model.edges).toHaveLength(1);
+    const model = parseJsonAndExpectOnlyEdges(json, 1);
 
     verifyLabelBounds(model.edges[0].label, { x: 25, y: 26, width: 27, height: 28 });
   });
@@ -137,13 +123,7 @@ describe('parse bpmn as json for label bounds', () => {
       },
     };
 
-    //const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
-
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(1);
-    expect(model.edges).toHaveLength(0);
+    const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
     expect(model.flowNodes[0].label).toBeUndefined();
   });
@@ -169,13 +149,7 @@ describe('parse bpmn as json for label bounds', () => {
       },
     };
 
-    // const model = parseJsonAndExpectOnlyEdges(json, 1);
-
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(0);
-    expect(model.edges).toHaveLength(1);
+    const model = parseJsonAndExpectOnlyEdges(json, 1);
 
     expect(model.edges[0].label).toBeUndefined();
   });

--- a/test/unit/component/parser/json/BpmnJsonParser.label.font.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.label.font.test.ts
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { parseJsonAndExpectOnlyEdges, parseJsonAndExpectOnlyFlowNodes, verifyLabelFont } from './JsonTestUtils';
+import { verifyLabelFont } from './JsonTestUtils';
+// import { parseJsonAndExpectOnlyEdges, parseJsonAndExpectOnlyFlowNodes, verifyLabelFont } from './JsonTestUtils';
 import each from 'jest-each';
+import { TProcess } from '../../../../../src/component/parser/xml/bpmn-json-model/baseElement/rootElement/rootElement';
+import { defaultBpmnJsonParser } from '../../../../../src/component/parser/json/BpmnJsonParser';
 
 describe('parse bpmn as json for label font', () => {
   jest.spyOn(console, 'warn');
@@ -44,366 +47,447 @@ describe('parse bpmn as json for label font', () => {
     // TODO: To uncomment when we support businessRuleTask
     //['businessRuleTask'],
   ]).it('json containing a BPMNShape who references a label style with font in a %s', sourceKind => {
-    const json = `{
-          "definitions": {
-              "process": {
-                  "id": "Process_1",
-                  "${sourceKind}": { "id": "source_id_0", "name": "${sourceKind}_id_0"}
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: {
+          id: 'Process_1',
+        },
+        BPMNDiagram: {
+          id: 'BpmnDiagram_1',
+          BPMNPlane: {
+            id: 'BpmnPlane_1',
+            BPMNShape: {
+              id: 'shape_source_id_0',
+              bpmnElement: 'source_id_0',
+              Bounds: { x: 362, y: 232, width: 36, height: 45 },
+              BPMNLabel: {
+                id: 'label_id',
+                labelStyle: 'style_id',
               },
-              "BPMNDiagram": {
-                  "id": "BpmnDiagram_1",
-                  "BPMNPlane": {
-                      "id": "BpmnPlane_1",
-                      "BPMNShape": {
-                          "id": "shape_source_id_0",
-                          "bpmnElement": "source_id_0",
-                          "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 },
-                          "BPMNLabel": {
-                             "id": "label_id",
-                             "labelStyle": "style_id"
-                          }
-                      }
-                  },
-                  "BPMNLabelStyle": {
-                     "id": "style_id",
-                     "Font": {
-                        "name": "Arial",
-                        "size": 11.0
-                     }
-                  }
-              }
-          }
-      }`;
+            },
+          },
+          BPMNLabelStyle: {
+            id: 'style_id',
+            Font: {
+              name: 'Arial',
+              size: 11.0,
+            },
+          },
+        },
+      },
+    };
+    (json.definitions.process as TProcess)[`${sourceKind}`] = { id: 'source_id_0', name: `${sourceKind}_id_0` };
 
-    const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
+    //const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
+
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(1);
+    expect(model.edges).toHaveLength(0);
 
     verifyLabelFont(model.flowNodes[0].label, { name: 'Arial', size: 11.0 });
   });
 
   it('json containing a BPMNEdge who references a label style with font', () => {
-    const json = `{
-       "definitions": {
-          "process": "",
-          "BPMNDiagram": {
-             "id": "BpmnDiagram_1",
-             "BPMNPlane": {
-                "id": "BpmnPlane_1",
-                "BPMNEdge": {
-                   "id": "BPMNEdge_id_0",
-                   "BPMNLabel": {
-                      "id": "label_id",
-                      "labelStyle": "style_id"
-                   }
-                }
-             },
-             "BPMNLabelStyle": {
-                "id": "style_id",
-                "Font": {
-                   "name": "Arial",
-                   "size": 11.0
-                }
-             }
-          }
-       }
-    }`;
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: '',
+        BPMNDiagram: {
+          id: 'BpmnDiagram_1',
+          BPMNPlane: {
+            id: 'BpmnPlane_1',
+            BPMNEdge: {
+              id: 'BPMNEdge_id_0',
+              waypoint: [{ x: 10, y: 10 }],
+              BPMNLabel: {
+                id: 'label_id',
+                labelStyle: 'style_id',
+              },
+            },
+          },
+          BPMNLabelStyle: {
+            id: 'style_id',
+            Font: {
+              name: 'Arial',
+              size: 11.0,
+            },
+          },
+        },
+      },
+    };
 
-    const model = parseJsonAndExpectOnlyEdges(json, 1);
+    // const model = parseJsonAndExpectOnlyEdges(json, 1);
+
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(0);
+    expect(model.edges).toHaveLength(1);
 
     verifyLabelFont(model.edges[0].label, { name: 'Arial', size: 11.0 });
   });
 
   it('json containing several BPMNShapes who reference the same label style', () => {
-    const json = `{
-       "definitions": {
-          "process": {
-             "task": {
-                "id": "task_id_0",
-                "name": "task name"
-             },
-             "userTask": {
-                "id": "user_task_id_0",
-                "name": "user task name"
-             }
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: {
+          task: {
+            id: 'task_id_0',
+            name: 'task name',
           },
-          "BPMNDiagram": {
-             "id": "BpmnDiagram_1",
-             "BPMNPlane": {
-                "id": "BpmnPlane_1",
-                "BPMNShape": [{
-                     "id": "BPMNShape_id_0",
-                     "bpmnElement": "task_id_0",
-                     "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 },
-                     "BPMNLabel": {
-                        "labelStyle": "style_id_1"
-                     }
-                  }, {
-                     "id": "BPMNShape_id_1",
-                     "bpmnElement": "user_task_id_0",
-                     "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 },
-                     "BPMNLabel": {
-                        "labelStyle": "style_id_1"
-                     }
-                  }
-                ]
-             },
-             "BPMNLabelStyle": {
-                "id": "style_id_1",
-                "Font": {
-                   "name": "Arial",
-                   "size": 11.0
-                }
-             }
-          }
-       }
-    }`;
+          userTask: {
+            id: 'user_task_id_0',
+            name: 'user task name',
+          },
+        },
+        BPMNDiagram: {
+          id: 'BpmnDiagram_1',
+          BPMNPlane: {
+            id: 'BpmnPlane_1',
+            BPMNShape: [
+              {
+                id: 'BPMNShape_id_0',
+                bpmnElement: 'task_id_0',
+                Bounds: { x: 362, y: 232, width: 36, height: 45 },
+                BPMNLabel: {
+                  labelStyle: 'style_id_1',
+                },
+              },
+              {
+                id: 'BPMNShape_id_1',
+                bpmnElement: 'user_task_id_0',
+                Bounds: { x: 362, y: 232, width: 36, height: 45 },
+                BPMNLabel: {
+                  labelStyle: 'style_id_1',
+                },
+              },
+            ],
+          },
+          BPMNLabelStyle: {
+            id: 'style_id_1',
+            Font: {
+              name: 'Arial',
+              size: 11.0,
+            },
+          },
+        },
+      },
+    };
 
-    const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
+    //const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
+
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(2);
+    expect(model.edges).toHaveLength(0);
 
     verifyLabelFont(model.flowNodes[0].label, { name: 'Arial', size: 11.0 });
     verifyLabelFont(model.flowNodes[1].label, { name: 'Arial', size: 11.0 });
   });
 
   it('json containing several BPMNEdges who reference the same label style', () => {
-    const json = `{
-       "definitions": {
-          "process": "",
-          "BPMNDiagram": {
-             "id": "BpmnDiagram_1",
-             "BPMNPlane": {
-                "id": "BpmnPlane_1",
-                "BPMNEdge": [{
-                     "id": "BPMNEdge_id_0",
-                     "BPMNLabel": {
-                        "labelStyle": "style_id_1"
-                     }
-                  }, {
-                     "id": "BPMNEdge_id_1",
-                     "BPMNLabel": {
-                        "labelStyle": "style_id_1"
-                     }
-                  }
-                ]
-             },
-             "BPMNLabelStyle": {
-                "id": "style_id_1",
-                "Font": {
-                   "name": "Arial",
-                   "size": 11.0
-                }
-             }
-          }
-       }
-    }`;
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: '',
+        BPMNDiagram: {
+          id: 'BpmnDiagram_1',
+          BPMNPlane: {
+            id: 'BpmnPlane_1',
+            BPMNEdge: [
+              {
+                id: 'BPMNEdge_id_0',
+                waypoint: [{ x: 10, y: 10 }],
+                BPMNLabel: {
+                  labelStyle: 'style_id_1',
+                },
+              },
+              {
+                id: 'BPMNEdge_id_1',
+                waypoint: [{ x: 10, y: 10 }],
+                BPMNLabel: {
+                  labelStyle: 'style_id_1',
+                },
+              },
+            ],
+          },
+          BPMNLabelStyle: {
+            id: 'style_id_1',
+            Font: {
+              name: 'Arial',
+              size: 11.0,
+            },
+          },
+        },
+      },
+    };
 
-    const model = parseJsonAndExpectOnlyEdges(json, 2);
+    // const model = parseJsonAndExpectOnlyEdges(json, 2);
+
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(0);
+    expect(model.edges).toHaveLength(2);
 
     verifyLabelFont(model.edges[0].label, { name: 'Arial', size: 11.0 });
     verifyLabelFont(model.edges[1].label, { name: 'Arial', size: 11.0 });
   });
 
   it('json containing an array of label styles and BPMNShapes who reference a label style with font with/without all attributes', () => {
-    const json = `{
-       "definitions": {
-          "process": {
-             "task": {
-                "id": "task_id_0",
-                "name": "task name"
-             },
-             "userTask": {
-                "id": "user_task_id_0",
-                "name": "user task name"
-             }
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: {
+          task: {
+            id: 'task_id_0',
+            name: 'task name',
           },
-          "BPMNDiagram": {
-             "id": "BpmnDiagram_1",
-             "BPMNPlane": {
-                "id": "BpmnPlane_1",
-                "BPMNShape": [{
-                     "id": "BPMNShape_id_0",
-                     "bpmnElement": "task_id_0",
-                     "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 },
-                     "BPMNLabel": {
-                        "id": "label_id_1",
-                        "labelStyle": "style_id_1"
-                     }
-                  }, {
-                     "id": "BPMNShape_id_1",
-                     "bpmnElement": "user_task_id_0",
-                     "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 },
-                     "BPMNLabel": {
-                        "id": "label_id_2",
-                        "labelStyle": "style_id_2"
-                     }
-                  }
-                ]
-             },
-             "BPMNLabelStyle": [{
-                  "id": "style_id_1",
-                  "Font": {
-                     "id": "1",
-                     "isBold": false,
-                     "isItalic": false,
-                     "isStrikeThrough": false,
-                     "isUnderline": false,
-                     "name": "Arial",
-                     "size": 11.0
-                  }
-               }, {
-                  "id": "style_id_2",
-                  "Font": ""
-               }
-             ]
-          }
-       }
-    }`;
+          userTask: {
+            id: 'user_task_id_0',
+            name: 'user task name',
+          },
+        },
+        BPMNDiagram: {
+          id: 'BpmnDiagram_1',
+          BPMNPlane: {
+            id: 'BpmnPlane_1',
+            BPMNShape: [
+              {
+                id: 'BPMNShape_id_0',
+                bpmnElement: 'task_id_0',
+                Bounds: { x: 362, y: 232, width: 36, height: 45 },
+                BPMNLabel: {
+                  id: 'label_id_1',
+                  labelStyle: 'style_id_1',
+                },
+              },
+              {
+                id: 'BPMNShape_id_1',
+                bpmnElement: 'user_task_id_0',
+                Bounds: { x: 362, y: 232, width: 36, height: 45 },
+                BPMNLabel: {
+                  id: 'label_id_2',
+                  labelStyle: 'style_id_2',
+                },
+              },
+            ],
+          },
+          BPMNLabelStyle: [
+            {
+              id: 'style_id_1',
+              Font: {
+                id: '1',
+                isBold: false,
+                isItalic: false,
+                isStrikeThrough: false,
+                isUnderline: false,
+                name: 'Arial',
+                size: 11.0,
+              },
+            },
+            {
+              id: 'style_id_2',
+              Font: '',
+            },
+          ],
+        },
+      },
+    };
 
-    const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
+    //const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
+
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(2);
+    expect(model.edges).toHaveLength(0);
 
     verifyLabelFont(model.flowNodes[0].label, { name: 'Arial', size: 11.0, isBold: false, isItalic: false, isStrikeThrough: false, isUnderline: false });
     expect(model.flowNodes[1].label).toBeUndefined();
   });
 
   it('json containing an array of label styles and BPMNEdges who reference a label style with font with/without all attributes', () => {
-    const json = `{
-       "definitions": {
-          "process": "",
-          "BPMNDiagram": {
-             "id": "BpmnDiagram_1",
-             "BPMNPlane": {
-                "id": "BpmnPlane_1",
-                "BPMNEdge": [{
-                     "id": "BPMNEdge_id_0",
-                     "BPMNLabel": {
-                        "id": "label_id_1",
-                        "labelStyle": "style_id_1"
-                     }
-                  }, {
-                     "id": "BPMNEdge_id_1",
-                     "BPMNLabel": {
-                        "id": "label_id_2",
-                        "labelStyle": "style_id_2"
-                     }
-                  }
-                ]
-             },
-             "BPMNLabelStyle": [{
-                  "id": "style_id_1",
-                  "Font": {
-                     "id": "1",
-                     "isBold": false,
-                     "isItalic": false,
-                     "isStrikeThrough": false,
-                     "isUnderline": false,
-                     "name": "Arial",
-                     "size": 11.0
-                  }
-               }, {
-                  "id": "style_id_2",
-                  "Font": ""
-               }
-             ]
-          }
-       }
-    }`;
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: '',
+        BPMNDiagram: {
+          id: 'BpmnDiagram_1',
+          BPMNPlane: {
+            id: 'BpmnPlane_1',
+            BPMNEdge: [
+              {
+                id: 'BPMNEdge_id_0',
+                waypoint: [{ x: 10, y: 10 }],
+                BPMNLabel: {
+                  id: 'label_id_1',
+                  labelStyle: 'style_id_1',
+                },
+              },
+              {
+                id: 'BPMNEdge_id_1',
+                waypoint: [{ x: 10, y: 10 }],
+                BPMNLabel: {
+                  id: 'label_id_2',
+                  labelStyle: 'style_id_2',
+                },
+              },
+            ],
+          },
+          BPMNLabelStyle: [
+            {
+              id: 'style_id_1',
+              Font: {
+                id: '1',
+                isBold: false,
+                isItalic: false,
+                isStrikeThrough: false,
+                isUnderline: false,
+                name: 'Arial',
+                size: 11.0,
+              },
+            },
+            {
+              id: 'style_id_2',
+              Font: '',
+            },
+          ],
+        },
+      },
+    };
 
-    const model = parseJsonAndExpectOnlyEdges(json, 2);
+    // const model = parseJsonAndExpectOnlyEdges(json, 2);
+
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(0);
+    expect(model.edges).toHaveLength(2);
 
     verifyLabelFont(model.edges[0].label, { name: 'Arial', size: 11.0, isBold: false, isItalic: false, isStrikeThrough: false, isUnderline: false });
     expect(model.edges[1].label).toBeUndefined();
   });
 
   it('json containing a BPMNShape who references a label style without font', () => {
-    const json = `{
-       "definitions": {
-          "process": {
-             "task": {
-                "id": "task_id_0",
-                "name": "task name"
-             }
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: {
+          task: {
+            id: 'task_id_0',
+            name: 'task name',
           },
-          "BPMNDiagram": {
-             "id": "BpmnDiagram_1",
-             "BPMNPlane": {
-                "id": "BpmnPlane_1",
-                "BPMNShape": {
-                   "id": "BPMNShape_id_0",
-                   "bpmnElement": "task_id_0",
-                   "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 },
-                   "BPMNLabel": {
-                      "id": "label_id",
-                      "labelStyle": "style_id"
-                   }
-                }
-             },
-             "BPMNLabelStyle": {
-                "id": "style_id"
-             }
-          }
-       }
-    }`;
+        },
+        BPMNDiagram: {
+          id: 'BpmnDiagram_1',
+          BPMNPlane: {
+            id: 'BpmnPlane_1',
+            BPMNShape: {
+              id: 'BPMNShape_id_0',
+              bpmnElement: 'task_id_0',
+              Bounds: { x: 362, y: 232, width: 36, height: 45 },
+              BPMNLabel: {
+                id: 'label_id',
+                labelStyle: 'style_id',
+              },
+            },
+          },
+          BPMNLabelStyle: {
+            id: 'style_id',
+          },
+        },
+      },
+    };
 
-    const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
+    //const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
+
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(1);
+    expect(model.edges).toHaveLength(0);
 
     expect(model.flowNodes[0].label).toBeUndefined();
   });
 
   it('json containing a BPMNEdge who references a label style without font', () => {
-    const json = `{
-       "definitions": {
-          "process": "",
-          "BPMNDiagram": {
-             "id": "BpmnDiagram_1",
-             "BPMNPlane": {
-                "id": "BpmnPlane_1",
-                "BPMNEdge": {
-                   "id": "BPMNEdge_id_0",
-                   "BPMNLabel": {
-                      "id": "label_id",
-                      "labelStyle": "style_id"
-                   }
-                }
-             },
-             "BPMNLabelStyle": {
-                "id": "style_id"
-             }
-          }
-       }
-    }`;
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: '',
+        BPMNDiagram: {
+          id: 'BpmnDiagram_1',
+          BPMNPlane: {
+            id: 'BpmnPlane_1',
+            BPMNEdge: {
+              id: 'BPMNEdge_id_0',
+              waypoint: [{ x: 10, y: 10 }],
+              BPMNLabel: {
+                id: 'label_id',
+                labelStyle: 'style_id',
+              },
+            },
+          },
+          BPMNLabelStyle: {
+            id: 'style_id',
+          },
+        },
+      },
+    };
 
-    const model = parseJsonAndExpectOnlyEdges(json, 1);
+    // const model = parseJsonAndExpectOnlyEdges(json, 1);
+
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(0);
+    expect(model.edges).toHaveLength(1);
 
     expect(model.edges[0].label).toBeUndefined();
   });
 
   it('json containing a BPMNShape who references a non-existing label style', () => {
     console.warn = jest.fn();
-    const json = `{
-       "definitions": {
-          "process": {
-             "task": {
-                "id": "task_id_0",
-                "name": "task name"
-             }
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: {
+          task: {
+            id: 'task_id_0',
+            name: 'task name',
           },
-          "BPMNDiagram": {
-             "id": "BpmnDiagram_1",
-             "BPMNPlane": {
-                "id": "BpmnPlane_1",
-                "BPMNShape": {
-                   "id": "BPMNShape_id_0",
-                   "bpmnElement": "task_id_0",
-                   "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 },
-                   "BPMNLabel": {
-                      "id": "label_id",
-                      "labelStyle": "non-existing_style_id"
-                   }
-                }
-             }
-          }
-       }
-    }`;
+        },
+        BPMNDiagram: {
+          id: 'BpmnDiagram_1',
+          BPMNPlane: {
+            id: 'BpmnPlane_1',
+            BPMNShape: {
+              id: 'BPMNShape_id_0',
+              bpmnElement: 'task_id_0',
+              Bounds: { x: 362, y: 232, width: 36, height: 45 },
+              BPMNLabel: {
+                id: 'label_id',
+                labelStyle: 'non-existing_style_id',
+              },
+            },
+          },
+        },
+      },
+    };
 
-    const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
+    //const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
+
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(1);
+    expect(model.edges).toHaveLength(0);
 
     expect(model.flowNodes[0].label).toBeUndefined();
     expect(console.warn).toHaveBeenCalledWith('Unable to assign font from style %s to shape/edge %s', 'non-existing_style_id', 'BPMNShape_id_0');
@@ -411,26 +495,34 @@ describe('parse bpmn as json for label font', () => {
 
   it('json containing a BPMNEdge who references a non-existing label style', () => {
     console.warn = jest.fn();
-    const json = `{
-       "definitions": {
-          "process": "",
-          "BPMNDiagram": {
-             "id": "BpmnDiagram_1",
-             "BPMNPlane": {
-                "id": "BpmnPlane_1",
-                "BPMNEdge": {
-                   "id": "BPMNEdge_id_0",
-                   "BPMNLabel": {
-                      "id": "label_id",
-                      "labelStyle": "non-existing_style_id"
-                   }
-                }
-             }
-          }
-       }
-    }`;
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: '',
+        BPMNDiagram: {
+          id: 'BpmnDiagram_1',
+          BPMNPlane: {
+            id: 'BpmnPlane_1',
+            BPMNEdge: {
+              id: 'BPMNEdge_id_0',
+              waypoint: [{ x: 10, y: 10 }],
+              BPMNLabel: {
+                id: 'label_id',
+                labelStyle: 'non-existing_style_id',
+              },
+            },
+          },
+        },
+      },
+    };
 
-    const model = parseJsonAndExpectOnlyEdges(json, 1);
+    // const model = parseJsonAndExpectOnlyEdges(json, 1);
+
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(0);
+    expect(model.edges).toHaveLength(1);
 
     expect(model.edges[0].label).toBeUndefined();
     expect(console.warn).toHaveBeenCalledWith('Unable to assign font from style %s to shape/edge %s', 'non-existing_style_id', 'BPMNEdge_id_0');

--- a/test/unit/component/parser/json/BpmnJsonParser.label.font.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.label.font.test.ts
@@ -13,11 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { verifyLabelFont } from './JsonTestUtils';
-// import { parseJsonAndExpectOnlyEdges, parseJsonAndExpectOnlyFlowNodes, verifyLabelFont } from './JsonTestUtils';
+import { parseJsonAndExpectOnlyEdges, parseJsonAndExpectOnlyFlowNodes, verifyLabelFont } from './JsonTestUtils';
 import each from 'jest-each';
 import { TProcess } from '../../../../../src/component/parser/xml/bpmn-json-model/baseElement/rootElement/rootElement';
-import { defaultBpmnJsonParser } from '../../../../../src/component/parser/json/BpmnJsonParser';
 
 describe('parse bpmn as json for label font', () => {
   jest.spyOn(console, 'warn');
@@ -79,13 +77,7 @@ describe('parse bpmn as json for label font', () => {
     };
     (json.definitions.process as TProcess)[`${sourceKind}`] = { id: 'source_id_0', name: `${sourceKind}_id_0` };
 
-    //const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
-
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(1);
-    expect(model.edges).toHaveLength(0);
+    const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
     verifyLabelFont(model.flowNodes[0].label, { name: 'Arial', size: 11.0 });
   });
@@ -119,13 +111,7 @@ describe('parse bpmn as json for label font', () => {
       },
     };
 
-    // const model = parseJsonAndExpectOnlyEdges(json, 1);
-
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(0);
-    expect(model.edges).toHaveLength(1);
+    const model = parseJsonAndExpectOnlyEdges(json, 1);
 
     verifyLabelFont(model.edges[0].label, { name: 'Arial', size: 11.0 });
   });
@@ -178,13 +164,7 @@ describe('parse bpmn as json for label font', () => {
       },
     };
 
-    //const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
-
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(2);
-    expect(model.edges).toHaveLength(0);
+    const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
 
     verifyLabelFont(model.flowNodes[0].label, { name: 'Arial', size: 11.0 });
     verifyLabelFont(model.flowNodes[1].label, { name: 'Arial', size: 11.0 });
@@ -227,13 +207,7 @@ describe('parse bpmn as json for label font', () => {
       },
     };
 
-    // const model = parseJsonAndExpectOnlyEdges(json, 2);
-
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(0);
-    expect(model.edges).toHaveLength(2);
+    const model = parseJsonAndExpectOnlyEdges(json, 2);
 
     verifyLabelFont(model.edges[0].label, { name: 'Arial', size: 11.0 });
     verifyLabelFont(model.edges[1].label, { name: 'Arial', size: 11.0 });
@@ -300,13 +274,7 @@ describe('parse bpmn as json for label font', () => {
       },
     };
 
-    //const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
-
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(2);
-    expect(model.edges).toHaveLength(0);
+    const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
 
     verifyLabelFont(model.flowNodes[0].label, { name: 'Arial', size: 11.0, isBold: false, isItalic: false, isStrikeThrough: false, isUnderline: false });
     expect(model.flowNodes[1].label).toBeUndefined();
@@ -362,13 +330,7 @@ describe('parse bpmn as json for label font', () => {
       },
     };
 
-    // const model = parseJsonAndExpectOnlyEdges(json, 2);
-
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(0);
-    expect(model.edges).toHaveLength(2);
+    const model = parseJsonAndExpectOnlyEdges(json, 2);
 
     verifyLabelFont(model.edges[0].label, { name: 'Arial', size: 11.0, isBold: false, isItalic: false, isStrikeThrough: false, isUnderline: false });
     expect(model.edges[1].label).toBeUndefined();
@@ -405,13 +367,7 @@ describe('parse bpmn as json for label font', () => {
       },
     };
 
-    //const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
-
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(1);
-    expect(model.edges).toHaveLength(0);
+    const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
     expect(model.flowNodes[0].label).toBeUndefined();
   });
@@ -441,13 +397,7 @@ describe('parse bpmn as json for label font', () => {
       },
     };
 
-    // const model = parseJsonAndExpectOnlyEdges(json, 1);
-
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(0);
-    expect(model.edges).toHaveLength(1);
+    const model = parseJsonAndExpectOnlyEdges(json, 1);
 
     expect(model.edges[0].label).toBeUndefined();
   });
@@ -481,13 +431,7 @@ describe('parse bpmn as json for label font', () => {
       },
     };
 
-    //const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
-
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(1);
-    expect(model.edges).toHaveLength(0);
+    const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
     expect(model.flowNodes[0].label).toBeUndefined();
     expect(console.warn).toHaveBeenCalledWith('Unable to assign font from style %s to shape/edge %s', 'non-existing_style_id', 'BPMNShape_id_0');
@@ -516,13 +460,7 @@ describe('parse bpmn as json for label font', () => {
       },
     };
 
-    // const model = parseJsonAndExpectOnlyEdges(json, 1);
-
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(0);
-    expect(model.edges).toHaveLength(1);
+    const model = parseJsonAndExpectOnlyEdges(json, 1);
 
     expect(model.edges[0].label).toBeUndefined();
     expect(console.warn).toHaveBeenCalledWith('Unable to assign font from style %s to shape/edge %s', 'non-existing_style_id', 'BPMNEdge_id_0');

--- a/test/unit/component/parser/json/BpmnJsonParser.label.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.label.test.ts
@@ -13,10 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// import { parseJsonAndExpectOnlyEdges, parseJsonAndExpectOnlyFlowNodes } from './JsonTestUtils';
+import { parseJsonAndExpectOnlyEdges, parseJsonAndExpectOnlyFlowNodes } from './JsonTestUtils';
 import each from 'jest-each';
 import { TProcess } from '../../../../../src/component/parser/xml/bpmn-json-model/baseElement/rootElement/rootElement';
-import { defaultBpmnJsonParser } from '../../../../../src/component/parser/json/BpmnJsonParser';
 
 describe('parse bpmn as json for label font', () => {
   each([
@@ -62,13 +61,7 @@ describe('parse bpmn as json for label font', () => {
     };
     (json.definitions.process as TProcess)[`${sourceKind}`] = { id: 'source_id_0', name: `${sourceKind}_id_0` };
 
-    //const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
-
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(1);
-    expect(model.edges).toHaveLength(0);
+    const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
     expect(model.flowNodes[0].label).toBeUndefined();
   });
@@ -92,13 +85,7 @@ describe('parse bpmn as json for label font', () => {
       },
     };
 
-    // const model = parseJsonAndExpectOnlyEdges(json, 1);
-
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(0);
-    expect(model.edges).toHaveLength(1);
+    const model = parseJsonAndExpectOnlyEdges(json, 1);
 
     expect(model.edges[0].label).toBeUndefined();
   });
@@ -130,13 +117,7 @@ describe('parse bpmn as json for label font', () => {
       },
     };
 
-    //const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
-
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(1);
-    expect(model.edges).toHaveLength(0);
+    const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
     expect(model.flowNodes[0].label).toBeUndefined();
   });
@@ -162,13 +143,7 @@ describe('parse bpmn as json for label font', () => {
       },
     };
 
-    // const model = parseJsonAndExpectOnlyEdges(json, 1);
-
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(0);
-    expect(model.edges).toHaveLength(1);
+    const model = parseJsonAndExpectOnlyEdges(json, 1);
 
     expect(model.edges[0].label).toBeUndefined();
   });
@@ -197,13 +172,7 @@ describe('parse bpmn as json for label font', () => {
       },
     };
 
-    //const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
-
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(1);
-    expect(model.edges).toHaveLength(0);
+    const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
     expect(model.flowNodes[0].label).toBeUndefined();
   });
@@ -226,13 +195,7 @@ describe('parse bpmn as json for label font', () => {
       },
     };
 
-    // const model = parseJsonAndExpectOnlyEdges(json, 1);
-
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(0);
-    expect(model.edges).toHaveLength(1);
+    const model = parseJsonAndExpectOnlyEdges(json, 1);
 
     expect(model.edges[0].label).toBeUndefined();
   });

--- a/test/unit/component/parser/json/BpmnJsonParser.label.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.label.test.ts
@@ -13,8 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { parseJsonAndExpectOnlyEdges, parseJsonAndExpectOnlyFlowNodes } from './JsonTestUtils';
+// import { parseJsonAndExpectOnlyEdges, parseJsonAndExpectOnlyFlowNodes } from './JsonTestUtils';
 import each from 'jest-each';
+import { TProcess } from '../../../../../src/component/parser/xml/bpmn-json-model/baseElement/rootElement/rootElement';
+import { defaultBpmnJsonParser } from '../../../../../src/component/parser/json/BpmnJsonParser';
 
 describe('parse bpmn as json for label font', () => {
   each([
@@ -38,154 +40,199 @@ describe('parse bpmn as json for label font', () => {
     // TODO: To uncomment when we support businessRuleTask
     //['businessRuleTask'],
   ]).it('json containing a BPMNShape with empty label in a %s', sourceKind => {
-    const json = `{
-          "definitions": {
-              "process": {
-                  "id": "Process_1",
-                  "${sourceKind}": { "id": "source_id_0", "name": "${sourceKind}_id_0"}
-              },
-              "BPMNDiagram": {
-                  "id": "BpmnDiagram_1",
-                  "BPMNPlane": {
-                      "id": "BpmnPlane_1",
-                      "BPMNShape": {
-                          "id": "shape_source_id_0",
-                          "bpmnElement": "source_id_0",
-                          "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 },
-                          "BPMNLabel": ""
-                      }
-                  }
-              }
-          }
-      }`;
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: {
+          id: 'Process_1',
+        },
+        BPMNDiagram: {
+          id: 'BpmnDiagram_1',
+          BPMNPlane: {
+            id: 'BpmnPlane_1',
+            BPMNShape: {
+              id: 'shape_source_id_0',
+              bpmnElement: 'source_id_0',
+              Bounds: { x: 362, y: 232, width: 36, height: 45 },
+              BPMNLabel: '',
+            },
+          },
+        },
+      },
+    };
+    (json.definitions.process as TProcess)[`${sourceKind}`] = { id: 'source_id_0', name: `${sourceKind}_id_0` };
 
-    const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
+    //const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
+
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(1);
+    expect(model.edges).toHaveLength(0);
 
     expect(model.flowNodes[0].label).toBeUndefined();
   });
 
   it('json containing a BPMNEdge with empty label', () => {
-    const json = `{
-       "definitions": {
-          "process": "",
-          "BPMNDiagram": {
-             "id": "BpmnDiagram_1",
-             "BPMNPlane": {
-                "id": "BpmnPlane_1",
-                "BPMNEdge": {
-                   "id": "BPMNEdge_id_0",
-                   "BPMNLabel": ""
-                }
-             }
-          }
-       }
-    }`;
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: '',
+        BPMNDiagram: {
+          id: 'BpmnDiagram_1',
+          BPMNPlane: {
+            id: 'BpmnPlane_1',
+            BPMNEdge: {
+              id: 'BPMNEdge_id_0',
+              waypoint: [{ x: 10, y: 10 }],
+              BPMNLabel: '',
+            },
+          },
+        },
+      },
+    };
 
-    const model = parseJsonAndExpectOnlyEdges(json, 1);
+    // const model = parseJsonAndExpectOnlyEdges(json, 1);
+
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(0);
+    expect(model.edges).toHaveLength(1);
 
     expect(model.edges[0].label).toBeUndefined();
   });
 
   it('json containing a BPMNShape with label with just id', () => {
-    const json = `{
-       "definitions": {
-          "process": {
-             "task": {
-                "id": "task_id_0",
-                "name": "task name"
-             }
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: {
+          task: {
+            id: 'task_id_0',
+            name: 'task name',
           },
-          "BPMNDiagram": {
-             "id": "BpmnDiagram_1",
-             "BPMNPlane": {
-                "id": "BpmnPlane_1",
-                "BPMNShape": {
-                   "id": "BPMNShape_id_0",
-                   "bpmnElement": "task_id_0",
-                   "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 },
-                   "BPMNLabel": {
-                      "id": ""
-                   }
-                }
-             }
-          }
-       }
-    }`;
+        },
+        BPMNDiagram: {
+          id: 'BpmnDiagram_1',
+          BPMNPlane: {
+            id: 'BpmnPlane_1',
+            BPMNShape: {
+              id: 'BPMNShape_id_0',
+              bpmnElement: 'task_id_0',
+              Bounds: { x: 362, y: 232, width: 36, height: 45 },
+              BPMNLabel: {
+                id: '',
+              },
+            },
+          },
+        },
+      },
+    };
 
-    const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
+    //const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
+
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(1);
+    expect(model.edges).toHaveLength(0);
 
     expect(model.flowNodes[0].label).toBeUndefined();
   });
 
   it('json containing a BPMNEdge with empty label with just id', () => {
-    const json = `{
-       "definitions": {
-          "process": "",
-          "BPMNDiagram": {
-             "id": "BpmnDiagram_1",
-             "BPMNPlane": {
-                "id": "BpmnPlane_1",
-                "BPMNEdge": {
-                   "id": "BPMNEdge_id_0",
-                   "BPMNLabel": {
-                      "id": ""
-                   }
-                }
-             }
-          }
-       }
-    }`;
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: '',
+        BPMNDiagram: {
+          id: 'BpmnDiagram_1',
+          BPMNPlane: {
+            id: 'BpmnPlane_1',
+            BPMNEdge: {
+              id: 'BPMNEdge_id_0',
+              waypoint: [{ x: 10, y: 10 }],
+              BPMNLabel: {
+                id: '',
+              },
+            },
+          },
+        },
+      },
+    };
 
-    const model = parseJsonAndExpectOnlyEdges(json, 1);
+    // const model = parseJsonAndExpectOnlyEdges(json, 1);
+
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(0);
+    expect(model.edges).toHaveLength(1);
 
     expect(model.edges[0].label).toBeUndefined();
   });
 
   it('json containing a BPMNShape without label', () => {
-    const json = `{
-       "definitions": {
-          "process": {
-             "task": {
-                "id": "task_id_0",
-                "name": "task name"
-             }
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: {
+          task: {
+            id: 'task_id_0',
+            name: 'task name',
           },
-          "BPMNDiagram": {
-             "id": "BpmnDiagram_1",
-             "BPMNPlane": {
-                "id": "BpmnPlane_1",
-                "BPMNShape": {
-                   "id": "BPMNShape_id_0",
-                   "bpmnElement": "task_id_0",
-                   "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 }
-                }
-             }
-          }
-       }
-    }`;
+        },
+        BPMNDiagram: {
+          id: 'BpmnDiagram_1',
+          BPMNPlane: {
+            id: 'BpmnPlane_1',
+            BPMNShape: {
+              id: 'BPMNShape_id_0',
+              bpmnElement: 'task_id_0',
+              Bounds: { x: 362, y: 232, width: 36, height: 45 },
+            },
+          },
+        },
+      },
+    };
 
-    const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
+    //const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
+
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(1);
+    expect(model.edges).toHaveLength(0);
 
     expect(model.flowNodes[0].label).toBeUndefined();
   });
 
   it('json containing a BPMNEdge without label', () => {
-    const json = `{
-       "definitions": {
-          "process": "",
-          "BPMNDiagram": {
-             "id": "BpmnDiagram_1",
-             "BPMNPlane": {
-                "id": "BpmnPlane_1",
-                "BPMNEdge": {
-                   "id": "BPMNEdge_id_0"
-                }
-             }
-          }
-       }
-    }`;
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: '',
+        BPMNDiagram: {
+          id: 'BpmnDiagram_1',
+          BPMNPlane: {
+            id: 'BpmnPlane_1',
+            BPMNEdge: {
+              id: 'BPMNEdge_id_0',
+              waypoint: [{ x: 10, y: 10 }],
+            },
+          },
+        },
+      },
+    };
 
-    const model = parseJsonAndExpectOnlyEdges(json, 1);
+    // const model = parseJsonAndExpectOnlyEdges(json, 1);
+
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(0);
+    expect(model.edges).toHaveLength(1);
 
     expect(model.edges[0].label).toBeUndefined();
   });

--- a/test/unit/component/parser/json/BpmnJsonParser.lane.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.lane.test.ts
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 import { ShapeBpmnElementKind } from '../../../../../src/model/bpmn/shape/ShapeBpmnElementKind';
-// import { parseJson, parseJsonAndExpectOnlyLanes, verifyShape } from './JsonTestUtils';
-import { verifyShape } from './JsonTestUtils';
-import { defaultBpmnJsonParser } from '../../../../../src/component/parser/json/BpmnJsonParser';
+import { parseJson, parseJsonAndExpectOnlyLanes, verifyShape } from './JsonTestUtils';
 
 describe('parse bpmn as json for lane', () => {
   it('json containing one process with a single lane without flowNodeRef', () => {
@@ -39,13 +37,7 @@ describe('parse bpmn as json for lane', () => {
       },
     };
 
-    //const model = parseJsonAndExpectOnlyLanes(json, 1);
-
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(1);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(0);
-    expect(model.edges).toHaveLength(0);
+    const model = parseJsonAndExpectOnlyLanes(json, 1);
 
     verifyShape(model.lanes[0], {
       shapeId: 'Lane_1h5yeu4_di',
@@ -89,8 +81,7 @@ describe('parse bpmn as json for lane', () => {
       },
     };
 
-    // const model = parseJson(json);
-    const model = defaultBpmnJsonParser().parse(json);
+    const model = parseJson(json);
 
     expect(model.lanes).toHaveLength(1);
     verifyShape(model.lanes[0], {
@@ -130,13 +121,7 @@ describe('parse bpmn as json for lane', () => {
       },
     };
 
-    //const model = parseJsonAndExpectOnlyLanes(json, 1);
-
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(1);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(0);
-    expect(model.edges).toHaveLength(0);
+    const model = parseJsonAndExpectOnlyLanes(json, 1);
 
     verifyShape(model.lanes[0], {
       shapeId: 'Lane_1h5yeu4_di',
@@ -172,8 +157,7 @@ describe('parse bpmn as json for lane', () => {
       },
     };
 
-    // const model = parseJson(json);
-    const model = defaultBpmnJsonParser().parse(json);
+    const model = parseJson(json);
 
     expect(model.lanes).toHaveLength(1);
     verifyShape(model.lanes[0], {
@@ -218,8 +202,7 @@ describe('parse bpmn as json for lane', () => {
       },
     };
 
-    // const model = parseJson(json);
-    const model = defaultBpmnJsonParser().parse(json);
+    const model = parseJson(json);
 
     expect(model.lanes).toHaveLength(1);
     verifyShape(model.lanes[0], {
@@ -264,13 +247,7 @@ describe('parse bpmn as json for lane', () => {
       },
     };
 
-    //const model = parseJsonAndExpectOnlyLanes(json, 1);
-
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(1);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(0);
-    expect(model.edges).toHaveLength(0);
+    const model = parseJsonAndExpectOnlyLanes(json, 1);
 
     verifyShape(model.lanes[0], {
       shapeId: 'Lane_1h5yeu4_di',
@@ -325,13 +302,7 @@ describe('parse bpmn as json for lane', () => {
       },
     };
 
-    //const model = parseJsonAndExpectOnlyLanes(json, 2);
-
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(2);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(0);
-    expect(model.edges).toHaveLength(0);
+    const model = parseJsonAndExpectOnlyLanes(json, 2);
 
     verifyShape(model.lanes[0], {
       shapeId: 'Lane_164yevk_di',

--- a/test/unit/component/parser/json/BpmnJsonParser.lane.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.lane.test.ts
@@ -14,30 +14,38 @@
  * limitations under the License.
  */
 import { ShapeBpmnElementKind } from '../../../../../src/model/bpmn/shape/ShapeBpmnElementKind';
-import { parseJson, parseJsonAndExpectOnlyLanes, verifyShape } from './JsonTestUtils';
+// import { parseJson, parseJsonAndExpectOnlyLanes, verifyShape } from './JsonTestUtils';
+import { verifyShape } from './JsonTestUtils';
+import { defaultBpmnJsonParser } from '../../../../../src/component/parser/json/BpmnJsonParser';
 
 describe('parse bpmn as json for lane', () => {
   it('json containing one process with a single lane without flowNodeRef', () => {
-    const json = `{
-                      "definitions":{
-                        "process":{
-                          "lane": { "id":"Lane_12u5n6x" }
-                        },
-                        "BPMNDiagram":{
-                          "BPMNPlane":{
-                            "BPMNShape":
-                              {
-                                "id":"Lane_1h5yeu4_di",
-                                "bpmnElement":"Lane_12u5n6x",
-                                "isHorizontal":true,
-                                "Bounds": { "x":362, "y":232, "width":36, "height":45 }
-                              }
-                          }
-                        }
-                      }
-                    }`;
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: {
+          lane: { id: 'Lane_12u5n6x' },
+        },
+        BPMNDiagram: {
+          BPMNPlane: {
+            BPMNShape: {
+              id: 'Lane_1h5yeu4_di',
+              bpmnElement: 'Lane_12u5n6x',
+              isHorizontal: true,
+              Bounds: { x: 362, y: 232, width: 36, height: 45 },
+            },
+          },
+        },
+      },
+    };
 
-    const model = parseJsonAndExpectOnlyLanes(json, 1);
+    //const model = parseJsonAndExpectOnlyLanes(json, 1);
+
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(1);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(0);
+    expect(model.edges).toHaveLength(0);
 
     verifyShape(model.lanes[0], {
       shapeId: 'Lane_1h5yeu4_di',
@@ -54,33 +62,35 @@ describe('parse bpmn as json for lane', () => {
   });
 
   it('json containing one process with a single lane with flowNodeRef as object & flowNode already parsed', () => {
-    const json = `{
-                      "definitions":{
-                        "process":{
-                          "lane": { "id":"Lane_12u5n6x", "flowNodeRef":"event_id_0" },
-                          "startEvent": { "id":"event_id_0" }
-                        },
-                        "BPMNDiagram":{
-                          "BPMNPlane":{
-                            "BPMNShape":[
-                              {
-                                "id":"Lane_1h5yeu4_di",
-                                "bpmnElement":"Lane_12u5n6x",
-                                "isHorizontal":true,
-                                "Bounds": { "x":362, "y":232, "width":36, "height":45 }
-                              },
-                              {
-                                "id":"event_id_0_di",
-                                "bpmnElement":"event_id_0",
-                                "Bounds":{ "x":11, "y":11, "width":11, "height":11 }
-                              }
-                            ]
-                          }
-                        }
-                      }
-                    }`;
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: {
+          lane: { id: 'Lane_12u5n6x', flowNodeRef: 'event_id_0' },
+          startEvent: { id: 'event_id_0' },
+        },
+        BPMNDiagram: {
+          BPMNPlane: {
+            BPMNShape: [
+              {
+                id: 'Lane_1h5yeu4_di',
+                bpmnElement: 'Lane_12u5n6x',
+                isHorizontal: true,
+                Bounds: { x: 362, y: 232, width: 36, height: 45 },
+              },
+              {
+                id: 'event_id_0_di',
+                bpmnElement: 'event_id_0',
+                Bounds: { x: 11, y: 11, width: 11, height: 11 },
+              },
+            ],
+          },
+        },
+      },
+    };
 
-    const model = parseJson(json);
+    // const model = parseJson(json);
+    const model = defaultBpmnJsonParser().parse(json);
 
     expect(model.lanes).toHaveLength(1);
     verifyShape(model.lanes[0], {
@@ -101,26 +111,32 @@ describe('parse bpmn as json for lane', () => {
   });
 
   it('json containing one process with a single lane with flowNodeRef as object & flowNode not parsed', () => {
-    const json = `{
-                      "definitions":{
-                        "process":{
-                          "lane": { "id":"Lane_12u5n6x", "flowNodeRef":"event_id_0" }
-                        },
-                        "BPMNDiagram":{
-                          "BPMNPlane":{
-                            "BPMNShape":
-                              {
-                                "id":"Lane_1h5yeu4_di",
-                                "bpmnElement":"Lane_12u5n6x",
-                                "isHorizontal":true,
-                                "Bounds": { "x":362, "y":232, "width":36, "height":45 }
-                              }
-                          }
-                        }
-                      }
-                    }`;
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: {
+          lane: { id: 'Lane_12u5n6x', flowNodeRef: 'event_id_0' },
+        },
+        BPMNDiagram: {
+          BPMNPlane: {
+            BPMNShape: {
+              id: 'Lane_1h5yeu4_di',
+              bpmnElement: 'Lane_12u5n6x',
+              isHorizontal: true,
+              Bounds: { x: 362, y: 232, width: 36, height: 45 },
+            },
+          },
+        },
+      },
+    };
 
-    const model = parseJsonAndExpectOnlyLanes(json, 1);
+    //const model = parseJsonAndExpectOnlyLanes(json, 1);
+
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(1);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(0);
+    expect(model.edges).toHaveLength(0);
 
     verifyShape(model.lanes[0], {
       shapeId: 'Lane_1h5yeu4_di',
@@ -137,26 +153,27 @@ describe('parse bpmn as json for lane', () => {
   });
 
   it('json containing one process with a single lane with flowNodeRef as object & flowNode not parsed', () => {
-    const json = `{
-                      "definitions":{
-                        "process":{
-                          "lane": { "id":"Lane_12u5n6x", "flowNodeRef":"event_id_0" }
-                        },
-                        "BPMNDiagram":{
-                          "BPMNPlane":{
-                            "BPMNShape":
-                              {
-                                "id":"Lane_1h5yeu4_di",
-                                "bpmnElement":"Lane_12u5n6x",
-                                "isHorizontal":true,
-                                "Bounds": { "x":362, "y":232, "width":36, "height":45 }
-                              }
-                          }
-                        }
-                      }
-                    }`;
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: {
+          lane: { id: 'Lane_12u5n6x', flowNodeRef: 'event_id_0' },
+        },
+        BPMNDiagram: {
+          BPMNPlane: {
+            BPMNShape: {
+              id: 'Lane_1h5yeu4_di',
+              bpmnElement: 'Lane_12u5n6x',
+              isHorizontal: true,
+              Bounds: { x: 362, y: 232, width: 36, height: 45 },
+            },
+          },
+        },
+      },
+    };
 
-    const model = parseJson(json);
+    // const model = parseJson(json);
+    const model = defaultBpmnJsonParser().parse(json);
 
     expect(model.lanes).toHaveLength(1);
     verifyShape(model.lanes[0], {
@@ -174,33 +191,35 @@ describe('parse bpmn as json for lane', () => {
   });
 
   it('json containing one process with a single lane with flowNodeRef as array', () => {
-    const json = `{
-                      "definitions":{
-                        "process":{
-                          "lane": { "id":"Lane_12u5n6x", "flowNodeRef":["event_id_0"] },
-                          "startEvent": { "id":"event_id_0" }
-                        },
-                        "BPMNDiagram":{
-                          "BPMNPlane":{
-                            "BPMNShape":[
-                              {
-                                "id":"Lane_1h5yeu4_di",
-                                "bpmnElement":"Lane_12u5n6x",
-                                "isHorizontal":true,
-                                "Bounds": { "x":362, "y":232, "width":36, "height":45 }
-                              },
-                              {
-                                "id":"event_id_0_di",
-                                "bpmnElement":"event_id_0",
-                                "Bounds":{ "x":11, "y":11, "width":11, "height":11 }
-                              }
-                            ]
-                          }
-                        }
-                      }
-                    }`;
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: {
+          lane: { id: 'Lane_12u5n6x', flowNodeRef: ['event_id_0'] },
+          startEvent: { id: 'event_id_0' },
+        },
+        BPMNDiagram: {
+          BPMNPlane: {
+            BPMNShape: [
+              {
+                id: 'Lane_1h5yeu4_di',
+                bpmnElement: 'Lane_12u5n6x',
+                isHorizontal: true,
+                Bounds: { x: 362, y: 232, width: 36, height: 45 },
+              },
+              {
+                id: 'event_id_0_di',
+                bpmnElement: 'event_id_0',
+                Bounds: { x: 11, y: 11, width: 11, height: 11 },
+              },
+            ],
+          },
+        },
+      },
+    };
 
-    const model = parseJson(json);
+    // const model = parseJson(json);
+    const model = defaultBpmnJsonParser().parse(json);
 
     expect(model.lanes).toHaveLength(1);
     verifyShape(model.lanes[0], {
@@ -221,29 +240,37 @@ describe('parse bpmn as json for lane', () => {
   });
 
   it('json containing one process declared as array with a laneset', () => {
-    const json = `{
-                      "definitions":{
-                        "process":[{
-                          "laneSet":{
-                            "id":"LaneSet_1i59xiy",
-                            "lane":{ "id":"Lane_12u5n6x" }
-                          }
-                        }],
-                        "BPMNDiagram":{
-                          "BPMNPlane":{
-                            "BPMNShape":
-                              {
-                                "id":"Lane_1h5yeu4_di",
-                                "bpmnElement":"Lane_12u5n6x",
-                                "isHorizontal":true,
-                                "Bounds":{ "x":362, "y":232, "width":36, "height":45 }
-                              }
-                          }
-                        }
-                      }
-                    }`;
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: [
+          {
+            laneSet: {
+              id: 'LaneSet_1i59xiy',
+              lane: { id: 'Lane_12u5n6x' },
+            },
+          },
+        ],
+        BPMNDiagram: {
+          BPMNPlane: {
+            BPMNShape: {
+              id: 'Lane_1h5yeu4_di',
+              bpmnElement: 'Lane_12u5n6x',
+              isHorizontal: true,
+              Bounds: { x: 362, y: 232, width: 36, height: 45 },
+            },
+          },
+        },
+      },
+    };
 
-    const model = parseJsonAndExpectOnlyLanes(json, 1);
+    //const model = parseJsonAndExpectOnlyLanes(json, 1);
+
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(1);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(0);
+    expect(model.edges).toHaveLength(0);
 
     verifyShape(model.lanes[0], {
       shapeId: 'Lane_1h5yeu4_di',
@@ -260,44 +287,51 @@ describe('parse bpmn as json for lane', () => {
   });
 
   it('json containing one process with an array of lanes with & without name', () => {
-    const json = `{
-                      "definitions":{
-                        "process":{
-                          "laneSet":{
-                            "id":"LaneSet_1i59xiy",
-                            "lane":[
-                              {
-                                "id":"Lane_164yevk",
-                                "name":"Customer",
-                                "flowNodeRef":"event_id_0"
-                              },
-                              { "id":"Lane_12u5n6x" }
-                            ]
-                          },
-                          "startEvent": { "id":"event_id_0" }
-                        },
-                        "BPMNDiagram":{
-                          "BPMNPlane":{
-                            "BPMNShape":[
-                              {
-                                "id":"Lane_164yevk_di",
-                                "bpmnElement":"Lane_164yevk",
-                                "isHorizontal":true,
-                                "Bounds":{ "x":362, "y":232, "width":36, "height":45 }
-                              },
-                              {
-                                "id":"Lane_12u5n6x_di",
-                                "bpmnElement":"Lane_12u5n6x",
-                                "isHorizontal":true,
-                                "Bounds":{ "x":666, "y":222, "width":22, "height":33 }
-                              }
-                            ]
-                          }
-                        }
-                      }
-                    }`;
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: {
+          laneSet: {
+            id: 'LaneSet_1i59xiy',
+            lane: [
+              {
+                id: 'Lane_164yevk',
+                name: 'Customer',
+                flowNodeRef: 'event_id_0',
+              },
+              { id: 'Lane_12u5n6x' },
+            ],
+          },
+          startEvent: { id: 'event_id_0' },
+        },
+        BPMNDiagram: {
+          BPMNPlane: {
+            BPMNShape: [
+              {
+                id: 'Lane_164yevk_di',
+                bpmnElement: 'Lane_164yevk',
+                isHorizontal: true,
+                Bounds: { x: 362, y: 232, width: 36, height: 45 },
+              },
+              {
+                id: 'Lane_12u5n6x_di',
+                bpmnElement: 'Lane_12u5n6x',
+                isHorizontal: true,
+                Bounds: { x: 666, y: 222, width: 22, height: 33 },
+              },
+            ],
+          },
+        },
+      },
+    };
 
-    const model = parseJsonAndExpectOnlyLanes(json, 2);
+    //const model = parseJsonAndExpectOnlyLanes(json, 2);
+
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(2);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(0);
+    expect(model.edges).toHaveLength(0);
 
     verifyShape(model.lanes[0], {
       shapeId: 'Lane_164yevk_di',

--- a/test/unit/component/parser/json/BpmnJsonParser.messageFlow.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.messageFlow.test.ts
@@ -13,38 +13,49 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { parseJsonAndExpectOnlyEdges, verifyEdge } from './JsonTestUtils';
+import { verifyEdge } from './JsonTestUtils';
+// import { parseJsonAndExpectOnlyEdges, verifyEdge } from './JsonTestUtils';
 import Waypoint from '../../../../../src/model/bpmn/edge/Waypoint';
 import { MessageVisibleKind } from '../../../../../src/model/bpmn/edge/MessageVisibleKind';
+import { defaultBpmnJsonParser } from '../../../../../src/component/parser/json/BpmnJsonParser';
+import * as bpmndi from '../../../../../src/component/parser/xml/bpmn-json-model/BPMNDI';
 
 describe('parse bpmn as json for message flow', () => {
   it('json containing a collaboration with a single message flow without waypoint', () => {
-    const json = `{
-          "definitions": {
-              "collaboration": {
-                  "id": "collaboration_id_0",
-                  "messageFlow": {
-                    "id": "messageFlow_id_0",
-                    "name": "Message Flow 0",
-                    "sourceRef": "sourceRef_id",
-                    "targetRef": "targetRef_id"
-                  }
-              },
-              "process":"",
-              "BPMNDiagram": {
-                  "id": "BpmnDiagram_1",
-                  "BPMNPlane": {
-                      "id": "BpmnPlane_1",
-                      "BPMNEdge": {
-                          "id": "edge_messageFlow_id_0",
-                          "bpmnElement": "messageFlow_id_0"
-                      }
-                  }
-              }
-          }
-      }`;
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        collaboration: {
+          id: 'collaboration_id_0',
+          messageFlow: {
+            id: 'messageFlow_id_0',
+            name: 'Message Flow 0',
+            sourceRef: 'sourceRef_id',
+            targetRef: 'targetRef_id',
+          },
+        },
+        process: '',
+        BPMNDiagram: {
+          id: 'BpmnDiagram_1',
+          BPMNPlane: {
+            id: 'BpmnPlane_1',
+            BPMNEdge: {
+              id: 'edge_messageFlow_id_0',
+              bpmnElement: 'messageFlow_id_0',
+              waypoint: [{ x: 10, y: 10 }],
+            },
+          },
+        },
+      },
+    };
 
-    const model = parseJsonAndExpectOnlyEdges(json, 1);
+    // const model = parseJsonAndExpectOnlyEdges(json, 1);
+
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(0);
+    expect(model.edges).toHaveLength(1);
 
     verifyEdge(model.edges[0], {
       edgeId: 'edge_messageFlow_id_0',
@@ -52,43 +63,59 @@ describe('parse bpmn as json for message flow', () => {
       bpmnElementName: 'Message Flow 0',
       bpmnElementSourceRefId: 'sourceRef_id',
       bpmnElementTargetRefId: 'targetRef_id',
+      waypoints: [new Waypoint(10, 10)],
     });
   });
 
   it('json containing a collaboration with an array of message flows with name & without name', () => {
-    const json = `{
-          "definitions": {
-              "collaboration": {
-                  "id": "collaboration_id_0",
-                  "messageFlow": [{
-                    "id": "messageFlow_id_0",
-                    "name": "Message Flow 0",
-                    "sourceRef": "sourceRef_id",
-                    "targetRef": "targetRef_id"
-                  },{
-                      "id": "messageFlow_id_1",
-                      "sourceRef": "messageFlow_id_1",
-                      "targetRef": "targetRef_id_1"
-                  }]
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        collaboration: {
+          id: 'collaboration_id_0',
+          messageFlow: [
+            {
+              id: 'messageFlow_id_0',
+              name: 'Message Flow 0',
+              sourceRef: 'sourceRef_id',
+              targetRef: 'targetRef_id',
+            },
+            {
+              id: 'messageFlow_id_1',
+              sourceRef: 'messageFlow_id_1',
+              targetRef: 'targetRef_id_1',
+            },
+          ],
+        },
+        process: '',
+        BPMNDiagram: {
+          id: 'BpmnDiagram_1',
+          BPMNPlane: {
+            id: 'BpmnPlane_1',
+            BPMNEdge: [
+              {
+                id: 'edge_messageFlow_id_0',
+                bpmnElement: 'messageFlow_id_0',
+                waypoint: [{ x: 10, y: 10 }],
               },
-              "process":"",
-              "BPMNDiagram": {
-                  "id": "BpmnDiagram_1",
-                  "BPMNPlane": {
-                      "id": "BpmnPlane_1",
-                      "BPMNEdge": [{
-                          "id": "edge_messageFlow_id_0",
-                          "bpmnElement": "messageFlow_id_0"
-                      },{
-                          "id": "edge_messageFlow_id_1",
-                          "bpmnElement": "messageFlow_id_1"
-                      }]
-                  }
-              }
-          }
-      }`;
+              {
+                id: 'edge_messageFlow_id_1',
+                bpmnElement: 'messageFlow_id_1',
+                waypoint: [{ x: 10, y: 10 }],
+              },
+            ],
+          },
+        },
+      },
+    };
 
-    const model = parseJsonAndExpectOnlyEdges(json, 2);
+    // const model = parseJsonAndExpectOnlyEdges(json, 2);
+
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(0);
+    expect(model.edges).toHaveLength(2);
 
     verifyEdge(model.edges[0], {
       edgeId: 'edge_messageFlow_id_0',
@@ -96,6 +123,7 @@ describe('parse bpmn as json for message flow', () => {
       bpmnElementName: 'Message Flow 0',
       bpmnElementSourceRefId: 'sourceRef_id',
       bpmnElementTargetRefId: 'targetRef_id',
+      waypoints: [new Waypoint(10, 10)],
     });
     verifyEdge(model.edges[1], {
       edgeId: 'edge_messageFlow_id_1',
@@ -103,53 +131,72 @@ describe('parse bpmn as json for message flow', () => {
       bpmnElementName: undefined,
       bpmnElementSourceRefId: 'messageFlow_id_1',
       bpmnElementTargetRefId: 'targetRef_id_1',
+      waypoints: [new Waypoint(10, 10)],
     });
   });
 
   it('json containing a collaboration with an array of message flows with one & several waypoints', () => {
-    const json = `{
-          "definitions": {
-              "collaboration": {
-                  "id": "collaboration_id_0",
-                  "messageFlow": [{
-                    "id": "messageFlow_id_0",
-                    "sourceRef": "sourceRef_id",
-                    "targetRef": "targetRef_id"
-                  },{
-                      "id": "messageFlow_id_1",
-                      "sourceRef": "sourceRef_id_1",
-                      "targetRef": "targetRef_id_1"
-                  }]
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        collaboration: {
+          id: 'collaboration_id_0',
+          messageFlow: [
+            {
+              id: 'messageFlow_id_0',
+              sourceRef: 'sourceRef_id',
+              targetRef: 'targetRef_id',
+            },
+            {
+              id: 'messageFlow_id_1',
+              sourceRef: 'sourceRef_id_1',
+              targetRef: 'targetRef_id_1',
+            },
+          ],
+        },
+        process: '',
+        BPMNDiagram: {
+          id: 'BpmnDiagram_1',
+          BPMNPlane: {
+            id: 'BpmnPlane_1',
+            BPMNEdge: [
+              {
+                id: 'edge_messageFlow_id_0',
+                bpmnElement: 'messageFlow_id_0',
+                waypoint: [
+                  {
+                    x: 1,
+                    y: 1,
+                  },
+                ],
               },
-              "process":"",
-              "BPMNDiagram": {
-                  "id": "BpmnDiagram_1",
-                  "BPMNPlane": {
-                      "id": "BpmnPlane_1",
-                      "BPMNEdge": [{
-                          "id": "edge_messageFlow_id_0",
-                          "bpmnElement": "messageFlow_id_0",
-                          "waypoint": {
-                            "x":1,
-                            "y":1
-                          }
-                      },{
-                          "id": "edge_messageFlow_id_1",
-                          "bpmnElement": "messageFlow_id_1",
-                          "waypoint": [{
-                            "x":2,
-                            "y":2
-                          }, {
-                            "x":3,
-                            "y":3
-                          }]
-                      }]
-                  }
-              }
-          }
-      }`;
+              {
+                id: 'edge_messageFlow_id_1',
+                bpmnElement: 'messageFlow_id_1',
+                waypoint: [
+                  {
+                    x: 2,
+                    y: 2,
+                  },
+                  {
+                    x: 3,
+                    y: 3,
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    };
 
-    const model = parseJsonAndExpectOnlyEdges(json, 2);
+    // const model = parseJsonAndExpectOnlyEdges(json, 2);
+
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(0);
+    expect(model.edges).toHaveLength(2);
 
     verifyEdge(model.edges[0], {
       edgeId: 'edge_messageFlow_id_0',
@@ -170,55 +217,65 @@ describe('parse bpmn as json for message flow', () => {
   });
 
   it('json containing a collaboration with none/initiating/non-initiating message flows', () => {
-    const json = `{
-          "definitions": {
-              "collaboration": {
-                  "id": "collaboration_id_0",
-                  "messageFlow": [{
-                    "id": "messageFlow_id_0",
-                    "sourceRef": "sourceRef_id",
-                    "targetRef": "targetRef_id"
-                  },{
-                      "id": "messageFlow_id_1",
-                      "sourceRef": "sourceRef_id_1",
-                      "targetRef": "targetRef_id_1"
-                  },{
-                      "id": "messageFlow_id_2",
-                      "sourceRef": "sourceRef_id_2",
-                      "targetRef": "targetRef_id_2"
-                  },{
-                      "id": "messageFlow_id_3",
-                      "sourceRef": "sourceRef_id_3",
-                      "targetRef": "targetRef_id_3"
-                  }]
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        collaboration: {
+          id: 'collaboration_id_0',
+          messageFlow: [
+            {
+              id: 'messageFlow_id_0',
+              sourceRef: 'sourceRef_id',
+              targetRef: 'targetRef_id',
+            },
+            {
+              id: 'messageFlow_id_1',
+              sourceRef: 'sourceRef_id_1',
+              targetRef: 'targetRef_id_1',
+            },
+            {
+              id: 'messageFlow_id_2',
+              sourceRef: 'sourceRef_id_2',
+              targetRef: 'targetRef_id_2',
+            },
+          ],
+        },
+        process: '',
+        BPMNDiagram: {
+          id: 'BpmnDiagram_1',
+          BPMNPlane: {
+            id: 'BpmnPlane_1',
+            BPMNEdge: [
+              {
+                id: 'edge_messageFlow_id_0',
+                bpmnElement: 'messageFlow_id_0',
+                waypoint: [{ x: 10, y: 10 }],
               },
-              "process":"",
-              "BPMNDiagram": {
-                  "id": "BpmnDiagram_1",
-                  "BPMNPlane": {
-                      "id": "BpmnPlane_1",
-                      "BPMNEdge": [{
-                          "id": "edge_messageFlow_id_0",
-                          "bpmnElement": "messageFlow_id_0"
-                      },{
-                          "id": "edge_messageFlow_id_1",
-                          "bpmnElement": "messageFlow_id_1",
-                          "messageVisibleKind":""
-                      },{
-                          "id": "edge_messageFlow_id_2",
-                          "bpmnElement": "messageFlow_id_2",
-                          "messageVisibleKind":"initiating"
-                      },{
-                          "id": "edge_messageFlow_id_3",
-                          "bpmnElement": "messageFlow_id_3",
-                          "messageVisibleKind":"non_initiating"
-                      }]
-                  }
-              }
-          }
-      }`;
+              {
+                id: 'edge_messageFlow_id_1',
+                bpmnElement: 'messageFlow_id_1',
+                messageVisibleKind: bpmndi.MessageVisibleKind.nonInitiating,
+                waypoint: [{ x: 10, y: 10 }],
+              },
+              {
+                id: 'edge_messageFlow_id_2',
+                bpmnElement: 'messageFlow_id_2',
+                messageVisibleKind: bpmndi.MessageVisibleKind.initiating,
+                waypoint: [{ x: 10, y: 10 }],
+              },
+            ],
+          },
+        },
+      },
+    };
 
-    const model = parseJsonAndExpectOnlyEdges(json, 4);
+    // const model = parseJsonAndExpectOnlyEdges(json, 3);
+
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(0);
+    expect(model.edges).toHaveLength(3);
 
     verifyEdge(model.edges[0], {
       edgeId: 'edge_messageFlow_id_0',
@@ -227,6 +284,7 @@ describe('parse bpmn as json for message flow', () => {
       bpmnElementSourceRefId: 'sourceRef_id',
       bpmnElementTargetRefId: 'targetRef_id',
       messageVisibleKind: MessageVisibleKind.NONE,
+      waypoints: [new Waypoint(10, 10)],
     });
     verifyEdge(model.edges[1], {
       edgeId: 'edge_messageFlow_id_1',
@@ -234,7 +292,8 @@ describe('parse bpmn as json for message flow', () => {
       bpmnElementName: undefined,
       bpmnElementSourceRefId: 'sourceRef_id_1',
       bpmnElementTargetRefId: 'targetRef_id_1',
-      messageVisibleKind: MessageVisibleKind.NONE,
+      messageVisibleKind: MessageVisibleKind.NON_INITIATING,
+      waypoints: [new Waypoint(10, 10)],
     });
     verifyEdge(model.edges[2], {
       edgeId: 'edge_messageFlow_id_2',
@@ -243,14 +302,7 @@ describe('parse bpmn as json for message flow', () => {
       bpmnElementSourceRefId: 'sourceRef_id_2',
       bpmnElementTargetRefId: 'targetRef_id_2',
       messageVisibleKind: MessageVisibleKind.INITIATING,
-    });
-    verifyEdge(model.edges[3], {
-      edgeId: 'edge_messageFlow_id_3',
-      bpmnElementId: 'messageFlow_id_3',
-      bpmnElementName: undefined,
-      bpmnElementSourceRefId: 'sourceRef_id_3',
-      bpmnElementTargetRefId: 'targetRef_id_3',
-      messageVisibleKind: MessageVisibleKind.NON_INITIATING,
+      waypoints: [new Waypoint(10, 10)],
     });
   });
 });

--- a/test/unit/component/parser/json/BpmnJsonParser.messageFlow.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.messageFlow.test.ts
@@ -13,11 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { verifyEdge } from './JsonTestUtils';
-// import { parseJsonAndExpectOnlyEdges, verifyEdge } from './JsonTestUtils';
+import { parseJsonAndExpectOnlyEdges, verifyEdge } from './JsonTestUtils';
 import Waypoint from '../../../../../src/model/bpmn/edge/Waypoint';
 import { MessageVisibleKind } from '../../../../../src/model/bpmn/edge/MessageVisibleKind';
-import { defaultBpmnJsonParser } from '../../../../../src/component/parser/json/BpmnJsonParser';
 import * as bpmndi from '../../../../../src/component/parser/xml/bpmn-json-model/BPMNDI';
 
 describe('parse bpmn as json for message flow', () => {
@@ -49,13 +47,7 @@ describe('parse bpmn as json for message flow', () => {
       },
     };
 
-    // const model = parseJsonAndExpectOnlyEdges(json, 1);
-
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(0);
-    expect(model.edges).toHaveLength(1);
+    const model = parseJsonAndExpectOnlyEdges(json, 1);
 
     verifyEdge(model.edges[0], {
       edgeId: 'edge_messageFlow_id_0',
@@ -109,13 +101,7 @@ describe('parse bpmn as json for message flow', () => {
       },
     };
 
-    // const model = parseJsonAndExpectOnlyEdges(json, 2);
-
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(0);
-    expect(model.edges).toHaveLength(2);
+    const model = parseJsonAndExpectOnlyEdges(json, 2);
 
     verifyEdge(model.edges[0], {
       edgeId: 'edge_messageFlow_id_0',
@@ -190,13 +176,7 @@ describe('parse bpmn as json for message flow', () => {
       },
     };
 
-    // const model = parseJsonAndExpectOnlyEdges(json, 2);
-
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(0);
-    expect(model.edges).toHaveLength(2);
+    const model = parseJsonAndExpectOnlyEdges(json, 2);
 
     verifyEdge(model.edges[0], {
       edgeId: 'edge_messageFlow_id_0',
@@ -269,13 +249,7 @@ describe('parse bpmn as json for message flow', () => {
       },
     };
 
-    // const model = parseJsonAndExpectOnlyEdges(json, 3);
-
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(0);
-    expect(model.edges).toHaveLength(3);
+    const model = parseJsonAndExpectOnlyEdges(json, 3);
 
     verifyEdge(model.edges[0], {
       edgeId: 'edge_messageFlow_id_0',

--- a/test/unit/component/parser/json/BpmnJsonParser.process.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.process.test.ts
@@ -14,37 +14,46 @@
  * limitations under the License.
  */
 import { ShapeBpmnElementKind } from '../../../../../src/model/bpmn/shape/ShapeBpmnElementKind';
-import { parseJsonAndExpect, parseJsonAndExpectOnlyPools, parseJsonAndExpectOnlyPoolsAndFlowNodes, parseJsonAndExpectOnlyPoolsAndLanes, verifyShape } from './JsonTestUtils';
+import { verifyShape } from './JsonTestUtils';
+// import { parseJsonAndExpect, parseJsonAndExpectOnlyPools, parseJsonAndExpectOnlyPoolsAndFlowNodes, parseJsonAndExpectOnlyPoolsAndLanes, verifyShape } from './JsonTestUtils';
 import { findProcessRefParticipant } from '../../../../../src/component/parser/json/converter/CollaborationConverter';
+import { defaultBpmnJsonParser } from '../../../../../src/component/parser/json/BpmnJsonParser';
 
 describe('parse bpmn as json for process/pool', () => {
   it('json containing one participant without name and the related process has a name', () => {
-    const json = `{
-  "definitions": {
-    "collaboration": {
-      "participant": { "id": "Participant_1", "processRef": "Process_1" }
-    },
-    "process": {
-      "id": "Process_1",
-      "name": "Process 1",
-      "isExecutable": false
-    },
-    "BPMNDiagram": {
-      "BPMNPlane": {
-        "BPMNShape": [
-          {
-            "id": "shape_Participant_1",
-            "bpmnElement": "Participant_1",
-            "isHorizontal": true,
-            "Bounds": { "x": 158, "y": 50, "width": 1620, "height": 430 }
-          }
-        ]
-      }
-    }
-  }
-}`;
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        collaboration: {
+          participant: { id: 'Participant_1', processRef: 'Process_1' },
+        },
+        process: {
+          id: 'Process_1',
+          name: 'Process 1',
+          isExecutable: false,
+        },
+        BPMNDiagram: {
+          BPMNPlane: {
+            BPMNShape: [
+              {
+                id: 'shape_Participant_1',
+                bpmnElement: 'Participant_1',
+                isHorizontal: true,
+                Bounds: { x: 158, y: 50, width: 1620, height: 430 },
+              },
+            ],
+          },
+        },
+      },
+    };
 
-    const model = parseJsonAndExpectOnlyPoolsAndLanes(json, 1, 0);
+    // const model = parseJsonAndExpectOnlyPoolsAndLanes(json, 1, 0);
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(1);
+    expect(model.flowNodes).toHaveLength(0);
+    expect(model.edges).toHaveLength(0);
+
     const pool = model.pools[0];
     verifyShape(pool, {
       shapeId: 'shape_Participant_1',
@@ -62,39 +71,46 @@ describe('parse bpmn as json for process/pool', () => {
   });
 
   it('json containing one process with a single lane without flowNodeRef', () => {
-    const json = `{
-  "definitions": {
-    "collaboration": {
-      "participant": { "id": "Participant_0nuvj8r", "name": "Pool 1", "processRef": "Process_0vbjbkf" }
-    },
-    "process": {
-      "id": "Process_0vbjbkf",
-      "name": "RequestLoan",
-      "isExecutable": false,
-      "lane": { "id":"Lane_12u5n6x" }
-    },
-    "BPMNDiagram": {
-      "BPMNPlane": {
-        "BPMNShape": [
-          {
-            "id": "shape_Participant_0nuvj8r",
-            "bpmnElement": "Participant_0nuvj8r",
-            "isHorizontal": true,
-            "Bounds": { "x": 158, "y": 50, "width": 1620, "height": 430 }
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        collaboration: {
+          participant: { id: 'Participant_0nuvj8r', name: 'Pool 1', processRef: 'Process_0vbjbkf' },
+        },
+        process: {
+          id: 'Process_0vbjbkf',
+          name: 'RequestLoan',
+          isExecutable: false,
+          lane: { id: 'Lane_12u5n6x' },
+        },
+        BPMNDiagram: {
+          BPMNPlane: {
+            BPMNShape: [
+              {
+                id: 'shape_Participant_0nuvj8r',
+                bpmnElement: 'Participant_0nuvj8r',
+                isHorizontal: true,
+                Bounds: { x: 158, y: 50, width: 1620, height: 430 },
+              },
+              {
+                id: 'shape_Lane_1h5yeu4',
+                bpmnElement: 'Lane_12u5n6x',
+                isHorizontal: true,
+                Bounds: { x: 362, y: 232, width: 36, height: 45 },
+              },
+            ],
           },
-          {
-            "id":"shape_Lane_1h5yeu4",
-            "bpmnElement":"Lane_12u5n6x",
-            "isHorizontal":true,
-            "Bounds": { "x":362, "y":232, "width":36, "height":45 }
-          }
-        ]
-      }
-    }
-  }
-}`;
+        },
+      },
+    };
 
-    const model = parseJsonAndExpectOnlyPoolsAndLanes(json, 1, 1);
+    // const model = parseJsonAndExpectOnlyPoolsAndLanes(json, 1, 1);
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(1);
+    expect(model.pools).toHaveLength(1);
+    expect(model.flowNodes).toHaveLength(0);
+    expect(model.edges).toHaveLength(0);
+
     const pool = model.pools[0];
     verifyShape(pool, {
       shapeId: 'shape_Participant_0nuvj8r',
@@ -127,65 +143,72 @@ describe('parse bpmn as json for process/pool', () => {
   });
 
   it('json containing several processes and participants (with lane or laneset)', () => {
-    const json = `{
-  "definitions": {
-    "collaboration": {
-      "participant": [
-        { "id": "Participant_1", "name": "Pool 1", "processRef": "Process_1" },
-        { "id": "Participant_2", "name": "Pool 2", "processRef": "Process_2" }
-      ]
-    },
-    "process": [
-      {
-        "id": "Process_1",
-        "name": "process 1",
-        "isExecutable": false,
-        "lane": { "id":"Lane_1_1" }
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        collaboration: {
+          participant: [
+            { id: 'Participant_1', name: 'Pool 1', processRef: 'Process_1' },
+            { id: 'Participant_2', name: 'Pool 2', processRef: 'Process_2' },
+          ],
+        },
+        process: [
+          {
+            id: 'Process_1',
+            name: 'process 1',
+            isExecutable: false,
+            lane: { id: 'Lane_1_1' },
+          },
+          {
+            id: 'Process_2',
+            name: 'process 2',
+            isExecutable: true,
+            laneSet: {
+              id: 'LaneSet_2',
+              lane: { id: 'Lane_2_1' },
+            },
+          },
+        ],
+        BPMNDiagram: {
+          BPMNPlane: {
+            BPMNShape: [
+              {
+                id: 'shape_Participant_1',
+                bpmnElement: 'Participant_1',
+                isHorizontal: true,
+                Bounds: { x: 158, y: 50, width: 1620, height: 430 },
+              },
+              {
+                id: 'shape_Lane_1_1',
+                bpmnElement: 'Lane_1_1',
+                isHorizontal: true,
+                Bounds: { x: 362, y: 232, width: 36, height: 45 },
+              },
+              {
+                id: 'Participant_2_di',
+                bpmnElement: 'Participant_2',
+                isHorizontal: true,
+                Bounds: { x: 158, y: 1050, width: 1620, height: 430 },
+              },
+              {
+                id: 'shape_Lane_2_1',
+                bpmnElement: 'Lane_2_1',
+                isHorizontal: true,
+                Bounds: { x: 362, y: 1232, width: 36, height: 45 },
+              },
+            ],
+          },
+        },
       },
-      {
-        "id": "Process_2",
-        "name": "process 2",
-        "isExecutable": true,
-        "laneSet":{
-          "id":"LaneSet_2",
-          "lane":{ "id":"Lane_2_1" }
-        }
-      }
-    ],
-    "BPMNDiagram": {
-      "BPMNPlane": {
-        "BPMNShape": [
-          {
-            "id": "shape_Participant_1",
-            "bpmnElement": "Participant_1",
-            "isHorizontal": true,
-            "Bounds": { "x": 158, "y": 50, "width": 1620, "height": 430 }
-          },
-          {
-            "id":"shape_Lane_1_1",
-            "bpmnElement":"Lane_1_1",
-            "isHorizontal":true,
-            "Bounds": { "x":362, "y":232, "width":36, "height":45 }
-          },
-          {
-            "id": "Participant_2_di",
-            "bpmnElement": "Participant_2",
-            "isHorizontal": true,
-            "Bounds": { "x": 158, "y": 1050, "width": 1620, "height": 430 }
-          },
-          {
-            "id":"shape_Lane_2_1",
-            "bpmnElement":"Lane_2_1",
-            "isHorizontal":true,
-            "Bounds": { "x":362, "y":1232, "width":36, "height":45 }
-          }
-        ]
-      }
-    }
-  }
-}`;
+    };
 
-    const model = parseJsonAndExpectOnlyPoolsAndLanes(json, 2, 2);
+    // const model = parseJsonAndExpectOnlyPoolsAndLanes(json, 2, 2);
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(2);
+    expect(model.pools).toHaveLength(2);
+    expect(model.flowNodes).toHaveLength(0);
+    expect(model.edges).toHaveLength(0);
+
     verifyShape(model.pools[0], {
       shapeId: 'shape_Participant_1',
       bpmnElementId: 'Participant_1',
@@ -242,35 +265,42 @@ describe('parse bpmn as json for process/pool', () => {
   });
 
   it('participant without processRef are not considered as pool', () => {
-    const json = `{
-  "definitions": {
-    "collaboration": {
-      "participant": [
-        { "id": "Participant_1", "name": "Pool 1", "processRef": "Process_1" },
-        { "id": "Participant_2", "name": "Not a process" }
-      ]
-    },
-    "process": {
-      "id": "Process_1",
-      "name": "Process 1",
-      "isExecutable": false
-    },
-    "BPMNDiagram": {
-      "BPMNPlane": {
-        "BPMNShape": [
-          {
-            "id": "shape_Participant_1",
-            "bpmnElement": "Participant_1",
-            "isHorizontal": true,
-            "Bounds": { "x": 158, "y": 50, "width": 1620, "height": 430 }
-          }
-        ]
-      }
-    }
-  }
-}`;
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        collaboration: {
+          participant: [
+            { id: 'Participant_1', name: 'Pool 1', processRef: 'Process_1' },
+            { id: 'Participant_2', name: 'Not a process' },
+          ],
+        },
+        process: {
+          id: 'Process_1',
+          name: 'Process 1',
+          isExecutable: false,
+        },
+        BPMNDiagram: {
+          BPMNPlane: {
+            BPMNShape: [
+              {
+                id: 'shape_Participant_1',
+                bpmnElement: 'Participant_1',
+                isHorizontal: true,
+                Bounds: { x: 158, y: 50, width: 1620, height: 430 },
+              },
+            ],
+          },
+        },
+      },
+    };
 
-    const model = parseJsonAndExpectOnlyPools(json, 1);
+    // const model = parseJsonAndExpectOnlyPools(json, 1);
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(1);
+    expect(model.flowNodes).toHaveLength(0);
+    expect(model.edges).toHaveLength(0);
+
     const pool = model.pools[0];
     verifyShape(pool, {
       shapeId: 'shape_Participant_1',
@@ -291,41 +321,48 @@ describe('parse bpmn as json for process/pool', () => {
   });
 
   it('json containing one process and flownode without lane and related participant', () => {
-    const json = `{
-  "definitions": {
-    "collaboration": {
-      "participant": [
-        { "id": "Participant_1", "name": "Pool 1", "processRef": "Process_1" },
-        { "id": "Participant_2", "name": "Not a process" }
-      ]
-    },
-    "process": {
-      "id": "Process_1",
-      "name": "Process 1",
-      "isExecutable": false,
-      "startEvent": { "id":"event_id_0" }
-    },
-    "BPMNDiagram": {
-      "BPMNPlane": {
-        "BPMNShape": [
-          {
-            "id": "shape_Participant_1",
-            "bpmnElement": "Participant_1",
-            "isHorizontal": true,
-            "Bounds": { "x": 158, "y": 50, "width": 1620, "height": 630 }
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        collaboration: {
+          participant: [
+            { id: 'Participant_1', name: 'Pool 1', processRef: 'Process_1' },
+            { id: 'Participant_2', name: 'Not a process' },
+          ],
+        },
+        process: {
+          id: 'Process_1',
+          name: 'Process 1',
+          isExecutable: false,
+          startEvent: { id: 'event_id_0' },
+        },
+        BPMNDiagram: {
+          BPMNPlane: {
+            BPMNShape: [
+              {
+                id: 'shape_Participant_1',
+                bpmnElement: 'Participant_1',
+                isHorizontal: true,
+                Bounds: { x: 158, y: 50, width: 1620, height: 630 },
+              },
+              {
+                id: 'shape_startEvent_id_0',
+                bpmnElement: 'event_id_0',
+                Bounds: { x: 362, y: 232, width: 36, height: 45 },
+              },
+            ],
           },
-          {
-            "id":"shape_startEvent_id_0",
-            "bpmnElement":"event_id_0",
-            "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 }
-          }
-        ]
-      }
-    }
-  }
-}`;
+        },
+      },
+    };
 
-    const model = parseJsonAndExpectOnlyPoolsAndFlowNodes(json, 1, 1);
+    // const model = parseJsonAndExpectOnlyPoolsAndFlowNodes(json, 1, 1);
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(1);
+    expect(model.flowNodes).toHaveLength(1);
+    expect(model.edges).toHaveLength(0);
+
     const pool = model.pools[0];
     verifyShape(pool, {
       shapeId: 'shape_Participant_1',
@@ -359,271 +396,276 @@ describe('parse bpmn as json for process/pool', () => {
 
   it('json containing one process, bpmn elements but no participant', () => {
     // json generated from https://github.com/bpmn-miwg/bpmn-miwg-test-suite/blob/b1569235563b58d7216caa880c447bafee3e23cf/Reference/A.1.0.bpmn
-    const json = `{
-  "definitions": {
-    "id": "_1373649849716",
-    "name": "A.1.0",
-    "targetNamespace": "http://www.trisotech.com/definitions/_1373649849716",
-    "process": {
-      "isExecutable": false,
-      "id": "WFP-6-",
-      "startEvent": {
-        "name": "Start Event",
-        "id": "_93c466ab-b271-4376-a427-f4c353d55ce8",
-        "outgoing": "_e16564d7-0c4c-413e-95f6-f668a3f851fb"
+    const json = {
+      definitions: {
+        id: '_1373649849716',
+        name: 'A.1.0',
+        targetNamespace: 'http://www.trisotech.com/definitions/_1373649849716',
+        process: {
+          isExecutable: false,
+          id: 'WFP-6-',
+          startEvent: {
+            name: 'Start Event',
+            id: '_93c466ab-b271-4376-a427-f4c353d55ce8',
+            outgoing: '_e16564d7-0c4c-413e-95f6-f668a3f851fb',
+          },
+          task: [
+            {
+              completionQuantity: 1,
+              isForCompensation: false,
+              startQuantity: 1,
+              name: 'Task 1',
+              id: '_ec59e164-68b4-4f94-98de-ffb1c58a84af',
+              incoming: '_e16564d7-0c4c-413e-95f6-f668a3f851fb',
+              outgoing: '_d77dd5ec-e4e7-420e-bbe7-8ac9cd1df599',
+            },
+            {
+              completionQuantity: 1,
+              isForCompensation: false,
+              startQuantity: 1,
+              name: 'Task 2',
+              id: '_820c21c0-45f3-473b-813f-06381cc637cd',
+              incoming: '_d77dd5ec-e4e7-420e-bbe7-8ac9cd1df599',
+              outgoing: '_2aa47410-1b0e-4f8b-ad54-d6f798080cb4',
+            },
+            {
+              completionQuantity: 1,
+              isForCompensation: false,
+              startQuantity: 1,
+              name: 'Task 3',
+              id: '_e70a6fcb-913c-4a7b-a65d-e83adc73d69c',
+              incoming: '_2aa47410-1b0e-4f8b-ad54-d6f798080cb4',
+              outgoing: '_8e8fe679-eb3b-4c43-a4d6-891e7087ff80',
+            },
+          ],
+          endEvent: {
+            name: 'End Event',
+            id: '_a47df184-085b-49f7-bb82-031c84625821',
+            incoming: '_8e8fe679-eb3b-4c43-a4d6-891e7087ff80',
+          },
+          sequenceFlow: [
+            {
+              sourceRef: '_93c466ab-b271-4376-a427-f4c353d55ce8',
+              targetRef: '_ec59e164-68b4-4f94-98de-ffb1c58a84af',
+              name: '',
+              id: '_e16564d7-0c4c-413e-95f6-f668a3f851fb',
+            },
+            {
+              sourceRef: '_ec59e164-68b4-4f94-98de-ffb1c58a84af',
+              targetRef: '_820c21c0-45f3-473b-813f-06381cc637cd',
+              name: '',
+              id: '_d77dd5ec-e4e7-420e-bbe7-8ac9cd1df599',
+            },
+            {
+              sourceRef: '_820c21c0-45f3-473b-813f-06381cc637cd',
+              targetRef: '_e70a6fcb-913c-4a7b-a65d-e83adc73d69c',
+              name: '',
+              id: '_2aa47410-1b0e-4f8b-ad54-d6f798080cb4',
+            },
+            {
+              sourceRef: '_e70a6fcb-913c-4a7b-a65d-e83adc73d69c',
+              targetRef: '_a47df184-085b-49f7-bb82-031c84625821',
+              name: '',
+              id: '_8e8fe679-eb3b-4c43-a4d6-891e7087ff80',
+            },
+          ],
+        },
+        BPMNDiagram: {
+          documentation: '',
+          id: 'Trisotech_Visio-_6',
+          name: 'A.1.0',
+          resolution: 96.00000267028808,
+          BPMNPlane: {
+            bpmnElement: 'WFP-6-',
+            BPMNShape: [
+              {
+                bpmnElement: '_93c466ab-b271-4376-a427-f4c353d55ce8',
+                id: 'S1373649849857__93c466ab-b271-4376-a427-f4c353d55ce8',
+                Bounds: {
+                  height: 30,
+                  width: 30,
+                  x: 186,
+                  y: 336,
+                },
+                BPMNLabel: {
+                  labelStyle: 'LS1373649849858',
+                  Bounds: {
+                    height: 12.804751171875008,
+                    width: 94.93333333333335,
+                    x: 153.67766754457273,
+                    y: 371.3333333333333,
+                  },
+                },
+              },
+              {
+                bpmnElement: '_ec59e164-68b4-4f94-98de-ffb1c58a84af',
+                id: 'S1373649849859__ec59e164-68b4-4f94-98de-ffb1c58a84af',
+                Bounds: {
+                  height: 68,
+                  width: 83,
+                  x: 258,
+                  y: 317,
+                },
+                BPMNLabel: {
+                  labelStyle: 'LS1373649849858',
+                  Bounds: {
+                    height: 12.804751171875008,
+                    width: 72.48293963254594,
+                    x: 263.3333333333333,
+                    y: 344.5818763825664,
+                  },
+                },
+              },
+              {
+                bpmnElement: '_820c21c0-45f3-473b-813f-06381cc637cd',
+                id: 'S1373649849860__820c21c0-45f3-473b-813f-06381cc637cd',
+                Bounds: {
+                  height: 68,
+                  width: 83,
+                  x: 390,
+                  y: 317,
+                },
+                BPMNLabel: {
+                  labelStyle: 'LS1373649849858',
+                  Bounds: {
+                    height: 12.804751171875008,
+                    width: 72.48293963254594,
+                    x: 395.3333333333333,
+                    y: 344.5818763825664,
+                  },
+                },
+              },
+              {
+                bpmnElement: '_e70a6fcb-913c-4a7b-a65d-e83adc73d69c',
+                id: 'S1373649849861__e70a6fcb-913c-4a7b-a65d-e83adc73d69c',
+                Bounds: {
+                  height: 68,
+                  width: 83,
+                  x: 522,
+                  y: 317,
+                },
+                BPMNLabel: {
+                  labelStyle: 'LS1373649849858',
+                  Bounds: {
+                    height: 12.804751171875008,
+                    width: 72.48293963254594,
+                    x: 527.3333333333334,
+                    y: 344.5818763825664,
+                  },
+                },
+              },
+              {
+                bpmnElement: '_a47df184-085b-49f7-bb82-031c84625821',
+                id: 'S1373649849862__a47df184-085b-49f7-bb82-031c84625821',
+                Bounds: {
+                  height: 32,
+                  width: 32,
+                  x: 648,
+                  y: 335,
+                },
+                BPMNLabel: {
+                  labelStyle: 'LS1373649849858',
+                  Bounds: {
+                    height: 12.804751171875008,
+                    width: 94.93333333333335,
+                    x: 616.5963254593177,
+                    y: 372.3333333333333,
+                  },
+                },
+              },
+            ],
+            BPMNEdge: [
+              {
+                bpmnElement: '_d77dd5ec-e4e7-420e-bbe7-8ac9cd1df599',
+                id: 'E1373649849864__d77dd5ec-e4e7-420e-bbe7-8ac9cd1df599',
+                waypoint: [
+                  {
+                    x: 342,
+                    y: 351,
+                  },
+                  {
+                    x: 390,
+                    y: 351,
+                  },
+                ],
+                BPMNLabel: '',
+              },
+              {
+                bpmnElement: '_e16564d7-0c4c-413e-95f6-f668a3f851fb',
+                id: 'E1373649849865__e16564d7-0c4c-413e-95f6-f668a3f851fb',
+                waypoint: [
+                  {
+                    x: 216,
+                    y: 351,
+                  },
+                  {
+                    x: 234,
+                    y: 351,
+                  },
+                  {
+                    x: 258,
+                    y: 351,
+                  },
+                ],
+                BPMNLabel: '',
+              },
+              {
+                bpmnElement: '_2aa47410-1b0e-4f8b-ad54-d6f798080cb4',
+                id: 'E1373649849866__2aa47410-1b0e-4f8b-ad54-d6f798080cb4',
+                waypoint: [
+                  {
+                    x: 474,
+                    y: 351,
+                  },
+                  {
+                    x: 522,
+                    y: 351,
+                  },
+                ],
+                BPMNLabel: '',
+              },
+              {
+                bpmnElement: '_8e8fe679-eb3b-4c43-a4d6-891e7087ff80',
+                id: 'E1373649849867__8e8fe679-eb3b-4c43-a4d6-891e7087ff80',
+                waypoint: [
+                  {
+                    x: 606,
+                    y: 351,
+                  },
+                  {
+                    x: 624,
+                    y: 351,
+                  },
+                  {
+                    x: 648,
+                    y: 351,
+                  },
+                ],
+                BPMNLabel: '',
+              },
+            ],
+          },
+          BPMNLabelStyle: {
+            id: 'LS1373649849858',
+            Font: {
+              isBold: false,
+              isItalic: false,
+              isStrikeThrough: false,
+              isUnderline: false,
+              name: 'Arial',
+              size: 11,
+            },
+          },
+        },
       },
-      "task": [
-        {
-          "completionQuantity": 1,
-          "isForCompensation": false,
-          "startQuantity": 1,
-          "name": "Task 1",
-          "id": "_ec59e164-68b4-4f94-98de-ffb1c58a84af",
-          "incoming": "_e16564d7-0c4c-413e-95f6-f668a3f851fb",
-          "outgoing": "_d77dd5ec-e4e7-420e-bbe7-8ac9cd1df599"
-        },
-        {
-          "completionQuantity": 1,
-          "isForCompensation": false,
-          "startQuantity": 1,
-          "name": "Task 2",
-          "id": "_820c21c0-45f3-473b-813f-06381cc637cd",
-          "incoming": "_d77dd5ec-e4e7-420e-bbe7-8ac9cd1df599",
-          "outgoing": "_2aa47410-1b0e-4f8b-ad54-d6f798080cb4"
-        },
-        {
-          "completionQuantity": 1,
-          "isForCompensation": false,
-          "startQuantity": 1,
-          "name": "Task 3",
-          "id": "_e70a6fcb-913c-4a7b-a65d-e83adc73d69c",
-          "incoming": "_2aa47410-1b0e-4f8b-ad54-d6f798080cb4",
-          "outgoing": "_8e8fe679-eb3b-4c43-a4d6-891e7087ff80"
-        }
-      ],
-      "endEvent": {
-        "name": "End Event",
-        "id": "_a47df184-085b-49f7-bb82-031c84625821",
-        "incoming": "_8e8fe679-eb3b-4c43-a4d6-891e7087ff80"
-      },
-      "sequenceFlow": [
-        {
-          "sourceRef": "_93c466ab-b271-4376-a427-f4c353d55ce8",
-          "targetRef": "_ec59e164-68b4-4f94-98de-ffb1c58a84af",
-          "name": "",
-          "id": "_e16564d7-0c4c-413e-95f6-f668a3f851fb"
-        },
-        {
-          "sourceRef": "_ec59e164-68b4-4f94-98de-ffb1c58a84af",
-          "targetRef": "_820c21c0-45f3-473b-813f-06381cc637cd",
-          "name": "",
-          "id": "_d77dd5ec-e4e7-420e-bbe7-8ac9cd1df599"
-        },
-        {
-          "sourceRef": "_820c21c0-45f3-473b-813f-06381cc637cd",
-          "targetRef": "_e70a6fcb-913c-4a7b-a65d-e83adc73d69c",
-          "name": "",
-          "id": "_2aa47410-1b0e-4f8b-ad54-d6f798080cb4"
-        },
-        {
-          "sourceRef": "_e70a6fcb-913c-4a7b-a65d-e83adc73d69c",
-          "targetRef": "_a47df184-085b-49f7-bb82-031c84625821",
-          "name": "",
-          "id": "_8e8fe679-eb3b-4c43-a4d6-891e7087ff80"
-        }
-      ]
-    },
-    "BPMNDiagram": {
-      "documentation": "",
-      "id": "Trisotech_Visio-_6",
-      "name": "A.1.0",
-      "resolution": 96.00000267028808,
-      "BPMNPlane": {
-        "bpmnElement": "WFP-6-",
-        "BPMNShape": [
-          {
-            "bpmnElement": "_93c466ab-b271-4376-a427-f4c353d55ce8",
-            "id": "S1373649849857__93c466ab-b271-4376-a427-f4c353d55ce8",
-            "Bounds": {
-              "height": 30,
-              "width": 30,
-              "x": 186,
-              "y": 336
-            },
-            "BPMNLabel": {
-              "labelStyle": "LS1373649849858",
-              "Bounds": {
-                "height": 12.804751171875008,
-                "width": 94.93333333333335,
-                "x": 153.67766754457273,
-                "y": 371.3333333333333
-              }
-            }
-          },
-          {
-            "bpmnElement": "_ec59e164-68b4-4f94-98de-ffb1c58a84af",
-            "id": "S1373649849859__ec59e164-68b4-4f94-98de-ffb1c58a84af",
-            "Bounds": {
-              "height": 68,
-              "width": 83,
-              "x": 258,
-              "y": 317
-            },
-            "BPMNLabel": {
-              "labelStyle": "LS1373649849858",
-              "Bounds": {
-                "height": 12.804751171875008,
-                "width": 72.48293963254594,
-                "x": 263.3333333333333,
-                "y": 344.5818763825664
-              }
-            }
-          },
-          {
-            "bpmnElement": "_820c21c0-45f3-473b-813f-06381cc637cd",
-            "id": "S1373649849860__820c21c0-45f3-473b-813f-06381cc637cd",
-            "Bounds": {
-              "height": 68,
-              "width": 83,
-              "x": 390,
-              "y": 317
-            },
-            "BPMNLabel": {
-              "labelStyle": "LS1373649849858",
-              "Bounds": {
-                "height": 12.804751171875008,
-                "width": 72.48293963254594,
-                "x": 395.3333333333333,
-                "y": 344.5818763825664
-              }
-            }
-          },
-          {
-            "bpmnElement": "_e70a6fcb-913c-4a7b-a65d-e83adc73d69c",
-            "id": "S1373649849861__e70a6fcb-913c-4a7b-a65d-e83adc73d69c",
-            "Bounds": {
-              "height": 68,
-              "width": 83,
-              "x": 522,
-              "y": 317
-            },
-            "BPMNLabel": {
-              "labelStyle": "LS1373649849858",
-              "Bounds": {
-                "height": 12.804751171875008,
-                "width": 72.48293963254594,
-                "x": 527.3333333333334,
-                "y": 344.5818763825664
-              }
-            }
-          },
-          {
-            "bpmnElement": "_a47df184-085b-49f7-bb82-031c84625821",
-            "id": "S1373649849862__a47df184-085b-49f7-bb82-031c84625821",
-            "Bounds": {
-              "height": 32,
-              "width": 32,
-              "x": 648,
-              "y": 335
-            },
-            "BPMNLabel": {
-              "labelStyle": "LS1373649849858",
-              "Bounds": {
-                "height": 12.804751171875008,
-                "width": 94.93333333333335,
-                "x": 616.5963254593177,
-                "y": 372.3333333333333
-              }
-            }
-          }
-        ],
-        "BPMNEdge": [
-          {
-            "bpmnElement": "_d77dd5ec-e4e7-420e-bbe7-8ac9cd1df599",
-            "id": "E1373649849864__d77dd5ec-e4e7-420e-bbe7-8ac9cd1df599",
-            "waypoint": [
-              {
-                "x": 342,
-                "y": 351
-              },
-              {
-                "x": 390,
-                "y": 351
-              }
-            ],
-            "BPMNLabel": ""
-          },
-          {
-            "bpmnElement": "_e16564d7-0c4c-413e-95f6-f668a3f851fb",
-            "id": "E1373649849865__e16564d7-0c4c-413e-95f6-f668a3f851fb",
-            "waypoint": [
-              {
-                "x": 216,
-                "y": 351
-              },
-              {
-                "x": 234,
-                "y": 351
-              },
-              {
-                "x": 258,
-                "y": 351
-              }
-            ],
-            "BPMNLabel": ""
-          },
-          {
-            "bpmnElement": "_2aa47410-1b0e-4f8b-ad54-d6f798080cb4",
-            "id": "E1373649849866__2aa47410-1b0e-4f8b-ad54-d6f798080cb4",
-            "waypoint": [
-              {
-                "x": 474,
-                "y": 351
-              },
-              {
-                "x": 522,
-                "y": 351
-              }
-            ],
-            "BPMNLabel": ""
-          },
-          {
-            "bpmnElement": "_8e8fe679-eb3b-4c43-a4d6-891e7087ff80",
-            "id": "E1373649849867__8e8fe679-eb3b-4c43-a4d6-891e7087ff80",
-            "waypoint": [
-              {
-                "x": 606,
-                "y": 351
-              },
-              {
-                "x": 624,
-                "y": 351
-              },
-              {
-                "x": 648,
-                "y": 351
-              }
-            ],
-            "BPMNLabel": ""
-          }
-        ]
-      },
-      "BPMNLabelStyle": {
-        "id": "LS1373649849858",
-        "Font": {
-          "isBold": false,
-          "isItalic": false,
-          "isStrikeThrough": false,
-          "isUnderline": false,
-          "name": "Arial",
-          "size": 11
-        }
-      }
-    }
-  }
-}`;
+    };
 
-    const model = parseJsonAndExpect(json, 0, 0, 5, 4);
+    // const model = parseJsonAndExpect(json, 0, 0, 5, 4);
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(5);
+    expect(model.edges).toHaveLength(4);
 
     model.flowNodes.map(flowNode => flowNode.bpmnElement).forEach(bpmnElement => expect(bpmnElement.parentId).toBeUndefined);
   });

--- a/test/unit/component/parser/json/BpmnJsonParser.process.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.process.test.ts
@@ -14,10 +14,8 @@
  * limitations under the License.
  */
 import { ShapeBpmnElementKind } from '../../../../../src/model/bpmn/shape/ShapeBpmnElementKind';
-import { verifyShape } from './JsonTestUtils';
-// import { parseJsonAndExpect, parseJsonAndExpectOnlyPools, parseJsonAndExpectOnlyPoolsAndFlowNodes, parseJsonAndExpectOnlyPoolsAndLanes, verifyShape } from './JsonTestUtils';
+import { parseJsonAndExpect, parseJsonAndExpectOnlyPools, parseJsonAndExpectOnlyPoolsAndFlowNodes, parseJsonAndExpectOnlyPoolsAndLanes, verifyShape } from './JsonTestUtils';
 import { findProcessRefParticipant } from '../../../../../src/component/parser/json/converter/CollaborationConverter';
-import { defaultBpmnJsonParser } from '../../../../../src/component/parser/json/BpmnJsonParser';
 
 describe('parse bpmn as json for process/pool', () => {
   it('json containing one participant without name and the related process has a name', () => {
@@ -47,12 +45,7 @@ describe('parse bpmn as json for process/pool', () => {
       },
     };
 
-    // const model = parseJsonAndExpectOnlyPoolsAndLanes(json, 1, 0);
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(1);
-    expect(model.flowNodes).toHaveLength(0);
-    expect(model.edges).toHaveLength(0);
+    const model = parseJsonAndExpectOnlyPoolsAndLanes(json, 1, 0);
 
     const pool = model.pools[0];
     verifyShape(pool, {
@@ -104,12 +97,7 @@ describe('parse bpmn as json for process/pool', () => {
       },
     };
 
-    // const model = parseJsonAndExpectOnlyPoolsAndLanes(json, 1, 1);
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(1);
-    expect(model.pools).toHaveLength(1);
-    expect(model.flowNodes).toHaveLength(0);
-    expect(model.edges).toHaveLength(0);
+    const model = parseJsonAndExpectOnlyPoolsAndLanes(json, 1, 1);
 
     const pool = model.pools[0];
     verifyShape(pool, {
@@ -202,12 +190,7 @@ describe('parse bpmn as json for process/pool', () => {
       },
     };
 
-    // const model = parseJsonAndExpectOnlyPoolsAndLanes(json, 2, 2);
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(2);
-    expect(model.pools).toHaveLength(2);
-    expect(model.flowNodes).toHaveLength(0);
-    expect(model.edges).toHaveLength(0);
+    const model = parseJsonAndExpectOnlyPoolsAndLanes(json, 2, 2);
 
     verifyShape(model.pools[0], {
       shapeId: 'shape_Participant_1',
@@ -294,12 +277,7 @@ describe('parse bpmn as json for process/pool', () => {
       },
     };
 
-    // const model = parseJsonAndExpectOnlyPools(json, 1);
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(1);
-    expect(model.flowNodes).toHaveLength(0);
-    expect(model.edges).toHaveLength(0);
+    const model = parseJsonAndExpectOnlyPools(json, 1);
 
     const pool = model.pools[0];
     verifyShape(pool, {
@@ -356,12 +334,7 @@ describe('parse bpmn as json for process/pool', () => {
       },
     };
 
-    // const model = parseJsonAndExpectOnlyPoolsAndFlowNodes(json, 1, 1);
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(1);
-    expect(model.flowNodes).toHaveLength(1);
-    expect(model.edges).toHaveLength(0);
+    const model = parseJsonAndExpectOnlyPoolsAndFlowNodes(json, 1, 1);
 
     const pool = model.pools[0];
     verifyShape(pool, {
@@ -660,12 +633,7 @@ describe('parse bpmn as json for process/pool', () => {
       },
     };
 
-    // const model = parseJsonAndExpect(json, 0, 0, 5, 4);
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(5);
-    expect(model.edges).toHaveLength(4);
+    const model = parseJsonAndExpect(json, 0, 0, 5, 4);
 
     model.flowNodes.map(flowNode => flowNode.bpmnElement).forEach(bpmnElement => expect(bpmnElement.parentId).toBeUndefined);
   });

--- a/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.conditional.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.conditional.test.ts
@@ -13,11 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { verifyEdge } from './JsonTestUtils';
-// import { parseJsonAndExpectOnlyEdgesAndFlowNodes, verifyEdge } from './JsonTestUtils';
+import { parseJsonAndExpectOnlyEdgesAndFlowNodes, verifyEdge } from './JsonTestUtils';
 import { SequenceFlowKind } from '../../../../../src/model/bpmn/edge/SequenceFlowKind';
 import each from 'jest-each';
-import { defaultBpmnJsonParser } from '../../../../../src/component/parser/json/BpmnJsonParser';
 import { TProcess } from '../../../../../src/component/parser/xml/bpmn-json-model/baseElement/rootElement/rootElement';
 import { TSequenceFlow } from '../../../../../src/component/parser/xml/bpmn-json-model/baseElement/flowElement';
 import Waypoint from '../../../../../src/model/bpmn/edge/Waypoint';
@@ -79,13 +77,7 @@ describe('parse bpmn as json for conditional sequence flow', () => {
     process[`${sourceKind}`] = { id: 'source_id_0' };
     (process.sequenceFlow as TSequenceFlow).conditionExpression['#text'] = '&quot;Contract to be written&quot;.equals(loanRequested.status)';
 
-    // const model = parseJsonAndExpectOnlyEdgesAndFlowNodes(json, 1, 1);
-
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(1);
-    expect(model.edges).toHaveLength(1);
+    const model = parseJsonAndExpectOnlyEdgesAndFlowNodes(json, 1, 1);
 
     verifyEdge(model.edges[0], {
       edgeId: 'edge_sequenceFlow_id_0',
@@ -134,12 +126,7 @@ describe('parse bpmn as json for conditional sequence flow', () => {
       },
     };
 
-    // const model = parseJsonAndExpectOnlyEdgesAndFlowNodes(json, 1, 1);
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(1);
-    expect(model.edges).toHaveLength(1);
+    const model = parseJsonAndExpectOnlyEdgesAndFlowNodes(json, 1, 1);
 
     verifyEdge(model.edges[0], {
       edgeId: 'edge_sequenceFlow_id_0',

--- a/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.default.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.default.test.ts
@@ -13,52 +13,68 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { parseJsonAndExpectOnlyEdgesAndFlowNodes, verifyEdge } from './JsonTestUtils';
+import { verifyEdge } from './JsonTestUtils';
+// import { parseJsonAndExpectOnlyEdgesAndFlowNodes, verifyEdge } from './JsonTestUtils';
 import { SequenceFlowKind } from '../../../../../src/model/bpmn/edge/SequenceFlowKind';
 import each from 'jest-each';
+import { defaultBpmnJsonParser } from '../../../../../src/component/parser/json/BpmnJsonParser';
+import Waypoint from '../../../../../src/model/bpmn/edge/Waypoint';
+import { TProcess } from '../../../../../src/component/parser/xml/bpmn-json-model/baseElement/rootElement/rootElement';
 
 describe('parse bpmn as json for default sequence flow', () => {
   it('json containing one process with a default sequence flow & a sequence flow', () => {
-    const json = `{
-          "definitions": {
-              "process": {
-                  "id": "Process_1",
-                  "task": { "id": "task_id_0", "default": "sequenceFlow_id_0"},
-                  "sequenceFlow": [{
-                        "id": "sequenceFlow_id_0",
-                        "name": "label 1",
-                        "sourceRef": "task_id_0",
-                        "targetRef": "targetRef_RLk"
-                    }, {
-                        "id": "sequenceFlow_id_1",
-                        "sourceRef": "task_id_0",
-                        "targetRef": "targetRef_2"
-                    }
-                  ]
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: {
+          id: 'Process_1',
+          task: { id: 'task_id_0', default: 'sequenceFlow_id_0' },
+          sequenceFlow: [
+            {
+              id: 'sequenceFlow_id_0',
+              name: 'label 1',
+              sourceRef: 'task_id_0',
+              targetRef: 'targetRef_RLk',
+            },
+            {
+              id: 'sequenceFlow_id_1',
+              sourceRef: 'task_id_0',
+              targetRef: 'targetRef_2',
+            },
+          ],
+        },
+        BPMNDiagram: {
+          id: 'BpmnDiagram_1',
+          BPMNPlane: {
+            id: 'BpmnPlane_1',
+            BPMNShape: {
+              id: 'shape_task_id_0',
+              bpmnElement: 'task_id_0',
+              Bounds: { x: 362, y: 232, width: 36, height: 45 },
+            },
+            BPMNEdge: [
+              {
+                id: 'edge_sequenceFlow_id_0',
+                bpmnElement: 'sequenceFlow_id_0',
+                waypoint: [{ x: 10, y: 10 }],
               },
-              "BPMNDiagram": {
-                  "id": "BpmnDiagram_1",
-                  "BPMNPlane": {
-                      "id": "BpmnPlane_1",
-                      "BPMNShape": {
-                          "id":"shape_task_id_0",
-                          "bpmnElement":"task_id_0",
-                          "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 }
-                      },
-                      "BPMNEdge": [{
-                            "id": "edge_sequenceFlow_id_0",
-                            "bpmnElement": "sequenceFlow_id_0"
-                        }, {
-                            "id": "edge_sequenceFlow_id_1",
-                            "bpmnElement": "sequenceFlow_id_1"
-                        }
-                      ]
-                  }
-              }
-          }
-      }`;
+              {
+                id: 'edge_sequenceFlow_id_1',
+                bpmnElement: 'sequenceFlow_id_1',
+                waypoint: [{ x: 10, y: 10 }],
+              },
+            ],
+          },
+        },
+      },
+    };
 
-    const model = parseJsonAndExpectOnlyEdgesAndFlowNodes(json, 2, 1);
+    // const model = parseJsonAndExpectOnlyEdgesAndFlowNodes(json, 2, 1);
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(1);
+    expect(model.edges).toHaveLength(2);
 
     verifyEdge(model.edges[0], {
       edgeId: 'edge_sequenceFlow_id_0',
@@ -67,6 +83,7 @@ describe('parse bpmn as json for default sequence flow', () => {
       bpmnElementSourceRefId: 'task_id_0',
       bpmnElementTargetRefId: 'targetRef_RLk',
       bpmnElementSequenceFlowKind: SequenceFlowKind.DEFAULT,
+      waypoints: [new Waypoint(10, 10)],
     });
     verifyEdge(model.edges[1], {
       edgeId: 'edge_sequenceFlow_id_1',
@@ -75,6 +92,7 @@ describe('parse bpmn as json for default sequence flow', () => {
       bpmnElementSourceRefId: 'task_id_0',
       bpmnElementTargetRefId: 'targetRef_2',
       bpmnElementSequenceFlowKind: SequenceFlowKind.NORMAL,
+      waypoints: [new Waypoint(10, 10)],
     });
   });
 
@@ -98,36 +116,43 @@ describe('parse bpmn as json for default sequence flow', () => {
     // TODO: To uncomment when we support businessRuleTask
     //['businessRuleTask'],
   ]).it('json containing one process with a sequence flow defined as default in a %s', sourceKind => {
-    const json = `{
-          "definitions": {
-              "process": {
-                  "id": "Process_1",
-                  "${sourceKind}": { "id": "source_id_0", "default": "sequenceFlow_id_0"},
-                  "sequenceFlow": {
-                      "id": "sequenceFlow_id_0",
-                      "sourceRef": "source_id_0",
-                      "targetRef": "targetRef_RLk"
-                  }
-              },
-              "BPMNDiagram": {
-                  "id": "BpmnDiagram_1",
-                  "BPMNPlane": {
-                      "id": "BpmnPlane_1",
-                      "BPMNShape": {
-                          "id":"shape_source_id_0",
-                          "bpmnElement":"source_id_0",
-                          "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 }
-                      },
-                      "BPMNEdge": {
-                          "id": "edge_sequenceFlow_id_0",
-                          "bpmnElement": "sequenceFlow_id_0"
-                      }
-                  }
-              }
-          }
-      }`;
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: {
+          id: 'Process_1',
+          sequenceFlow: {
+            id: 'sequenceFlow_id_0',
+            sourceRef: 'source_id_0',
+            targetRef: 'targetRef_RLk',
+          },
+        },
+        BPMNDiagram: {
+          id: 'BpmnDiagram_1',
+          BPMNPlane: {
+            id: 'BpmnPlane_1',
+            BPMNShape: {
+              id: 'shape_source_id_0',
+              bpmnElement: 'source_id_0',
+              Bounds: { x: 362, y: 232, width: 36, height: 45 },
+            },
+            BPMNEdge: {
+              id: 'edge_sequenceFlow_id_0',
+              bpmnElement: 'sequenceFlow_id_0',
+              waypoint: [{ x: 10, y: 10 }],
+            },
+          },
+        },
+      },
+    };
+    (json.definitions.process as TProcess)[`${sourceKind}`] = { id: 'source_id_0', default: 'sequenceFlow_id_0' };
 
-    const model = parseJsonAndExpectOnlyEdgesAndFlowNodes(json, 1, 1);
+    // const model = parseJsonAndExpectOnlyEdgesAndFlowNodes(json, 1, 1);
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(1);
+    expect(model.edges).toHaveLength(1);
 
     verifyEdge(model.edges[0], {
       edgeId: 'edge_sequenceFlow_id_0',
@@ -136,40 +161,48 @@ describe('parse bpmn as json for default sequence flow', () => {
       bpmnElementSourceRefId: 'source_id_0',
       bpmnElementTargetRefId: 'targetRef_RLk',
       bpmnElementSequenceFlowKind: SequenceFlowKind.DEFAULT,
+      waypoints: [new Waypoint(10, 10)],
     });
   });
 
   it('json containing one process with a flow node who define a sequence flow as default, but not possible in BPMN Semantic', () => {
-    const json = `{
-          "definitions": {
-              "process": {
-                  "id": "Process_1",
-                  "parallelGateway": { "id": "gateway_id_0", "default": "sequenceFlow_id_0"},
-                  "sequenceFlow": {
-                      "id": "sequenceFlow_id_0",
-                      "sourceRef": "gateway_id_0",
-                      "targetRef": "targetRef_RLk"
-                  }
-              },
-              "BPMNDiagram": {
-                  "id": "BpmnDiagram_1",
-                  "BPMNPlane": {
-                      "id": "BpmnPlane_1",
-                      "BPMNShape": {
-                          "id":"shape_gateway_id_0",
-                          "bpmnElement":"gateway_id_0",
-                          "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 }
-                      },
-                      "BPMNEdge": {
-                          "id": "edge_sequenceFlow_id_0",
-                          "bpmnElement": "sequenceFlow_id_0"
-                      }
-                  }
-              }
-          }
-      }`;
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: {
+          id: 'Process_1',
+          parallelGateway: { id: 'gateway_id_0', default: 'sequenceFlow_id_0' },
+          sequenceFlow: {
+            id: 'sequenceFlow_id_0',
+            sourceRef: 'gateway_id_0',
+            targetRef: 'targetRef_RLk',
+          },
+        },
+        BPMNDiagram: {
+          id: 'BpmnDiagram_1',
+          BPMNPlane: {
+            id: 'BpmnPlane_1',
+            BPMNShape: {
+              id: 'shape_gateway_id_0',
+              bpmnElement: 'gateway_id_0',
+              Bounds: { x: 362, y: 232, width: 36, height: 45 },
+            },
+            BPMNEdge: {
+              id: 'edge_sequenceFlow_id_0',
+              bpmnElement: 'sequenceFlow_id_0',
+              waypoint: [{ x: 10, y: 10 }],
+            },
+          },
+        },
+      },
+    };
 
-    const model = parseJsonAndExpectOnlyEdgesAndFlowNodes(json, 1, 1);
+    // const model = parseJsonAndExpectOnlyEdgesAndFlowNodes(json, 1, 1);
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(1);
+    expect(model.edges).toHaveLength(1);
 
     verifyEdge(model.edges[0], {
       edgeId: 'edge_sequenceFlow_id_0',
@@ -178,6 +211,7 @@ describe('parse bpmn as json for default sequence flow', () => {
       bpmnElementSourceRefId: 'gateway_id_0',
       bpmnElementTargetRefId: 'targetRef_RLk',
       bpmnElementSequenceFlowKind: SequenceFlowKind.NORMAL,
+      waypoints: [new Waypoint(10, 10)],
     });
   });
 });

--- a/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.default.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.default.test.ts
@@ -13,11 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { verifyEdge } from './JsonTestUtils';
-// import { parseJsonAndExpectOnlyEdgesAndFlowNodes, verifyEdge } from './JsonTestUtils';
+import { parseJsonAndExpectOnlyEdgesAndFlowNodes, verifyEdge } from './JsonTestUtils';
 import { SequenceFlowKind } from '../../../../../src/model/bpmn/edge/SequenceFlowKind';
 import each from 'jest-each';
-import { defaultBpmnJsonParser } from '../../../../../src/component/parser/json/BpmnJsonParser';
 import Waypoint from '../../../../../src/model/bpmn/edge/Waypoint';
 import { TProcess } from '../../../../../src/component/parser/xml/bpmn-json-model/baseElement/rootElement/rootElement';
 
@@ -69,12 +67,7 @@ describe('parse bpmn as json for default sequence flow', () => {
       },
     };
 
-    // const model = parseJsonAndExpectOnlyEdgesAndFlowNodes(json, 2, 1);
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(1);
-    expect(model.edges).toHaveLength(2);
+    const model = parseJsonAndExpectOnlyEdgesAndFlowNodes(json, 2, 1);
 
     verifyEdge(model.edges[0], {
       edgeId: 'edge_sequenceFlow_id_0',
@@ -147,12 +140,7 @@ describe('parse bpmn as json for default sequence flow', () => {
     };
     (json.definitions.process as TProcess)[`${sourceKind}`] = { id: 'source_id_0', default: 'sequenceFlow_id_0' };
 
-    // const model = parseJsonAndExpectOnlyEdgesAndFlowNodes(json, 1, 1);
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(1);
-    expect(model.edges).toHaveLength(1);
+    const model = parseJsonAndExpectOnlyEdgesAndFlowNodes(json, 1, 1);
 
     verifyEdge(model.edges[0], {
       edgeId: 'edge_sequenceFlow_id_0',
@@ -197,12 +185,7 @@ describe('parse bpmn as json for default sequence flow', () => {
       },
     };
 
-    // const model = parseJsonAndExpectOnlyEdgesAndFlowNodes(json, 1, 1);
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(1);
-    expect(model.edges).toHaveLength(1);
+    const model = parseJsonAndExpectOnlyEdgesAndFlowNodes(json, 1, 1);
 
     verifyEdge(model.edges[0], {
       edgeId: 'edge_sequenceFlow_id_0',

--- a/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.normal.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.normal.test.ts
@@ -13,10 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { verifyEdge } from './JsonTestUtils';
-// import { parseJsonAndExpectOnlyEdges, verifyEdge } from './JsonTestUtils';
+import { parseJsonAndExpectOnlyEdges, verifyEdge } from './JsonTestUtils';
 import Waypoint from '../../../../../src/model/bpmn/edge/Waypoint';
-import { defaultBpmnJsonParser } from '../../../../../src/component/parser/json/BpmnJsonParser';
 
 describe('parse bpmn as json for sequence flow', () => {
   it('json containing one process with a single sequence flow without waypoint', () => {
@@ -46,12 +44,7 @@ describe('parse bpmn as json for sequence flow', () => {
       },
     };
 
-    // const model = parseJsonAndExpectOnlyEdges(json, 1);
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(0);
-    expect(model.edges).toHaveLength(1);
+    const model = parseJsonAndExpectOnlyEdges(json, 1);
 
     verifyEdge(model.edges[0], {
       edgeId: 'edge_sequenceFlow_id_0',
@@ -92,12 +85,7 @@ describe('parse bpmn as json for sequence flow', () => {
       },
     };
 
-    // const model = parseJsonAndExpectOnlyEdges(json, 1);
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(0);
-    expect(model.edges).toHaveLength(1);
+    const model = parseJsonAndExpectOnlyEdges(json, 1);
 
     verifyEdge(model.edges[0], {
       edgeId: 'edge_sequenceFlow_id_0',
@@ -150,12 +138,7 @@ describe('parse bpmn as json for sequence flow', () => {
       },
     };
 
-    // const model = parseJsonAndExpectOnlyEdges(json, 2);
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(0);
-    expect(model.edges).toHaveLength(2);
+    const model = parseJsonAndExpectOnlyEdges(json, 2);
 
     verifyEdge(model.edges[0], {
       edgeId: 'edge_sequenceFlow_id_0',
@@ -222,12 +205,7 @@ describe('parse bpmn as json for sequence flow', () => {
       },
     };
 
-    // const model = parseJsonAndExpectOnlyEdges(json, 2);
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(0);
-    expect(model.edges).toHaveLength(2);
+    const model = parseJsonAndExpectOnlyEdges(json, 2);
 
     verifyEdge(model.edges[0], {
       edgeId: 'edge_sequenceFlow_id_0',

--- a/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.normal.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.normal.test.ts
@@ -13,36 +13,45 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { parseJsonAndExpectOnlyEdges, verifyEdge } from './JsonTestUtils';
+import { verifyEdge } from './JsonTestUtils';
+// import { parseJsonAndExpectOnlyEdges, verifyEdge } from './JsonTestUtils';
 import Waypoint from '../../../../../src/model/bpmn/edge/Waypoint';
+import { defaultBpmnJsonParser } from '../../../../../src/component/parser/json/BpmnJsonParser';
 
 describe('parse bpmn as json for sequence flow', () => {
   it('json containing one process with a single sequence flow without waypoint', () => {
-    const json = `{
-          "definitions": {
-              "process": {
-                  "id": "Process_1",
-                  "sequenceFlow": {
-                      "id": "sequenceFlow_id_0",
-                      "name": "label 1",
-                      "sourceRef": "sourceRef_id_xsdas",
-                      "targetRef": "targetRef_RLk"
-                  }
-              },
-              "BPMNDiagram": {
-                  "id": "BpmnDiagram_1",
-                  "BPMNPlane": {
-                      "id": "BpmnPlane_1",
-                      "BPMNEdge": {
-                          "id": "edge_sequenceFlow_id_0",
-                          "bpmnElement": "sequenceFlow_id_0"
-                      }
-                  }
-              }
-          }
-      }`;
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: {
+          id: 'Process_1',
+          sequenceFlow: {
+            id: 'sequenceFlow_id_0',
+            name: 'label 1',
+            sourceRef: 'sourceRef_id_xsdas',
+            targetRef: 'targetRef_RLk',
+          },
+        },
+        BPMNDiagram: {
+          id: 'BpmnDiagram_1',
+          BPMNPlane: {
+            id: 'BpmnPlane_1',
+            BPMNEdge: {
+              id: 'edge_sequenceFlow_id_0',
+              bpmnElement: 'sequenceFlow_id_0',
+              waypoint: [{ x: 10, y: 10 }],
+            },
+          },
+        },
+      },
+    };
 
-    const model = parseJsonAndExpectOnlyEdges(json, 1);
+    // const model = parseJsonAndExpectOnlyEdges(json, 1);
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(0);
+    expect(model.edges).toHaveLength(1);
 
     verifyEdge(model.edges[0], {
       edgeId: 'edge_sequenceFlow_id_0',
@@ -50,35 +59,45 @@ describe('parse bpmn as json for sequence flow', () => {
       bpmnElementName: 'label 1',
       bpmnElementSourceRefId: 'sourceRef_id_xsdas',
       bpmnElementTargetRefId: 'targetRef_RLk',
+      waypoints: [new Waypoint(10, 10)],
     });
   });
 
   it('json containing one process declared as array with a single sequence flow', () => {
-    const json = `{
-          "definitions": {
-              "process": [{
-                  "id": "Process_1",
-                  "sequenceFlow": {
-                      "id": "sequenceFlow_id_0",
-                      "name": "label 1",
-                      "sourceRef": "sourceRef_id_xsdas",
-                      "targetRef": "targetRef_RLk"
-                  }
-              }],
-              "BPMNDiagram": {
-                  "id": "BpmnDiagram_1",
-                  "BPMNPlane": {
-                      "id": "BpmnPlane_1",
-                      "BPMNEdge": {
-                          "id": "edge_sequenceFlow_id_0",
-                          "bpmnElement": "sequenceFlow_id_0"
-                      }
-                  }
-              }
-          }
-      }`;
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: [
+          {
+            id: 'Process_1',
+            sequenceFlow: {
+              id: 'sequenceFlow_id_0',
+              name: 'label 1',
+              sourceRef: 'sourceRef_id_xsdas',
+              targetRef: 'targetRef_RLk',
+            },
+          },
+        ],
+        BPMNDiagram: {
+          id: 'BpmnDiagram_1',
+          BPMNPlane: {
+            id: 'BpmnPlane_1',
+            BPMNEdge: {
+              id: 'edge_sequenceFlow_id_0',
+              bpmnElement: 'sequenceFlow_id_0',
+              waypoint: [{ x: 10, y: 10 }],
+            },
+          },
+        },
+      },
+    };
 
-    const model = parseJsonAndExpectOnlyEdges(json, 1);
+    // const model = parseJsonAndExpectOnlyEdges(json, 1);
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(0);
+    expect(model.edges).toHaveLength(1);
 
     verifyEdge(model.edges[0], {
       edgeId: 'edge_sequenceFlow_id_0',
@@ -86,42 +105,57 @@ describe('parse bpmn as json for sequence flow', () => {
       bpmnElementName: 'label 1',
       bpmnElementSourceRefId: 'sourceRef_id_xsdas',
       bpmnElementTargetRefId: 'targetRef_RLk',
+      waypoints: [new Waypoint(10, 10)],
     });
   });
 
   it('json containing one process with an array of sequence flows with name & without name', () => {
-    const json = `{
-          "definitions": {
-              "process": {
-                  "id": "Process_1",
-                  "sequenceFlow": [{
-                      "id": "sequenceFlow_id_0",
-                      "name": "label 1",
-                      "sourceRef": "sourceRef_id_xsdas",
-                      "targetRef": "targetRef_RLk"
-                  },{
-                      "id": "sequenceFlow_id_1",
-                      "sourceRef": "sequenceFlow_id_1",
-                      "targetRef": "targetRef_1"
-                  }]
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: {
+          id: 'Process_1',
+          sequenceFlow: [
+            {
+              id: 'sequenceFlow_id_0',
+              name: 'label 1',
+              sourceRef: 'sourceRef_id_xsdas',
+              targetRef: 'targetRef_RLk',
+            },
+            {
+              id: 'sequenceFlow_id_1',
+              sourceRef: 'sequenceFlow_id_1',
+              targetRef: 'targetRef_1',
+            },
+          ],
+        },
+        BPMNDiagram: {
+          id: 'BpmnDiagram_1',
+          BPMNPlane: {
+            id: 'BpmnPlane_1',
+            BPMNEdge: [
+              {
+                id: 'edge_sequenceFlow_id_0',
+                bpmnElement: 'sequenceFlow_id_0',
+                waypoint: [{ x: 10, y: 10 }],
               },
-              "BPMNDiagram": {
-                  "id": "BpmnDiagram_1",
-                  "BPMNPlane": {
-                      "id": "BpmnPlane_1",
-                      "BPMNEdge": [{
-                          "id": "edge_sequenceFlow_id_0",
-                          "bpmnElement": "sequenceFlow_id_0"
-                      },{
-                          "id": "edge_sequenceFlow_id_1",
-                          "bpmnElement": "sequenceFlow_id_1"
-                      }]
-                  }
-              }
-          }
-      }`;
+              {
+                id: 'edge_sequenceFlow_id_1',
+                bpmnElement: 'sequenceFlow_id_1',
+                waypoint: [{ x: 10, y: 10 }],
+              },
+            ],
+          },
+        },
+      },
+    };
 
-    const model = parseJsonAndExpectOnlyEdges(json, 2);
+    // const model = parseJsonAndExpectOnlyEdges(json, 2);
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(0);
+    expect(model.edges).toHaveLength(2);
 
     verifyEdge(model.edges[0], {
       edgeId: 'edge_sequenceFlow_id_0',
@@ -129,6 +163,7 @@ describe('parse bpmn as json for sequence flow', () => {
       bpmnElementName: 'label 1',
       bpmnElementSourceRefId: 'sourceRef_id_xsdas',
       bpmnElementTargetRefId: 'targetRef_RLk',
+      waypoints: [new Waypoint(10, 10)],
     });
     verifyEdge(model.edges[1], {
       edgeId: 'edge_sequenceFlow_id_1',
@@ -136,52 +171,63 @@ describe('parse bpmn as json for sequence flow', () => {
       bpmnElementName: undefined,
       bpmnElementSourceRefId: 'sequenceFlow_id_1',
       bpmnElementTargetRefId: 'targetRef_1',
+      waypoints: [new Waypoint(10, 10)],
     });
   });
 
-  it('json containing one process with an array of sequence flows with one & several waypoints', () => {
-    const json = `{
-          "definitions": {
-              "process": {
-                  "id": "Process_1",
-                  "sequenceFlow": [{
-                      "id": "sequenceFlow_id_0",
-                      "sourceRef": "sourceRef_id_xsdas",
-                      "targetRef": "targetRef_RLk"
-                  },{
-                      "id": "sequenceFlow_id_1",
-                      "sourceRef": "sequenceFlow_id_1",
-                      "targetRef": "targetRef_1"
-                  }]
+  it('json containing one process with an array of sequence flows with 2 & several waypoints', () => {
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: {
+          id: 'Process_1',
+          sequenceFlow: [
+            {
+              id: 'sequenceFlow_id_0',
+              sourceRef: 'sourceRef_id_xsdas',
+              targetRef: 'targetRef_RLk',
+            },
+            {
+              id: 'sequenceFlow_id_1',
+              sourceRef: 'sequenceFlow_id_1',
+              targetRef: 'targetRef_1',
+            },
+          ],
+        },
+        BPMNDiagram: {
+          id: 'BpmnDiagram_1',
+          BPMNPlane: {
+            id: 'BpmnPlane_1',
+            BPMNEdge: [
+              {
+                id: 'edge_sequenceFlow_id_0',
+                bpmnElement: 'sequenceFlow_id_0',
+                waypoint: [
+                  { x: 1, y: 1 },
+                  { x: 2, y: 2 },
+                ],
               },
-              "BPMNDiagram": {
-                  "id": "BpmnDiagram_1",
-                  "BPMNPlane": {
-                      "id": "BpmnPlane_1",
-                      "BPMNEdge": [{
-                          "id": "edge_sequenceFlow_id_0",
-                          "bpmnElement": "sequenceFlow_id_0",
-                          "waypoint": {
-                            "x":1,
-                            "y":1 
-                          }
-                      },{
-                          "id": "edge_sequenceFlow_id_1",
-                          "bpmnElement": "sequenceFlow_id_1",
-                          "waypoint": [{
-                            "x":2,
-                            "y":2 
-                          }, {
-                            "x":3,
-                            "y":3 
-                          }]
-                      }]
-                  }
-              }
-          }
-      }`;
+              {
+                id: 'edge_sequenceFlow_id_1',
+                bpmnElement: 'sequenceFlow_id_1',
+                waypoint: [
+                  { x: 2, y: 2 },
+                  { x: 3, y: 3 },
+                  { x: 4, y: 4 },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    };
 
-    const model = parseJsonAndExpectOnlyEdges(json, 2);
+    // const model = parseJsonAndExpectOnlyEdges(json, 2);
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(0);
+    expect(model.edges).toHaveLength(2);
 
     verifyEdge(model.edges[0], {
       edgeId: 'edge_sequenceFlow_id_0',
@@ -189,7 +235,7 @@ describe('parse bpmn as json for sequence flow', () => {
       bpmnElementName: undefined,
       bpmnElementSourceRefId: 'sourceRef_id_xsdas',
       bpmnElementTargetRefId: 'targetRef_RLk',
-      waypoints: [new Waypoint(1, 1)],
+      waypoints: [new Waypoint(1, 1), new Waypoint(2, 2)],
     });
     verifyEdge(model.edges[1], {
       edgeId: 'edge_sequenceFlow_id_1',
@@ -197,7 +243,7 @@ describe('parse bpmn as json for sequence flow', () => {
       bpmnElementName: undefined,
       bpmnElementSourceRefId: 'sequenceFlow_id_1',
       bpmnElementTargetRefId: 'targetRef_1',
-      waypoints: [new Waypoint(2, 2), new Waypoint(3, 3)],
+      waypoints: [new Waypoint(2, 2), new Waypoint(3, 3), new Waypoint(4, 4)],
     });
   });
 });

--- a/test/unit/component/parser/json/BpmnJsonParser.sub.process.embedded.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.sub.process.embedded.test.ts
@@ -23,28 +23,29 @@ describe('parse bpmn as json for embedded sub-process', () => {
     ['expanded', true],
     ['collapsed', false],
   ]).it('json containing one process with a single %s embedded sub-process', (testName, isExpanded: boolean) => {
-    const json = `{
-                "definitions" : {
-                    "process": {
-                        "subProcess": {
-                            "id":"sub-process_id_0",
-                            "name":"sub-process name",
-                            "triggeredByEvent":false
-                        }
-                    },
-                    "BPMNDiagram": {
-                        "name":"process 0",
-                        "BPMNPlane": {
-                            "BPMNShape": {
-                                "id":"shape_sub-process_id_0",
-                                "bpmnElement":"sub-process_id_0",
-                                "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 },
-                                "isExpanded":${isExpanded}
-                            }
-                        }
-                    }
-                }
-            }`;
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: {
+          subProcess: {
+            id: 'sub-process_id_0',
+            name: 'sub-process name',
+            triggeredByEvent: false,
+          },
+        },
+        BPMNDiagram: {
+          name: 'process 0',
+          BPMNPlane: {
+            BPMNShape: {
+              id: 'shape_sub-process_id_0',
+              bpmnElement: 'sub-process_id_0',
+              Bounds: { x: 362, y: 232, width: 36, height: 45 },
+              isExpanded: isExpanded,
+            },
+          },
+        },
+      },
+    };
 
     const model = parseJsonAndExpectOnlySubProcess(json, ShapeBpmnSubProcessKind.EMBEDDED, 1);
 
@@ -64,30 +65,31 @@ describe('parse bpmn as json for embedded sub-process', () => {
   });
 
   it('json containing one process declared as array with a single embedded sub-process', () => {
-    const json = `{
-                "definitions": {
-                    "process": [
-                        {
-                            "subProcess": {
-                                "id":"sub-process_id_1",
-                                "name":"sub-process name",
-                                "triggeredByEvent":false
-                            }
-                        }
-                    ],
-                    "BPMNDiagram": {
-                        "name":"process 0",
-                        "BPMNPlane": {
-                            "BPMNShape": {
-                                "id":"shape_sub-process_id_1",
-                                "bpmnElement":"sub-process_id_1",
-                                "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 },
-                                "isExpanded":false
-                            }
-                        }
-                    }
-                }
-            }`;
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: [
+          {
+            subProcess: {
+              id: 'sub-process_id_1',
+              name: 'sub-process name',
+              triggeredByEvent: false,
+            },
+          },
+        ],
+        BPMNDiagram: {
+          name: 'process 0',
+          BPMNPlane: {
+            BPMNShape: {
+              id: 'shape_sub-process_id_1',
+              bpmnElement: 'sub-process_id_1',
+              Bounds: { x: 362, y: 232, width: 36, height: 45 },
+              isExpanded: false,
+            },
+          },
+        },
+      },
+    };
 
     const model = parseJsonAndExpectOnlySubProcess(json, ShapeBpmnSubProcessKind.EMBEDDED, 1);
 
@@ -107,38 +109,41 @@ describe('parse bpmn as json for embedded sub-process', () => {
   });
 
   it('json containing one process with an array of embedded sub-processes with/without name, triggeredByEvent & isExpanded', () => {
-    const json = `{
-                "definitions" : {
-                    "process": {
-                        "subProcess": [
-                          {
-                              "id":"sub-process_id_0",
-                              "name":"sub-process name",
-                              "triggeredByEvent":false
-                          },{
-                              "id":"sub-process_id_1"
-                          }
-                        ]
-                    },
-                    "BPMNDiagram": {
-                        "name":"process 0",
-                        "BPMNPlane": {
-                            "BPMNShape": [
-                              {
-                                "id":"shape_sub-process_id_0",
-                                "bpmnElement":"sub-process_id_0",
-                                "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 },
-                                "isExpanded":false
-                              }, {
-                                "id":"shape_sub-process_id_1",
-                                "bpmnElement":"sub-process_id_1",
-                                "Bounds": { "x": 365, "y": 235, "width": 35, "height": 46 }
-                              }
-                            ]
-                        }
-                    }
-                }
-            }`;
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: {
+          subProcess: [
+            {
+              id: 'sub-process_id_0',
+              name: 'sub-process name',
+              triggeredByEvent: false,
+            },
+            {
+              id: 'sub-process_id_1',
+            },
+          ],
+        },
+        BPMNDiagram: {
+          name: 'process 0',
+          BPMNPlane: {
+            BPMNShape: [
+              {
+                id: 'shape_sub-process_id_0',
+                bpmnElement: 'sub-process_id_0',
+                Bounds: { x: 362, y: 232, width: 36, height: 45 },
+                isExpanded: false,
+              },
+              {
+                id: 'shape_sub-process_id_1',
+                bpmnElement: 'sub-process_id_1',
+                Bounds: { x: 365, y: 235, width: 35, height: 46 },
+              },
+            ],
+          },
+        },
+      },
+    };
 
     const model = parseJsonAndExpectOnlySubProcess(json, ShapeBpmnSubProcessKind.EMBEDDED, 2);
 

--- a/test/unit/component/parser/json/BpmnJsonParser.sub.process.event.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.sub.process.event.test.ts
@@ -23,28 +23,29 @@ describe('parse bpmn as json for event sub-process', () => {
     ['expanded', true],
     ['collapsed', false],
   ]).it('json containing one process with a single %s event sub-process', (testName, isExpanded: boolean) => {
-    const json = `{
-                "definitions" : {
-                    "process": {
-                        "subProcess": {
-                            "id":"sub-process_id_0",
-                            "name":"sub-process name",
-                            "triggeredByEvent":true
-                        }
-                    },
-                    "BPMNDiagram": {
-                        "name":"process 0",
-                        "BPMNPlane": {
-                            "BPMNShape": {
-                                "id":"shape_sub-process_id_0",
-                                "bpmnElement":"sub-process_id_0",
-                                "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 },
-                                "isExpanded":${isExpanded}
-                            }
-                        }
-                    }
-                }
-            }`;
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: {
+          subProcess: {
+            id: 'sub-process_id_0',
+            name: 'sub-process name',
+            triggeredByEvent: true,
+          },
+        },
+        BPMNDiagram: {
+          name: 'process 0',
+          BPMNPlane: {
+            BPMNShape: {
+              id: 'shape_sub-process_id_0',
+              bpmnElement: 'sub-process_id_0',
+              Bounds: { x: 362, y: 232, width: 36, height: 45 },
+              isExpanded: isExpanded,
+            },
+          },
+        },
+      },
+    };
 
     const model = parseJsonAndExpectOnlySubProcess(json, ShapeBpmnSubProcessKind.EVENT, 1);
 
@@ -64,30 +65,31 @@ describe('parse bpmn as json for event sub-process', () => {
   });
 
   it('json containing one process declared as array with a single event sub-process', () => {
-    const json = `{
-                "definitions": {
-                    "process": [
-                        {
-                            "subProcess": {
-                                "id":"sub-process_id_1",
-                                "name":"sub-process name",
-                                "triggeredByEvent":true
-                            }
-                        }
-                    ],
-                    "BPMNDiagram": {
-                        "name":"process 0",
-                        "BPMNPlane": {
-                            "BPMNShape": {
-                                "id":"shape_sub-process_id_1",
-                                "bpmnElement":"sub-process_id_1",
-                                "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 },
-                                "isExpanded":false
-                            }
-                        }
-                    }
-                }
-            }`;
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: [
+          {
+            subProcess: {
+              id: 'sub-process_id_1',
+              name: 'sub-process name',
+              triggeredByEvent: true,
+            },
+          },
+        ],
+        BPMNDiagram: {
+          name: 'process 0',
+          BPMNPlane: {
+            BPMNShape: {
+              id: 'shape_sub-process_id_1',
+              bpmnElement: 'sub-process_id_1',
+              Bounds: { x: 362, y: 232, width: 36, height: 45 },
+              isExpanded: false,
+            },
+          },
+        },
+      },
+    };
 
     const model = parseJsonAndExpectOnlySubProcess(json, ShapeBpmnSubProcessKind.EVENT, 1);
 
@@ -107,39 +109,42 @@ describe('parse bpmn as json for event sub-process', () => {
   });
 
   it('json containing one process with an array of event sub-processes with/without name & isExpanded', () => {
-    const json = `{
-                "definitions" : {
-                    "process": {
-                        "subProcess": [
-                          {
-                              "id":"sub-process_id_0",
-                              "name":"sub-process name",
-                              "triggeredByEvent":true
-                          },{
-                              "id":"sub-process_id_1",
-                              "triggeredByEvent":true
-                          }
-                        ]
-                    },
-                    "BPMNDiagram": {
-                        "name":"process 0",
-                        "BPMNPlane": {
-                            "BPMNShape": [
-                              {
-                                "id":"shape_sub-process_id_0",
-                                "bpmnElement":"sub-process_id_0",
-                                "Bounds": { "x": 362, "y": 232, "width": 36, "height": 45 },
-                                "isExpanded":false
-                              }, {
-                                "id":"shape_sub-process_id_1",
-                                "bpmnElement":"sub-process_id_1",
-                                "Bounds": { "x": 365, "y": 235, "width": 35, "height": 46 }
-                              }
-                            ]
-                        }
-                    }
-                }
-            }`;
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: {
+          subProcess: [
+            {
+              id: 'sub-process_id_0',
+              name: 'sub-process name',
+              triggeredByEvent: true,
+            },
+            {
+              id: 'sub-process_id_1',
+              triggeredByEvent: true,
+            },
+          ],
+        },
+        BPMNDiagram: {
+          name: 'process 0',
+          BPMNPlane: {
+            BPMNShape: [
+              {
+                id: 'shape_sub-process_id_0',
+                bpmnElement: 'sub-process_id_0',
+                Bounds: { x: 362, y: 232, width: 36, height: 45 },
+                isExpanded: false,
+              },
+              {
+                id: 'shape_sub-process_id_1',
+                bpmnElement: 'sub-process_id_1',
+                Bounds: { x: 365, y: 235, width: 35, height: 46 },
+              },
+            ],
+          },
+        },
+      },
+    };
 
     const model = parseJsonAndExpectOnlySubProcess(json, ShapeBpmnSubProcessKind.EVENT, 2);
 

--- a/test/unit/component/parser/json/BpmnJsonParser.task.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.task.test.ts
@@ -14,10 +14,8 @@
  * limitations under the License.
  */
 import { ShapeBpmnElementKind } from '../../../../../src/model/bpmn/shape/ShapeBpmnElementKind';
-import { verifyShape } from './JsonTestUtils';
-// import { parseJsonAndExpectOnlyFlowNodes, verifyShape } from './JsonTestUtils';
+import { parseJsonAndExpectOnlyFlowNodes, verifyShape } from './JsonTestUtils';
 import { TProcess } from '../../../../../src/component/parser/xml/bpmn-json-model/baseElement/rootElement/rootElement';
-import { defaultBpmnJsonParser } from '../../../../../src/component/parser/json/BpmnJsonParser';
 
 describe.each([
   ['task', ShapeBpmnElementKind.TASK],
@@ -52,13 +50,7 @@ describe.each([
       },
     };
 
-    //const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
-
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(1);
-    expect(model.edges).toHaveLength(0);
+    const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
     verifyShape(model.flowNodes[0], {
       shapeId: `shape_${bpmnKind}_id_0`,
@@ -108,13 +100,7 @@ describe.each([
       },
     ];
 
-    //const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
-
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(2);
-    expect(model.edges).toHaveLength(0);
+    const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
 
     verifyShape(model.flowNodes[0], {
       shapeId: `shape_${bpmnKind}_id_0`,
@@ -178,13 +164,7 @@ describe.each([
         },
       };
 
-      //const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
-
-      const model = defaultBpmnJsonParser().parse(json);
-      expect(model.lanes).toHaveLength(0);
-      expect(model.pools).toHaveLength(0);
-      expect(model.flowNodes).toHaveLength(2);
-      expect(model.edges).toHaveLength(0);
+      const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
 
       verifyShape(model.flowNodes[0], {
         shapeId: 'shape_receiveTask_id_0',

--- a/test/unit/component/parser/json/BpmnJsonParser.text.annotation.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.text.annotation.test.ts
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 import { ShapeBpmnElementKind } from '../../../../../src/model/bpmn/shape/ShapeBpmnElementKind';
-// import { parseJsonAndExpectOnlyFlowNodes, verifyShape } from './JsonTestUtils';
-import { verifyShape } from './JsonTestUtils';
-import { defaultBpmnJsonParser } from '../../../../../src/component/parser/json/BpmnJsonParser';
+import { parseJsonAndExpectOnlyFlowNodes, verifyShape } from './JsonTestUtils';
 
 describe('parse bpmn as json for text annotation', () => {
   it('json containing one process with a text annotation', () => {
@@ -47,13 +45,7 @@ describe('parse bpmn as json for text annotation', () => {
       },
     };
 
-    //const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
-
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(1);
-    expect(model.edges).toHaveLength(0);
+    const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
     verifyShape(model.flowNodes[0], {
       shapeId: 'TextAnnotation_01_di',
@@ -99,13 +91,7 @@ describe('parse bpmn as json for text annotation', () => {
       },
     };
 
-    //const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
-
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(1);
-    expect(model.edges).toHaveLength(0);
+    const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
     verifyShape(model.flowNodes[0], {
       shapeId: 'TextAnnotation_01_di',
@@ -166,13 +152,7 @@ describe('parse bpmn as json for text annotation', () => {
       },
     };
 
-    //const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
-
-    const model = defaultBpmnJsonParser().parse(json);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
-    expect(model.flowNodes).toHaveLength(2);
-    expect(model.edges).toHaveLength(0);
+    const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
 
     verifyShape(model.flowNodes[0], {
       shapeId: 'TextAnnotation_01_di',

--- a/test/unit/component/parser/json/BpmnJsonParser.text.annotation.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.text.annotation.test.ts
@@ -14,37 +14,46 @@
  * limitations under the License.
  */
 import { ShapeBpmnElementKind } from '../../../../../src/model/bpmn/shape/ShapeBpmnElementKind';
-import { parseJsonAndExpectOnlyFlowNodes, verifyShape } from './JsonTestUtils';
+// import { parseJsonAndExpectOnlyFlowNodes, verifyShape } from './JsonTestUtils';
+import { verifyShape } from './JsonTestUtils';
+import { defaultBpmnJsonParser } from '../../../../../src/component/parser/json/BpmnJsonParser';
 
 describe('parse bpmn as json for text annotation', () => {
   it('json containing one process with a text annotation', () => {
-    const json = `{
-                "definitions" : {
-                    "process": {
-                        "textAnnotation": {
-                            "id": "TextAnnotation_01",
-                            "text": "Task Annotation"
-                          }
-                    },
-                    "BPMNDiagram": {
-                        "name":"process 0",
-                        "BPMNPlane": {
-                            "BPMNShape": {
-                              "id": "TextAnnotation_01_di",
-                              "bpmnElement": "TextAnnotation_01",
-                              "Bounds": {
-                                "x": 430,
-                                "y": 160,
-                                "width": 100,
-                                "height": 30
-                              }
-                            }
-                        }
-                    }
-                }
-            }`;
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: {
+          textAnnotation: {
+            id: 'TextAnnotation_01',
+            text: 'Task Annotation',
+          },
+        },
+        BPMNDiagram: {
+          name: 'process 0',
+          BPMNPlane: {
+            BPMNShape: {
+              id: 'TextAnnotation_01_di',
+              bpmnElement: 'TextAnnotation_01',
+              Bounds: {
+                x: 430,
+                y: 160,
+                width: 100,
+                height: 30,
+              },
+            },
+          },
+        },
+      },
+    };
 
-    const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
+    //const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
+
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(1);
+    expect(model.edges).toHaveLength(0);
 
     verifyShape(model.flowNodes[0], {
       shapeId: 'TextAnnotation_01_di',
@@ -61,33 +70,42 @@ describe('parse bpmn as json for text annotation', () => {
   });
 
   it('json containing one process declared as array with a single text annotation', () => {
-    const json = `{
-                "definitions" : {
-                    "process": [{
-                        "textAnnotation": {
-                            "id": "TextAnnotation_01",
-                            "text": "Task Annotation"
-                          }
-                    }],
-                    "BPMNDiagram": {
-                        "name":"process 0",
-                        "BPMNPlane": {
-                            "BPMNShape": {
-                              "id": "TextAnnotation_01_di",
-                              "bpmnElement": "TextAnnotation_01",
-                              "Bounds": {
-                                "x": 430,
-                                "y": 160,
-                                "width": 100,
-                                "height": 30
-                              }
-                            }
-                        }
-                    }
-                }
-            }`;
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: [
+          {
+            textAnnotation: {
+              id: 'TextAnnotation_01',
+              text: 'Task Annotation',
+            },
+          },
+        ],
+        BPMNDiagram: {
+          name: 'process 0',
+          BPMNPlane: {
+            BPMNShape: {
+              id: 'TextAnnotation_01_di',
+              bpmnElement: 'TextAnnotation_01',
+              Bounds: {
+                x: 430,
+                y: 160,
+                width: 100,
+                height: 30,
+              },
+            },
+          },
+        },
+      },
+    };
 
-    const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
+    //const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
+
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(1);
+    expect(model.edges).toHaveLength(0);
 
     verifyShape(model.flowNodes[0], {
       shapeId: 'TextAnnotation_01_di',
@@ -104,45 +122,57 @@ describe('parse bpmn as json for text annotation', () => {
   });
 
   it('json containing one process with an array of text annotations with text & without text', () => {
-    const json = `{
-                "definitions" : {
-                    "process": {
-                        "textAnnotation": [{
-                            "id": "TextAnnotation_01",
-                            "text": "Task Annotation"
-                          }, {
-                            "id": "TextAnnotation_02"
-                          }
-                        ]
-                    },
-                    "BPMNDiagram": {
-                        "name":"process 0",
-                        "BPMNPlane": {
-                            "BPMNShape": [{
-                              "id": "TextAnnotation_01_di",
-                              "bpmnElement": "TextAnnotation_01",
-                              "Bounds": {
-                                "x": 430,
-                                "y": 160,
-                                "width": 100,
-                                "height": 30
-                              }
-                            }, {
-                              "id": "TextAnnotation_02_di",
-                              "bpmnElement": "TextAnnotation_02",
-                              "Bounds": {
-                                "x": 180,
-                                "y": 80,
-                                "width": 270,
-                                "height": 54
-                              }
-                            }]
-                        }
-                    }
-                }
-            }`;
+    const json = {
+      definitions: {
+        targetNamespace: '',
+        process: {
+          textAnnotation: [
+            {
+              id: 'TextAnnotation_01',
+              text: 'Task Annotation',
+            },
+            {
+              id: 'TextAnnotation_02',
+            },
+          ],
+        },
+        BPMNDiagram: {
+          name: 'process 0',
+          BPMNPlane: {
+            BPMNShape: [
+              {
+                id: 'TextAnnotation_01_di',
+                bpmnElement: 'TextAnnotation_01',
+                Bounds: {
+                  x: 430,
+                  y: 160,
+                  width: 100,
+                  height: 30,
+                },
+              },
+              {
+                id: 'TextAnnotation_02_di',
+                bpmnElement: 'TextAnnotation_02',
+                Bounds: {
+                  x: 180,
+                  y: 80,
+                  width: 270,
+                  height: 54,
+                },
+              },
+            ],
+          },
+        },
+      },
+    };
 
-    const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
+    //const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
+
+    const model = defaultBpmnJsonParser().parse(json);
+    expect(model.lanes).toHaveLength(0);
+    expect(model.pools).toHaveLength(0);
+    expect(model.flowNodes).toHaveLength(2);
+    expect(model.edges).toHaveLength(0);
 
     verifyShape(model.flowNodes[0], {
       shapeId: 'TextAnnotation_01_di',

--- a/test/unit/component/parser/json/JsonTestUtils.ts
+++ b/test/unit/component/parser/json/JsonTestUtils.ts
@@ -249,8 +249,9 @@ export function parseJsonAndExpectOnlyBoundaryEvent(json: BpmnJsonModel, kind: S
 
   return model;
 }
-export function parseJsonAndExpectOnlySubProcess(json: string, kind: ShapeBpmnSubProcessKind, expectedNumber: number): BpmnModel {
-  const model = parseJson(json);
+export function parseJsonAndExpectOnlySubProcess(json: BpmnJsonModel, kind: ShapeBpmnSubProcessKind, expectedNumber: number): BpmnModel {
+  //const model = parseJson(json);
+  const model = defaultBpmnJsonParser().parse(json);
 
   expect(model.lanes).toHaveLength(0);
   expect(model.pools).toHaveLength(0);

--- a/test/unit/component/parser/json/JsonTestUtils.ts
+++ b/test/unit/component/parser/json/JsonTestUtils.ts
@@ -27,7 +27,7 @@ import { ShapeBpmnSubProcessKind } from '../../../../../src/model/bpmn/shape/Sha
 import { SequenceFlow } from '../../../../../src/model/bpmn/edge/Flow';
 import { FlowKind } from '../../../../../src/model/bpmn/edge/FlowKind';
 import { MessageVisibleKind } from '../../../../../src/model/bpmn/edge/MessageVisibleKind';
-import {BpmnJsonModel} from "../../../../../src/component/parser/xml/bpmn-json-model/BPMN20";
+import { BpmnJsonModel } from '../../../../../src/component/parser/xml/bpmn-json-model/BPMN20';
 
 export interface ExpectedShape {
   shapeId: string;

--- a/test/unit/component/parser/json/JsonTestUtils.ts
+++ b/test/unit/component/parser/json/JsonTestUtils.ts
@@ -44,7 +44,7 @@ interface ExpectedEdge {
   bpmnElementName: string;
   bpmnElementSourceRefId: string;
   bpmnElementTargetRefId: string;
-  waypoints?: Waypoint[];
+  waypoints: Waypoint[];
   messageVisibleKind?: MessageVisibleKind;
 }
 

--- a/test/unit/component/parser/json/JsonTestUtils.ts
+++ b/test/unit/component/parser/json/JsonTestUtils.ts
@@ -27,6 +27,7 @@ import { ShapeBpmnSubProcessKind } from '../../../../../src/model/bpmn/shape/Sha
 import { SequenceFlow } from '../../../../../src/model/bpmn/edge/Flow';
 import { FlowKind } from '../../../../../src/model/bpmn/edge/FlowKind';
 import { MessageVisibleKind } from '../../../../../src/model/bpmn/edge/MessageVisibleKind';
+import {BpmnJsonModel} from "../../../../../src/component/parser/xml/bpmn-json-model/BPMN20";
 
 export interface ExpectedShape {
   shapeId: string;
@@ -223,8 +224,9 @@ export function verifyLabelBounds(label: Label, expectedBounds?: ExpectedBounds)
   }
 }
 
-export function parseJsonAndExpectOnlyEvent(json: string, kind: ShapeBpmnEventKind, expectedNumber: number): BpmnModel {
-  const model = parseJson(json);
+export function parseJsonAndExpectOnlyEvent(json: BpmnJsonModel, kind: ShapeBpmnEventKind, expectedNumber: number): BpmnModel {
+  //const model = parseJson(json);
+  const model = defaultBpmnJsonParser().parse(json);
 
   expect(model.lanes).toHaveLength(0);
   expect(model.pools).toHaveLength(0);
@@ -235,8 +237,9 @@ export function parseJsonAndExpectOnlyEvent(json: string, kind: ShapeBpmnEventKi
   return model;
 }
 
-export function parseJsonAndExpectOnlyBoundaryEvent(json: string, kind: ShapeBpmnEventKind, expectedNumber: number, isInterrupting?: boolean): BpmnModel {
-  const model = parseJson(json);
+export function parseJsonAndExpectOnlyBoundaryEvent(json: BpmnJsonModel, kind: ShapeBpmnEventKind, expectedNumber: number, isInterrupting?: boolean): BpmnModel {
+  //const model = parseJson(json);
+  const model = defaultBpmnJsonParser().parse(json);
 
   expect(model.lanes).toHaveLength(0);
   expect(model.pools).toHaveLength(0);

--- a/test/unit/component/parser/json/JsonTestUtils.ts
+++ b/test/unit/component/parser/json/JsonTestUtils.ts
@@ -69,12 +69,12 @@ export interface ExpectedBounds {
   height: number;
 }
 
-export function parseJson(json: string): BpmnModel {
-  return defaultBpmnJsonParser().parse(JSON.parse(json));
+export function parseJson(json: BpmnJsonModel): BpmnModel {
+  return defaultBpmnJsonParser().parse(json);
 }
 
 export function parseJsonAndExpect(
-  json: string,
+  json: BpmnJsonModel,
   numberOfExpectedPools: number,
   numberOfExpectedLanes: number,
   numberOfExpectedFlowNodes: number,
@@ -88,31 +88,31 @@ export function parseJsonAndExpect(
   return model;
 }
 
-export function parseJsonAndExpectOnlyLanes(json: string, numberOfExpectedLanes: number): BpmnModel {
+export function parseJsonAndExpectOnlyLanes(json: BpmnJsonModel, numberOfExpectedLanes: number): BpmnModel {
   return parseJsonAndExpect(json, 0, numberOfExpectedLanes, 0, 0);
 }
 
-export function parseJsonAndExpectOnlyPoolsAndLanes(json: string, numberOfExpectedPools: number, numberOfExpectedLanes: number): BpmnModel {
+export function parseJsonAndExpectOnlyPoolsAndLanes(json: BpmnJsonModel, numberOfExpectedPools: number, numberOfExpectedLanes: number): BpmnModel {
   return parseJsonAndExpect(json, numberOfExpectedPools, numberOfExpectedLanes, 0, 0);
 }
 
-export function parseJsonAndExpectOnlyPools(json: string, numberOfExpectedPools: number): BpmnModel {
+export function parseJsonAndExpectOnlyPools(json: BpmnJsonModel, numberOfExpectedPools: number): BpmnModel {
   return parseJsonAndExpect(json, numberOfExpectedPools, 0, 0, 0);
 }
 
-export function parseJsonAndExpectOnlyPoolsAndFlowNodes(json: string, numberOfExpectedPools: number, numberOfExpectedFlowNodes: number): BpmnModel {
+export function parseJsonAndExpectOnlyPoolsAndFlowNodes(json: BpmnJsonModel, numberOfExpectedPools: number, numberOfExpectedFlowNodes: number): BpmnModel {
   return parseJsonAndExpect(json, numberOfExpectedPools, 0, numberOfExpectedFlowNodes, 0);
 }
 
-export function parseJsonAndExpectOnlyFlowNodes(json: string, numberOfExpectedFlowNodes: number): BpmnModel {
+export function parseJsonAndExpectOnlyFlowNodes(json: BpmnJsonModel, numberOfExpectedFlowNodes: number): BpmnModel {
   return parseJsonAndExpect(json, 0, 0, numberOfExpectedFlowNodes, 0);
 }
 
-export function parseJsonAndExpectOnlyEdges(json: string, numberOfExpectedEdges: number): BpmnModel {
+export function parseJsonAndExpectOnlyEdges(json: BpmnJsonModel, numberOfExpectedEdges: number): BpmnModel {
   return parseJsonAndExpect(json, 0, 0, 0, numberOfExpectedEdges);
 }
 
-export function parseJsonAndExpectOnlyEdgesAndFlowNodes(json: string, numberOfExpectedEdges: number, numberOfExpectedFlowNodes: number): BpmnModel {
+export function parseJsonAndExpectOnlyEdgesAndFlowNodes(json: BpmnJsonModel, numberOfExpectedEdges: number, numberOfExpectedFlowNodes: number): BpmnModel {
   return parseJsonAndExpect(json, 0, 0, numberOfExpectedFlowNodes, numberOfExpectedEdges);
 }
 
@@ -225,8 +225,7 @@ export function verifyLabelBounds(label: Label, expectedBounds?: ExpectedBounds)
 }
 
 export function parseJsonAndExpectOnlyEvent(json: BpmnJsonModel, kind: ShapeBpmnEventKind, expectedNumber: number): BpmnModel {
-  //const model = parseJson(json);
-  const model = defaultBpmnJsonParser().parse(json);
+  const model = parseJson(json);
 
   expect(model.lanes).toHaveLength(0);
   expect(model.pools).toHaveLength(0);
@@ -238,8 +237,7 @@ export function parseJsonAndExpectOnlyEvent(json: BpmnJsonModel, kind: ShapeBpmn
 }
 
 export function parseJsonAndExpectOnlyBoundaryEvent(json: BpmnJsonModel, kind: ShapeBpmnEventKind, expectedNumber: number, isInterrupting?: boolean): BpmnModel {
-  //const model = parseJson(json);
-  const model = defaultBpmnJsonParser().parse(json);
+  const model = parseJson(json);
 
   expect(model.lanes).toHaveLength(0);
   expect(model.pools).toHaveLength(0);
@@ -250,8 +248,7 @@ export function parseJsonAndExpectOnlyBoundaryEvent(json: BpmnJsonModel, kind: S
   return model;
 }
 export function parseJsonAndExpectOnlySubProcess(json: BpmnJsonModel, kind: ShapeBpmnSubProcessKind, expectedNumber: number): BpmnModel {
-  //const model = parseJson(json);
-  const model = defaultBpmnJsonParser().parse(json);
+  const model = parseJson(json);
 
   expect(model.lanes).toHaveLength(0);
   expect(model.pools).toHaveLength(0);

--- a/test/unit/component/parser/xml/BpmnXmlParser.activiti-5_14_1.test.ts
+++ b/test/unit/component/parser/xml/BpmnXmlParser.activiti-5_14_1.test.ts
@@ -16,6 +16,8 @@
 import BpmnXmlParser from '../../../../../src/component/parser/xml/BpmnXmlParser';
 import arrayContaining = jasmine.arrayContaining;
 import anything = jasmine.anything;
+import { TProcess } from '../../../../../src/component/parser/xml/bpmn-json-model/baseElement/rootElement/rootElement';
+import { BPMNDiagram } from '../../../../../src/component/parser/xml/bpmn-json-model/BPMNDI';
 
 describe('parse bpmn as xml for Activiti Designer 5.14.1', () => {
   it('bpmn with process with extension, ensure elements are present', () => {
@@ -40,7 +42,7 @@ describe('parse bpmn as xml for Activiti Designer 5.14.1', () => {
     <sequenceFlow id="flow8" sourceRef="exclusivegateway2" targetRef="endevent1"></sequenceFlow>
     <sequenceFlow id="flow9" sourceRef="usertask3" targetRef="endevent1"></sequenceFlow>
     <textAnnotation id="textannotation1">
-      <text>3. Gateways display the X symbol in all cases (no user control) but actually do not write it to the file. Always displaying it seems quite reasonable if the attribute is stored in the model. 
+      <text>3. Gateways display the X symbol in all cases (no user control) but actually do not write it to the file. Always displaying it seems quite reasonable if the attribute is stored in the model.
 4. Gateway labels not displayed on diagram. </text>
     </textAnnotation>
   </process>
@@ -148,10 +150,13 @@ describe('parse bpmn as xml for Activiti Designer 5.14.1', () => {
       },
     });
 
-    expect(json.definitions.process.userTask).toHaveLength(4);
-    expect(json.definitions.process.exclusiveGateway).toHaveLength(2);
-    expect(json.definitions.process.sequenceFlow).toHaveLength(9);
-    expect(json.definitions.BPMNDiagram.BPMNPlane.BPMNShape).toHaveLength(9);
-    expect(json.definitions.BPMNDiagram.BPMNPlane.BPMNEdge).toHaveLength(9);
+    const process: TProcess = json.definitions.process as TProcess;
+    expect(process.userTask).toHaveLength(4);
+    expect(process.exclusiveGateway).toHaveLength(2);
+    expect(process.sequenceFlow).toHaveLength(9);
+
+    const bpmnDiagram: BPMNDiagram = json.definitions.BPMNDiagram as BPMNDiagram;
+    expect(bpmnDiagram.BPMNPlane.BPMNShape).toHaveLength(9);
+    expect(bpmnDiagram.BPMNPlane.BPMNEdge).toHaveLength(9);
   });
 });

--- a/test/unit/component/parser/xml/BpmnXmlParser.adonis-np-8_0.test.ts
+++ b/test/unit/component/parser/xml/BpmnXmlParser.adonis-np-8_0.test.ts
@@ -16,6 +16,8 @@
 import BpmnXmlParser from '../../../../../src/component/parser/xml/BpmnXmlParser';
 import arrayContaining = jasmine.arrayContaining;
 import anything = jasmine.anything;
+import { TProcess } from '../../../../../src/component/parser/xml/bpmn-json-model/baseElement/rootElement/rootElement';
+import { BPMNDiagram } from '../../../../../src/component/parser/xml/bpmn-json-model/BPMNDI';
 
 describe('parse bpmn as xml for ADONIS NP 8.0', () => {
   it('bpmn with process with extension, ensure elements are present', () => {
@@ -2171,10 +2173,13 @@ describe('parse bpmn as xml for ADONIS NP 8.0', () => {
       },
     });
 
-    expect(json.definitions.process.task).toHaveLength(4);
-    expect(json.definitions.process.exclusiveGateway).toHaveLength(2);
-    expect(json.definitions.process.sequenceFlow).toHaveLength(11);
-    expect(json.definitions.BPMNDiagram.BPMNPlane.BPMNShape).toHaveLength(8);
-    expect(json.definitions.BPMNDiagram.BPMNPlane.BPMNEdge).toHaveLength(11);
+    const process: TProcess = json.definitions.process as TProcess;
+    expect(process.task).toHaveLength(4);
+    expect(process.exclusiveGateway).toHaveLength(2);
+    expect(process.sequenceFlow).toHaveLength(11);
+
+    const bpmnDiagram: BPMNDiagram = json.definitions.BPMNDiagram as BPMNDiagram;
+    expect(bpmnDiagram.BPMNPlane.BPMNShape).toHaveLength(8);
+    expect(bpmnDiagram.BPMNPlane.BPMNEdge).toHaveLength(11);
   });
 });

--- a/test/unit/component/parser/xml/BpmnXmlParser.bizagi-modeler-2_8_0_8.test.ts
+++ b/test/unit/component/parser/xml/BpmnXmlParser.bizagi-modeler-2_8_0_8.test.ts
@@ -16,6 +16,8 @@
 import BpmnXmlParser from '../../../../../src/component/parser/xml/BpmnXmlParser';
 import arrayContaining = jasmine.arrayContaining;
 import anything = jasmine.anything;
+import { TProcess } from '../../../../../src/component/parser/xml/bpmn-json-model/baseElement/rootElement/rootElement';
+import { BPMNDiagram } from '../../../../../src/component/parser/xml/bpmn-json-model/BPMNDI';
 
 describe('parse bpmn as xml for Bizagi Modeler 2.8.0.8', () => {
   it('bpmn with process with extension, ensure elements are present', () => {
@@ -522,11 +524,14 @@ describe('parse bpmn as xml for Bizagi Modeler 2.8.0.8', () => {
       },
     });
 
-    expect(json.definitions.process[0].task).toHaveLength(4);
-    expect(json.definitions.process[0].exclusiveGateway).toHaveLength(2);
-    expect(json.definitions.process[0].sequenceFlow).toHaveLength(9);
-    expect(json.definitions.BPMNDiagram.BPMNPlane.BPMNShape).toHaveLength(10);
-    expect(json.definitions.BPMNDiagram.BPMNPlane.BPMNEdge).toHaveLength(9);
-    expect(json.definitions.BPMNDiagram.BPMNLabelStyle).toHaveLength(17);
+    const process: TProcess = (json.definitions.process as TProcess[])[0];
+    expect(process.task).toHaveLength(4);
+    expect(process.exclusiveGateway).toHaveLength(2);
+    expect(process.sequenceFlow).toHaveLength(9);
+
+    const bpmnDiagram: BPMNDiagram = json.definitions.BPMNDiagram as BPMNDiagram;
+    expect(bpmnDiagram.BPMNPlane.BPMNShape).toHaveLength(10);
+    expect(bpmnDiagram.BPMNPlane.BPMNEdge).toHaveLength(9);
+    expect(bpmnDiagram.BPMNLabelStyle).toHaveLength(17);
   });
 });

--- a/test/unit/component/parser/xml/BpmnXmlParser.camuda-eclipse-plugin-3_0_0.test.ts
+++ b/test/unit/component/parser/xml/BpmnXmlParser.camuda-eclipse-plugin-3_0_0.test.ts
@@ -16,6 +16,8 @@
 import BpmnXmlParser from '../../../../../src/component/parser/xml/BpmnXmlParser';
 import arrayContaining = jasmine.arrayContaining;
 import anything = jasmine.anything;
+import { TProcess } from '../../../../../src/component/parser/xml/bpmn-json-model/baseElement/rootElement/rootElement';
+import { BPMNDiagram } from '../../../../../src/component/parser/xml/bpmn-json-model/BPMNDI';
 
 describe('parse bpmn as xml for Camunda Eclipse Plugin 3.0.0', () => {
   it('bpmn with process with extension, ensure elements are present', () => {
@@ -211,10 +213,13 @@ describe('parse bpmn as xml for Camunda Eclipse Plugin 3.0.0', () => {
       },
     });
 
-    expect(json.definitions.process.task).toHaveLength(4);
-    expect(json.definitions.process.exclusiveGateway).toHaveLength(2);
-    expect(json.definitions.process.sequenceFlow).toHaveLength(9);
-    expect(json.definitions.BPMNDiagram.BPMNPlane.BPMNShape).toHaveLength(8);
-    expect(json.definitions.BPMNDiagram.BPMNPlane.BPMNEdge).toHaveLength(9);
+    const process: TProcess = json.definitions.process as TProcess;
+    expect(process.task).toHaveLength(4);
+    expect(process.exclusiveGateway).toHaveLength(2);
+    expect(process.sequenceFlow).toHaveLength(9);
+
+    const bpmnDiagram: BPMNDiagram = json.definitions.BPMNDiagram as BPMNDiagram;
+    expect(bpmnDiagram.BPMNPlane.BPMNShape).toHaveLength(8);
+    expect(bpmnDiagram.BPMNPlane.BPMNEdge).toHaveLength(9);
   });
 });

--- a/test/unit/component/parser/xml/BpmnXmlParser.miwg.test.ts
+++ b/test/unit/component/parser/xml/BpmnXmlParser.miwg.test.ts
@@ -17,6 +17,8 @@ import BpmnXmlParser from '../../../../../src/component/parser/xml/BpmnXmlParser
 import arrayContaining = jasmine.arrayContaining;
 import objectContaining = jasmine.objectContaining;
 import anything = jasmine.anything;
+import { BPMNDiagram } from '../../../../../src/component/parser/xml/bpmn-json-model/BPMNDI';
+import { TProcess } from '../../../../../src/component/parser/xml/bpmn-json-model/baseElement/rootElement/rootElement';
 
 describe('parse bpmn as xml for MIWG', () => {
   it('bpmn with process with extension, ensure elements are present', () => {
@@ -420,12 +422,15 @@ describe('parse bpmn as xml for MIWG', () => {
       },
     });
 
-    expect(json.definitions.process.task).toHaveLength(4);
-    expect(json.definitions.process.exclusiveGateway).toHaveLength(2);
-    expect(json.definitions.process.sequenceFlow).toHaveLength(11);
-    expect(json.definitions.BPMNDiagram.BPMNPlane.BPMNShape).toHaveLength(8);
-    expect(json.definitions.BPMNDiagram.BPMNPlane.BPMNEdge).toHaveLength(11);
-    expect(json.definitions.BPMNDiagram.BPMNLabelStyle).toHaveLength(10);
+    const process: TProcess = json.definitions.process as TProcess;
+    expect(process.task).toHaveLength(4);
+    expect(process.exclusiveGateway).toHaveLength(2);
+    expect(process.sequenceFlow).toHaveLength(11);
+
+    const bpmnDiagram: BPMNDiagram = json.definitions.BPMNDiagram as BPMNDiagram;
+    expect(bpmnDiagram.BPMNPlane.BPMNShape).toHaveLength(8);
+    expect(bpmnDiagram.BPMNPlane.BPMNEdge).toHaveLength(11);
+    expect(bpmnDiagram.BPMNLabelStyle).toHaveLength(10);
   });
 
   it('bpmn with number attribute, ensure xml number are json number', () => {


### PR DESCRIPTION
- Add interfaces for BPMN Model (in Json) after XML Parsing, in order to build easier the json tests and to not make mistakes (Maybe need to put BPMN Json model in a specific repository)
- Replace string content for BPMN content by json object, in all unit json tests
