### PR TITLE
[FIX] A boundary event can only be attached to an activity

### DIFF
--- a/src/component/parser/json/converter/ProcessConverter.ts
+++ b/src/component/parser/json/converter/ProcessConverter.ts
@@ -25,7 +25,7 @@ import { SequenceFlowKind } from '../../../../model/bpmn/edge/SequenceFlowKind';
 import { ShapeBpmnSubProcessKind } from '../../../../model/bpmn/shape/ShapeBpmnSubProcessKind';
 import { FlowKind } from '../../../../model/bpmn/edge/FlowKind';
 import { TProcess } from '../../xml/bpmn-json-model/baseElement/rootElement/rootElement';
-import {TBoundaryEvent, TCatchEvent, TEvent, TThrowEvent} from '../../xml/bpmn-json-model/baseElement/flowNode/event';
+import { TBoundaryEvent, TCatchEvent, TEvent, TThrowEvent } from '../../xml/bpmn-json-model/baseElement/flowNode/event';
 import { TSubProcess } from '../../xml/bpmn-json-model/baseElement/flowNode/activity/activity';
 import { TLane, TLaneSet } from '../../xml/bpmn-json-model/baseElement/baseElement';
 import { TSequenceFlow } from '../../xml/bpmn-json-model/baseElement/flowElement';

--- a/src/component/parser/json/converter/ProcessConverter.ts
+++ b/src/component/parser/json/converter/ProcessConverter.ts
@@ -99,6 +99,7 @@ export default class ProcessConverter extends AbstractConverter<Process> {
     ShapeUtil.flowNodeKinds()
       .filter(kind => kind != ShapeBpmnElementKind.EVENT_BOUNDARY)
       .forEach(kind => this.buildFlowNodeBpmnElements(processId, process[kind], kind));
+    // process boundary events afterwards as we need its parent activity to be available when building it
     this.buildFlowNodeBpmnElements(processId, process.boundaryEvent, ShapeBpmnElementKind.EVENT_BOUNDARY);
 
     // containers

--- a/src/component/parser/xml/bpmn-json-model/BPMN20.ts
+++ b/src/component/parser/xml/bpmn-json-model/BPMN20.ts
@@ -106,6 +106,9 @@ export interface TDefinitions {
   typeLanguage?: string; // default="http://www.w3.org/2001/XMLSchema"
   exporter?: string;
   exporterVersion?: string;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
 }
 
 export interface TImport {

--- a/test/unit/component/parser/json/BpmnJsonParser.event.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.event.test.ts
@@ -147,7 +147,8 @@ function executeEventCommonTests(
         const json = buildDefinitionsAndProcessWithTask({ eventDefinitionKind });
         addEvent(json, bpmnKind, { ...buildEventDefinitionParameter, withDifferentDefinition: true }, specificBuildEventParameter);
 
-        parseJsonAndExpectOnlyFlowNodes(json, 1);
+        const bpmnModel = parseJsonAndExpectOnlyFlowNodes(json, 1);
+        expect(getEventShapes(bpmnModel)).toHaveLength(0);
       });
 
       it(`should NOT convert, when there are several '${eventDefinitionKind}EventDefinition' in the same element${specificTitle}, ${titleForEventDefinitionIsAttributeOf}`, () => {
@@ -155,7 +156,8 @@ function executeEventCommonTests(
         const json = buildDefinitionsAndProcessWithTask();
         addEvent(json, bpmnKind, { ...buildEventDefinitionParameter, eventDefinition }, specificBuildEventParameter);
 
-        parseJsonAndExpectOnlyFlowNodes(json, 1);
+        const bpmnModel = parseJsonAndExpectOnlyFlowNodes(json, 1);
+        expect(getEventShapes(bpmnModel)).toHaveLength(0);
       });
 
       if (expectedShapeBpmnElementKind !== ShapeBpmnElementKind.EVENT_BOUNDARY) {
@@ -186,8 +188,8 @@ function executeEventCommonTests(
             definitions: {
               targetNamespace: '',
               process: {
-                startEvent: {
-                  id: 'not_task_id_0',
+                exclusiveGateway: {
+                  id: 'not_activity_id_0',
                 },
               },
               BPMNDiagram: {
@@ -195,8 +197,8 @@ function executeEventCommonTests(
                 BPMNPlane: {
                   BPMNShape: [
                     {
-                      id: 'shape_not_task_id_0',
-                      bpmnElement: 'not_task_id_0',
+                      id: 'shape_not_activity_id_0',
+                      bpmnElement: 'not_activity_id_0',
                       Bounds: { x: 362, y: 232, width: 36, height: 45 },
                     },
                   ],
@@ -204,9 +206,26 @@ function executeEventCommonTests(
               },
             },
           };
-          addEvent(json, 'boundaryEvent', buildEventDefinitionParameter, { ...specificBuildEventParameter, attachedToRef: 'not_task_id_0' });
+          addEvent(json, 'boundaryEvent', buildEventDefinitionParameter, { ...specificBuildEventParameter, attachedToRef: 'not_activity_id_0' });
 
-          parseJsonAndExpectEvent(json, undefined, 0);
+          const bpmnModel = parseJsonAndExpectOnlyFlowNodes(json, 1);
+          expect(getEventShapes(bpmnModel)).toHaveLength(0);
+        });
+
+        it(`should NOT convert, when 'boundaryEvent' is ${boundaryEventKind} & attached to unexisting activity, ${titleForEventDefinitionIsAttributeOf}`, () => {
+          const json = {
+            definitions: {
+              targetNamespace: '',
+              process: {},
+              BPMNDiagram: {
+                name: 'process 0',
+                BPMNPlane: {},
+              },
+            },
+          };
+          addEvent(json, 'boundaryEvent', buildEventDefinitionParameter, { ...specificBuildEventParameter, attachedToRef: 'unexisting_activity_id_0' });
+
+          parseJsonAndExpectOnlyFlowNodes(json, 0);
         });
       }
     }

--- a/test/unit/component/parser/json/BpmnJsonParser.event.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.event.test.ts
@@ -50,7 +50,7 @@ function verifyEventShape(
     shapeId: expectedShapeId,
     parentId: buildEventParameter.attachedToRef,
     bpmnElementId: expectedBpmnElementId,
-    bpmnElementName: buildEventParameter.eventName,
+    bpmnElementName: buildEventParameter.name,
     bpmnElementKind: expectedShapeBpmnElementKind,
     bounds: {
       x: 362,
@@ -145,7 +145,7 @@ function executeEventCommonTests(
       ["'name'", 'event name'],
       ["no 'name'", undefined],
     ])(`should convert as Shape, when '${bpmnKind}' has %s${specificTitle}, ${titleForEventDefinitionIsAttributeOf}`, (title: string, eventName: string) => {
-      testMustConvertOneShape({ ...testParameter, buildEventParameter: { ...specificBuildEventParameter, eventName } });
+      testMustConvertOneShape({ ...testParameter, buildEventParameter: { ...specificBuildEventParameter, name: eventName } });
     });
 
     if (expectedShapeBpmnEventKind !== ShapeBpmnEventKind.NONE) {
@@ -232,7 +232,7 @@ describe('parse bpmn as json for all events', () => {
     ['endEvent', ['message', 'error', 'escalation', 'cancel', 'compensate', 'signal', 'terminate'], ShapeBpmnElementKind.EVENT_END],
     ['intermediateCatchEvent', ['message', 'timer', 'conditional', 'link', 'signal'], ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH],
     ['intermediateThrowEvent', ['message', 'escalation', 'compensate', 'link', 'signal'], ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW],
-    ['boundaryEvent', ['message', 'timer', 'conditional', 'error', 'escalation', 'cancel', 'compensate', 'signal'], ShapeBpmnElementKind.EVENT_BOUNDARY],
+    ['boundaryEvent', undefined, ShapeBpmnElementKind.EVENT_BOUNDARY],
   ])('for %ss', (bpmnKind: string, allDefinitionKinds: string[], expectedShapeBpmnElementKind: ShapeBpmnElementKind) => {
     describe.each([
       ['none', ShapeBpmnEventKind.NONE],

--- a/test/unit/component/parser/json/BpmnJsonParser.event.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.event.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { ShapeBpmnElementKind } from '../../../../../src/model/bpmn/shape/ShapeBpmnElementKind';
-import { parseJsonAndExpectOnlyBoundaryEvent, parseJsonAndExpectOnlyEvent, parseJsonAndExpectOnlyFlowNodes, verifyShape } from './JsonTestUtils';
+import { parseJsonAndExpectEvent, parseJsonAndExpectOnlyFlowNodes, verifyShape } from './JsonTestUtils';
 import { ShapeBpmnEventKind } from '../../../../../src/model/bpmn/shape/ShapeBpmnEventKind';
 import { TProcess } from '../../../../../src/component/parser/xml/bpmn-json-model/baseElement/rootElement/rootElement';
 import { TEventDefinition } from '../../../../../src/component/parser/xml/bpmn-json-model/baseElement/rootElement/eventDefinition';
@@ -36,6 +36,49 @@ const eventDefinitionParameters = [
   // ['escalation', ShapeBpmnEventKind.ESCALATION],
   // ['link', ShapeBpmnEventKind.LINK],
 ];
+
+function buildTitleForEventDefinitionIsAttributeOf(bpmnKind: string, eventDefinitionKind: string, expectedShapeBpmnEventKind: ShapeBpmnEventKind): string[] {
+  if (expectedShapeBpmnEventKind === ShapeBpmnEventKind.NONE) {
+    return [`'${bpmnKind}' has no 'eventDefinition' & no 'eventDefinitionRef'`];
+  } else {
+    return [`'${bpmnKind}' has '${eventDefinitionKind}EventDefinition' & no 'eventDefinitionRef'`];
+  }
+}
+
+type BPMNTEvent = TCatchEvent | TThrowEvent | TBoundaryEvent;
+
+function buildTEvent(eventDefinitionKind: string, index = 0, withName = true, eventDefinition?: string | TEventDefinition | TEventDefinition[]): BPMNTEvent {
+  const event: TCatchEvent | TThrowEvent = {
+    id: `event_id_${index}`,
+  };
+
+  if (withName) {
+    event.name = 'event name';
+  }
+
+  if (eventDefinitionKind !== 'none') {
+    event[`${eventDefinitionKind}EventDefinition`] = eventDefinition ? eventDefinition : '';
+  }
+  return event;
+}
+
+function buildTBoundaryEvent(
+  eventDefinitionKind: string,
+  isInterrupting: boolean,
+  withName = true,
+  eventDefinition?: string | TEventDefinition | TEventDefinition[],
+): TBoundaryEvent {
+  const event: TBoundaryEvent = buildTEvent(eventDefinitionKind, 0, withName, eventDefinition) as TBoundaryEvent;
+  event.attachedToRef = 'task_id_0';
+  event.cancelActivity = isInterrupting;
+  return event;
+}
+
+function addOtherEventDefinition(expectedShapeBpmnEventKind: ShapeBpmnEventKind, eventWithOtherEventDefinition: BPMNTEvent) {
+  const otherEventDefinition = expectedShapeBpmnEventKind === ShapeBpmnEventKind.SIGNAL ? 'message' : 'signal';
+  eventWithOtherEventDefinition[`${otherEventDefinition}EventDefinition`] = '';
+  return eventWithOtherEventDefinition;
+}
 
 describe('parse bpmn as json for all events', () => {
   describe.each([
@@ -75,128 +118,117 @@ describe('parse bpmn as json for all events', () => {
         return;
       }
 
-      function buildTEvent(index = 0, withName = true, eventDefinition?: string | TEventDefinition | TEventDefinition[]): TCatchEvent | TThrowEvent {
-        const event: TCatchEvent | TThrowEvent = {
-          id: `event_id_${index}`,
-        };
-        if (withName) {
-          event.name = 'event name';
-        }
-        if (expectedShapeBpmnEventKind !== ShapeBpmnEventKind.NONE) {
-          if (eventDefinition) {
-            event[`${eventDefinitionKind}EventDefinition`] = eventDefinition;
-          } else {
-            event[`${eventDefinitionKind}EventDefinition`] = '';
-          }
-        }
-        return event;
-      }
-
-      const processJsonAsObjectWithEventJsonAsObject = {} as TProcess;
-      processJsonAsObjectWithEventJsonAsObject[bpmnKind] = buildTEvent(0, true);
-
-      it.each([
-        ['object', processJsonAsObjectWithEventJsonAsObject],
-        ['array', [processJsonAsObjectWithEventJsonAsObject]],
-      ])(
-        `should convert as Shape, when a ${bpmnKind} (with ${eventDefinitionKind} event definition) is an attribute (as object) of 'process' (as %s)`,
-        (title: string, processJson: TProcess | TProcess[]) => {
-          const json = {
-            definitions: {
-              targetNamespace: '',
-              process: processJson,
-              BPMNDiagram: {
-                name: 'process 0',
-                BPMNPlane: {
-                  BPMNShape: {
-                    id: `shape_${bpmnKind}_id_0`,
-                    bpmnElement: 'event_id_0',
-                    Bounds: { x: 362, y: 232, width: 36, height: 45 },
+      describe.each(buildTitleForEventDefinitionIsAttributeOf(bpmnKind, eventDefinitionKind, expectedShapeBpmnEventKind))(
+        `when %s`,
+        (titleForEventDefinitionIsAttributeOf: string) => {
+          const processAsObjectWithEventAsObject = {} as TProcess;
+          processAsObjectWithEventAsObject[bpmnKind] = buildTEvent(eventDefinitionKind);
+          it.each([
+            ['object', processAsObjectWithEventAsObject],
+            ['array', [processAsObjectWithEventAsObject]],
+          ])(
+            `should convert as Shape, when 'process' (as %s) has '${bpmnKind}' (as object), ${titleForEventDefinitionIsAttributeOf}`,
+            (title: string, processJson: TProcess | TProcess[]) => {
+              const json = {
+                definitions: {
+                  targetNamespace: '',
+                  process: processJson,
+                  BPMNDiagram: {
+                    name: 'process 0',
+                    BPMNPlane: {
+                      BPMNShape: {
+                        id: `shape_${bpmnKind}_id_0`,
+                        bpmnElement: 'event_id_0',
+                        Bounds: { x: 362, y: 232, width: 36, height: 45 },
+                      },
+                    },
                   },
                 },
-              },
+              };
+
+              const model = parseJsonAndExpectEvent(json, expectedShapeBpmnEventKind, 1);
+
+              verifyShape(model.flowNodes[0], {
+                shapeId: `shape_${bpmnKind}_id_0`,
+                bpmnElementId: 'event_id_0',
+                bpmnElementName: 'event name',
+                bpmnElementKind: expectedShapeBpmnElementKind,
+                bounds: {
+                  x: 362,
+                  y: 232,
+                  width: 36,
+                  height: 45,
+                },
+              });
             },
-          };
+          );
 
-          const model = parseJsonAndExpectOnlyEvent(json, expectedShapeBpmnEventKind, 1);
-
-          verifyShape(model.flowNodes[0], {
-            shapeId: `shape_${bpmnKind}_id_0`,
-            bpmnElementId: 'event_id_0',
-            bpmnElementName: 'event name',
-            bpmnElementKind: expectedShapeBpmnElementKind,
-            bounds: {
-              x: 362,
-              y: 232,
-              width: 36,
-              height: 45,
-            },
-          });
-        },
-      );
-
-      it(`should convert as Shape, when a ${bpmnKind} (with ${eventDefinitionKind} event definition & with/without name) is an attribute (as array) of 'process'`, () => {
-        const json = {
-          definitions: {
-            targetNamespace: '',
-            process: {},
-            BPMNDiagram: {
-              name: 'process 0',
-              BPMNPlane: {
-                BPMNShape: [
-                  {
-                    id: `shape_${bpmnKind}_id_0`,
-                    bpmnElement: 'event_id_0',
-                    Bounds: { x: 362, y: 232, width: 36, height: 45 },
+          const processAsObjectWithEventAsArray = {} as TProcess;
+          processAsObjectWithEventAsArray[bpmnKind] = [buildTEvent(eventDefinitionKind), buildTEvent(eventDefinitionKind, 1)];
+          it.each([
+            ['object', processAsObjectWithEventAsArray],
+            ['array', [processAsObjectWithEventAsArray]],
+          ])(
+            `should convert as Shape, when 'process' (as %s) has '${bpmnKind}' (as array), ${titleForEventDefinitionIsAttributeOf}`,
+            (title: string, processJson: TProcess | TProcess[]) => {
+              const json = {
+                definitions: {
+                  targetNamespace: '',
+                  process: processJson,
+                  BPMNDiagram: {
+                    name: 'process 0',
+                    BPMNPlane: {
+                      BPMNShape: [
+                        {
+                          id: `shape_${bpmnKind}_id_0`,
+                          bpmnElement: 'event_id_0',
+                          Bounds: { x: 362, y: 232, width: 36, height: 45 },
+                        },
+                        {
+                          id: `shape_${bpmnKind}_id_1`,
+                          bpmnElement: 'event_id_1',
+                          Bounds: { x: 365, y: 235, width: 35, height: 46 },
+                        },
+                      ],
+                    },
                   },
-                  {
-                    id: `shape_${bpmnKind}_id_1`,
-                    bpmnElement: 'event_id_1',
-                    Bounds: { x: 365, y: 235, width: 35, height: 46 },
-                  },
-                ],
-              },
+                },
+              };
+
+              const model = parseJsonAndExpectEvent(json, expectedShapeBpmnEventKind, 2);
+
+              verifyShape(model.flowNodes[0], {
+                shapeId: `shape_${bpmnKind}_id_0`,
+                bpmnElementId: 'event_id_0',
+                bpmnElementName: 'event name',
+                bpmnElementKind: expectedShapeBpmnElementKind,
+                bounds: {
+                  x: 362,
+                  y: 232,
+                  width: 36,
+                  height: 45,
+                },
+              });
+
+              verifyShape(model.flowNodes[1], {
+                shapeId: `shape_${bpmnKind}_id_1`,
+                bpmnElementId: 'event_id_1',
+                bpmnElementName: 'event name',
+                bpmnElementKind: expectedShapeBpmnElementKind,
+                bounds: {
+                  x: 365,
+                  y: 235,
+                  width: 35,
+                  height: 46,
+                },
+              });
             },
-          },
-        };
-        (json.definitions.process as TProcess)[`${bpmnKind}`] = [buildTEvent(), buildTEvent(1, false)];
+          );
 
-        const model = parseJsonAndExpectOnlyEvent(json, expectedShapeBpmnEventKind, 2);
-
-        verifyShape(model.flowNodes[0], {
-          shapeId: `shape_${bpmnKind}_id_0`,
-          bpmnElementId: 'event_id_0',
-          bpmnElementName: 'event name',
-          bpmnElementKind: expectedShapeBpmnElementKind,
-          bounds: {
-            x: 362,
-            y: 232,
-            width: 36,
-            height: 45,
-          },
-        });
-
-        verifyShape(model.flowNodes[1], {
-          shapeId: `shape_${bpmnKind}_id_1`,
-          bpmnElementId: 'event_id_1',
-          bpmnElementName: undefined,
-          bpmnElementKind: expectedShapeBpmnElementKind,
-          bounds: {
-            x: 365,
-            y: 235,
-            width: 35,
-            height: 46,
-          },
-        });
-      });
-
-      if (expectedShapeBpmnEventKind !== ShapeBpmnEventKind.NONE) {
-        it.each([
-          ['empty string', ''],
-          ['object', { id: `${eventDefinitionKind}EventDefinition_1` }],
-        ])(
-          `should convert as Shape, when a ${bpmnKind} (with ${eventDefinitionKind} event definition) is an attribute (as %s) of 'process'`,
-          (title: string, eventDefinitionJson: string | TEventDefinition) => {
+          it.each([
+            ["'name'", true],
+            ["no 'name'", false],
+          ])(`should convert as Shape, when '${bpmnKind}' has %s, ${titleForEventDefinitionIsAttributeOf}`, (title: string, withName: boolean) => {
             const json = {
               definitions: {
                 targetNamespace: '',
@@ -213,14 +245,14 @@ describe('parse bpmn as json for all events', () => {
                 },
               },
             };
-            (json.definitions.process as TProcess)[`${bpmnKind}`] = buildTEvent(0, true, eventDefinitionJson);
+            (json.definitions.process as TProcess)[`${bpmnKind}`] = buildTEvent(eventDefinitionKind, 0, withName);
 
-            const model = parseJsonAndExpectOnlyEvent(json, expectedShapeBpmnEventKind, 1);
+            const model = parseJsonAndExpectEvent(json, expectedShapeBpmnEventKind, 1);
 
             verifyShape(model.flowNodes[0], {
               shapeId: `shape_${bpmnKind}_id_0`,
               bpmnElementId: 'event_id_0',
-              bpmnElementName: 'event name',
+              bpmnElementName: withName ? 'event name' : undefined,
               bpmnElementKind: expectedShapeBpmnElementKind,
               bounds: {
                 x: 362,
@@ -229,46 +261,87 @@ describe('parse bpmn as json for all events', () => {
                 height: 45,
               },
             });
-          },
-        );
+          });
 
-        const otherEventDefinition = expectedShapeBpmnEventKind === ShapeBpmnEventKind.SIGNAL ? 'message' : 'signal';
-        const eventWithOtherDefinition = buildTEvent();
-        eventWithOtherDefinition[`${otherEventDefinition}EventDefinition`] = '';
+          if (expectedShapeBpmnEventKind !== ShapeBpmnEventKind.NONE) {
+            it.each([
+              ['empty string', ''],
+              ['object', { id: `${eventDefinitionKind}EventDefinition_1` }],
+            ])(
+              `should convert as Shape, when '${eventDefinitionKind}EventDefinition' is %s, ${titleForEventDefinitionIsAttributeOf}`,
+              (title: string, eventDefinitionJson: string | TEventDefinition) => {
+                const json = {
+                  definitions: {
+                    targetNamespace: '',
+                    process: {},
+                    BPMNDiagram: {
+                      name: 'process 0',
+                      BPMNPlane: {
+                        BPMNShape: {
+                          id: `shape_${bpmnKind}_id_0`,
+                          bpmnElement: 'event_id_0',
+                          Bounds: { x: 362, y: 232, width: 36, height: 45 },
+                        },
+                      },
+                    },
+                  },
+                };
+                (json.definitions.process as TProcess)[`${bpmnKind}`] = buildTEvent(eventDefinitionKind, 0, true, eventDefinitionJson);
 
-        it.each([
-          [`${eventDefinitionKind} event definition and another event definition`, eventWithOtherDefinition],
-          [`several ${eventDefinitionKind} event definitions`, buildTEvent(0, true, [{}, {}])],
-        ])(`should NOT convert, when a ${bpmnKind} (with %s) is an attribute of 'process'`, (title: string, eventJson: TEvent[]) => {
-          const json = {
-            definitions: {
-              targetNamespace: '',
-              process: {},
-              BPMNDiagram: {
-                name: 'process 0',
-                BPMNPlane: {
-                  BPMNShape: {
-                    id: 'shape_${bpmnKind}_id_0',
-                    bpmnElement: 'event_id_0',
-                    Bounds: { x: 362, y: 232, width: 36, height: 45 },
+                const model = parseJsonAndExpectEvent(json, expectedShapeBpmnEventKind, 1);
+
+                verifyShape(model.flowNodes[0], {
+                  shapeId: `shape_${bpmnKind}_id_0`,
+                  bpmnElementId: 'event_id_0',
+                  bpmnElementName: 'event name',
+                  bpmnElementKind: expectedShapeBpmnElementKind,
+                  bounds: {
+                    x: 362,
+                    y: 232,
+                    width: 36,
+                    height: 45,
+                  },
+                });
+              },
+            );
+
+            it.each([
+              [`'${eventDefinitionKind}EventDefinition' and another 'EventDefinition'`, addOtherEventDefinition(expectedShapeBpmnEventKind, buildTEvent(eventDefinitionKind))],
+              [`several '${eventDefinitionKind}EventDefinition'`, buildTEvent(eventDefinitionKind, 0, true, [{}, {}])],
+            ])(`should NOT convert, when there are %s in the same element`, (title: string, eventJson: TEvent[]) => {
+              const json = {
+                definitions: {
+                  targetNamespace: '',
+                  process: {},
+                  BPMNDiagram: {
+                    name: 'process 0',
+                    BPMNPlane: {
+                      BPMNShape: {
+                        id: 'shape_${bpmnKind}_id_0',
+                        bpmnElement: 'event_id_0',
+                        Bounds: { x: 362, y: 232, width: 36, height: 45 },
+                      },
+                    },
                   },
                 },
-              },
-            },
-          };
-          (json.definitions.process as TProcess)[`${bpmnKind}`] = eventJson;
+              };
+              (json.definitions.process as TProcess)[`${bpmnKind}`] = eventJson;
 
-          parseJsonAndExpectOnlyFlowNodes(json, 0);
-        });
-      }
+              parseJsonAndExpectOnlyFlowNodes(json, 0);
+            });
+          }
+        },
+      );
     });
 
     //TODO We can delete it when all kind of event definition are implemented
     if (expectedShapeBpmnElementKind !== ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH) {
-      it(`should convert as NONE Shape only the ${bpmnKind} without event definition, when an array of ${bpmnKind}s (without/with one or several event definition) is an attribute of 'process'`, () => {
+      it(`should convert as NONE Shape only the '${bpmnKind}' without 'eventDefinition' & without 'eventDefinitionRef', when an array of '${bpmnKind}' (without/with one or several event definition) is an attribute of 'process'`, () => {
         const json = {
           definitions: {
             targetNamespace: '',
+            messageEventDefinition: { id: 'message_event_definition_id' },
+            timerEventDefinition: { id: 'timer_event_definition_id' },
             process: {},
             BPMNDiagram: {
               name: 'process 0',
@@ -291,7 +364,18 @@ describe('parse bpmn as json for all events', () => {
         };
         (json.definitions.process as TProcess)[`${bpmnKind}`] = [
           { id: `none_${bpmnKind}_id`, name: `none ${bpmnKind}` },
-          { id: `multiple_${bpmnKind}_id`, name: `multiple ${bpmnKind}`, messageEventDefinition: {}, timerEventDefinition: {} },
+          { id: `multiple_${bpmnKind}_with_event_definitions_id`, name: `multiple ${bpmnKind} with event definitions`, messageEventDefinition: {}, timerEventDefinition: {} },
+          {
+            id: `multiple_${bpmnKind}_with_eventDefinitionRefs_id`,
+            name: `multiple ${bpmnKind} with eventDefinitionRefs`,
+            eventDefinitionRef: ['message_event_definition_id', 'timer_event_definition_id'],
+          },
+          {
+            id: `multiple_${bpmnKind}_with_event_definition_and_eventDefinitionRef_id`,
+            name: `multiple ${bpmnKind} with event definition and eventDefinitionRef`,
+            messageEventDefinition: {},
+            eventDefinitionRef: 'timer_event_definition_id',
+          },
         ];
 
         allDefinitionKinds.forEach((definitionKind, index) => {
@@ -307,7 +391,7 @@ describe('parse bpmn as json for all events', () => {
           (json.definitions.BPMNDiagram.BPMNPlane.BPMNShape as BPMNShape[]).push(shape);
         });
 
-        const model = parseJsonAndExpectOnlyEvent(json, ShapeBpmnEventKind.NONE, 1);
+        const model = parseJsonAndExpectEvent(json, ShapeBpmnEventKind.NONE, 1);
 
         verifyShape(model.flowNodes[0], {
           shapeId: `shape_none_${bpmnKind}_id`,
@@ -327,28 +411,6 @@ describe('parse bpmn as json for all events', () => {
 
   describe('for intermediate boundary events', () => {
     describe.each(eventDefinitionParameters)('for %s intermediate boundary events', (eventDefinitionKind: string, expectedShapeBpmnEventKind: ShapeBpmnEventKind) => {
-      function buildTBoundaryEvent(isInterrupting: boolean, withName = true, eventDefinition?: string | TEventDefinition | TEventDefinition[]): TBoundaryEvent {
-        const event: TBoundaryEvent = {
-          id: 'event_id_0',
-          name: 'event name',
-          attachedToRef: 'task_id_0',
-        };
-        if (isInterrupting !== undefined) {
-          event.cancelActivity = isInterrupting;
-        }
-        if (withName) {
-          event.name = 'event name';
-        }
-        if (expectedShapeBpmnEventKind !== ShapeBpmnEventKind.NONE) {
-          if (eventDefinition) {
-            event[`${eventDefinitionKind}EventDefinition`] = eventDefinition;
-          } else {
-            event[`${eventDefinitionKind}EventDefinition`] = '';
-          }
-        }
-        return event;
-      }
-
       describe.each([
         ['interrupting', true],
         ['non-interrupting', false],
@@ -370,182 +432,190 @@ describe('parse bpmn as json for all events', () => {
           return;
         }
 
-        it.each([
-          ['empty string', ''],
-          ['object', { id: '${eventDefinitionKind}EventDefinition_1' }],
-        ])(
-          `should convert as Shape, when a ${boundaryEventKind} boundary event (with ${eventDefinitionKind} event definition), attached to an activity, is an attribute (as %s) of 'process'`,
-          (title: string, eventDefinitionJson: string | TEventDefinition) => {
-            const json = {
-              definitions: {
-                targetNamespace: '',
-                process: {
-                  task: {
-                    id: 'task_id_0',
-                    name: 'task name',
+        describe.each(buildTitleForEventDefinitionIsAttributeOf('boundaryEvent', eventDefinitionKind, expectedShapeBpmnEventKind))(
+          `when %s`,
+          (titleForEventDefinitionIsAttributeOf: string) => {
+            it.each([
+              ['empty string', ''],
+              ['object', { id: `${eventDefinitionKind}EventDefinition_1` }],
+            ])(
+              `should convert as Shape, when '${eventDefinitionKind}EventDefinition' is %s, 'boundaryEvent' is ${boundaryEventKind} & attached to an 'activity', ${titleForEventDefinitionIsAttributeOf}`,
+              (title: string, eventDefinitionJson: string | TEventDefinition) => {
+                const json = {
+                  definitions: {
+                    targetNamespace: '',
+                    process: {
+                      task: {
+                        id: 'task_id_0',
+                        name: 'task name',
+                      },
+                    },
+                    BPMNDiagram: {
+                      name: 'process 0',
+                      BPMNPlane: {
+                        BPMNShape: [
+                          {
+                            id: 'shape_task_id_0',
+                            bpmnElement: 'task_id_0',
+                            Bounds: { x: 362, y: 232, width: 36, height: 45 },
+                          },
+                          {
+                            id: 'shape_boundaryEvent_id_0',
+                            bpmnElement: 'event_id_0',
+                            Bounds: { x: 362, y: 232, width: 36, height: 45 },
+                          },
+                        ],
+                      },
+                    },
+                  },
+                };
+                (json.definitions.process as TProcess)['boundaryEvent'] = buildTBoundaryEvent(eventDefinitionKind, isInterrupting, true, eventDefinitionJson);
+
+                const model = parseJsonAndExpectEvent(json, expectedShapeBpmnEventKind, 1);
+
+                verifyShape(model.flowNodes[1], {
+                  shapeId: 'shape_boundaryEvent_id_0',
+                  parentId: 'task_id_0',
+                  bpmnElementId: 'event_id_0',
+                  bpmnElementName: 'event name',
+                  bpmnElementKind: ShapeBpmnElementKind.EVENT_BOUNDARY,
+                  bounds: {
+                    x: 362,
+                    y: 232,
+                    width: 36,
+                    height: 45,
+                  },
+                  bpmnElementIsInterrupting: isInterrupting,
+                });
+              },
+            );
+
+            if (isInterrupting) {
+              it(`should convert as Shape, when 'boundaryEvent' has no 'cancelActivity' & is attached to an 'activity', ${titleForEventDefinitionIsAttributeOf}'`, () => {
+                const json = {
+                  definitions: {
+                    targetNamespace: '',
+                    process: {
+                      task: {
+                        id: 'task_id_0',
+                        name: 'task name',
+                      },
+                    },
+                    BPMNDiagram: {
+                      name: 'process 0',
+                      BPMNPlane: {
+                        BPMNShape: [
+                          {
+                            id: 'shape_task_id_0',
+                            bpmnElement: 'task_id_0',
+                            Bounds: { x: 362, y: 232, width: 36, height: 45 },
+                          },
+                          {
+                            id: 'shape_boundaryEvent_id_0',
+                            bpmnElement: 'event_id_0',
+                            Bounds: { x: 362, y: 232, width: 36, height: 45 },
+                          },
+                        ],
+                      },
+                    },
+                  },
+                };
+                (json.definitions.process as TProcess)['boundaryEvent'] = buildTBoundaryEvent(eventDefinitionKind, undefined, true, '');
+
+                const model = parseJsonAndExpectEvent(json, expectedShapeBpmnEventKind, 1);
+
+                verifyShape(model.flowNodes[1], {
+                  shapeId: 'shape_boundaryEvent_id_0',
+                  parentId: 'task_id_0',
+                  bpmnElementId: 'event_id_0',
+                  bpmnElementName: 'event name',
+                  bpmnElementKind: ShapeBpmnElementKind.EVENT_BOUNDARY,
+                  bounds: {
+                    x: 362,
+                    y: 232,
+                    width: 36,
+                    height: 45,
+                  },
+                  bpmnElementIsInterrupting: isInterrupting,
+                });
+              });
+            }
+
+            it.each([
+              [
+                `'${eventDefinitionKind}EventDefinition' and another 'EventDefinition'`,
+                addOtherEventDefinition(expectedShapeBpmnEventKind, buildTBoundaryEvent(eventDefinitionKind, isInterrupting)),
+              ],
+              [`several '${eventDefinitionKind}EventDefinitions'`, buildTBoundaryEvent(eventDefinitionKind, isInterrupting)],
+            ])(
+              `should NOT convert, when there are %s in the same element, 'boundaryEvent' is ${boundaryEventKind} & attached to an 'activity'`,
+              (title: string, eventJson: TBoundaryEvent) => {
+                const json = {
+                  definitions: {
+                    targetNamespace: '',
+                    process: {
+                      task: { id: 'task_id_0', name: 'task name' },
+                    },
+                    BPMNDiagram: {
+                      name: 'process 0',
+                      BPMNPlane: {
+                        BPMNShape: [
+                          {
+                            id: 'shape_task_id_0',
+                            bpmnElement: 'task_id_0',
+                            Bounds: { x: 362, y: 232, width: 36, height: 45 },
+                          },
+                          {
+                            id: 'shape_boundaryEvent_id_0',
+                            bpmnElement: 'event_id_0',
+                            Bounds: { x: 362, y: 232, width: 36, height: 45 },
+                          },
+                        ],
+                      },
+                    },
+                  },
+                };
+                (json.definitions.process as TProcess)['boundaryEvent'] = eventJson;
+
+                parseJsonAndExpectEvent(json, undefined, 0);
+              },
+            );
+
+            it(`
+            should NOT convert, when 'boundaryEvent' is ${boundaryEventKind} & attached to anything than an 'activity', ${titleForEventDefinitionIsAttributeOf}`, () => {
+              const json = {
+                definitions: {
+                  targetNamespace: '',
+                  process: {
+                    startEvent: {
+                      id: 'not_task_id_0',
+                    },
+                  },
+                  BPMNDiagram: {
+                    name: 'process 0',
+                    BPMNPlane: {
+                      BPMNShape: [
+                        {
+                          id: 'shape_task_id_0',
+                          bpmnElement: 'task_id_0',
+                          Bounds: { x: 362, y: 232, width: 36, height: 45 },
+                        },
+                        {
+                          id: 'shape_boundaryEvent_id_0',
+                          bpmnElement: 'event_id_0',
+                          Bounds: { x: 362, y: 232, width: 36, height: 45 },
+                        },
+                      ],
+                    },
                   },
                 },
-                BPMNDiagram: {
-                  name: 'process 0',
-                  BPMNPlane: {
-                    BPMNShape: [
-                      {
-                        id: 'shape_task_id_0',
-                        bpmnElement: 'task_id_0',
-                        Bounds: { x: 362, y: 232, width: 36, height: 45 },
-                      },
-                      {
-                        id: 'shape_boundaryEvent_id_0',
-                        bpmnElement: 'event_id_0',
-                        Bounds: { x: 362, y: 232, width: 36, height: 45 },
-                      },
-                    ],
-                  },
-                },
-              },
-            };
-            (json.definitions.process as TProcess)['boundaryEvent'] = buildTBoundaryEvent(isInterrupting, true, eventDefinitionJson);
+              };
+              (json.definitions.process as TProcess)['boundaryEvent'] = buildTBoundaryEvent(eventDefinitionKind, isInterrupting, true, '');
 
-            const model = parseJsonAndExpectOnlyBoundaryEvent(json, expectedShapeBpmnEventKind, 1, isInterrupting);
-
-            verifyShape(model.flowNodes[1], {
-              shapeId: 'shape_boundaryEvent_id_0',
-              parentId: 'task_id_0',
-              bpmnElementId: 'event_id_0',
-              bpmnElementName: 'event name',
-              bpmnElementKind: ShapeBpmnElementKind.EVENT_BOUNDARY,
-              bounds: {
-                x: 362,
-                y: 232,
-                width: 36,
-                height: 45,
-              },
+              parseJsonAndExpectEvent(json, undefined, 0);
             });
           },
         );
-
-        if (isInterrupting) {
-          it(`should convert as Shape, when a ${boundaryEventKind} boundary event (with ${eventDefinitionKind} event definition & without cancelActivity), attached to an activity, is an attribute (as %s) of 'process'`, () => {
-            const json = {
-              definitions: {
-                targetNamespace: '',
-                process: {
-                  task: {
-                    id: 'task_id_0',
-                    name: 'task name',
-                  },
-                },
-                BPMNDiagram: {
-                  name: 'process 0',
-                  BPMNPlane: {
-                    BPMNShape: [
-                      {
-                        id: 'shape_task_id_0',
-                        bpmnElement: 'task_id_0',
-                        Bounds: { x: 362, y: 232, width: 36, height: 45 },
-                      },
-                      {
-                        id: 'shape_boundaryEvent_id_0',
-                        bpmnElement: 'event_id_0',
-                        Bounds: { x: 362, y: 232, width: 36, height: 45 },
-                      },
-                    ],
-                  },
-                },
-              },
-            };
-            (json.definitions.process as TProcess)['boundaryEvent'] = buildTBoundaryEvent(undefined, true, '');
-
-            const model = parseJsonAndExpectOnlyBoundaryEvent(json, expectedShapeBpmnEventKind, 1, isInterrupting);
-
-            verifyShape(model.flowNodes[1], {
-              shapeId: 'shape_boundaryEvent_id_0',
-              parentId: 'task_id_0',
-              bpmnElementId: 'event_id_0',
-              bpmnElementName: 'event name',
-              bpmnElementKind: ShapeBpmnElementKind.EVENT_BOUNDARY,
-              bounds: {
-                x: 362,
-                y: 232,
-                width: 36,
-                height: 45,
-              },
-            });
-          });
-        }
-
-        const otherEventDefinition = expectedShapeBpmnEventKind === ShapeBpmnEventKind.SIGNAL ? 'message' : 'signal';
-        const eventWithOtherEventDefinition = buildTBoundaryEvent(isInterrupting);
-        eventWithOtherEventDefinition[`${otherEventDefinition}EventDefinition`] = '';
-        it.each([
-          [`${eventDefinitionKind} event definition and another event definition`, eventWithOtherEventDefinition],
-          [`several ${eventDefinitionKind} event definitions`, buildTBoundaryEvent(isInterrupting)],
-        ])(
-          `should NOT convert, when a ${boundaryEventKind} boundary event (with %s), attached to an activity, is an attribute of 'process'`,
-          (title: string, eventJson: TBoundaryEvent) => {
-            const json = {
-              definitions: {
-                targetNamespace: '',
-                process: {
-                  task: { id: 'task_id_0', name: 'task name' },
-                },
-                BPMNDiagram: {
-                  name: 'process 0',
-                  BPMNPlane: {
-                    BPMNShape: [
-                      {
-                        id: 'shape_task_id_0',
-                        bpmnElement: 'task_id_0',
-                        Bounds: { x: 362, y: 232, width: 36, height: 45 },
-                      },
-                      {
-                        id: 'shape_boundaryEvent_id_0',
-                        bpmnElement: 'event_id_0',
-                        Bounds: { x: 362, y: 232, width: 36, height: 45 },
-                      },
-                    ],
-                  },
-                },
-              },
-            };
-            (json.definitions.process as TProcess)['boundaryEvent'] = eventJson;
-
-            parseJsonAndExpectOnlyBoundaryEvent(json, expectedShapeBpmnEventKind, 0);
-          },
-        );
-
-        it(`should NOT convert, when a ${boundaryEventKind} boundary event (with ${eventDefinitionKind} event definition), attached to anything than an activity, is an attribute of 'process'`, () => {
-          const json = {
-            definitions: {
-              targetNamespace: '',
-              process: {
-                startEvent: {
-                  id: 'not_task_id_0',
-                },
-              },
-              BPMNDiagram: {
-                name: 'process 0',
-                BPMNPlane: {
-                  BPMNShape: [
-                    {
-                      id: 'shape_task_id_0',
-                      bpmnElement: 'task_id_0',
-                      Bounds: { x: 362, y: 232, width: 36, height: 45 },
-                    },
-                    {
-                      id: 'shape_boundaryEvent_id_0',
-                      bpmnElement: 'event_id_0',
-                      Bounds: { x: 362, y: 232, width: 36, height: 45 },
-                    },
-                  ],
-                },
-              },
-            },
-          };
-          (json.definitions.process as TProcess)['boundaryEvent'] = buildTBoundaryEvent(isInterrupting, true, '');
-
-          parseJsonAndExpectOnlyBoundaryEvent(json, expectedShapeBpmnEventKind, 0);
-        });
       });
     });
   });

--- a/test/unit/component/parser/json/BpmnJsonParser.event.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.event.test.ts
@@ -35,7 +35,7 @@ interface TestParameter {
   process?: TProcess | TProcess[];
 }
 
-function getEventShapes(model: BpmnModel) {
+function getEventShapes(model: BpmnModel): Shape[] {
   return model.flowNodes.filter(shape => ShapeUtil.isEvent(shape.bpmnElement.kind));
 }
 
@@ -45,7 +45,7 @@ function verifyEventShape(
   expectedShapeBpmnElementKind: ShapeBpmnElementKind,
   expectedShapeId = `shape_event_id_0`,
   expectedBpmnElementId = 'event_id_0',
-) {
+): void {
   verifyShape(shape, {
     shapeId: expectedShapeId,
     parentId: buildEventParameter.attachedToRef,
@@ -73,7 +73,7 @@ function testMustConvertOneShape({
   expectedShapeBpmnEventKind,
   expectedShapeBpmnElementKind,
   process,
-}: TestParameter) {
+}: TestParameter): void {
   const json = buildDefinitionsAndProcessWithTask(process);
   addEvent(json, bpmnKind, buildEventDefinitionParameter, buildEventParameter);
 
@@ -91,7 +91,7 @@ function executeEventCommonTests(
   boundaryEventKind?: string,
   specificBuildEventParameter: BuildEventParameter = {},
   specificTitle = '',
-) {
+): void {
   let titlesForEventDefinitionIsAttributeOf;
   if (expectedShapeBpmnEventKind === ShapeBpmnEventKind.NONE) {
     titlesForEventDefinitionIsAttributeOf = [[`'${bpmnKind}' has no 'eventDefinition' & no 'eventDefinitionRef'`, EventDefinitionOn.NONE]];

--- a/test/unit/component/parser/json/BpmnJsonParser.event.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.event.test.ts
@@ -96,13 +96,7 @@ function executeEventCommonTests(
   if (expectedShapeBpmnEventKind === ShapeBpmnEventKind.NONE) {
     titlesForEventDefinitionIsAttributeOf = [[`'${bpmnKind}' has no 'eventDefinition' & no 'eventDefinitionRef'`, EventDefinitionOn.NONE]];
   } else {
-    titlesForEventDefinitionIsAttributeOf = [
-      [`'${bpmnKind}' has '${eventDefinitionKind}EventDefinition' & no 'eventDefinitionRef'`, EventDefinitionOn.EVENT],
-      // [
-      //   `'definitions' has '${eventDefinitionKind}EventDefinition' and '${bpmnKind}' has no '${eventDefinitionKind}EventDefinition' & 'eventDefinitionRef'`,
-      //   EventDefinitionOn.DEFINITIONS,
-      // ],
-    ];
+    titlesForEventDefinitionIsAttributeOf = [[`'${bpmnKind}' has '${eventDefinitionKind}EventDefinition' & no 'eventDefinitionRef'`, EventDefinitionOn.EVENT]];
   }
   describe.each(titlesForEventDefinitionIsAttributeOf)(`when %s`, (titleForEventDefinitionIsAttributeOf: string, eventDefinitionOn: EventDefinitionOn) => {
     const buildEventDefinitionParameter: BuildEventDefinitionParameter = { eventDefinitionKind, eventDefinitionOn };
@@ -217,13 +211,6 @@ function executeEventCommonTests(
       }
     }
   });
-
-  // it(`should NOT convert, when 'definitions' has ${eventDefinitionKind}EventDefinition and '${bpmnKind}' has ${eventDefinitionKind}EventDefinition & eventDefinitionRef${specificTitle}`, () => {
-  //   const json = buildDefinitionsAndProcessWithTask();
-  //   addEvent(json, bpmnKind, {eventDefinitionKind, EventDefinitionOn.BOTH,} specificBuildEventParameter);
-  //
-  //   parseJsonAndExpectOnlyFlowNodes(json, 0);
-  // });
 }
 
 describe('parse bpmn as json for all events', () => {

--- a/test/unit/component/parser/json/JsonBuilder.test.ts
+++ b/test/unit/component/parser/json/JsonBuilder.test.ts
@@ -15,7 +15,6 @@
  */
 
 import { addEvent, buildDefinitionsAndProcessWithTask, BuildEventDefinitionParameter, EventDefinitionOn } from './JsonBuilder';
-import { BPMNPlane } from '../../../../../src/component/parser/xml/bpmn-json-model/BPMNDI';
 
 describe('build json', () => {
   it(

--- a/test/unit/component/parser/json/JsonBuilder.test.ts
+++ b/test/unit/component/parser/json/JsonBuilder.test.ts
@@ -1,0 +1,910 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { addEvent, buildDefinitionsAndProcessWithTask, BuildEventDefinitionParameter, EventDefinitionOn } from './JsonBuilder';
+import { BPMNPlane } from '../../../../../src/component/parser/xml/bpmn-json-model/BPMNDI';
+
+describe('build json', () => {
+  it(
+    'build json with definitions, process, task, interrupting boundary event with attachedToRef & empty messageEventDefinition, ' +
+      "when bpmnKind='boundaryEvent', eventDefinitionKind='message', eventDefinitionOn=EVENT, isInterrupting=true, attachedToRef is defined",
+    () => {
+      const buildEventDefinitionParameter: BuildEventDefinitionParameter = { eventDefinitionKind: 'message', eventDefinitionOn: EventDefinitionOn.EVENT };
+      const json = buildDefinitionsAndProcessWithTask();
+      addEvent(json, 'boundaryEvent', buildEventDefinitionParameter, {
+        isInterrupting: true,
+        attachedToRef: 'task_id_0',
+      });
+
+      expect(json).toEqual({
+        definitions: {
+          targetNamespace: '',
+          process: {
+            task: {
+              id: 'task_id_0',
+              name: 'task name',
+            },
+            boundaryEvent: {
+              id: 'event_id_0',
+              cancelActivity: true,
+              attachedToRef: 'task_id_0',
+              messageEventDefinition: '',
+              name: undefined,
+            },
+          },
+          BPMNDiagram: {
+            name: 'process 0',
+            BPMNPlane: {
+              BPMNShape: [
+                {
+                  id: 'shape_task_id_0',
+                  bpmnElement: 'task_id_0',
+                  Bounds: {
+                    x: 362,
+                    y: 232,
+                    width: 36,
+                    height: 45,
+                  },
+                },
+                {
+                  id: 'shape_event_id_0',
+                  bpmnElement: 'event_id_0',
+                  Bounds: {
+                    x: 362,
+                    y: 232,
+                    width: 36,
+                    height: 45,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      });
+    },
+  );
+
+  it(
+    'build json with definitions, process, task, boundary event with attachedToRef & empty messageEventDefinition & name, without cancelActivity, ' +
+      "when bpmnKind='boundaryEvent', eventDefinitionKind='message', eventDefinitionOn=EVENT, isInterrupting is not defined, attachedToRef & name are defined",
+    () => {
+      const buildEventDefinitionParameter: BuildEventDefinitionParameter = { eventDefinitionKind: 'message', eventDefinitionOn: EventDefinitionOn.EVENT };
+      const json = buildDefinitionsAndProcessWithTask();
+      addEvent(json, 'boundaryEvent', buildEventDefinitionParameter, {
+        attachedToRef: 'task_id_0',
+        name: 'name',
+      });
+
+      expect(json).toEqual({
+        definitions: {
+          targetNamespace: '',
+          process: {
+            task: {
+              id: 'task_id_0',
+              name: 'task name',
+            },
+            boundaryEvent: {
+              id: 'event_id_0',
+              attachedToRef: 'task_id_0',
+              messageEventDefinition: '',
+              name: 'name',
+            },
+          },
+          BPMNDiagram: {
+            name: 'process 0',
+            BPMNPlane: {
+              BPMNShape: [
+                {
+                  id: 'shape_task_id_0',
+                  bpmnElement: 'task_id_0',
+                  Bounds: {
+                    x: 362,
+                    y: 232,
+                    width: 36,
+                    height: 45,
+                  },
+                },
+                {
+                  id: 'shape_event_id_0',
+                  bpmnElement: 'event_id_0',
+                  Bounds: {
+                    x: 362,
+                    y: 232,
+                    width: 36,
+                    height: 45,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      });
+    },
+  );
+
+  it(
+    'build json with definitions with messageEventDefinition with id, process, task, interrupting boundary event with eventDefinitionRef, ' +
+      "when bpmnKind='boundaryEvent', eventDefinitionKind='message', eventDefinitionOn=DEFINITIONS, isInterrupting=true, attachedToRef is not defined",
+    () => {
+      const buildEventDefinitionParameter: BuildEventDefinitionParameter = { eventDefinitionKind: 'message', eventDefinitionOn: EventDefinitionOn.DEFINITIONS };
+      const json = buildDefinitionsAndProcessWithTask();
+      addEvent(json, 'boundaryEvent', buildEventDefinitionParameter, {
+        isInterrupting: true,
+      });
+
+      expect(json).toEqual({
+        definitions: {
+          targetNamespace: '',
+          messageEventDefinition: {
+            id: 'event_definition_id',
+          },
+          process: {
+            task: {
+              id: 'task_id_0',
+              name: 'task name',
+            },
+            boundaryEvent: {
+              id: 'event_id_0',
+              cancelActivity: true,
+              eventDefinitionRef: 'event_definition_id',
+              attachedToRef: undefined,
+              name: undefined,
+            },
+          },
+          BPMNDiagram: {
+            name: 'process 0',
+            BPMNPlane: {
+              BPMNShape: [
+                {
+                  id: 'shape_task_id_0',
+                  bpmnElement: 'task_id_0',
+                  Bounds: {
+                    x: 362,
+                    y: 232,
+                    width: 36,
+                    height: 45,
+                  },
+                },
+                {
+                  id: 'shape_event_id_0',
+                  bpmnElement: 'event_id_0',
+                  Bounds: {
+                    x: 362,
+                    y: 232,
+                    width: 36,
+                    height: 45,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      });
+    },
+  );
+
+  it(
+    'build json with definitions, process, task, non-interrupting boundary event with empty signalEventDefinition, ' +
+      "when bpmnKind='boundaryEvent', eventDefinitionKind='signal', eventDefinitionOn=EVENT, isInterrupting=false, attachedToRef is NOT defined",
+    () => {
+      const buildEventDefinitionParameter: BuildEventDefinitionParameter = { eventDefinitionKind: 'signal', eventDefinitionOn: EventDefinitionOn.EVENT };
+      const json = buildDefinitionsAndProcessWithTask();
+      addEvent(json, 'boundaryEvent', buildEventDefinitionParameter, {
+        isInterrupting: false,
+      });
+
+      expect(json).toEqual({
+        definitions: {
+          targetNamespace: '',
+          process: {
+            task: {
+              id: 'task_id_0',
+              name: 'task name',
+            },
+            boundaryEvent: {
+              id: 'event_id_0',
+              cancelActivity: false,
+              attachedToRef: undefined,
+              signalEventDefinition: '',
+              name: undefined,
+            },
+          },
+          BPMNDiagram: {
+            name: 'process 0',
+            BPMNPlane: {
+              BPMNShape: [
+                {
+                  id: 'shape_task_id_0',
+                  bpmnElement: 'task_id_0',
+                  Bounds: {
+                    x: 362,
+                    y: 232,
+                    width: 36,
+                    height: 45,
+                  },
+                },
+                {
+                  id: 'shape_event_id_0',
+                  bpmnElement: 'event_id_0',
+                  Bounds: {
+                    x: 362,
+                    y: 232,
+                    width: 36,
+                    height: 45,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      });
+    },
+  );
+
+  it(
+    'build json with definitions, process, task, non-interrupting boundary event with empty signalEventDefinition and increased id, ' +
+      "when bpmnKind='boundaryEvent', eventDefinitionKind='signal', eventDefinitionOn=EVENT, isInterrupting=false, attachedToRef is not defined, index=1",
+    () => {
+      const buildEventDefinitionParameter: BuildEventDefinitionParameter = { eventDefinitionKind: 'signal', eventDefinitionOn: EventDefinitionOn.EVENT };
+      const json = buildDefinitionsAndProcessWithTask();
+      addEvent(json, 'boundaryEvent', buildEventDefinitionParameter, {
+        isInterrupting: false,
+        index: 1,
+      });
+
+      expect(json).toEqual({
+        definitions: {
+          targetNamespace: '',
+          process: {
+            task: {
+              id: 'task_id_0',
+              name: 'task name',
+            },
+            boundaryEvent: {
+              id: 'event_id_1',
+              cancelActivity: false,
+              attachedToRef: undefined,
+              signalEventDefinition: '',
+              name: undefined,
+            },
+          },
+          BPMNDiagram: {
+            name: 'process 0',
+            BPMNPlane: {
+              BPMNShape: [
+                {
+                  id: 'shape_task_id_0',
+                  bpmnElement: 'task_id_0',
+                  Bounds: {
+                    x: 362,
+                    y: 232,
+                    width: 36,
+                    height: 45,
+                  },
+                },
+                {
+                  id: 'shape_event_id_1',
+                  bpmnElement: 'event_id_1',
+                  Bounds: {
+                    x: 362,
+                    y: 232,
+                    width: 36,
+                    height: 45,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      });
+    },
+  );
+
+  it(
+    'build json with definitions with signalEventDefinition with id, process, task, non-interrupting boundary event with attachedToRef & eventDefinitionRef, ' +
+      "when bpmnKind='boundaryEvent', eventDefinitionKind='signal', eventDefinitionOn=DEFINITIONS, isInterrupting=false, attachedToRef is defined",
+    () => {
+      const buildEventDefinitionParameter: BuildEventDefinitionParameter = { eventDefinitionKind: 'signal', eventDefinitionOn: EventDefinitionOn.DEFINITIONS };
+      const json = buildDefinitionsAndProcessWithTask();
+      addEvent(json, 'boundaryEvent', buildEventDefinitionParameter, {
+        isInterrupting: false,
+        attachedToRef: 'task_id_0',
+      });
+
+      expect(json).toEqual({
+        definitions: {
+          targetNamespace: '',
+          signalEventDefinition: {
+            id: 'event_definition_id',
+          },
+          process: {
+            task: {
+              id: 'task_id_0',
+              name: 'task name',
+            },
+            boundaryEvent: {
+              id: 'event_id_0',
+              cancelActivity: false,
+              eventDefinitionRef: 'event_definition_id',
+              attachedToRef: 'task_id_0',
+              name: undefined,
+            },
+          },
+          BPMNDiagram: {
+            name: 'process 0',
+            BPMNPlane: {
+              BPMNShape: [
+                {
+                  id: 'shape_task_id_0',
+                  bpmnElement: 'task_id_0',
+                  Bounds: {
+                    x: 362,
+                    y: 232,
+                    width: 36,
+                    height: 45,
+                  },
+                },
+                {
+                  id: 'shape_event_id_0',
+                  bpmnElement: 'event_id_0',
+                  Bounds: {
+                    x: 362,
+                    y: 232,
+                    width: 36,
+                    height: 45,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      });
+    },
+  );
+
+  it(
+    'build json with definitions, process, task, start event with messageEventDefinition & name, ' +
+      "when bpmnKind='startEvent', eventDefinitionKind='message', eventDefinitionOn=EVENT, name is defined, attachedToRef & isInterrupting is not defined",
+    () => {
+      const buildEventDefinitionParameter: BuildEventDefinitionParameter = { eventDefinitionKind: 'message', eventDefinitionOn: EventDefinitionOn.EVENT };
+      const json = buildDefinitionsAndProcessWithTask();
+      addEvent(json, 'startEvent', buildEventDefinitionParameter, {
+        name: 'name',
+      });
+
+      expect(json).toEqual({
+        definitions: {
+          targetNamespace: '',
+          process: {
+            task: {
+              id: 'task_id_0',
+              name: 'task name',
+            },
+            startEvent: {
+              id: 'event_id_0',
+              messageEventDefinition: '',
+              name: 'name',
+            },
+          },
+          BPMNDiagram: {
+            name: 'process 0',
+            BPMNPlane: {
+              BPMNShape: [
+                {
+                  id: 'shape_task_id_0',
+                  bpmnElement: 'task_id_0',
+                  Bounds: {
+                    x: 362,
+                    y: 232,
+                    width: 36,
+                    height: 45,
+                  },
+                },
+                {
+                  id: 'shape_event_id_0',
+                  bpmnElement: 'event_id_0',
+                  Bounds: {
+                    x: 362,
+                    y: 232,
+                    width: 36,
+                    height: 45,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      });
+    },
+  );
+
+  it(
+    'build json with definitions with messageEventDefinition with id, process, task, start event with name, ' +
+      "when bpmnKind='endEvent', eventDefinitionKind='message', eventDefinitionOn=DEFINITIONS, name is defined, attachedToRef & isInterrupting is not defined",
+    () => {
+      const buildEventDefinitionParameter: BuildEventDefinitionParameter = { eventDefinitionKind: 'message', eventDefinitionOn: EventDefinitionOn.DEFINITIONS };
+      const json = buildDefinitionsAndProcessWithTask();
+      addEvent(json, 'endEvent', buildEventDefinitionParameter, {
+        name: 'name',
+      });
+
+      expect(json).toEqual({
+        definitions: {
+          targetNamespace: '',
+          messageEventDefinition: {
+            id: 'event_definition_id',
+          },
+          process: {
+            task: {
+              id: 'task_id_0',
+              name: 'task name',
+            },
+            endEvent: {
+              id: 'event_id_0',
+              eventDefinitionRef: 'event_definition_id',
+              name: 'name',
+            },
+          },
+          BPMNDiagram: {
+            name: 'process 0',
+            BPMNPlane: {
+              BPMNShape: [
+                {
+                  id: 'shape_task_id_0',
+                  bpmnElement: 'task_id_0',
+                  Bounds: {
+                    x: 362,
+                    y: 232,
+                    width: 36,
+                    height: 45,
+                  },
+                },
+                {
+                  id: 'shape_event_id_0',
+                  bpmnElement: 'event_id_0',
+                  Bounds: {
+                    x: 362,
+                    y: 232,
+                    width: 36,
+                    height: 45,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      });
+    },
+  );
+
+  it(
+    'build json with definitions with messageEventDefinition with id, process, task, intermediate catch event with messageEventDefinition & eventDefinitionRef & name, ' +
+      "when bpmnKind='intermediateCatchEvent', eventDefinitionKind='message', eventDefinitionOn=BOTH, name is defined, attachedToRef & isInterrupting is not defined",
+    () => {
+      const buildEventDefinitionParameter: BuildEventDefinitionParameter = { eventDefinitionKind: 'message', eventDefinitionOn: EventDefinitionOn.BOTH };
+      const json = buildDefinitionsAndProcessWithTask();
+      addEvent(json, 'intermediateCatchEvent', buildEventDefinitionParameter, {
+        name: 'name',
+      });
+
+      expect(json).toEqual({
+        definitions: {
+          targetNamespace: '',
+          messageEventDefinition: {
+            id: 'event_definition_id',
+          },
+          process: {
+            task: {
+              id: 'task_id_0',
+              name: 'task name',
+            },
+            intermediateCatchEvent: {
+              id: 'event_id_0',
+              messageEventDefinition: '',
+              eventDefinitionRef: 'event_definition_id',
+              name: 'name',
+            },
+          },
+          BPMNDiagram: {
+            name: 'process 0',
+            BPMNPlane: {
+              BPMNShape: [
+                {
+                  id: 'shape_task_id_0',
+                  bpmnElement: 'task_id_0',
+                  Bounds: {
+                    x: 362,
+                    y: 232,
+                    width: 36,
+                    height: 45,
+                  },
+                },
+                {
+                  id: 'shape_event_id_0',
+                  bpmnElement: 'event_id_0',
+                  Bounds: {
+                    x: 362,
+                    y: 232,
+                    width: 36,
+                    height: 45,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      });
+    },
+  );
+
+  it(
+    'build json with definitions, process, task, intermediate throw event, ' +
+      "when bpmnKind='intermediateThrowEvent', eventDefinitionKind='message', eventDefinitionOn=NONE, eventDefinition is defined, name & attachedToRef & isInterrupting is not defined",
+    () => {
+      const buildEventDefinitionParameter: BuildEventDefinitionParameter = {
+        eventDefinitionKind: 'message',
+        eventDefinitionOn: EventDefinitionOn.NONE,
+        eventDefinition: { id: '9' },
+      };
+      const json = buildDefinitionsAndProcessWithTask();
+      addEvent(json, 'intermediateThrowEvent', buildEventDefinitionParameter, {});
+
+      expect(json).toEqual({
+        definitions: {
+          targetNamespace: '',
+          process: {
+            task: {
+              id: 'task_id_0',
+              name: 'task name',
+            },
+            intermediateThrowEvent: {
+              id: 'event_id_0',
+              name: undefined,
+            },
+          },
+          BPMNDiagram: {
+            name: 'process 0',
+            BPMNPlane: {
+              BPMNShape: [
+                {
+                  id: 'shape_task_id_0',
+                  bpmnElement: 'task_id_0',
+                  Bounds: {
+                    x: 362,
+                    y: 232,
+                    width: 36,
+                    height: 45,
+                  },
+                },
+                {
+                  id: 'shape_event_id_0',
+                  bpmnElement: 'event_id_0',
+                  Bounds: {
+                    x: 362,
+                    y: 232,
+                    width: 36,
+                    height: 45,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      });
+    },
+  );
+
+  it(
+    'build json with definitions, process, task, intermediate throw event with defined messageEventDefinition, ' +
+      "when bpmnKind='intermediateThrowEvent', eventDefinitionKind='message', eventDefinitionOn=EVENT, eventDefinition is defined, name & attachedToRef & isInterrupting is not defined",
+    () => {
+      const buildEventDefinitionParameter: BuildEventDefinitionParameter = {
+        eventDefinitionKind: 'message',
+        eventDefinitionOn: EventDefinitionOn.EVENT,
+        eventDefinition: { id: '9' },
+      };
+      const json = buildDefinitionsAndProcessWithTask();
+      addEvent(json, 'intermediateThrowEvent', buildEventDefinitionParameter, {});
+
+      expect(json).toEqual({
+        definitions: {
+          targetNamespace: '',
+          process: {
+            task: {
+              id: 'task_id_0',
+              name: 'task name',
+            },
+            intermediateThrowEvent: {
+              id: 'event_id_0',
+              messageEventDefinition: { id: '9' },
+              name: undefined,
+            },
+          },
+          BPMNDiagram: {
+            name: 'process 0',
+            BPMNPlane: {
+              BPMNShape: [
+                {
+                  id: 'shape_task_id_0',
+                  bpmnElement: 'task_id_0',
+                  Bounds: {
+                    x: 362,
+                    y: 232,
+                    width: 36,
+                    height: 45,
+                  },
+                },
+                {
+                  id: 'shape_event_id_0',
+                  bpmnElement: 'event_id_0',
+                  Bounds: {
+                    x: 362,
+                    y: 232,
+                    width: 36,
+                    height: 45,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      });
+    },
+  );
+
+  it(
+    'build json with definitions with defined messageEventDefinition, process, task, intermediate throw event with eventDefinitionRef, ' +
+      "when bpmnKind='intermediateThrowEvent', eventDefinitionKind='message', eventDefinitionOn=DEFINITIONS, eventDefinition is defined, name & attachedToRef & isInterrupting is not defined",
+    () => {
+      const buildEventDefinitionParameter: BuildEventDefinitionParameter = {
+        eventDefinitionKind: 'message',
+        eventDefinitionOn: EventDefinitionOn.DEFINITIONS,
+        eventDefinition: { id: '9' },
+      };
+      const json = buildDefinitionsAndProcessWithTask();
+      addEvent(json, 'intermediateThrowEvent', buildEventDefinitionParameter, {});
+
+      expect(json).toEqual({
+        definitions: {
+          targetNamespace: '',
+          messageEventDefinition: { id: '9' },
+          process: {
+            task: {
+              id: 'task_id_0',
+              name: 'task name',
+            },
+            intermediateThrowEvent: {
+              id: 'event_id_0',
+              eventDefinitionRef: '9',
+              name: undefined,
+            },
+          },
+          BPMNDiagram: {
+            name: 'process 0',
+            BPMNPlane: {
+              BPMNShape: [
+                {
+                  id: 'shape_task_id_0',
+                  bpmnElement: 'task_id_0',
+                  Bounds: {
+                    x: 362,
+                    y: 232,
+                    width: 36,
+                    height: 45,
+                  },
+                },
+                {
+                  id: 'shape_event_id_0',
+                  bpmnElement: 'event_id_0',
+                  Bounds: {
+                    x: 362,
+                    y: 232,
+                    width: 36,
+                    height: 45,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      });
+    },
+  );
+
+  it(
+    'build json with definitions, process, task, intermediate throw event with messageEventDefinition & signalEventDefinition, ' +
+      "when bpmnKind='intermediateThrowEvent', eventDefinitionKind='message', eventDefinitionOn=EVENT, withDifferentDefinition=true, name & attachedToRef & isInterrupting is not defined",
+    () => {
+      const buildEventDefinitionParameter: BuildEventDefinitionParameter = {
+        eventDefinitionKind: 'message',
+        eventDefinitionOn: EventDefinitionOn.EVENT,
+        withDifferentDefinition: true,
+      };
+      const json = buildDefinitionsAndProcessWithTask();
+      addEvent(json, 'intermediateThrowEvent', buildEventDefinitionParameter, {});
+
+      expect(json).toEqual({
+        definitions: {
+          targetNamespace: '',
+          process: {
+            task: {
+              id: 'task_id_0',
+              name: 'task name',
+            },
+            intermediateThrowEvent: {
+              id: 'event_id_0',
+              messageEventDefinition: '',
+              signalEventDefinition: '',
+              name: undefined,
+            },
+          },
+          BPMNDiagram: {
+            name: 'process 0',
+            BPMNPlane: {
+              BPMNShape: [
+                {
+                  id: 'shape_task_id_0',
+                  bpmnElement: 'task_id_0',
+                  Bounds: {
+                    x: 362,
+                    y: 232,
+                    width: 36,
+                    height: 45,
+                  },
+                },
+                {
+                  id: 'shape_event_id_0',
+                  bpmnElement: 'event_id_0',
+                  Bounds: {
+                    x: 362,
+                    y: 232,
+                    width: 36,
+                    height: 45,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      });
+    },
+  );
+
+  it(
+    'build json with definitions, process, task, intermediate throw event with messageEventDefinition & signalEventDefinition, ' +
+      "when bpmnKind='intermediateThrowEvent', eventDefinitionKind='signal', eventDefinitionOn=EVENT, withDifferentDefinition=true, name & attachedToRef & isInterrupting is not defined",
+    () => {
+      const buildEventDefinitionParameter: BuildEventDefinitionParameter = {
+        eventDefinitionKind: 'signal',
+        eventDefinitionOn: EventDefinitionOn.EVENT,
+        withDifferentDefinition: true,
+      };
+      const json = buildDefinitionsAndProcessWithTask();
+      addEvent(json, 'intermediateThrowEvent', buildEventDefinitionParameter, {});
+
+      expect(json).toEqual({
+        definitions: {
+          targetNamespace: '',
+          process: {
+            task: {
+              id: 'task_id_0',
+              name: 'task name',
+            },
+            intermediateThrowEvent: {
+              id: 'event_id_0',
+              messageEventDefinition: '',
+              signalEventDefinition: '',
+              name: undefined,
+            },
+          },
+          BPMNDiagram: {
+            name: 'process 0',
+            BPMNPlane: {
+              BPMNShape: [
+                {
+                  id: 'shape_task_id_0',
+                  bpmnElement: 'task_id_0',
+                  Bounds: {
+                    x: 362,
+                    y: 232,
+                    width: 36,
+                    height: 45,
+                  },
+                },
+                {
+                  id: 'shape_event_id_0',
+                  bpmnElement: 'event_id_0',
+                  Bounds: {
+                    x: 362,
+                    y: 232,
+                    width: 36,
+                    height: 45,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      });
+    },
+  );
+
+  it(
+    'build json with definitions with messageEventDefinition & signalEventDefinition with ids, process, task, intermediate throw event with messageEventDefinition & signalEventDefinition & eventDefinitionRefs, ' +
+      "when bpmnKind='intermediateThrowEvent', eventDefinitionKind='signal', eventDefinitionOn=BOTH, withDifferentDefinition=true, name & attachedToRef & isInterrupting is not defined",
+    () => {
+      const buildEventDefinitionParameter: BuildEventDefinitionParameter = {
+        eventDefinitionKind: 'signal',
+        eventDefinitionOn: EventDefinitionOn.BOTH,
+        withDifferentDefinition: true,
+      };
+      const json = buildDefinitionsAndProcessWithTask();
+      addEvent(json, 'intermediateThrowEvent', buildEventDefinitionParameter, {});
+
+      expect(json).toEqual({
+        definitions: {
+          targetNamespace: '',
+          messageEventDefinition: {
+            id: 'other_event_definition_id',
+          },
+          signalEventDefinition: {
+            id: 'event_definition_id',
+          },
+          process: {
+            task: {
+              id: 'task_id_0',
+              name: 'task name',
+            },
+            intermediateThrowEvent: {
+              id: 'event_id_0',
+              messageEventDefinition: '',
+              signalEventDefinition: '',
+              eventDefinitionRef: ['event_definition_id', 'other_event_definition_id'],
+              name: undefined,
+            },
+          },
+          BPMNDiagram: {
+            name: 'process 0',
+            BPMNPlane: {
+              BPMNShape: [
+                {
+                  id: 'shape_task_id_0',
+                  bpmnElement: 'task_id_0',
+                  Bounds: {
+                    x: 362,
+                    y: 232,
+                    width: 36,
+                    height: 45,
+                  },
+                },
+                {
+                  id: 'shape_event_id_0',
+                  bpmnElement: 'event_id_0',
+                  Bounds: {
+                    x: 362,
+                    y: 232,
+                    width: 36,
+                    height: 45,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      });
+    },
+  );
+});

--- a/test/unit/component/parser/json/JsonBuilder.ts
+++ b/test/unit/component/parser/json/JsonBuilder.ts
@@ -44,6 +44,7 @@ export interface BuildEventDefinitionParameter {
   withDifferentDefinition?: boolean;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function getFirstElementOfArray(object: any | any[]): any {
   if (Array.isArray(object)) {
     return object[0];
@@ -52,7 +53,7 @@ export function getFirstElementOfArray(object: any | any[]): any {
   }
 }
 
-export function updateBpmnElement<T>(parentElement: T | T[], childElement: T, setValue: (value: T | T[]) => void) {
+export function updateBpmnElement<T>(parentElement: T | T[], childElement: T, setValue: (value: T | T[]) => void): void {
   if (parentElement) {
     if (!Array.isArray(parentElement)) {
       setValue([parentElement, childElement]);
@@ -64,17 +65,17 @@ export function updateBpmnElement<T>(parentElement: T | T[], childElement: T, se
   }
 }
 
-export function addFlownode(jsonModel: BpmnJsonModel, bpmnKind: string, flowNode: TFlowNode) {
+export function addFlownode(jsonModel: BpmnJsonModel, bpmnKind: string, flowNode: TFlowNode): void {
   const process: TProcess = getFirstElementOfArray(jsonModel.definitions.process);
   updateBpmnElement(process[bpmnKind], flowNode, (value: TFlowNode | TFlowNode[]) => (process[bpmnKind] = value));
 }
 
-export function addShape(jsonModel: BpmnJsonModel, taskShape: BPMNShape) {
+export function addShape(jsonModel: BpmnJsonModel, taskShape: BPMNShape): void {
   const bpmnPlane: BPMNPlane = getFirstElementOfArray(jsonModel.definitions.BPMNDiagram).BPMNPlane;
   updateBpmnElement(bpmnPlane.BPMNShape, taskShape, (value: BPMNShape | BPMNShape[]) => (bpmnPlane.BPMNShape = value));
 }
 
-export function addTask(jsonModel: BpmnJsonModel) {
+export function addTask(jsonModel: BpmnJsonModel): void {
   const task = {
     id: 'task_id_0',
     name: 'task name',
@@ -89,7 +90,7 @@ export function addTask(jsonModel: BpmnJsonModel) {
   addShape(jsonModel, taskShape);
 }
 
-export function buildDefinitionsAndProcessWithTask(process: TProcess | TProcess[] = {}) {
+export function buildDefinitionsAndProcessWithTask(process: TProcess | TProcess[] = {}): BpmnJsonModel {
   const json: BpmnJsonModel = {
     definitions: {
       targetNamespace: '',
@@ -124,14 +125,14 @@ export function addEventDefinitions(
   event: BPMNTEvent,
   { eventDefinitionKind, eventDefinition, withDifferentDefinition = false }: BuildEventDefinitionParameter,
   differentEventDefinition?: TEventDefinition,
-) {
+): void {
   addEventDefinition(event, eventDefinitionKind, eventDefinition);
   if (withDifferentDefinition) {
     addDifferentEventDefinition(event, eventDefinitionKind, differentEventDefinition);
   }
 }
 
-export function addEventDefinitionsOnDefinition(jsonModel: BpmnJsonModel, buildParameter: BuildEventDefinitionParameter, event: BPMNTEvent) {
+export function addEventDefinitionsOnDefinition(jsonModel: BpmnJsonModel, buildParameter: BuildEventDefinitionParameter, event: BPMNTEvent): void {
   if (buildParameter.withDifferentDefinition) {
     addEventDefinitions(jsonModel.definitions, { ...buildParameter, eventDefinition: { id: 'event_definition_id' } }, { id: 'other_event_definition_id' });
     (event.eventDefinitionRef as string[]) = ['event_definition_id', 'other_event_definition_id'];
@@ -161,7 +162,7 @@ export function buildEvent({ index = 0, name, isInterrupting, attachedToRef }: B
   return event;
 }
 
-export function addEvent(jsonModel: BpmnJsonModel, bpmnKind: string, eventDefinitionParameter: BuildEventDefinitionParameter, eventParameter: BuildEventParameter) {
+export function addEvent(jsonModel: BpmnJsonModel, bpmnKind: string, eventDefinitionParameter: BuildEventDefinitionParameter, eventParameter: BuildEventParameter): void {
   const event = buildEvent(eventParameter);
   switch (eventDefinitionParameter.eventDefinitionOn) {
     case EventDefinitionOn.BOTH:

--- a/test/unit/component/parser/json/JsonBuilder.ts
+++ b/test/unit/component/parser/json/JsonBuilder.ts
@@ -32,7 +32,7 @@ export enum EventDefinitionOn {
 
 export interface BuildEventParameter {
   index?: number;
-  eventName?: string;
+  name?: string;
   isInterrupting?: boolean;
   attachedToRef?: string;
 }
@@ -42,33 +42,6 @@ export interface BuildEventDefinitionParameter {
   eventDefinitionOn: EventDefinitionOn;
   eventDefinition?: BPMNEventDefinition;
   withDifferentDefinition?: boolean;
-}
-
-export function addEventDefinition(bpmnElement: TDefinitions | BPMNTEvent, eventDefinitionKind: string, eventDefinition: BPMNEventDefinition = ''): TProcess | BPMNTEvent {
-  if (eventDefinitionKind !== 'none') {
-    bpmnElement[`${eventDefinitionKind}EventDefinition`] = eventDefinition;
-  }
-  return bpmnElement;
-}
-
-export function addDifferentEventDefinition(
-  bpmnElement: TDefinitions | BPMNTEvent,
-  eventDefinitionKind: string,
-  differentEventDefinition?: TEventDefinition,
-): TProcess | BPMNTEvent {
-  const otherEventDefinition = eventDefinitionKind === 'signal' ? 'message' : 'signal';
-  return addEventDefinition(bpmnElement, otherEventDefinition, differentEventDefinition);
-}
-
-export function addEventDefinitions(
-  event: BPMNTEvent,
-  { eventDefinitionKind, eventDefinition, withDifferentDefinition = false }: BuildEventDefinitionParameter,
-  differentEventDefinition?: TEventDefinition,
-) {
-  addEventDefinition(event, eventDefinitionKind, eventDefinition);
-  if (withDifferentDefinition) {
-    addDifferentEventDefinition(event, eventDefinitionKind, differentEventDefinition);
-  }
 }
 
 export function getFirstElementOfArray(object: any | any[]): any {
@@ -116,6 +89,48 @@ export function addTask(jsonModel: BpmnJsonModel) {
   addShape(jsonModel, taskShape);
 }
 
+export function buildDefinitionsAndProcessWithTask(process: TProcess | TProcess[] = {}) {
+  const json: BpmnJsonModel = {
+    definitions: {
+      targetNamespace: '',
+      process: process,
+      BPMNDiagram: {
+        name: 'process 0',
+        BPMNPlane: {},
+      },
+    },
+  };
+  addTask(json);
+  return json;
+}
+
+export function addEventDefinition(bpmnElement: TDefinitions | BPMNTEvent, eventDefinitionKind: string, eventDefinition: BPMNEventDefinition = ''): TProcess | BPMNTEvent {
+  if (eventDefinitionKind !== 'none') {
+    bpmnElement[`${eventDefinitionKind}EventDefinition`] = eventDefinition;
+  }
+  return bpmnElement;
+}
+
+export function addDifferentEventDefinition(
+  bpmnElement: TDefinitions | BPMNTEvent,
+  eventDefinitionKind: string,
+  differentEventDefinition?: TEventDefinition,
+): TProcess | BPMNTEvent {
+  const otherEventDefinition = eventDefinitionKind === 'signal' ? 'message' : 'signal';
+  return addEventDefinition(bpmnElement, otherEventDefinition, differentEventDefinition);
+}
+
+export function addEventDefinitions(
+  event: BPMNTEvent,
+  { eventDefinitionKind, eventDefinition, withDifferentDefinition = false }: BuildEventDefinitionParameter,
+  differentEventDefinition?: TEventDefinition,
+) {
+  addEventDefinition(event, eventDefinitionKind, eventDefinition);
+  if (withDifferentDefinition) {
+    addDifferentEventDefinition(event, eventDefinitionKind, differentEventDefinition);
+  }
+}
+
 export function addEventDefinitionsOnDefinition(jsonModel: BpmnJsonModel, buildParameter: BuildEventDefinitionParameter, event: BPMNTEvent) {
   if (buildParameter.withDifferentDefinition) {
     addEventDefinitions(jsonModel.definitions, { ...buildParameter, eventDefinition: { id: 'event_definition_id' } }, { id: 'other_event_definition_id' });
@@ -131,10 +146,10 @@ export function addEventDefinitionsOnDefinition(jsonModel: BpmnJsonModel, buildP
   }
 }
 
-export function buildEvent({ index = 0, eventName, isInterrupting, attachedToRef }: BuildEventParameter = {}): BPMNTEvent {
+export function buildEvent({ index = 0, name, isInterrupting, attachedToRef }: BuildEventParameter = {}): BPMNTEvent {
   const event: BPMNTEvent = {
     id: `event_id_${index}`,
-    name: eventName,
+    name: name,
   };
 
   if (isInterrupting !== undefined) {
@@ -171,19 +186,4 @@ export function addEvent(jsonModel: BpmnJsonModel, bpmnKind: string, eventDefini
     Bounds: { x: 362, y: 232, width: 36, height: 45 },
   };
   addShape(jsonModel, eventShape);
-}
-
-export function buildDefinitionsAndProcessWithTask(process: TProcess | TProcess[] = {}) {
-  const json: BpmnJsonModel = {
-    definitions: {
-      targetNamespace: '',
-      process: process,
-      BPMNDiagram: {
-        name: 'process 0',
-        BPMNPlane: {},
-      },
-    },
-  };
-  addTask(json);
-  return json;
 }

--- a/test/unit/component/parser/json/JsonTestUtils.ts
+++ b/test/unit/component/parser/json/JsonTestUtils.ts
@@ -166,14 +166,6 @@ export function verifyEdge(edge: Edge, expectedValue: ExpectedEdge | ExpectedSeq
   }
 }
 
-export function verifyEvent(model: BpmnModel, eventKind: ShapeBpmnEventKind, expectedNumber: number): void {
-  const events = model.flowNodes.filter(shape => {
-    const bpmnElement = shape.bpmnElement;
-    return bpmnElement instanceof ShapeBpmnEvent && (bpmnElement as ShapeBpmnEvent).eventKind === eventKind;
-  });
-  expect(events).toHaveLength(expectedNumber);
-}
-
 export function verifySubProcess(model: BpmnModel, kind: ShapeBpmnSubProcessKind, expectedNumber: number): void {
   const events = model.flowNodes.filter(shape => {
     const bpmnElement = shape.bpmnElement;
@@ -212,14 +204,18 @@ export function verifyLabelBounds(label: Label, expectedBounds?: ExpectedBounds)
   }
 }
 
-export function parseJsonAndExpectEvent(json: BpmnJsonModel, kind: ShapeBpmnEventKind, expectedNumber: number): BpmnModel {
+export function parseJsonAndExpectEvent(json: BpmnJsonModel, eventKind: ShapeBpmnEventKind, expectedNumber: number): BpmnModel {
   const model = parseJson(json);
 
   expect(model.lanes).toHaveLength(0);
   expect(model.pools).toHaveLength(0);
   expect(model.edges).toHaveLength(0);
 
-  verifyEvent(model, kind, expectedNumber);
+  const events = model.flowNodes.filter(shape => {
+    const bpmnElement = shape.bpmnElement;
+    return bpmnElement instanceof ShapeBpmnEvent && (bpmnElement as ShapeBpmnEvent).eventKind === eventKind;
+  });
+  expect(events).toHaveLength(expectedNumber);
 
   return model;
 }

--- a/test/unit/component/parser/json/JsonTestUtils.ts
+++ b/test/unit/component/parser/json/JsonTestUtils.ts
@@ -19,7 +19,7 @@ import { defaultBpmnJsonParser } from '../../../../../src/component/parser/json/
 import Edge from '../../../../../src/model/bpmn/edge/Edge';
 import BpmnModel from '../../../../../src/model/bpmn/BpmnModel';
 import Waypoint from '../../../../../src/model/bpmn/edge/Waypoint';
-import { ShapeBpmnBoundaryEvent, ShapeBpmnEvent, ShapeBpmnSubProcess } from '../../../../../src/model/bpmn/shape/ShapeBpmnElement';
+import { ShapeBpmnEvent, ShapeBpmnSubProcess } from '../../../../../src/model/bpmn/shape/ShapeBpmnElement';
 import { ShapeBpmnEventKind } from '../../../../../src/model/bpmn/shape/ShapeBpmnEventKind';
 import { SequenceFlowKind } from '../../../../../src/model/bpmn/edge/SequenceFlowKind';
 import Label from '../../../../../src/model/bpmn/Label';
@@ -37,10 +37,6 @@ export interface ExpectedShape {
   parentId?: string;
   bounds?: ExpectedBounds;
   isExpanded?: boolean;
-}
-
-export interface ExpectedBoundaryEventShape extends ExpectedShape {
-  bpmnElementIsInterrupting: boolean;
 }
 
 interface ExpectedEdge {
@@ -120,7 +116,7 @@ export function parseJsonAndExpectOnlyEdgesAndFlowNodes(json: BpmnJsonModel, num
   return parseJsonAndExpect(json, 0, 0, numberOfExpectedFlowNodes, numberOfExpectedEdges);
 }
 
-export function verifyShape(shape: Shape, expectedShape: ExpectedShape | ExpectedBoundaryEventShape): void {
+export function verifyShape(shape: Shape, expectedShape: ExpectedShape): void {
   expect(shape.id).toEqual(expectedShape.shapeId);
 
   if (shape.isExpanded) {
@@ -141,11 +137,6 @@ export function verifyShape(shape: Shape, expectedShape: ExpectedShape | Expecte
   expect(bounds.y).toEqual(expectedBounds.y);
   expect(bounds.width).toEqual(expectedBounds.width);
   expect(bounds.height).toEqual(expectedBounds.height);
-
-  if (expectedShape.hasOwnProperty('bpmnElementIsInterrupting')) {
-    expect(bpmnElement instanceof ShapeBpmnBoundaryEvent).toBeTruthy();
-    expect((bpmnElement as ShapeBpmnBoundaryEvent).isInterrupting).toEqual((expectedShape as ExpectedBoundaryEventShape).bpmnElementIsInterrupting);
-  }
 }
 
 export function verifyEdge(edge: Edge, expectedValue: ExpectedEdge | ExpectedSequenceEdge): void {


### PR DESCRIPTION
Closes #441 

- Refactor the event tests
- Fix the test for the boundary event attached to anything than an activity