### PR TITLE
[INFRA] fix dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,6 @@
+# See https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
 version: 2
-update_configs:
+updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:


### PR DESCRIPTION
It was previously using a 'update_configs' array (this is the configuration for
the dependabot version 1) instead of 'updates'.