### PR TITLE
[FEAT] Detect Error End Event & Error Interrupting Boundary Event

### DIFF
--- a/docs/bpmn-support.adoc
+++ b/docs/bpmn-support.adoc
@@ -216,6 +216,10 @@ The event definition can be defined on the event or on the definitions.
 |Signal Interrupting Boundary Event
 |icon:check-circle-o[]
 |The stroke & icon width may be adjusted
+
+|Error Interrupting Boundary Event
+|
+|
 |===
 
 
@@ -262,6 +266,10 @@ The event definition can be defined on the event or on the definitions.
 |Signal End Event
 |icon:check-circle-o[]
 |The stroke & icon width may be adjusted
+
+|Error End Event
+|
+|
 |===
 
 

--- a/src/component/mxgraph/shape/event-shapes.ts
+++ b/src/component/mxgraph/shape/event-shapes.ts
@@ -61,11 +61,11 @@ abstract class EventShape extends mxEllipse {
   // This will be removed after implementation of all supported events
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   private markNonFullyRenderedEvents(c: mxAbstractCanvas2D): void {
-    // const eventKind = StyleUtils.getBpmnEventKind(this.style);
-    // if (eventKind == ShapeBpmnEventKind.LINK) {
-    //   c.setFillColor('deeppink');
-    //   c.setFillAlpha(0.3);
-    // }
+    const eventKind = StyleUtils.getBpmnEventKind(this.style);
+    if (eventKind == ShapeBpmnEventKind.ERROR) {
+      c.setFillColor('deeppink');
+      c.setFillAlpha(0.3);
+    }
   }
 
   protected paintOuterShape({ c, shape: { x, y, w, h } }: PaintParameter): void {

--- a/src/model/bpmn/shape/ShapeBpmnEventKind.ts
+++ b/src/model/bpmn/shape/ShapeBpmnEventKind.ts
@@ -39,4 +39,11 @@ export enum ShapeBpmnEventKind {
  * Temporarily used until we support all events
  */
 // TODO When a new kind is supported, uncomment the corresponding line in test/unit/component/parser/json/BpmnJsonParser.event.test.ts
-export const supportedBpmnEventKinds = [ShapeBpmnEventKind.TERMINATE, ShapeBpmnEventKind.TIMER, ShapeBpmnEventKind.MESSAGE, ShapeBpmnEventKind.SIGNAL, ShapeBpmnEventKind.LINK];
+export const supportedBpmnEventKinds = [
+  ShapeBpmnEventKind.TERMINATE,
+  ShapeBpmnEventKind.TIMER,
+  ShapeBpmnEventKind.MESSAGE,
+  ShapeBpmnEventKind.SIGNAL,
+  ShapeBpmnEventKind.LINK,
+  ShapeBpmnEventKind.ERROR,
+];

--- a/test/e2e/mxGraph.model.test.ts
+++ b/test/e2e/mxGraph.model.test.ts
@@ -247,6 +247,8 @@ describe('mxGraph model', () => {
     expectModelContainsBpmnEvent('messageEndEvent_on_top', { kind: ShapeBpmnElementKind.EVENT_END, eventKind: ShapeBpmnEventKind.MESSAGE, label: 'Message End Event On Top' });
     expectModelContainsBpmnEvent('signalEndEvent', { kind: ShapeBpmnElementKind.EVENT_END, eventKind: ShapeBpmnEventKind.SIGNAL, label: 'Signal End Event' });
     expectModelContainsBpmnEvent('signalEndEvent_on_top', { kind: ShapeBpmnElementKind.EVENT_END, eventKind: ShapeBpmnEventKind.SIGNAL, label: 'Signal End Event On Top' });
+    expectModelContainsBpmnEvent('errorEndEvent', { kind: ShapeBpmnElementKind.EVENT_END, eventKind: ShapeBpmnEventKind.ERROR, label: 'Error End Event' });
+    expectModelContainsBpmnEvent('errorEndEvent_on_top', { kind: ShapeBpmnElementKind.EVENT_END, eventKind: ShapeBpmnEventKind.ERROR, label: 'Error End Event On Top' });
 
     // throw intermediate event
     expectModelContainsBpmnEvent('noneIntermediateThrowEvent', {
@@ -371,6 +373,18 @@ describe('mxGraph model', () => {
       eventKind: ShapeBpmnEventKind.SIGNAL,
       isInterrupting: true,
       label: 'Boundary Intermediate Event Interrupting Signal On Top',
+    });
+    expectModelContainsBpmnBoundaryEvent('boundary_event_interrupting_error_id', {
+      kind: null,
+      eventKind: ShapeBpmnEventKind.ERROR,
+      isInterrupting: true,
+      label: 'Boundary Intermediate Event Interrupting Error',
+    });
+    expectModelContainsBpmnBoundaryEvent('boundary_event_interrupting_error_on_top_id', {
+      kind: null,
+      eventKind: ShapeBpmnEventKind.ERROR,
+      isInterrupting: true,
+      label: 'Boundary Intermediate Event Interrupting Error On Top',
     });
 
     // boundary event: non-interrupting

--- a/test/fixtures/bpmn/model-complete-semantic.bpmn
+++ b/test/fixtures/bpmn/model-complete-semantic.bpmn
@@ -13,6 +13,7 @@
   <semantic:signalEventDefinition id="top_signal_definition_id"/>
   <semantic:terminateEventDefinition id="top_terminate_definition_id"/>
   <semantic:linkEventDefinition id="top_link_definition_id"/>
+  <semantic:errorEventDefinition id="top_error_definition_id"/>
 
   <semantic:process isExecutable="false" id="WFP-6-">
     <!-- Activity -->
@@ -221,6 +222,12 @@
     <semantic:boundaryEvent attachedToRef="userTask_3" cancelActivity="true" name="Boundary Intermediate Event Interrupting Signal On Top" id="boundary_event_interrupting_signal_on_top_id">
       <semantic:eventDefinitionRef>top_signal_definition_id</semantic:eventDefinitionRef>
     </semantic:boundaryEvent>
+    <semantic:boundaryEvent attachedToRef="userTask_3" cancelActivity="true" name="Boundary Intermediate Event Interrupting Error" id="boundary_event_interrupting_error_id">
+      <semantic:errorEventDefinition/>
+    </semantic:boundaryEvent>
+    <semantic:boundaryEvent attachedToRef="userTask_3" cancelActivity="true" name="Boundary Intermediate Event Interrupting Error On Top" id="boundary_event_interrupting_error_on_top_id">
+      <semantic:eventDefinitionRef>top_error_definition_id</semantic:eventDefinitionRef>
+    </semantic:boundaryEvent>
 
     <!-- Non-interrupting Boundary Event -->
     <semantic:boundaryEvent attachedToRef="userTask_3" cancelActivity="false" name="Boundary Intermediate Event Non-interrupting Message" id="boundary_event_non_interrupting_message_id">
@@ -309,6 +316,12 @@
     </semantic:endEvent>
     <semantic:endEvent name="Signal End Event On Top" id="signalEndEvent_on_top">
       <semantic:eventDefinitionRef>top_signal_definition_id</semantic:eventDefinitionRef>
+    </semantic:endEvent>
+    <semantic:endEvent name="Error End Event" id="errorEndEvent">
+      <semantic:errorEventDefinition/>
+    </semantic:endEvent>
+    <semantic:endEvent name="Error End Event On Top" id="errorEndEvent_on_top">
+      <semantic:eventDefinitionRef>top_error_definition_id</semantic:eventDefinitionRef>
     </semantic:endEvent>
 
     <!-- Gateway -->
@@ -610,6 +623,12 @@
       <bpmndi:BPMNShape bpmnElement="boundary_event_interrupting_signal_on_top_id" id="S1373649849862_boundary_event_interrupting_signal_on_top_id">
         <dc:Bounds height="32.0" width="32.0" x="98.0" y="335.0" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="boundary_event_interrupting_error_id" id="S1373649849862_boundary_event_interrupting_error_id">
+        <dc:Bounds height="32.0" width="32.0" x="98.0" y="335.0" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="boundary_event_interrupting_error_on_top_id" id="S1373649849862_boundary_event_interrupting_error_on_top_id">
+        <dc:Bounds height="32.0" width="32.0" x="98.0" y="335.0" />
+      </bpmndi:BPMNShape>
 
       <!-- Non-interrupting Boundary Event -->
       <bpmndi:BPMNShape bpmnElement="boundary_event_non_interrupting_message_id" id="S1373649849862_boundary_event_non_interrupting_message_id">
@@ -712,6 +731,12 @@
         <dc:Bounds height="32.0" width="32.0" x="87.0" y="335.0" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape bpmnElement="signalEndEvent_on_top" id="S1373649849862_signalEndEvent_on_top">
+        <dc:Bounds height="32.0" width="32.0" x="87.0" y="335.0" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="errorEndEvent" id="S1373649849862_errorEndEvent">
+        <dc:Bounds height="32.0" width="32.0" x="87.0" y="335.0" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="errorEndEvent_on_top" id="S1373649849862_errorEndEvent_on_top">
         <dc:Bounds height="32.0" width="32.0" x="87.0" y="335.0" />
       </bpmndi:BPMNShape>
 

--- a/test/unit/component/parser/json/BpmnJsonParser.event.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.event.test.ts
@@ -263,12 +263,12 @@ describe('parse bpmn as json for all events', () => {
       ['terminate', ShapeBpmnEventKind.TERMINATE],
       ['signal', ShapeBpmnEventKind.SIGNAL],
       ['link', ShapeBpmnEventKind.LINK],
+      ['error', ShapeBpmnEventKind.ERROR],
 
       // TODO To uncomment when an element is supported
       // ['cancel', ShapeBpmnEventKind.CANCEL],
       // ['compensate', ShapeBpmnEventKind.COMPENSATION],
       // ['conditional', ShapeBpmnEventKind.CONDITIONAL],
-      // ['error', ShapeBpmnEventKind.ERROR],
       // ['escalation', ShapeBpmnEventKind.ESCALATION],
     ])(`for %s ${bpmnKind}`, (eventDefinitionKind: string, expectedShapeBpmnEventKind: ShapeBpmnEventKind) => {
       if (


### PR DESCRIPTION
Closes #92  
Closes #87  

## Event Definition on Top
### Expected
![image](https://raw.githubusercontent.com/process-analytics/bpmn-visualization-examples/642ad345ddccebeaa1e2cccc7717a6d447efe554/bpmn-files/all_event_types_on_top__bpmn.io.svg)
### Result
![image](https://user-images.githubusercontent.com/4921914/89907111-88140680-dbec-11ea-8d7d-31937e4b0315.png)



## Event Definition on Event
### Expected
![image](https://raw.githubusercontent.com/process-analytics/bpmn-visualization-examples/642ad345ddccebeaa1e2cccc7717a6d447efe554/bpmn-files/all_event_types__bpmn.io.svg)
### Result
![image](https://user-images.githubusercontent.com/4921914/89907158-96622280-dbec-11ea-8354-40ce691bc694.png)


## Boundary Event
### Expected
![image](https://raw.githubusercontent.com/process-analytics/bpmn-visualization-examples/642ad345ddccebeaa1e2cccc7717a6d447efe554/bpmn-files/all_event_boundaries__bpmn.io.svg)
### Result
![image](https://user-images.githubusercontent.com/4921914/89906105-40d94600-dbeb-11ea-830a-ba5dd18864f5.png)

