### PR TITLE
[FEAT] detect activities and gateways in subprocess

### DIFF
--- a/src/component/parser/json/converter/ProcessConverter.ts
+++ b/src/component/parser/json/converter/ProcessConverter.ts
@@ -238,8 +238,8 @@ export default class ProcessConverter {
   }
 
   private buildShapeBpmnSubProcess(bpmnElement: TSubProcess, processId: string, markers: ShapeBpmnMarkerKind[]): ShapeBpmnSubProcess {
+    this.buildSubProcessInnerElements(bpmnElement);
     if (!bpmnElement.triggeredByEvent) {
-      this.buildSubProcessInnerElements(bpmnElement);
       return new ShapeBpmnSubProcess(bpmnElement.id, bpmnElement.name, ShapeBpmnSubProcessKind.EMBEDDED, processId, markers);
     }
     return new ShapeBpmnSubProcess(bpmnElement.id, bpmnElement.name, ShapeBpmnSubProcessKind.EVENT, processId, markers);
@@ -250,7 +250,7 @@ export default class ProcessConverter {
     const process = subProcess;
 
     // flow nodes
-    ShapeUtil.topLevelBpmnEventKinds()
+    ShapeUtil.flowNodeKinds()
       .filter(kind => kind != ShapeBpmnElementKind.EVENT_BOUNDARY)
       .forEach(kind => this.buildFlowNodeBpmnElements(processId, process[kind], kind));
     // process boundary events afterwards as we need its parent activity to be available when building it

--- a/src/model/bpmn/shape/ShapeUtil.ts
+++ b/src/model/bpmn/shape/ShapeUtil.ts
@@ -98,7 +98,7 @@ export default class ShapeUtil {
 
   public static flowNodeKinds(): ShapeBpmnElementKind[] {
     return Object.values(ShapeBpmnElementKind).filter(kind => {
-      return kind != ShapeBpmnElementKind.LANE;
+      return !ShapeUtil.isPoolOrLane(kind);
     });
   }
 

--- a/test/unit/component/parser/json/BpmnJsonParser.sub.process.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.sub.process.test.ts
@@ -200,7 +200,7 @@ describe('parse bpmn as json for sub-process', () => {
         });
       });
 
-      it(`should convert event elements in sub-process`, () => {
+      it(`should convert events in sub-process`, () => {
         const json = {
           definitions: {
             targetNamespace: '',

--- a/test/unit/component/parser/json/BpmnJsonParser.sub.process.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.sub.process.test.ts
@@ -282,5 +282,87 @@ describe('parse bpmn as json for sub-process', () => {
         });
       });
     }
+
+    it(`should convert activities and gateways in sub-process`, () => {
+      const json = {
+        definitions: {
+          targetNamespace: '',
+          process: {
+            subProcess: {
+              id: 'sub-process_id_1',
+              collapsed: false,
+              triggeredByEvent: triggeredByEvent,
+              userTask: {
+                id: 'sub-process_id_1_userTask_1',
+                name: 'SubProcess User Task',
+              },
+              exclusiveGateway: {
+                id: 'sub-process_id_1_exclusiveGateway_1',
+                name: 'SubProcess Exclusive Gateway',
+              },
+            },
+          },
+          BPMNDiagram: {
+            name: 'process 0',
+            BPMNPlane: {
+              BPMNShape: [
+                {
+                  id: 'shape_sub-process_id_1',
+                  bpmnElement: 'sub-process_id_1',
+                  Bounds: { x: 365, y: 235, width: 300, height: 200 },
+                  isExpanded: true,
+                },
+                {
+                  id: 'shape_sub-process_id_1_userTask_1',
+                  bpmnElement: 'sub-process_id_1_userTask_1',
+                  Bounds: { x: 465, y: 335, width: 10, height: 10 },
+                },
+                {
+                  id: 'shape_sub-process_id_1_exclusiveGateway_1',
+                  bpmnElement: 'sub-process_id_1_exclusiveGateway_1',
+                  Bounds: { x: 565, y: 335, width: 20, height: 20 },
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      const model = parseJson(json);
+      expectNoEdgePoolLane(model);
+
+      verifySubProcess(model, expectedShapeBpmnSubProcessKind, 1);
+      verifyShape(model.flowNodes[0], {
+        shapeId: 'shape_sub-process_id_1',
+        bpmnElementId: 'sub-process_id_1',
+        bpmnElementName: undefined,
+        bpmnElementKind: ShapeBpmnElementKind.SUB_PROCESS,
+        bounds: {
+          x: 365,
+          y: 235,
+          width: 300,
+          height: 200,
+        },
+      });
+
+      expect(model.flowNodes).toHaveLength(3);
+      verifyShape(model.flowNodes[1], {
+        shapeId: 'shape_sub-process_id_1_userTask_1',
+        parentId: 'sub-process_id_1',
+        bpmnElementId: 'sub-process_id_1_userTask_1',
+        bpmnElementName: 'SubProcess User Task',
+        bpmnElementKind: ShapeBpmnElementKind.TASK_USER,
+        bounds: { x: 465, y: 335, width: 10, height: 10 },
+      });
+
+      verifyShape(model.flowNodes[2], {
+        shapeId: 'shape_sub-process_id_1_exclusiveGateway_1',
+        parentId: 'sub-process_id_1',
+        bpmnElementId: 'sub-process_id_1_exclusiveGateway_1',
+        bpmnElementName: 'SubProcess Exclusive Gateway',
+        bpmnElementKind: ShapeBpmnElementKind.GATEWAY_EXCLUSIVE,
+        bounds: { x: 565, y: 335, width: 20, height: 20 },
+      });
+    });
   });
 });

--- a/test/unit/component/parser/json/BpmnJsonParser.sub.process.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.sub.process.test.ts
@@ -199,91 +199,9 @@ describe('parse bpmn as json for sub-process', () => {
           bpmnElementMarkers: [ShapeBpmnMarkerKind.EXPAND],
         });
       });
-
-      it(`should convert events in sub-process`, () => {
-        const json = {
-          definitions: {
-            targetNamespace: '',
-            process: {
-              subProcess: {
-                id: 'sub-process_id_1',
-                collapsed: false,
-                startEvent: {
-                  id: 'sub-process_id_1_startEvent_1',
-                  name: 'SubProcess Start Event',
-                  eventDefinition: toEventDefinition(ShapeBpmnEventKind.TIMER),
-                },
-                endEvent: {
-                  id: 'sub-process_id_1_endEvent_1',
-                  name: 'SubProcess End Event',
-                  eventDefinition: toEventDefinition(ShapeBpmnEventKind.TERMINATE),
-                },
-              },
-            },
-            BPMNDiagram: {
-              name: 'process 0',
-              BPMNPlane: {
-                BPMNShape: [
-                  {
-                    id: 'shape_sub-process_id_1',
-                    bpmnElement: 'sub-process_id_1',
-                    Bounds: { x: 365, y: 235, width: 300, height: 200 },
-                    isExpanded: true,
-                  },
-                  {
-                    id: 'shape_sub-process_id_1_startEvent_1',
-                    bpmnElement: 'sub-process_id_1_startEvent_1',
-                    Bounds: { x: 465, y: 335, width: 10, height: 10 },
-                  },
-                  {
-                    id: 'shape_sub-process_id_1_endEvent_1',
-                    bpmnElement: 'sub-process_id_1_endEvent_1',
-                    Bounds: { x: 565, y: 335, width: 20, height: 20 },
-                  },
-                ],
-              },
-            },
-          },
-        };
-
-        const model = parseJson(json);
-        expectNoEdgePoolLane(model);
-
-        verifySubProcess(model, expectedShapeBpmnSubProcessKind, 1);
-        verifyShape(model.flowNodes[0], {
-          shapeId: 'shape_sub-process_id_1',
-          bpmnElementId: 'sub-process_id_1',
-          bpmnElementName: undefined,
-          bpmnElementKind: ShapeBpmnElementKind.SUB_PROCESS,
-          bounds: {
-            x: 365,
-            y: 235,
-            width: 300,
-            height: 200,
-          },
-        });
-        const eventShapes = getEventShapes(model);
-        expect(eventShapes).toHaveLength(2);
-        verifyShape(eventShapes[0], {
-          shapeId: 'shape_sub-process_id_1_startEvent_1',
-          parentId: 'sub-process_id_1',
-          bpmnElementId: 'sub-process_id_1_startEvent_1',
-          bpmnElementName: 'SubProcess Start Event',
-          bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
-          bounds: { x: 465, y: 335, width: 10, height: 10 },
-        });
-        verifyShape(eventShapes[1], {
-          shapeId: 'shape_sub-process_id_1_endEvent_1',
-          parentId: 'sub-process_id_1',
-          bpmnElementId: 'sub-process_id_1_endEvent_1',
-          bpmnElementName: 'SubProcess End Event',
-          bpmnElementKind: ShapeBpmnElementKind.EVENT_END,
-          bounds: { x: 565, y: 335, width: 20, height: 20 },
-        });
-      });
     }
 
-    it(`should convert activities and gateways in sub-process`, () => {
+    it(`should convert activities, events and gateways in sub-process`, () => {
       const json = {
         definitions: {
           targetNamespace: '',
@@ -292,6 +210,16 @@ describe('parse bpmn as json for sub-process', () => {
               id: 'sub-process_id_1',
               collapsed: false,
               triggeredByEvent: triggeredByEvent,
+              startEvent: {
+                id: 'sub-process_id_1_startEvent_1',
+                name: 'SubProcess Start Event',
+                eventDefinition: toEventDefinition(ShapeBpmnEventKind.TIMER),
+              },
+              endEvent: {
+                id: 'sub-process_id_1_endEvent_1',
+                name: 'SubProcess End Event',
+                eventDefinition: toEventDefinition(ShapeBpmnEventKind.TERMINATE),
+              },
               userTask: {
                 id: 'sub-process_id_1_userTask_1',
                 name: 'SubProcess User Task',
@@ -313,6 +241,11 @@ describe('parse bpmn as json for sub-process', () => {
                   isExpanded: true,
                 },
                 {
+                  id: 'shape_sub-process_id_1_startEvent_1',
+                  bpmnElement: 'sub-process_id_1_startEvent_1',
+                  Bounds: { x: 465, y: 335, width: 10, height: 10 },
+                },
+                {
                   id: 'shape_sub-process_id_1_userTask_1',
                   bpmnElement: 'sub-process_id_1_userTask_1',
                   Bounds: { x: 465, y: 335, width: 10, height: 10 },
@@ -320,6 +253,11 @@ describe('parse bpmn as json for sub-process', () => {
                 {
                   id: 'shape_sub-process_id_1_exclusiveGateway_1',
                   bpmnElement: 'sub-process_id_1_exclusiveGateway_1',
+                  Bounds: { x: 565, y: 335, width: 20, height: 20 },
+                },
+                {
+                  id: 'shape_sub-process_id_1_endEvent_1',
+                  bpmnElement: 'sub-process_id_1_endEvent_1',
                   Bounds: { x: 565, y: 335, width: 20, height: 20 },
                 },
               ],
@@ -345,8 +283,26 @@ describe('parse bpmn as json for sub-process', () => {
         },
       });
 
-      expect(model.flowNodes).toHaveLength(3);
-      verifyShape(model.flowNodes[1], {
+      const eventShapes = getEventShapes(model);
+      expect(eventShapes).toHaveLength(2);
+      verifyShape(eventShapes[0], {
+        shapeId: 'shape_sub-process_id_1_startEvent_1',
+        parentId: 'sub-process_id_1',
+        bpmnElementId: 'sub-process_id_1_startEvent_1',
+        bpmnElementName: 'SubProcess Start Event',
+        bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
+        bounds: { x: 465, y: 335, width: 10, height: 10 },
+      });
+      verifyShape(eventShapes[1], {
+        shapeId: 'shape_sub-process_id_1_endEvent_1',
+        parentId: 'sub-process_id_1',
+        bpmnElementId: 'sub-process_id_1_endEvent_1',
+        bpmnElementName: 'SubProcess End Event',
+        bpmnElementKind: ShapeBpmnElementKind.EVENT_END,
+        bounds: { x: 565, y: 335, width: 20, height: 20 },
+      });
+
+      verifyShape(model.flowNodes[2], {
         shapeId: 'shape_sub-process_id_1_userTask_1',
         parentId: 'sub-process_id_1',
         bpmnElementId: 'sub-process_id_1_userTask_1',
@@ -355,7 +311,7 @@ describe('parse bpmn as json for sub-process', () => {
         bounds: { x: 465, y: 335, width: 10, height: 10 },
       });
 
-      verifyShape(model.flowNodes[2], {
+      verifyShape(model.flowNodes[3], {
         shapeId: 'shape_sub-process_id_1_exclusiveGateway_1',
         parentId: 'sub-process_id_1',
         bpmnElementId: 'sub-process_id_1_exclusiveGateway_1',

--- a/test/unit/component/parser/json/BpmnJsonParser.sub.process.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.sub.process.test.ts
@@ -23,6 +23,16 @@ import { ShapeBpmnEventKind } from '../../../../../src/model/bpmn/shape/ShapeBpm
 import BpmnModel from '../../../../../src/model/bpmn/BpmnModel';
 import { getEventShapes } from './BpmnJsonParser.event.test';
 
+function toEventDefinition(eventKind: ShapeBpmnEventKind): string {
+  return `${eventKind}EventDefinition`;
+}
+
+function expectNoEdgePoolLane(model: BpmnModel): void {
+  expect(model.lanes).toHaveLength(0);
+  expect(model.pools).toHaveLength(0);
+  expect(model.edges).toHaveLength(0);
+}
+
 describe('parse bpmn as json for sub-process', () => {
   each([
     ['embedded', false, ShapeBpmnSubProcessKind.EMBEDDED],
@@ -189,16 +199,6 @@ describe('parse bpmn as json for sub-process', () => {
           bpmnElementMarkers: [ShapeBpmnMarkerKind.EXPAND],
         });
       });
-
-      function toEventDefinition(eventKind: ShapeBpmnEventKind): string {
-        return `${eventKind}EventDefinition`;
-      }
-
-      function expectNoEdgePoolLane(model: BpmnModel): void {
-        expect(model.lanes).toHaveLength(0);
-        expect(model.pools).toHaveLength(0);
-        expect(model.edges).toHaveLength(0);
-      }
 
       it(`should convert event elements in sub-process`, () => {
         const json = {

--- a/test/unit/component/parser/xml/BpmnXmlParser.trisotech-bpmn-modeler-6_2_0.test.ts
+++ b/test/unit/component/parser/xml/BpmnXmlParser.trisotech-bpmn-modeler-6_2_0.test.ts
@@ -19,6 +19,7 @@ import { readFileSync } from '../../../../helpers/file-helper';
 import { TSubProcess } from '../../../../../src/component/parser/xml/bpmn-json-model/baseElement/flowNode/activity/activity';
 import { ensureIsArray } from '../../../../../src/component/parser/json/converter/ConverterUtil';
 import { TStartEvent } from '../../../../../src/component/parser/xml/bpmn-json-model/baseElement/flowNode/event';
+import { TTask } from '../../../../../src/component/parser/xml/bpmn-json-model/baseElement/flowNode/activity/task';
 
 describe('parse bpmn as xml for Trisotech BPMN Modeler 6.2.0', () => {
   it('bpmn with process with extension, ensure elements are present', () => {
@@ -32,12 +33,16 @@ describe('parse bpmn as xml for Trisotech BPMN Modeler 6.2.0', () => {
       },
     });
 
-    const process: TProcess = json.definitions.process as TProcess[];
+    const process = json.definitions.process as TProcess[];
     expect(process).toHaveLength(2);
     const subProcess1 = process[0] as TSubProcess;
-    expect(subProcess1.task).toHaveLength(2);
     const subProcess1StartEvents: TStartEvent[] = ensureIsArray(subProcess1.startEvent);
     expect(subProcess1StartEvents).toHaveLength(1);
     expect(subProcess1StartEvents[0].name).toBe('Start Event 2');
+
+    const subProcess1Tasks: TTask[] = ensureIsArray(subProcess1.task);
+    expect(subProcess1Tasks).toHaveLength(2);
+    expect(subProcess1Tasks[0].name).toBe('Task 3');
+    expect(subProcess1Tasks[1].name).toBe('Task 5');
   });
 });


### PR DESCRIPTION
closes #357 
closes #358

Events are now also detected in Event Sub-Process. They are currently rendered as Process Event (without dashed circle), this will be implemented later.

### Sub-Process

![image](https://user-images.githubusercontent.com/27200110/90015865-78a6c300-dca9-11ea-9d36-23aa8d72494c.png)

### Event Sub-Process

![image](https://user-images.githubusercontent.com/27200110/90015936-93793780-dca9-11ea-8899-ea5aaa1ed18c.png)
