### PR TITLE
[FEAT] detect sequence flows of subprocess

### DIFF
--- a/src/component/parser/json/converter/ProcessConverter.ts
+++ b/src/component/parser/json/converter/ProcessConverter.ts
@@ -255,6 +255,9 @@ export default class ProcessConverter {
       .forEach(kind => this.buildFlowNodeBpmnElements(processId, process[kind], kind));
     // process boundary events afterwards as we need its parent activity to be available when building it
     this.buildFlowNodeBpmnElements(processId, process.boundaryEvent, ShapeBpmnElementKind.EVENT_BOUNDARY);
+
+    // flows
+    this.buildSequenceFlows(process[FlowKind.SEQUENCE_FLOW]);
   }
 
   private buildLaneSetBpmnElements(processId: string, laneSets: Array<TLaneSet> | TLaneSet): void {

--- a/src/component/parser/json/converter/ProcessConverter.ts
+++ b/src/component/parser/json/converter/ProcessConverter.ts
@@ -100,6 +100,11 @@ export default class ProcessConverter {
   private parseProcess(process: TProcess): void {
     const processId = process.id;
     convertedProcessBpmnElements.set(processId, new ShapeBpmnElement(processId, process.name, ShapeBpmnElementKind.POOL));
+    this.buildProcessInnerElements(process);
+  }
+
+  private buildProcessInnerElements(process: TProcess | TSubProcess): void {
+    const processId = process.id;
 
     // flow nodes
     ShapeUtil.flowNodeKinds()
@@ -246,18 +251,7 @@ export default class ProcessConverter {
   }
 
   private buildSubProcessInnerElements(subProcess: TSubProcess): void {
-    const processId = subProcess.id;
-    const process = subProcess;
-
-    // flow nodes
-    ShapeUtil.flowNodeKinds()
-      .filter(kind => kind != ShapeBpmnElementKind.EVENT_BOUNDARY)
-      .forEach(kind => this.buildFlowNodeBpmnElements(processId, process[kind], kind));
-    // process boundary events afterwards as we need its parent activity to be available when building it
-    this.buildFlowNodeBpmnElements(processId, process.boundaryEvent, ShapeBpmnElementKind.EVENT_BOUNDARY);
-
-    // flows
-    this.buildSequenceFlows(process[FlowKind.SEQUENCE_FLOW]);
+    this.buildProcessInnerElements(subProcess);
   }
 
   private buildLaneSetBpmnElements(processId: string, laneSets: Array<TLaneSet> | TLaneSet): void {

--- a/test/unit/component/parser/xml/BpmnXmlParser.trisotech-bpmn-modeler-6_2_0.test.ts
+++ b/test/unit/component/parser/xml/BpmnXmlParser.trisotech-bpmn-modeler-6_2_0.test.ts
@@ -20,6 +20,7 @@ import { TSubProcess } from '../../../../../src/component/parser/xml/bpmn-json-m
 import { ensureIsArray } from '../../../../../src/component/parser/json/converter/ConverterUtil';
 import { TStartEvent } from '../../../../../src/component/parser/xml/bpmn-json-model/baseElement/flowNode/event';
 import { TTask } from '../../../../../src/component/parser/xml/bpmn-json-model/baseElement/flowNode/activity/task';
+import { TSequenceFlow } from '../../../../../src/component/parser/xml/bpmn-json-model/baseElement/flowElement';
 
 describe('parse bpmn as xml for Trisotech BPMN Modeler 6.2.0', () => {
   it('bpmn with process with extension, ensure elements are present', () => {
@@ -44,5 +45,13 @@ describe('parse bpmn as xml for Trisotech BPMN Modeler 6.2.0', () => {
     expect(subProcess1Tasks).toHaveLength(2);
     expect(subProcess1Tasks[0].name).toBe('Task 3');
     expect(subProcess1Tasks[1].name).toBe('Task 5');
+
+    const subProcess1SequenceFlows: TSequenceFlow[] = ensureIsArray(subProcess1.sequenceFlow);
+    expect(subProcess1SequenceFlows).toHaveLength(6);
+    expect(subProcess1SequenceFlows[0]).toEqual({
+      id: '_2cb09ba0-6d1a-40b9-959f-2c885400064c',
+      sourceRef: '_0db4187e-a1f6-4f1f-9089-607067907037',
+      targetRef: '_7f2b08f8-2042-434c-8181-4fbf1b03a97d',
+    });
   });
 });


### PR DESCRIPTION
**WIP depends on #514** 

closes #360 

This is final step to support regular inner elements. It contains a refactoring to ensure that process and sub-process elements are managed in the same way.
As a consequence, extra features for sub-process are availalble: inner subprocess, lane

### Regular subprocess

![image](https://user-images.githubusercontent.com/27200110/90019467-be19bf00-dcae-11ea-8df2-42f25ffdd94e.png)

### Event subprocess

In the following, the blank part inside the `event sub-process` are related to a not render `transaction sub-process` (not supported for now)
![image](https://user-images.githubusercontent.com/27200110/90019546-dc7fba80-dcae-11ea-8591-4b3993c485af.png)

