### PR TITLE
 [FEAT] Detect Error Start Interrupting Event on Event Sub-Processes

### DIFF
--- a/test/e2e/mxGraph.model.test.ts
+++ b/test/e2e/mxGraph.model.test.ts
@@ -37,6 +37,7 @@ export interface ExpectedShapeModelElement {
   label?: string;
   kind: ShapeBpmnElementKind;
   font?: ExpectedFont;
+  parentId?: string;
   /** Only needed when the BPMN shape doesn't exist yet (use an arbitrary shape until the final render is implemented) */
   styleShape?: string;
   markers?: ShapeBpmnMarkerKind[];
@@ -55,6 +56,7 @@ export interface ExpectedSubProcessModelElement extends ExpectedShapeModelElemen
 interface ExpectedEdgeModelElement {
   label?: string;
   kind?: FlowKind;
+  parentId?: string;
   font?: ExpectedFont;
   startArrow?: string;
   messageVisibleKind?: MessageVisibleKind;
@@ -118,6 +120,10 @@ describe('mxGraph model', () => {
 
   function expectModelContainsShape(cellId: string, modelElement: ExpectedShapeModelElement): mxCell {
     const cell = expectModelContainsCell(cellId);
+    const parentId = modelElement.parentId;
+    if (parentId) {
+      expect(cell.parent.id).toEqual(parentId);
+    }
     expect(cell.style).toContain(modelElement.kind);
 
     if (modelElement.markers?.length > 0) {
@@ -139,6 +145,10 @@ describe('mxGraph model', () => {
   function expectModelContainsEdge(cellId: string, modelElement: ExpectedEdgeModelElement): mxCell {
     const cell = expectModelContainsCell(cellId);
     expect(cell.style).toContain(modelElement.kind);
+    const parentId = modelElement.parentId;
+    if (parentId) {
+      expect(cell.parent.id).toEqual(parentId);
+    }
 
     if (modelElement.messageVisibleKind === MessageVisibleKind.NON_INITIATING) {
       expect(cell.style).toContain('strokeColor=DeepSkyBlue');
@@ -527,6 +537,31 @@ describe('mxGraph model', () => {
       subProcessKind: ShapeBpmnSubProcessKind.EVENT,
       label: 'Collapsed Event Sub-Process With Parallel Multi-instance',
       markers: [ShapeBpmnMarkerKind.MULTI_INSTANCE_PARALLEL, ShapeBpmnMarkerKind.EXPAND],
+    });
+
+    // Elements in subprocess
+    expectModelContainsShape('expanded_embedded_sub_process_id_startEvent_1', {
+      kind: ShapeBpmnElementKind.EVENT_START,
+      label: 'start event subprocess',
+      parentId: 'expanded_embedded_sub_process_id',
+    });
+    expectModelContainsShape('expanded_embedded_sub_process_id_task_1', {
+      kind: ShapeBpmnElementKind.TASK,
+      label: 'Task in suprocess',
+      parentId: 'expanded_embedded_sub_process_id',
+    });
+    expectModelContainsShape('expanded_embedded_sub_process_id_endEvent_1', {
+      kind: ShapeBpmnElementKind.EVENT_END,
+      label: 'end event subprocess',
+      parentId: 'expanded_embedded_sub_process_id',
+    });
+    expectModelContainsEdge('expanded_embedded_sub_process_id_SeqFlow_1', {
+      kind: FlowKind.SEQUENCE_FLOW,
+      parentId: 'expanded_embedded_sub_process_id',
+    });
+    expectModelContainsEdge('expanded_embedded_sub_process_id_SeqFlow_2', {
+      kind: FlowKind.SEQUENCE_FLOW,
+      parentId: 'expanded_embedded_sub_process_id',
     });
 
     // Call Activity calling process

--- a/test/fixtures/bpmn/model-complete-semantic.bpmn
+++ b/test/fixtures/bpmn/model-complete-semantic.bpmn
@@ -143,7 +143,20 @@
 
     <!-- Embedded Sub-Process -->
     <!-- Expanded -->
-    <semantic:subProcess triggeredByEvent="false" completionQuantity="1" isForCompensation="false" startQuantity="1" name="Expanded Embedded Sub-Process" id="expanded_embedded_sub_process_id"/>
+    <semantic:subProcess triggeredByEvent="false" completionQuantity="1" isForCompensation="false" startQuantity="1" name="Expanded Embedded Sub-Process" id="expanded_embedded_sub_process_id">
+      <semantic:startEvent id="expanded_embedded_sub_process_id_startEvent_1" name="start event subprocess">
+        <semantic:outgoing>expanded_embedded_sub_process_id_SeqFlow_1</semantic:outgoing>
+      </semantic:startEvent>
+      <semantic:task id="expanded_embedded_sub_process_id_task_1" name="Task in suprocess">
+        <semantic:incoming>expanded_embedded_sub_process_id_SeqFlow_1</semantic:incoming>
+        <semantic:outgoing>expanded_embedded_sub_process_id_SeqFlow_2</semantic:outgoing>
+      </semantic:task>
+      <semantic:sequenceFlow id="expanded_embedded_sub_process_id_SeqFlow_1" sourceRef="expanded_embedded_sub_process_id_startEvent_1" targetRef="expanded_embedded_sub_process_id_task_1" />
+      <semantic:endEvent id="expanded_embedded_sub_process_id_endEvent_1" name="end event subprocess">
+        <semantic:incoming>expanded_embedded_sub_process_id_SeqFlow_2</semantic:incoming>
+      </semantic:endEvent>
+      <semantic:sequenceFlow id="expanded_embedded_sub_process_id_SeqFlow_2" sourceRef="expanded_embedded_sub_process_id_task_1" targetRef="expanded_embedded_sub_process_id_endEvent_1" />
+    </semantic:subProcess>
     <semantic:subProcess triggeredByEvent="false" completionQuantity="1" isForCompensation="false" startQuantity="1" name="Expanded Embedded Sub-Process With Loop" id="expanded_embedded_sub_process_with_loop_id">
       <semantic:standardLoopCharacteristics />
     </semantic:subProcess>
@@ -559,9 +572,34 @@
 
       <!-- Embedded Sub-Process -->
       <!-- Expanded -->
-      <bpmndi:BPMNShape isExpanded="true" bpmnElement="expanded_embedded_sub_process_id" id="S1373649849862_expanded_embedded_sub_process_id">
-        <dc:Bounds height="32.0" width="32.0" x="87.0" y="335.0" />
+      <!-- Expanded with elements -->
+      <bpmndi:BPMNShape isExpanded="true" bpmnElement="expanded_embedded_sub_process_id" id="Shape_expanded_embedded_sub_process_id">
+        <dc:Bounds x="350" y="540" width="370" height="200" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Edge_expanded_embedded_sub_process_id_SeqFlow_1" bpmnElement="expanded_embedded_sub_process_id_SeqFlow_1">
+        <di:waypoint x="426" y="640" />
+        <di:waypoint x="480" y="640" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Edge_expanded_embedded_sub_process_id_SeqFlow_2" bpmnElement="expanded_embedded_sub_process_id_SeqFlow_2">
+        <di:waypoint x="580" y="640" />
+        <di:waypoint x="642" y="640" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Shape_expanded_embedded_sub_process_id_startEvent_1" bpmnElement="expanded_embedded_sub_process_id_startEvent_1">
+        <dc:Bounds x="390" y="622" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="380" y="665" width="57" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Shape_expanded_embedded_sub_process_id_task_1" bpmnElement="expanded_embedded_sub_process_id_task_1">
+        <dc:Bounds x="480" y="600" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Shape_expanded_embedded_sub_process_id_endEvent_1" bpmnElement="expanded_embedded_sub_process_id_endEvent_1">
+        <dc:Bounds x="642" y="622" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="632" y="665" width="57" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <!-- END OF "Expanded with elements" -->
       <bpmndi:BPMNShape isExpanded="true" bpmnElement="expanded_embedded_sub_process_with_loop_id" id="S1373649849862_expanded_embedded_sub_process_with_loop_id">
         <dc:Bounds height="32.0" width="32.0" x="87.0" y="335.0" />
       </bpmndi:BPMNShape>


### PR DESCRIPTION
**WIP depends on ##517**

closes #384

No implementation, only tests to validate the parsing works.

### Render

With the file taken from https://github.com/process-analytics/bpmn-visualization-examples/pull/43

![image](https://user-images.githubusercontent.com/27200110/90028574-1f935b00-dcba-11ea-8dbb-0fc0db26870d.png)
