### PR TITLE
[INFRA] Bump entities from 2.0.0 to 2.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12468,9 +12468,9 @@
       }
     },
     "typescript": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.2.tgz",
-      "integrity": "sha512-EgOVgL/4xfVrCMbhYKUQTdF37SQn4Iw73H5BgCrF1Abdun7Kwy/QZsE/ssAy0y4LxBbvua3PIbFsbRczWWnDdQ==",
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
       "dev": true
     },
     "unbzip2-stream": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3773,9 +3773,9 @@
       }
     },
     "entities": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
-      "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+      "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ=="
     },
     "error-ex": {
       "version": "1.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4427,9 +4427,9 @@
       "dev": true
     },
     "fast-xml-parser": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.16.0.tgz",
-      "integrity": "sha512-U+bpScacfgnfNfIKlWHDu4u6rtOaCyxhblOLJ8sZPkhsjgGqdZmVPBhdOyvdMGCDt8CsAv+cssOP3NzQptNt2w=="
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.17.4.tgz",
+      "integrity": "sha512-qudnQuyYBgnvzf5Lj/yxMcf4L9NcVWihXJg7CiU1L+oUCq8MUnFEfH2/nXR/W5uq+yvUN1h7z6s7vs2v1WkL1A=="
     },
     "fastq": {
       "version": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   },
   "dependencies": {
     "entities": "^2.0.0",
-    "fast-xml-parser": "^3.16.0",
+    "fast-xml-parser": "^3.17.4",
     "mxgraph": "4.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "rollup-plugin-typescript2": "^0.26.0",
     "ts-jest": "^25.5.1",
     "ts-mxgraph": "git+https://github.com/process-analytics/ts-mxgraph.git#v1.0.1",
-    "typescript": "^3.8.2"
+    "typescript": "^3.9.7"
   },
   "dependencies": {
     "entities": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "typescript": "^3.9.7"
   },
   "dependencies": {
-    "entities": "^2.0.0",
+    "entities": "^2.0.3",
     "fast-xml-parser": "^3.17.4",
     "mxgraph": "4.1.0"
   }


### PR DESCRIPTION
**WIP depends on #528** 

Changelog:
- https://github.com/fb55/entities/releases/tag/v2.0.3
- https://github.com/fb55/entities/releases/tag/v2.0.2
- https://github.com/fb55/entities/releases/tag/v2.0.1