### PR TITLE
[TEST] increase puppeteer server launch timeout

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,8 +72,14 @@ See `package.json` for extra available scripts
 - `npm run test`                *Run all tests*
 - `npm run test:unit`           *Run unit tests*
 - `npm run test:unit:coverage`  *Run unit tests with coverage*
-- `npm run test:e2e`            *Run end-to-end tests*. To see the web browser used by tests, disable the `headless` mode by
-                                setting the `HEADLESS` environment variable to `false`.
+- `npm run test:e2e`            *Run end-to-end tests*.
+
+#### Debugging end-to-end tests
+
+To see what is happening in the web browser used by the tests
+- disable the `headless` mode by setting the `HEADLESS` environment variable to `false`
+- set the `SLOWMO` environment variable to a positive millisecond value (between `200` and `500` should be enough). This
+slows Puppeteer down by milliseconds that we specify. So we will be able to observe what it actually does.
 
 ### Code style
 

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -17,12 +17,13 @@ module.exports = {
   server: {
     command: `npm run start`,
     port: 10001,
-    launchTimeout: 10000,
+    launchTimeout: 30000, // high value mainly for GitHub Workflows running on macOS (slow machines)
     debug: true,
   },
   launch: {
     dumpio: true,
     headless: process.env.HEADLESS !== 'false',
+    slowMo: process.env.SLOWMO ? process.env.SLOWMO : 0,
     args: ['--disable-infobars'],
     timeout: 120000,
   },


### PR DESCRIPTION
This is an attempt to avoid startup error when running GitHub Workflows on
macOS. This error probably occurs because the machines running the workflows
have low performances.

In addition, allow to configure puppeteer 'slowMo' with an environment variable
when debugging tests.