### PR TITLE
[FEAT] Render Instantiating Receive Task

### DIFF
--- a/src/component/mxgraph/shape/activity-shapes.ts
+++ b/src/component/mxgraph/shape/activity-shapes.ts
@@ -127,22 +127,27 @@ export class ReceiveTaskShape extends BaseTaskShape {
     super(bounds, fill, stroke, strokewidth);
   }
 
-  // TODO To remove when the instantiating receive task render is implemented
-  public paintVertexShape(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): void {
-    const isInstantiating = StyleUtils.getBpmnIsInstantiating(this.style);
-
-    if (isInstantiating) {
-      c.setFillColor('Salmon');
-    }
-
-    super.paintVertexShape(c, x, y, w, h);
-  }
-
   protected paintTaskIcon(paintParameter: PaintParameter): void {
     const isInstantiating = StyleUtils.getBpmnIsInstantiating(this.style);
 
     if (!isInstantiating) {
       paintEnvelopeIcon(paintParameter, false);
+    } else {
+      this.iconPainter.paintCircleIcon({
+        ...paintParameter,
+        shape: { ...paintParameter.shape, w: 80, h: 80 },
+        setIconOrigin: (canvas: BpmnCanvas) => canvas.setIconOriginToShapeTopLeft(),
+        // ratioFromParent: 0.2,
+        icon: { ...paintParameter.icon, isFilled: false },
+      });
+      // paintEnvelopeIcon(paintParameter, false);
+      const isFilled = false;
+      this.iconPainter.paintEnvelopeIcon({
+        ...paintParameter,
+        setIconOrigin: (canvas: BpmnCanvas) => canvas.setIconOriginToShapeTopLeft(11, 11),
+        ratioFromParent: 0.14,
+        icon: { ...paintParameter.icon, isFilled: isFilled },
+      });
     }
   }
 }

--- a/src/component/mxgraph/shape/activity-shapes.ts
+++ b/src/component/mxgraph/shape/activity-shapes.ts
@@ -133,34 +133,24 @@ export class ReceiveTaskShape extends BaseTaskShape {
       return;
     }
 
-    // const circleIconSize: Size = { width: 80, height: 80 };
-    // const circleShapeConfiguration = { x: paintParameter.shape.x, y: paintParameter.shape.y, w: circleIconSize.width, h: circleIconSize.height };
-    // const circleShapeConfiguration = { x: paintParameter.shape.x, y: paintParameter.shape.y, w: 80, h: 80 };
-    // const circleShapeConfiguration = { ...paintParameter.shape, w: 80, h: 80 };
+    // paint a fixed size circle
     const circleShapeConfiguration = { ...paintParameter.shape, w: 20, h: 20 };
-    // const circleShapeRatioFromParent = 0.25; // TODO this is the default value
-
     this.iconPainter.paintCircleIcon({
-      ...paintParameter,
-      //shape: { ...paintParameter.shape, w: circleIconSize.width, h: circleIconSize.height }, // TODO change this, too hacky!
+      c: paintParameter.c,
       shape: circleShapeConfiguration,
-      setIconOrigin: (canvas: BpmnCanvas) => canvas.setIconOriginToShapeTopLeft(),
       icon: { ...paintParameter.icon, isFilled: false },
-      // ratioFromParent: circleShapeRatioFromParent,
       ratioFromParent: undefined, // ensure we will paint the icon with its original size
+      setIconOrigin: (canvas: BpmnCanvas) => canvas.setIconOriginToShapeTopLeft(),
     });
 
-    // paint an envelope centered inside the circle, dimensions: 80% of the circle dimensions
-    // this is what 'setIconOriginToShapeTopLeft' does
+    // paint an envelope centered inside the circle, with dimensions proportional to the circle dimensions
+    // set the actual origin of the circle icon: this is what 'setIconOriginToShapeTopLeft' has done prior painting the cirle icon
     circleShapeConfiguration.x += StyleDefault.SHAPE_ACTIVITY_LEFT_MARGIN;
     circleShapeConfiguration.y += StyleDefault.SHAPE_ACTIVITY_TOP_MARGIN;
-    // circleShapeConfiguration.w *= circleShapeRatioFromParent;
-    // circleShapeConfiguration.h *= circleShapeRatioFromParent;
 
     this.iconPainter.paintEnvelopeIcon({
       ...paintParameter,
       shape: circleShapeConfiguration,
-      //ratioFromParent: 0.5, // TODO: use a constant as we have the same ratio as for message event??
       ratioFromParent: 0.65,
       setIconOrigin: (canvas: BpmnCanvas) => canvas.setIconOriginForIconCentered(),
     });

--- a/src/component/mxgraph/shape/activity-shapes.ts
+++ b/src/component/mxgraph/shape/activity-shapes.ts
@@ -136,8 +136,9 @@ export class ReceiveTaskShape extends BaseTaskShape {
     // const circleIconSize: Size = { width: 80, height: 80 };
     // const circleShapeConfiguration = { x: paintParameter.shape.x, y: paintParameter.shape.y, w: circleIconSize.width, h: circleIconSize.height };
     // const circleShapeConfiguration = { x: paintParameter.shape.x, y: paintParameter.shape.y, w: 80, h: 80 };
-    const circleShapeConfiguration = { ...paintParameter.shape, w: 80, h: 80 };
-    const circleShapeRatioFromParent = 0.25; // TODO this is the default value
+    // const circleShapeConfiguration = { ...paintParameter.shape, w: 80, h: 80 };
+    const circleShapeConfiguration = { ...paintParameter.shape, w: 20, h: 20 };
+    // const circleShapeRatioFromParent = 0.25; // TODO this is the default value
 
     this.iconPainter.paintCircleIcon({
       ...paintParameter,
@@ -146,14 +147,15 @@ export class ReceiveTaskShape extends BaseTaskShape {
       setIconOrigin: (canvas: BpmnCanvas) => canvas.setIconOriginToShapeTopLeft(),
       icon: { ...paintParameter.icon, isFilled: false },
       // ratioFromParent: circleShapeRatioFromParent,
+      ratioFromParent: undefined, // ensure we will paint the icon with its original size
     });
 
     // paint an envelope centered inside the circle, dimensions: 80% of the circle dimensions
     // this is what 'setIconOriginToShapeTopLeft' does
     circleShapeConfiguration.x += StyleDefault.SHAPE_ACTIVITY_LEFT_MARGIN;
     circleShapeConfiguration.y += StyleDefault.SHAPE_ACTIVITY_TOP_MARGIN;
-    circleShapeConfiguration.w *= circleShapeRatioFromParent;
-    circleShapeConfiguration.h *= circleShapeRatioFromParent;
+    // circleShapeConfiguration.w *= circleShapeRatioFromParent;
+    // circleShapeConfiguration.h *= circleShapeRatioFromParent;
 
     this.iconPainter.paintEnvelopeIcon({
       ...paintParameter,

--- a/src/component/mxgraph/shape/activity-shapes.ts
+++ b/src/component/mxgraph/shape/activity-shapes.ts
@@ -128,27 +128,40 @@ export class ReceiveTaskShape extends BaseTaskShape {
   }
 
   protected paintTaskIcon(paintParameter: PaintParameter): void {
-    const isInstantiating = StyleUtils.getBpmnIsInstantiating(this.style);
-
-    if (!isInstantiating) {
+    if (!StyleUtils.getBpmnIsInstantiating(this.style)) {
       paintEnvelopeIcon(paintParameter, false);
-    } else {
-      this.iconPainter.paintCircleIcon({
-        ...paintParameter,
-        shape: { ...paintParameter.shape, w: 80, h: 80 },
-        setIconOrigin: (canvas: BpmnCanvas) => canvas.setIconOriginToShapeTopLeft(),
-        // ratioFromParent: 0.2,
-        icon: { ...paintParameter.icon, isFilled: false },
-      });
-      // paintEnvelopeIcon(paintParameter, false);
-      const isFilled = false;
-      this.iconPainter.paintEnvelopeIcon({
-        ...paintParameter,
-        setIconOrigin: (canvas: BpmnCanvas) => canvas.setIconOriginToShapeTopLeft(11, 11),
-        ratioFromParent: 0.14,
-        icon: { ...paintParameter.icon, isFilled: isFilled },
-      });
+      return;
     }
+
+    // const circleIconSize: Size = { width: 80, height: 80 };
+    // const circleShapeConfiguration = { x: paintParameter.shape.x, y: paintParameter.shape.y, w: circleIconSize.width, h: circleIconSize.height };
+    // const circleShapeConfiguration = { x: paintParameter.shape.x, y: paintParameter.shape.y, w: 80, h: 80 };
+    const circleShapeConfiguration = { ...paintParameter.shape, w: 80, h: 80 };
+    const circleShapeRatioFromParent = 0.25; // TODO this is the default value
+
+    this.iconPainter.paintCircleIcon({
+      ...paintParameter,
+      //shape: { ...paintParameter.shape, w: circleIconSize.width, h: circleIconSize.height }, // TODO change this, too hacky!
+      shape: circleShapeConfiguration,
+      setIconOrigin: (canvas: BpmnCanvas) => canvas.setIconOriginToShapeTopLeft(),
+      icon: { ...paintParameter.icon, isFilled: false },
+      // ratioFromParent: circleShapeRatioFromParent,
+    });
+
+    // paint an envelope centered inside the circle, dimensions: 80% of the circle dimensions
+    // this is what 'setIconOriginToShapeTopLeft' does
+    circleShapeConfiguration.x += StyleDefault.SHAPE_ACTIVITY_LEFT_MARGIN;
+    circleShapeConfiguration.y += StyleDefault.SHAPE_ACTIVITY_TOP_MARGIN;
+    circleShapeConfiguration.w *= circleShapeRatioFromParent;
+    circleShapeConfiguration.h *= circleShapeRatioFromParent;
+
+    this.iconPainter.paintEnvelopeIcon({
+      ...paintParameter,
+      shape: circleShapeConfiguration,
+      //ratioFromParent: 0.5, // TODO: use a constant as we have the same ratio as for message event??
+      ratioFromParent: 0.65,
+      setIconOrigin: (canvas: BpmnCanvas) => canvas.setIconOriginForIconCentered(),
+    });
   }
 }
 

--- a/src/component/mxgraph/shape/activity-shapes.ts
+++ b/src/component/mxgraph/shape/activity-shapes.ts
@@ -133,6 +133,9 @@ export class ReceiveTaskShape extends BaseTaskShape {
       return;
     }
 
+    const leftMargin = 4;
+    const topMargin = 4;
+
     // paint a fixed size circle
     const circleShapeConfiguration = { ...paintParameter.shape, w: 20, h: 20 };
     this.iconPainter.paintCircleIcon({
@@ -140,13 +143,13 @@ export class ReceiveTaskShape extends BaseTaskShape {
       shape: circleShapeConfiguration,
       icon: { ...paintParameter.icon, isFilled: false },
       ratioFromParent: undefined, // ensure we will paint the icon with its original size
-      setIconOrigin: (canvas: BpmnCanvas) => canvas.setIconOriginToShapeTopLeft(),
+      setIconOrigin: (canvas: BpmnCanvas) => canvas.setIconOriginToShapeTopLeft(topMargin, leftMargin),
     });
 
     // paint an envelope centered inside the circle, with dimensions proportional to the circle dimensions
-    // set the actual origin of the circle icon: this is what 'setIconOriginToShapeTopLeft' has done prior painting the cirle icon
-    circleShapeConfiguration.x += StyleDefault.SHAPE_ACTIVITY_LEFT_MARGIN;
-    circleShapeConfiguration.y += StyleDefault.SHAPE_ACTIVITY_TOP_MARGIN;
+    // set the actual origin of the circle icon: this is what 'setIconOriginToShapeTopLeft' has done prior painting the circle icon
+    circleShapeConfiguration.x += leftMargin;
+    circleShapeConfiguration.y += topMargin;
 
     this.iconPainter.paintEnvelopeIcon({
       ...paintParameter,


### PR DESCRIPTION

Closes #511 
Introduced a temporary way to generate task icon with a fixed size. This will be reworked and reviewed as part of #211 and #465 

### Icon rendering on task with various sizes

Using diagram from https://github.com/process-analytics/bpmn-visualization-examples/pull/47
![image](https://user-images.githubusercontent.com/27200110/90479149-82f41180-e12e-11ea-832b-37a0870578f4.png)


### Icon rendering comparisons between all supported tasks

Using a diagram adapted from the non-regression tasks diagram from #523 
![image](https://user-images.githubusercontent.com/27200110/90479312-c3538f80-e12e-11ea-8b92-4b4c1d8e72ce.png)
