### PR TITLE
[INFRA] Automate release process - step 1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      type:
+        description: 'New version type [new-version | major | minor | patch]'
+        required: true
+        default: 'patch'
+jobs:
+  bumpVersion:
+    runs-on: ubuntu-20.04
+    steps:
+      - run: |
+          echo "New version type: ${{ github.event.inputs.type }}"
+      - name: Branch Protection Bot - Temporarily disable "include administrators" branch protection
+        uses: benjefferies/branch-protection-bot@1.0.5
+        if: always()
+        with:
+          access-token: ${{ secrets.GH_RELEASE_TOKEN }}
+          enforce_admins: false
+          branch: master
+
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - name: Setup checkout
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_RELEASE_TOKEN }}
+      - name: Config git
+        run: |
+          git config --local user.email "62586190+process-analytics-bot@users.noreply.github.com"
+          git config --local user.name "process-analytics-bot"
+          git config pull.rebase true
+      - name: Checkout master
+        run: git checkout master && git pull --tags
+      - name: Bump Version
+        run: npm version ${{ github.event.inputs.type }} --message "[RELEASE] %s"
+      - name: Push Version
+        run: git push && git push --tags
+
+      - name: Branch Protection Bot - Reenable "include administrators" branch protection
+        uses: benjefferies/branch-protection-bot@1.0.5
+        if: always()  # Force to always run this step to ensure "include administrators" is always turned back on
+        with:
+          access-token: ${{ secrets.GH_RELEASE_TOKEN }}
+          enforce_admins: true
+          branch: master

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -263,10 +263,12 @@ of the `Done` column related to the milestone
 
 #### Git Tag
 
-- Ensures you’re on master and don’t have local, un-commited changes: `git checkout master && git pull --tags`
-- Bumps the version number in package.json based on major, minor or patch (see https://docs.npmjs.com/cli/version, type:
- [new-version | major | minor | patch]): `npm version [type] --message "[RELEASE] %s"`
-- Push to GitHub: `git push && git push --tags`
+- Open [github actions](https://github.com/process-analytics/bpmn-visualization-js/actions?query=workflow%3ARelease)
+- Click on the 'Run workflow' dropdown located on the right side of the page
+- Provide parameter value for New version type (default is patch, but you can choose one of the [new-version | major | minor | patch])
+- Click on the button 'Run workflow'
+- Make sure job execution was successful by checking the status
+- If everything went well you can see new tag created
 
 #### GitHub update
 


### PR DESCRIPTION
**Automatize release process - step 1**

The manually launched GH Workflow that automatizes:
- npm version bump
- tag creation
- tag push
- it overcomes the problem of pushing the tag to master

closes #139 