### PR TITLE
[INFRA] fix the `parseBpmn` utils build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,3 +70,6 @@ jobs:
         with:
           name: e2e-test-results-${{matrix.os.name}}-${{github.sha}}
           path: build/test-report/e2e
+      # Ensure we don't break scripts
+      - name: Build utils
+        run: npm run build-utils

--- a/scripts/utils/parseBpmn.ts
+++ b/scripts/utils/parseBpmn.ts
@@ -16,9 +16,9 @@
 import * as path from 'path';
 import clipboardy from 'clipboardy';
 import parseArgs from 'minimist';
-import BpmnModel from '../../src/model/bpmn/BpmnModel';
+import BpmnModel from '../../src/model/bpmn/internal/BpmnModel';
 import BpmnXmlParser from '../../src/component/parser/xml/BpmnXmlParser';
-import { BpmnJsonModel } from '../../src/component/parser/xml/bpmn-json-model/BPMN20';
+import { BpmnJsonModel } from '../../src/model/bpmn/json/BPMN20';
 import { defaultBpmnJsonParser } from '../../src/component/parser/json/BpmnJsonParser';
 import { readFileSync } from '../../test/helpers/file-helper';
 


### PR DESCRIPTION
The issue has been introduced when moving the BpmnModel to a new folder.
We miss to update the script at that time.
To avoid this in the future, the GitHub build workflow now builds the utils
script at the end of the job to ensure we don't break anything.