### PR TITLE
[INFRA] enforce TypeScript noImplicitReturns

### DIFF
--- a/src/component/mxgraph/MxGraphRenderer.ts
+++ b/src/component/mxgraph/MxGraphRenderer.ts
@@ -49,7 +49,7 @@ export default class MxGraphRenderer {
     });
   }
 
-  private getParent(bpmnElement: ShapeBpmnElement): mxCell {
+  private getParent(bpmnElement: ShapeBpmnElement): mxCell | undefined {
     const bpmnElementParent = this.getCell(bpmnElement.parentId);
     if (bpmnElementParent) {
       return bpmnElementParent;
@@ -58,6 +58,8 @@ export default class MxGraphRenderer {
     if (!ShapeUtil.isBoundaryEvent(bpmnElement.kind)) {
       return this.graph.getDefaultParent();
     }
+
+    return undefined;
   }
 
   private insertShape(shape: Shape): void {

--- a/src/component/parser/json/converter/DiagramConverter.ts
+++ b/src/component/parser/json/converter/DiagramConverter.ts
@@ -40,6 +40,7 @@ function findProcessElement(participantId: string): ShapeBpmnElement | undefined
     // black box pool
     return new ShapeBpmnElement(participant.id, participant.name, ShapeBpmnElementKind.POOL);
   }
+  return undefined;
 }
 
 export default class DiagramConverter {
@@ -143,13 +144,15 @@ export default class DiagramConverter {
       const label = this.deserializeLabel(shape.BPMNLabel, shape.id);
       return new Shape(shape.id, bpmnElement, bounds, label, isHorizontal);
     }
+    return undefined;
   }
 
-  private deserializeBounds(boundedElement: BPMNShape | BPMNLabel): Bounds {
+  private deserializeBounds(boundedElement: BPMNShape | BPMNLabel): Bounds | undefined {
     const bounds = boundedElement.Bounds;
     if (bounds) {
       return new Bounds(bounds.x, bounds.y, bounds.width, bounds.height);
     }
+    return undefined;
   }
 
   private deserializeEdges(edges: BPMNEdge | BPMNEdge[]): Edge[] {
@@ -169,7 +172,7 @@ export default class DiagramConverter {
     return ensureIsArray(waypoints).map(waypoint => new Waypoint(waypoint.x, waypoint.y));
   }
 
-  private deserializeLabel(bpmnLabel: string | BPMNLabel, id: string): Label {
+  private deserializeLabel(bpmnLabel: string | BPMNLabel, id: string): Label | undefined {
     if (bpmnLabel && typeof bpmnLabel === 'object') {
       const font = this.findFont(bpmnLabel.labelStyle, id);
       const bounds = this.deserializeBounds(bpmnLabel);
@@ -178,6 +181,7 @@ export default class DiagramConverter {
         return new Label(font, bounds);
       }
     }
+    return undefined;
   }
 
   private findFont(labelStyle: string, id: string): Font {

--- a/src/component/parser/json/converter/ProcessConverter.ts
+++ b/src/component/parser/json/converter/ProcessConverter.ts
@@ -153,7 +153,7 @@ export default class ProcessConverter {
     });
   }
 
-  private buildShapeBpmnActivity(bpmnElement: TActivity, kind: ShapeBpmnElementKind, processId: string): ShapeBpmnActivity {
+  private buildShapeBpmnActivity(bpmnElement: TActivity, kind: ShapeBpmnElementKind, processId: string): ShapeBpmnActivity | undefined {
     const markers = this.buildMarkers(bpmnElement);
 
     if (ShapeUtil.isSubProcess(kind)) {
@@ -168,6 +168,8 @@ export default class ProcessConverter {
     if (!isGlobalTask((bpmnElement as TCallActivity).calledElement)) {
       return new ShapeBpmnCallActivity(bpmnElement.id, bpmnElement.name, ShapeBpmnCallActivityKind.CALLING_PROCESS, processId, markers);
     }
+
+    return undefined;
   }
 
   private buildMarkers(bpmnElement: TActivity): ShapeBpmnMarkerKind[] {
@@ -186,7 +188,7 @@ export default class ProcessConverter {
     return markers;
   }
 
-  private buildShapeBpmnEvent(bpmnElement: TCatchEvent | TThrowEvent, elementKind: BpmnEventKind, processId: string): ShapeBpmnEvent {
+  private buildShapeBpmnEvent(bpmnElement: TCatchEvent | TThrowEvent, elementKind: BpmnEventKind, processId: string): ShapeBpmnEvent | undefined {
     const eventDefinitions = this.getEventDefinitions(bpmnElement);
     const numberOfEventDefinitions = eventDefinitions.map(eventDefinition => eventDefinition.counter).reduce((counter, it) => counter + it, 0);
 
@@ -207,17 +209,19 @@ export default class ProcessConverter {
         return new ShapeBpmnEvent(bpmnElement.id, bpmnElement.name, elementKind, eventKind, processId);
       }
     }
+
+    return undefined;
   }
 
-  private buildShapeBpmnBoundaryEvent(bpmnElement: TBoundaryEvent, eventKind: ShapeBpmnEventKind): ShapeBpmnBoundaryEvent {
+  private buildShapeBpmnBoundaryEvent(bpmnElement: TBoundaryEvent, eventKind: ShapeBpmnEventKind): ShapeBpmnBoundaryEvent | undefined {
     const parent = findFlowNodeBpmnElement(bpmnElement.attachedToRef);
 
     if (ShapeUtil.isActivity(parent?.kind)) {
       return new ShapeBpmnBoundaryEvent(bpmnElement.id, bpmnElement.name, eventKind, bpmnElement.attachedToRef, bpmnElement.cancelActivity);
-    } else {
-      // TODO error management
-      console.warn('The boundary event %s must be attach to an activity, and not to %s', bpmnElement.id, parent?.kind);
     }
+    // TODO error management
+    console.warn('The boundary event %s must be attach to an activity, and not to %s', bpmnElement.id, parent?.kind);
+    return undefined;
   }
 
   /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "module": "es6",
     "target": "es6",
     "noImplicitAny": true,
+    "noImplicitReturns": true,
     "strictBindCallApply": true,
     "alwaysStrict": true,
     "strictFunctionTypes": true,


### PR DESCRIPTION
In addition, align method signatures to document that a method can return
`undefined`.

covers #421

I am not sure this makes the code easier to understand nor if additional code required by this flag brings enough value.