### PR TITLE
[TEST] Convert expectModelContainsAssociationFlow function to jest extension 

### DIFF
--- a/test/e2e/ExpectModelUtils.ts
+++ b/test/e2e/ExpectModelUtils.ts
@@ -18,7 +18,7 @@ import { FlowKind } from '../../src/model/bpmn/internal/edge/FlowKind';
 import { MessageVisibleKind } from '../../src/model/bpmn/internal/edge/MessageVisibleKind';
 import { SequenceFlowKind } from '../../src/model/bpmn/internal/edge/SequenceFlowKind';
 import BpmnVisualization from '../../src/component/BpmnVisualization';
-import { toBeCell, withGeometry, withFont, toBeEdge, toBeSequenceFlow, toBeMessageFlow } from './matchers';
+import { toBeCell, withGeometry, withFont, toBeSequenceFlow, toBeMessageFlow, toBeAssociationFlow } from './matchers';
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -27,9 +27,9 @@ declare global {
       toBeCell(): R;
       withGeometry(geometry: mxGeometry): R;
       withFont(font: ExpectedFont): R;
-      toBeEdge(modelElement: ExpectedEdgeModelElement): R;
       toBeSequenceFlow(modelElement: ExpectedSequenceFlowModelElement): R;
       toBeMessageFlow(modelElement: ExpectedEdgeModelElement): R;
+      toBeAssociationFlow(modelElement: ExpectedEdgeModelElement): R;
     }
   }
 }
@@ -38,9 +38,9 @@ expect.extend({
   toBeCell,
   withGeometry,
   withFont,
-  toBeEdge,
   toBeSequenceFlow,
   toBeMessageFlow,
+  toBeAssociationFlow,
 });
 
 export interface ExpectedFont {
@@ -131,10 +131,6 @@ export function expectModelContainsShape(cellId: string, modelElement: ExpectedS
   expect(cell.value).toEqual(modelElement.label);
   expect(cell).withFont(modelElement.font);
   return cell;
-}
-
-export function expectModelContainsAssociationFlow(cellId: string, modelElement: ExpectedEdgeModelElement): void {
-  expect(cellId).toBeEdge({ ...modelElement, kind: FlowKind.ASSOCIATION_FLOW });
 }
 
 export function expectModelContainsBpmnEvent(cellId: string, eventModelElement: ExpectedEventModelElement): mxCell {

--- a/test/e2e/matchers/index.ts
+++ b/test/e2e/matchers/index.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { toBeEdge, toBeSequenceFlow, toBeMessageFlow } from './toBeEdge';
+export { toBeSequenceFlow, toBeMessageFlow, toBeAssociationFlow } from './toBeEdge';
 export { toBeCell } from './toBeCell';
 export { withGeometry } from './withGeometry';
 export { withFont } from './withFont';

--- a/test/e2e/matchers/toBeEdge/index.ts
+++ b/test/e2e/matchers/toBeEdge/index.ts
@@ -58,14 +58,14 @@ function buildEdgeMatcher(matcherName: string, matcherContext: MatcherContext, r
   };
 }
 
-export function toBeEdge(this: MatcherContext, received: string, expected: ExpectedEdgeModelElement): CustomMatcherResult {
-  return buildEdgeMatcher('toBeEdge', this, received, expected);
-}
-
 export function toBeSequenceFlow(this: MatcherContext, received: string, expected: ExpectedSequenceFlowModelElement): CustomMatcherResult {
   return buildEdgeMatcher('toBeSequenceFlow', this, received, { ...expected, kind: FlowKind.SEQUENCE_FLOW, endArrow: 'blockThin' });
 }
 
 export function toBeMessageFlow(this: MatcherContext, received: string, expected: ExpectedEdgeModelElement): CustomMatcherResult {
   return buildEdgeMatcher('toBeMessageFlow', this, received, { ...expected, kind: FlowKind.MESSAGE_FLOW, startArrow: mxConstants.ARROW_OVAL, endArrow: 'blockThin' });
+}
+
+export function toBeAssociationFlow(this: MatcherContext, received: string, expected: ExpectedEdgeModelElement): CustomMatcherResult {
+  return buildEdgeMatcher('toBeAssociationFlow', this, received, { ...expected, kind: FlowKind.ASSOCIATION_FLOW });
 }

--- a/test/e2e/mxGraph.model.test.ts
+++ b/test/e2e/mxGraph.model.test.ts
@@ -22,7 +22,6 @@ import { readFileSync } from '../helpers/file-helper';
 import {
   bpmnVisualization,
   ExpectedShapeModelElement,
-  expectModelContainsAssociationFlow,
   expectModelContainsBpmnBoundaryEvent,
   expectModelContainsBpmnEvent,
   expectModelContainsBpmnStartEvent,
@@ -828,7 +827,7 @@ describe('mxGraph model', () => {
     expect('message_flow_no_visible_id').toBeMessageFlow({ label: 'Message Flow without message', messageVisibleKind: MessageVisibleKind.NONE, verticalAlign: 'bottom' });
 
     // association
-    expectModelContainsAssociationFlow('association_id', { kind: FlowKind.ASSOCIATION_FLOW, parentId: 'participant_1_id', verticalAlign: 'bottom' });
+    expect('association_id').toBeAssociationFlow({ kind: FlowKind.ASSOCIATION_FLOW, parentId: 'participant_1_id', verticalAlign: 'bottom' });
   });
 
   it('bpmn elements should not be available in the mxGraph model, if they are attached to not existing elements', async () => {

--- a/test/e2e/mxGraph.model.test.ts
+++ b/test/e2e/mxGraph.model.test.ts
@@ -16,7 +16,6 @@
 import { ShapeBpmnElementKind, ShapeBpmnEventKind, ShapeBpmnMarkerKind, ShapeBpmnSubProcessKind } from '../../src/model/bpmn/internal/shape';
 import { SequenceFlowKind } from '../../src/model/bpmn/internal/edge/SequenceFlowKind';
 import { MarkerIdentifier } from '../../src/bpmn-visualization';
-import { FlowKind } from '../../src/model/bpmn/internal/edge/FlowKind';
 import { MessageVisibleKind } from '../../src/model/bpmn/internal/edge/MessageVisibleKind';
 import { readFileSync } from '../helpers/file-helper';
 import {
@@ -827,7 +826,7 @@ describe('mxGraph model', () => {
     expect('message_flow_no_visible_id').toBeMessageFlow({ label: 'Message Flow without message', messageVisibleKind: MessageVisibleKind.NONE, verticalAlign: 'bottom' });
 
     // association
-    expect('association_id').toBeAssociationFlow({ kind: FlowKind.ASSOCIATION_FLOW, parentId: 'participant_1_id', verticalAlign: 'bottom' });
+    expect('association_id').toBeAssociationFlow({ parentId: 'participant_1_id', verticalAlign: 'bottom' });
   });
 
   it('bpmn elements should not be available in the mxGraph model, if they are attached to not existing elements', async () => {


### PR DESCRIPTION
- Convert 'expectModelContainsAssociationFlow' in Jest extension 'toBeAssociationFlow' 
- Remove useless 'toBeEdge' Jest extension
