### PR TITLE
[INFRA] use @types/jest-image-snapshot instead of custom types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4240,6 +4240,17 @@
         }
       }
     },
+    "@types/jest-image-snapshot": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@types/jest-image-snapshot/-/jest-image-snapshot-4.1.2.tgz",
+      "integrity": "sha512-UlbjIz4pFMHTnF+nny/qOFW0OinXltlGfXnvAZm6FoaJhDvNJKHWeyVmcGm/BmJXx+H5Wod+OIY2oy+llHxwsw==",
+      "dev": true,
+      "requires": {
+        "@types/jest": "*",
+        "@types/pixelmatch": "*",
+        "ssim.js": "^3.1.0"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
@@ -4284,6 +4295,15 @@
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
+    },
+    "@types/pixelmatch": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@types/pixelmatch/-/pixelmatch-5.2.2.tgz",
+      "integrity": "sha512-ndpfW/H8+SAiI3wt+f8DlHGgB7OeBdgFgBJ6v/1l3SpJ0MCn9wtXFb4mUccMujN5S4DMmAh7MVy1O3WcXrHUKw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/prettier": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@types/debug": "^4.1.5",
     "@types/jest": "^26.0.15",
     "@types/jest-environment-puppeteer": "^4.3.2",
+    "@types/jest-image-snapshot": "^4.1.2",
     "@types/minimist": "^1.2.0",
     "@types/puppeteer": "^3.0.2",
     "@typescript-eslint/eslint-plugin": "^4.4.1",

--- a/test/e2e/config/jest.image.ts
+++ b/test/e2e/config/jest.image.ts
@@ -13,8 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// TODO give a try to import when we will use 'jest-image-snapshot' types
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const { toMatchImageSnapshot } = require('jest-image-snapshot');
-
+import { toMatchImageSnapshot } from 'jest-image-snapshot';
 expect.extend({ toMatchImageSnapshot });

--- a/test/e2e/helpers/visu-utils.ts
+++ b/test/e2e/helpers/visu-utils.ts
@@ -14,25 +14,9 @@
  * limitations under the License.
  */
 import { ElementHandle } from 'puppeteer';
-
-// TODO use 'jest-image-snapshot' definition types when the lib will be updated
-// The type lib does not support setting config for ssim (4.2.0 released on july 2020)
-// typescript integration: https://github.com/americanexpress/jest-image-snapshot#usage-in-typescript
-//
-// inspired from https://medium.com/javascript-in-plain-english/jest-how-to-use-extend-with-typescript-4011582a2217
-declare global {
-  // eslint-disable-next-line @typescript-eslint/no-namespace
-  namespace jest {
-    interface Matchers<R> {
-      toMatchImageSnapshot(imageSnapshotConfig?: ImageSnapshotConfig): R;
-    }
-    // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    interface ImageSnapshotConfig {}
-  }
-}
-
 import debugLogger from 'debug';
 import { copyFileSync, loadBpmnContentForUrlQueryParam } from '../../helpers/file-helper';
+import { MatchImageSnapshotOptions } from 'jest-image-snapshot';
 
 const log = debugLogger('test');
 
@@ -55,7 +39,7 @@ export interface ImageSnapshotThresholdConfig {
   windows: number;
 }
 
-const defaultImageSnapshotConfig = {
+const defaultImageSnapshotConfig: MatchImageSnapshotOptions = {
   diffDirection: 'vertical',
   dumpDiffToConsole: true, // useful on CI (no need to retrieve the diff image, copy/paste image content from logs)
   // use SSIM to limit false positive
@@ -74,7 +58,7 @@ export class ImageSnapshotConfigurator {
    */
   constructor(readonly thresholdConfig: Map<string, ImageSnapshotThresholdConfig>) {}
 
-  getConfig(fileName: string): jest.ImageSnapshotConfig {
+  getConfig(fileName: string): MatchImageSnapshotOptions {
     // minimal threshold to make tests for diagram renders pass on local
     // macOS: Expected image to match or be a close match to snapshot but was 0.00031509446166699817% different from snapshot
     let failureThreshold = 0.000004;


### PR DESCRIPTION
Latest 4.1.2 version provides missing types related to jest-image-snapshot@4.2.0.
So no need for our custom types anymore.