### PR TITLE
[TEST] Remove unnecessary duplicated dependency: jest-each

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "fs-extra": "^9.0.1",
     "husky": "^4.3.0",
     "jest": "^26.5.3",
-    "jest-each": "^26.6.1",
     "jest-environment-puppeteer-jsdom": "^4.3.1",
     "jest-html-reporter": "^3.3.0",
     "jest-image-snapshot": "^4.2.0",


### PR DESCRIPTION
`jest-each` is include in Jest: https://jestjs.io/docs/en/api

To avoid conflict of versions, no need to specify it as dependency.