### PR TITLE
[POC] 3rd demo improvements poc - sketch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2255,15 +2255,6 @@
         "type-fest": "^0.8.1"
       }
     },
-    "ansi-gray": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
-      "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
-      "dev": true,
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
     "ansi-regex": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
@@ -2278,12 +2269,6 @@
       "requires": {
         "color-convert": "^1.9.0"
       }
-    },
-    "ansi-wrap": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
-      "dev": true
     },
     "anymatch": {
       "version": "2.0.0",
@@ -2415,12 +2400,6 @@
         }
       }
     },
-    "argh": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/argh/-/argh-0.1.4.tgz",
-      "integrity": "sha1-PrTWEpc/xrbcbvM49W91nyrFw6Y=",
-      "dev": true
-    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -2448,12 +2427,6 @@
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
-    "array-differ": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
-      "dev": true
-    },
     "array-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
@@ -2464,12 +2437,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true
-    },
-    "array-uniq": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
       "dev": true
     },
     "array-unique": {
@@ -2569,12 +2536,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
-      "dev": true
-    },
-    "async": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
     },
     "async-limiter": {
@@ -2845,12 +2806,6 @@
         "tweetnacl": "^0.14.3"
       }
     },
-    "beeper": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
-      "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
-      "dev": true
-    },
     "binary-extensions": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
@@ -3100,28 +3055,6 @@
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
       "dev": true
     },
-    "cli-color": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-1.1.0.tgz",
-      "integrity": "sha1-3hiM3Ekp2DtnrqBBEPvtQP2/Z3U=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "2",
-        "d": "^0.1.1",
-        "es5-ext": "^0.10.8",
-        "es6-iterator": "2",
-        "memoizee": "^0.3.9",
-        "timers-ext": "0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        }
-      }
-    },
     "cli-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -3207,12 +3140,6 @@
         }
       }
     },
-    "clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-      "dev": true
-    },
     "clone-deep": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
@@ -3252,12 +3179,6 @@
         }
       }
     },
-    "clone-stats": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-      "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
-      "dev": true
-    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -3280,24 +3201,6 @@
         "object-visit": "^1.0.0"
       }
     },
-    "color": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/color/-/color-0.8.0.tgz",
-      "integrity": "sha1-iQwHw/1OZJU3Y4kRz2keVFi2/KU=",
-      "dev": true,
-      "requires": {
-        "color-convert": "^0.5.0",
-        "color-string": "^0.3.0"
-      },
-      "dependencies": {
-        "color-convert": {
-          "version": "0.5.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
-          "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0=",
-          "dev": true
-        }
-      }
-    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -3313,42 +3216,11 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
-    "color-string": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
-      "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
-      "dev": true,
-      "requires": {
-        "color-name": "^1.0.0"
-      }
-    },
-    "color-support": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-      "dev": true
-    },
     "colorette": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.1.0.tgz",
       "integrity": "sha512-6S062WDQUXi6hOfkO/sBPVwE5ASXY4G2+b4atvhJfSsuUUhIaUKlkjLe9692Ipyt5/a+IPF5aVTu3V5gvXq5cg==",
       "dev": true
-    },
-    "colornames": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/colornames/-/colornames-0.0.2.tgz",
-      "integrity": "sha1-2BH9bIT1kClJmorEQ2ICk1uSvjE=",
-      "dev": true
-    },
-    "colorspace": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.0.1.tgz",
-      "integrity": "sha1-yZx5btMRKLmHalLh7l7gOkpxl0k=",
-      "dev": true,
-      "requires": {
-        "color": "0.8.x",
-        "text-hex": "0.0.x"
-      }
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -3535,15 +3407,6 @@
         "fs-exists-sync": "^0.1.0"
       }
     },
-    "d": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-      "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
-      "dev": true,
-      "requires": {
-        "es5-ext": "~0.10.2"
-      }
-    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -3563,12 +3426,6 @@
         "whatwg-mimetype": "^2.2.0",
         "whatwg-url": "^7.0.0"
       }
-    },
-    "dateformat": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
-      "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
-      "dev": true
     },
     "debug": {
       "version": "4.1.1",
@@ -3677,18 +3534,6 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
-    "desandro-get-style-property": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/desandro-get-style-property/-/desandro-get-style-property-1.0.4.tgz",
-      "integrity": "sha1-9YQsIeo0tjq89pvvNarJVuHFf3k=",
-      "dev": true
-    },
-    "desandro-matches-selector": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/desandro-matches-selector/-/desandro-matches-selector-1.0.3.tgz",
-      "integrity": "sha1-4bM3gcTcZU0GzU/FbO5EccKYTSM=",
-      "dev": true
-    },
     "detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -3700,17 +3545,6 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.781568.tgz",
       "integrity": "sha512-9Uqnzy6m6zEStluH9iyJ3iHyaQziFnMnLeC8vK0eN6smiJmIx7+yB64d67C2lH/LZra+5cGscJAJsNXO+MdPMg==",
       "dev": true
-    },
-    "diagnostics": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.0.1.tgz",
-      "integrity": "sha1-rM2wgMgrsl0N1zQwqeaof7tDFUE=",
-      "dev": true,
-      "requires": {
-        "colorspace": "1.0.x",
-        "enabled": "1.0.x",
-        "kuler": "0.0.x"
-      }
     },
     "diff-sequences": {
       "version": "25.2.6",
@@ -3727,15 +3561,6 @@
         "path-type": "^4.0.0"
       }
     },
-    "doc-ready": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/doc-ready/-/doc-ready-1.0.4.tgz",
-      "integrity": "sha1-N/U5GWnP+ZQwP9/vLl1QNX+BZNM=",
-      "dev": true,
-      "requires": {
-        "eventie": "^1"
-      }
-    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -3745,30 +3570,6 @@
         "esutils": "^2.0.2"
       }
     },
-    "dom-serializer": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
-      "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
-      "dev": true,
-      "requires": {
-        "domelementtype": "^2.0.1",
-        "entities": "^2.0.0"
-      },
-      "dependencies": {
-        "domelementtype": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
-          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==",
-          "dev": true
-        }
-      }
-    },
-    "domelementtype": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
-      "dev": true
-    },
     "domexception": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
@@ -3776,60 +3577,6 @@
       "dev": true,
       "requires": {
         "webidl-conversions": "^4.0.2"
-      }
-    },
-    "domhandler": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
-      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
-      "dev": true,
-      "requires": {
-        "domelementtype": "1"
-      }
-    },
-    "domutils": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
-      "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
-      "dev": true,
-      "requires": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
-      }
-    },
-    "duplexer2": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-      "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "~1.1.9"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
       }
     },
     "ecc-jsbn": {
@@ -3842,12 +3589,6 @@
         "safer-buffer": "^2.1.0"
       }
     },
-    "emits": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/emits/-/emits-3.0.0.tgz",
-      "integrity": "sha1-MnUrupXhcHshlWI4Srm7ix/WL3A=",
-      "dev": true
-    },
     "emittery": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.1.tgz",
@@ -3859,15 +3600,6 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
-    },
-    "enabled": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
-      "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
-      "dev": true,
-      "requires": {
-        "env-variable": "0.0.x"
-      }
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -3891,12 +3623,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
       "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw=="
-    },
-    "env-variable": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.6.tgz",
-      "integrity": "sha512-bHz59NlBbtS0NhftmR8+ExBEekE7br0e01jw+kk0NDro7TtZzBYZ5ScGPs3OmwnpyfHTHOtr1Y6uedCdrIldtg==",
-      "dev": true
     },
     "error-ex": {
       "version": "1.3.2",
@@ -3935,97 +3661,6 @@
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
-      }
-    },
-    "es5-ext": {
-      "version": "0.10.53",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-      "dev": true,
-      "requires": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.3",
-        "next-tick": "~1.0.0"
-      }
-    },
-    "es6-iterator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-      "dev": true,
-      "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
-      },
-      "dependencies": {
-        "d": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-          "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-          "dev": true,
-          "requires": {
-            "es5-ext": "^0.10.50",
-            "type": "^1.0.1"
-          }
-        }
-      }
-    },
-    "es6-symbol": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-      "dev": true,
-      "requires": {
-        "d": "^1.0.1",
-        "ext": "^1.1.2"
-      },
-      "dependencies": {
-        "d": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-          "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-          "dev": true,
-          "requires": {
-            "es5-ext": "^0.10.50",
-            "type": "^1.0.1"
-          }
-        }
-      }
-    },
-    "es6-weak-map": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
-      "integrity": "sha1-cGzvnpmqI2undmwjnIueKG6n0ig=",
-      "dev": true,
-      "requires": {
-        "d": "~0.1.1",
-        "es5-ext": "~0.10.6",
-        "es6-iterator": "~0.1.3",
-        "es6-symbol": "~2.0.1"
-      },
-      "dependencies": {
-        "es6-iterator": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
-          "integrity": "sha1-1vWLjE/EE8JJtLqhl2j45NfIlE4=",
-          "dev": true,
-          "requires": {
-            "d": "~0.1.1",
-            "es5-ext": "~0.10.5",
-            "es6-symbol": "~2.0.1"
-          }
-        },
-        "es6-symbol": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
-          "integrity": "sha1-dhtcZ8/U8dGK+yNPaR1nhoLLO/M=",
-          "dev": true,
-          "requires": {
-            "d": "~0.1.1",
-            "es5-ext": "~0.10.5"
-          }
-        }
       }
     },
     "escape-string-regexp": {
@@ -4367,34 +4002,6 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
-    "event-emitter": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-      "dev": true,
-      "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
-      },
-      "dependencies": {
-        "d": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-          "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-          "dev": true,
-          "requires": {
-            "es5-ext": "^0.10.50",
-            "type": "^1.0.1"
-          }
-        }
-      }
-    },
-    "eventie": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/eventie/-/eventie-1.0.6.tgz",
-      "integrity": "sha1-1P/IsMK15JPCqhsiy+kY067nRDc=",
-      "dev": true
-    },
     "exec-sh": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.4.tgz",
@@ -4626,23 +4233,6 @@
       "integrity": "sha512-6Ey4Xy2xvmuQu7z7YQtMsaMV0EHJRpVxIDOd5GRrm04/I3nkTKIutELfECsLp6le+b3SSa3cXhPiw6PgqzxYWA==",
       "dev": true
     },
-    "ext": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
-      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
-      "dev": true,
-      "requires": {
-        "type": "^2.0.0"
-      },
-      "dependencies": {
-        "type": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
-          "integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA==",
-          "dev": true
-        }
-      }
-    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -4784,18 +4374,6 @@
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
-    },
-    "fancy-log": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.3.tgz",
-      "integrity": "sha512-k9oEhlyc0FrVh25qYuSELjr8oxsCoc4/LEZfg2iJJrfEk/tZL9bCoJE47gqAvI2m/AUjluCS4+3I0eTx8n3AEw==",
-      "dev": true,
-      "requires": {
-        "ansi-gray": "^0.1.1",
-        "color-support": "^1.1.3",
-        "parse-node-version": "^1.0.0",
-        "time-stamp": "^1.0.0"
-      }
     },
     "fast-deep-equal": {
       "version": "3.1.1",
@@ -4988,16 +4566,6 @@
       "dev": true,
       "requires": {
         "semver-regex": "^2.0.0"
-      }
-    },
-    "fizzy-ui-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fizzy-ui-utils/-/fizzy-ui-utils-1.0.1.tgz",
-      "integrity": "sha1-qkEGZB51O8ilzqAQMVskiYyTRAw=",
-      "dev": true,
-      "requires": {
-        "desandro-matches-selector": "~1.0.2",
-        "doc-ready": "~1.0.3"
       }
     },
     "flat-cache": {
@@ -5693,15 +5261,6 @@
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
       "dev": true
     },
-    "get-size": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/get-size/-/get-size-1.2.2.tgz",
-      "integrity": "sha1-v8PvHQGeNFCMmU+jJ9GDwoddYuY=",
-      "dev": true,
-      "requires": {
-        "desandro-get-style-property": "^1"
-      }
-    },
     "get-stdin": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
@@ -5818,15 +5377,6 @@
         "slash": "^3.0.0"
       }
     },
-    "glogg": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.2.tgz",
-      "integrity": "sha512-5mwUoSuBk44Y4EshyiqcH95ZntbDdTQqA3QYSrxmzj28Ai0vXBGMH1ApSANH14j2sIRtqCEyg6PfsuP7ElOEDA==",
-      "dev": true,
-      "requires": {
-        "sparkles": "^1.0.0"
-      }
-    },
     "glur": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/glur/-/glur-1.1.2.tgz",
@@ -5845,104 +5395,6 @@
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true,
       "optional": true
-    },
-    "gulp-minify-html": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/gulp-minify-html/-/gulp-minify-html-1.0.6.tgz",
-      "integrity": "sha1-+Ufz8TlHW74bCP/+cUxHKfH/Bwo=",
-      "dev": true,
-      "requires": {
-        "gulp-util": "^3.0.3",
-        "minimize": "^1.5.0",
-        "through2": "^0.6.1"
-      }
-    },
-    "gulp-util": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
-      "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
-      "dev": true,
-      "requires": {
-        "array-differ": "^1.0.0",
-        "array-uniq": "^1.0.2",
-        "beeper": "^1.0.0",
-        "chalk": "^1.0.0",
-        "dateformat": "^2.0.0",
-        "fancy-log": "^1.1.0",
-        "gulplog": "^1.0.0",
-        "has-gulplog": "^0.1.0",
-        "lodash._reescape": "^3.0.0",
-        "lodash._reevaluate": "^3.0.0",
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.template": "^3.0.0",
-        "minimist": "^1.1.0",
-        "multipipe": "^0.1.2",
-        "object-assign": "^3.0.0",
-        "replace-ext": "0.0.1",
-        "through2": "^2.0.0",
-        "vinyl": "^0.5.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "dev": true,
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
-      }
-    },
-    "gulplog": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
-      "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
-      "dev": true,
-      "requires": {
-        "glogg": "^1.0.0"
-      }
     },
     "har-schema": {
       "version": "2.0.0",
@@ -5991,15 +5443,6 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
-    },
-    "has-gulplog": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
-      "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
-      "dev": true,
-      "requires": {
-        "sparkles": "^1.0.0"
-      }
     },
     "has-symbols": {
       "version": "1.0.1",
@@ -6096,28 +5539,6 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
-    },
-    "htmlparser2": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
-      "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
-      "dev": true,
-      "requires": {
-        "domelementtype": "^1.3.0",
-        "domhandler": "^2.3.0",
-        "domutils": "^1.5.1",
-        "entities": "^1.1.1",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.2"
-      },
-      "dependencies": {
-        "entities": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-          "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
-          "dev": true
-        }
-      }
     },
     "http-signature": {
       "version": "1.2.0",
@@ -6253,16 +5674,6 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
       "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
       "dev": true
-    },
-    "imagesloaded": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/imagesloaded/-/imagesloaded-3.2.0.tgz",
-      "integrity": "sha1-MffAhA3udxhM5v+ega5Rk29OU4Q=",
-      "dev": true,
-      "requires": {
-        "eventie": "~1.0.4",
-        "wolfy87-eventemitter": ">=4.2 <5.0"
-      }
     },
     "import-fresh": {
       "version": "3.2.1",
@@ -9709,12 +9120,6 @@
         }
       }
     },
-    "jquery": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.2.4.tgz",
-      "integrity": "sha1-LInWiJterFIqfuoywUUhVZxsvwI=",
-      "dev": true
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -9945,25 +9350,10 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
-    "kuler": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/kuler/-/kuler-0.0.0.tgz",
-      "integrity": "sha1-tmu0a5NOVQ9Z2BiEjgq7pPf1VTw=",
-      "dev": true,
-      "requires": {
-        "colornames": "0.0.2"
-      }
-    },
     "lazy-cache": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-      "dev": true
-    },
-    "lazysizes": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lazysizes/-/lazysizes-1.5.0.tgz",
-      "integrity": "sha1-Zk36hucIU3i6iTiKTOuGCkPyupk=",
       "dev": true
     },
     "left-pad": {
@@ -10228,102 +9618,10 @@
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
-    "lodash._basecopy": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
-      "dev": true
-    },
-    "lodash._basetostring": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-      "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
-      "dev": true
-    },
-    "lodash._basevalues": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-      "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
-      "dev": true
-    },
-    "lodash._getnative": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-      "dev": true
-    },
-    "lodash._isiterateecall": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
-      "dev": true
-    },
-    "lodash._reescape": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
-      "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
-      "dev": true
-    },
-    "lodash._reevaluate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
-      "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
-      "dev": true
-    },
-    "lodash._reinterpolate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
-      "dev": true
-    },
-    "lodash._root": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-      "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
-      "dev": true
-    },
-    "lodash.escape": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
-      "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
-      "dev": true,
-      "requires": {
-        "lodash._root": "^3.0.0"
-      }
-    },
-    "lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-      "dev": true
-    },
-    "lodash.isarray": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-      "dev": true
-    },
-    "lodash.keys": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true,
-      "requires": {
-        "lodash._getnative": "^3.0.0",
-        "lodash.isarguments": "^3.0.0",
-        "lodash.isarray": "^3.0.0"
-      }
-    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
-      "dev": true
-    },
-    "lodash.restparam": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
       "dev": true
     },
     "lodash.sortby": {
@@ -10331,33 +9629,6 @@
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
-    },
-    "lodash.template": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
-      "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
-      "dev": true,
-      "requires": {
-        "lodash._basecopy": "^3.0.0",
-        "lodash._basetostring": "^3.0.0",
-        "lodash._basevalues": "^3.0.0",
-        "lodash._isiterateecall": "^3.0.0",
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.escape": "^3.0.0",
-        "lodash.keys": "^3.0.0",
-        "lodash.restparam": "^3.0.0",
-        "lodash.templatesettings": "^3.0.0"
-      }
-    },
-    "lodash.templatesettings": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
-      "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
-      "dev": true,
-      "requires": {
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.escape": "^3.0.0"
-      }
     },
     "log-symbols": {
       "version": "4.0.0",
@@ -10485,15 +9756,6 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
-    "lru-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
-      "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
-      "dev": true,
-      "requires": {
-        "es5-ext": "~0.10.2"
-      }
-    },
     "magic-string": {
       "version": "0.25.6",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.6.tgz",
@@ -10502,12 +9764,6 @@
       "requires": {
         "sourcemap-codec": "^1.4.4"
       }
-    },
-    "magnific-popup": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/magnific-popup/-/magnific-popup-1.1.0.tgz",
-      "integrity": "sha1-PnNixb0Y9nhf6Z5Z0BPiCvM9MEk=",
-      "dev": true
     },
     "make-dir": {
       "version": "3.0.2",
@@ -10546,40 +9802,6 @@
       "dev": true,
       "requires": {
         "object-visit": "^1.0.0"
-      }
-    },
-    "masonry-layout": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/masonry-layout/-/masonry-layout-3.3.2.tgz",
-      "integrity": "sha1-uQwMClCaXtKoBrvIqBEokKdjQbo=",
-      "dev": true,
-      "requires": {
-        "fizzy-ui-utils": "^1.0.1",
-        "get-size": "~1.2.2",
-        "outlayer": "~1.4.0"
-      }
-    },
-    "memoizee": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.10.tgz",
-      "integrity": "sha1-TsoNiu057J0Bf0xcLy9kMvQuXI8=",
-      "dev": true,
-      "requires": {
-        "d": "~0.1.1",
-        "es5-ext": "~0.10.11",
-        "es6-weak-map": "~0.1.4",
-        "event-emitter": "~0.3.4",
-        "lru-queue": "0.1",
-        "next-tick": "~0.2.2",
-        "timers-ext": "0.1"
-      },
-      "dependencies": {
-        "next-tick": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
-          "integrity": "sha1-ddpKkn7liH45BliABltzNkE7MQ0=",
-          "dev": true
-        }
       }
     },
     "memorystream": {
@@ -10680,29 +9902,6 @@
       "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw==",
       "dev": true
     },
-    "minimize": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/minimize/-/minimize-1.8.1.tgz",
-      "integrity": "sha1-o2dK3pPyinX/ojuODzZc3CPWnYs=",
-      "dev": true,
-      "requires": {
-        "argh": "~0.1.4",
-        "async": "~1.5.2",
-        "cli-color": "~1.1.0",
-        "diagnostics": "~1.0.1",
-        "emits": "~3.0.0",
-        "htmlparser2": "~3.9.0",
-        "node-uuid": "~1.4.7"
-      },
-      "dependencies": {
-        "node-uuid": {
-          "version": "1.4.8",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
-          "dev": true
-        }
-      }
-    },
     "mixin-deep": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
@@ -10786,15 +9985,6 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
-    "multipipe": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-      "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
-      "dev": true,
-      "requires": {
-        "duplexer2": "0.0.2"
-      }
-    },
     "mxgraph": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/mxgraph/-/mxgraph-4.1.0.tgz",
@@ -10836,12 +10026,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-      "dev": true
-    },
-    "next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
     "nice-try": {
@@ -10973,12 +10157,6 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "dev": true
-    },
-    "object-assign": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-      "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
       "dev": true
     },
     "object-copy": {
@@ -11136,21 +10314,6 @@
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
-    "outlayer": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/outlayer/-/outlayer-1.4.2.tgz",
-      "integrity": "sha1-bT81+QeMLLdyqb7JOLXqL8dSv0M=",
-      "dev": true,
-      "requires": {
-        "desandro-get-style-property": "~1.0.4",
-        "desandro-matches-selector": "~1.0.2",
-        "doc-ready": "1.0.x",
-        "eventie": "~1.0.3",
-        "fizzy-ui-utils": "~1.0.1",
-        "get-size": "~1.2.2",
-        "wolfy87-eventemitter": ">=4.2 <5"
-      }
-    },
     "p-each-series": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.1.0.tgz",
@@ -11210,12 +10373,6 @@
         "json-parse-better-errors": "^1.0.1",
         "lines-and-columns": "^1.1.6"
       }
-    },
-    "parse-node-version": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz",
-      "integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==",
-      "dev": true
     },
     "parse-passwd": {
       "version": "1.0.0",
@@ -11435,12 +10592,6 @@
           "dev": true
         }
       }
-    },
-    "process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
     },
     "progress": {
       "version": "2.0.3",
@@ -11685,12 +10836,6 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
-    },
-    "replace-ext": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-      "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
       "dev": true
     },
     "request": {
@@ -12128,21 +11273,6 @@
       "dev": true,
       "requires": {
         "estree-walker": "^0.6.1"
-      }
-    },
-    "rough": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/rough/-/rough-3.0.1.tgz",
-      "integrity": "sha1-NJqAs8dNFlMzQHbvEwzoONR4SLc=",
-      "dev": true,
-      "requires": {
-        "gulp-minify-html": "^1.0.4",
-        "imagesloaded": "^3.1.8",
-        "jquery": "^2.1.4",
-        "lazysizes": "^1.3.1",
-        "magnific-popup": "^1.0.0",
-        "masonry-layout": "^3.3.2",
-        "susy": "^2.2.6"
       }
     },
     "roughjs": {
@@ -12730,12 +11860,6 @@
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
     },
-    "sparkles": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
-      "integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==",
-      "dev": true
-    },
     "spawnd": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/spawnd/-/spawnd-4.4.0.tgz",
@@ -13019,12 +12143,6 @@
         }
       }
     },
-    "susy": {
-      "version": "2.2.14",
-      "resolved": "https://registry.npmjs.org/susy/-/susy-2.2.14.tgz",
-      "integrity": "sha512-4I7Cb4Cjw2TF6ZEMxT8W9/Ap35Kn/r6y3LIO+NzaMRBxfbmT+w2KvbrANG/JCqJjlPgqvwLfLF9vmndSMGZuLg==",
-      "dev": true
-    },
     "symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -13167,12 +12285,6 @@
         "minimatch": "^3.0.4"
       }
     },
-    "text-hex": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-0.0.0.tgz",
-      "integrity": "sha1-V4+8haapJjbkLdF7QdAhjM6esrM=",
-      "dev": true
-    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -13190,58 +12302,6 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
-    },
-    "through2": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-      "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-      "dev": true,
-      "requires": {
-        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-        "xtend": ">=4.0.0 <4.1.0-0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
-      }
-    },
-    "time-stamp": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
-      "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
-      "dev": true
-    },
-    "timers-ext": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
-      "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
-      "dev": true,
-      "requires": {
-        "es5-ext": "~0.10.46",
-        "next-tick": "1"
-      }
     },
     "tmpl": {
       "version": "1.0.4",
@@ -13388,12 +12448,6 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true
-    },
-    "type": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
       "dev": true
     },
     "type-check": {
@@ -13603,17 +12657,6 @@
         "extsprintf": "^1.2.0"
       }
     },
-    "vinyl": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
-      "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
-      "dev": true,
-      "requires": {
-        "clone": "^1.0.0",
-        "clone-stats": "^0.0.1",
-        "replace-ext": "0.0.1"
-      }
-    },
     "w3c-hr-time": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
@@ -13749,12 +12792,6 @@
       "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
       "dev": true
     },
-    "wolfy87-eventemitter": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/wolfy87-eventemitter/-/wolfy87-eventemitter-4.3.0.tgz",
-      "integrity": "sha1-ZJc5bJXnQ1nwa241QJM5MY2Nlk8=",
-      "dev": true
-    },
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -13854,12 +12891,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true
-    },
-    "xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "dev": true
     },
     "y18n": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2255,6 +2255,15 @@
         "type-fest": "^0.8.1"
       }
     },
+    "ansi-gray": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+      "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
     "ansi-regex": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
@@ -2269,6 +2278,12 @@
       "requires": {
         "color-convert": "^1.9.0"
       }
+    },
+    "ansi-wrap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+      "dev": true
     },
     "anymatch": {
       "version": "2.0.0",
@@ -2400,6 +2415,12 @@
         }
       }
     },
+    "argh": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/argh/-/argh-0.1.4.tgz",
+      "integrity": "sha1-PrTWEpc/xrbcbvM49W91nyrFw6Y=",
+      "dev": true
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -2427,6 +2448,12 @@
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
+    "array-differ": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+      "dev": true
+    },
     "array-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
@@ -2437,6 +2464,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
       "dev": true
     },
     "array-unique": {
@@ -2536,6 +2569,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true
+    },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
     },
     "async-limiter": {
@@ -2806,6 +2845,12 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "beeper": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+      "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
+      "dev": true
+    },
     "binary-extensions": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
@@ -3055,6 +3100,28 @@
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
       "dev": true
     },
+    "cli-color": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-1.1.0.tgz",
+      "integrity": "sha1-3hiM3Ekp2DtnrqBBEPvtQP2/Z3U=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2",
+        "d": "^0.1.1",
+        "es5-ext": "^0.10.8",
+        "es6-iterator": "2",
+        "memoizee": "^0.3.9",
+        "timers-ext": "0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        }
+      }
+    },
     "cli-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -3140,6 +3207,12 @@
         }
       }
     },
+    "clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+      "dev": true
+    },
     "clone-deep": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
@@ -3179,6 +3252,12 @@
         }
       }
     },
+    "clone-stats": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+      "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+      "dev": true
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -3201,6 +3280,24 @@
         "object-visit": "^1.0.0"
       }
     },
+    "color": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/color/-/color-0.8.0.tgz",
+      "integrity": "sha1-iQwHw/1OZJU3Y4kRz2keVFi2/KU=",
+      "dev": true,
+      "requires": {
+        "color-convert": "^0.5.0",
+        "color-string": "^0.3.0"
+      },
+      "dependencies": {
+        "color-convert": {
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
+          "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0=",
+          "dev": true
+        }
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -3216,11 +3313,42 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "color-string": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
+      "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
+      "dev": true,
+      "requires": {
+        "color-name": "^1.0.0"
+      }
+    },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true
+    },
     "colorette": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.1.0.tgz",
       "integrity": "sha512-6S062WDQUXi6hOfkO/sBPVwE5ASXY4G2+b4atvhJfSsuUUhIaUKlkjLe9692Ipyt5/a+IPF5aVTu3V5gvXq5cg==",
       "dev": true
+    },
+    "colornames": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/colornames/-/colornames-0.0.2.tgz",
+      "integrity": "sha1-2BH9bIT1kClJmorEQ2ICk1uSvjE=",
+      "dev": true
+    },
+    "colorspace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.0.1.tgz",
+      "integrity": "sha1-yZx5btMRKLmHalLh7l7gOkpxl0k=",
+      "dev": true,
+      "requires": {
+        "color": "0.8.x",
+        "text-hex": "0.0.x"
+      }
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -3407,6 +3535,15 @@
         "fs-exists-sync": "^0.1.0"
       }
     },
+    "d": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+      "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
+      "dev": true,
+      "requires": {
+        "es5-ext": "~0.10.2"
+      }
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -3426,6 +3563,12 @@
         "whatwg-mimetype": "^2.2.0",
         "whatwg-url": "^7.0.0"
       }
+    },
+    "dateformat": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+      "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
+      "dev": true
     },
     "debug": {
       "version": "4.1.1",
@@ -3534,6 +3677,18 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
+    "desandro-get-style-property": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/desandro-get-style-property/-/desandro-get-style-property-1.0.4.tgz",
+      "integrity": "sha1-9YQsIeo0tjq89pvvNarJVuHFf3k=",
+      "dev": true
+    },
+    "desandro-matches-selector": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/desandro-matches-selector/-/desandro-matches-selector-1.0.3.tgz",
+      "integrity": "sha1-4bM3gcTcZU0GzU/FbO5EccKYTSM=",
+      "dev": true
+    },
     "detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -3545,6 +3700,17 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.781568.tgz",
       "integrity": "sha512-9Uqnzy6m6zEStluH9iyJ3iHyaQziFnMnLeC8vK0eN6smiJmIx7+yB64d67C2lH/LZra+5cGscJAJsNXO+MdPMg==",
       "dev": true
+    },
+    "diagnostics": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.0.1.tgz",
+      "integrity": "sha1-rM2wgMgrsl0N1zQwqeaof7tDFUE=",
+      "dev": true,
+      "requires": {
+        "colorspace": "1.0.x",
+        "enabled": "1.0.x",
+        "kuler": "0.0.x"
+      }
     },
     "diff-sequences": {
       "version": "25.2.6",
@@ -3561,6 +3727,15 @@
         "path-type": "^4.0.0"
       }
     },
+    "doc-ready": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/doc-ready/-/doc-ready-1.0.4.tgz",
+      "integrity": "sha1-N/U5GWnP+ZQwP9/vLl1QNX+BZNM=",
+      "dev": true,
+      "requires": {
+        "eventie": "^1"
+      }
+    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -3570,6 +3745,30 @@
         "esutils": "^2.0.2"
       }
     },
+    "dom-serializer": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+      "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "entities": "^2.0.0"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
+          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==",
+          "dev": true
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+      "dev": true
+    },
     "domexception": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
@@ -3577,6 +3776,60 @@
       "dev": true,
       "requires": {
         "webidl-conversions": "^4.0.2"
+      }
+    },
+    "domhandler": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1"
+      }
+    },
+    "domutils": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+      "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+      "dev": true,
+      "requires": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
+      }
+    },
+    "duplexer2": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+      "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "~1.1.9"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
       }
     },
     "ecc-jsbn": {
@@ -3589,6 +3842,12 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "emits": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/emits/-/emits-3.0.0.tgz",
+      "integrity": "sha1-MnUrupXhcHshlWI4Srm7ix/WL3A=",
+      "dev": true
+    },
     "emittery": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.1.tgz",
@@ -3600,6 +3859,15 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "enabled": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
+      "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
+      "dev": true,
+      "requires": {
+        "env-variable": "0.0.x"
+      }
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -3623,6 +3891,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
       "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw=="
+    },
+    "env-variable": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.6.tgz",
+      "integrity": "sha512-bHz59NlBbtS0NhftmR8+ExBEekE7br0e01jw+kk0NDro7TtZzBYZ5ScGPs3OmwnpyfHTHOtr1Y6uedCdrIldtg==",
+      "dev": true
     },
     "error-ex": {
       "version": "1.3.2",
@@ -3661,6 +3935,97 @@
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
+      }
+    },
+    "es5-ext": {
+      "version": "0.10.53",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+      "dev": true,
+      "requires": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.3",
+        "next-tick": "~1.0.0"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      },
+      "dependencies": {
+        "d": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+          "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+          "dev": true,
+          "requires": {
+            "es5-ext": "^0.10.50",
+            "type": "^1.0.1"
+          }
+        }
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "dev": true,
+      "requires": {
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
+      },
+      "dependencies": {
+        "d": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+          "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+          "dev": true,
+          "requires": {
+            "es5-ext": "^0.10.50",
+            "type": "^1.0.1"
+          }
+        }
+      }
+    },
+    "es6-weak-map": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
+      "integrity": "sha1-cGzvnpmqI2undmwjnIueKG6n0ig=",
+      "dev": true,
+      "requires": {
+        "d": "~0.1.1",
+        "es5-ext": "~0.10.6",
+        "es6-iterator": "~0.1.3",
+        "es6-symbol": "~2.0.1"
+      },
+      "dependencies": {
+        "es6-iterator": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+          "integrity": "sha1-1vWLjE/EE8JJtLqhl2j45NfIlE4=",
+          "dev": true,
+          "requires": {
+            "d": "~0.1.1",
+            "es5-ext": "~0.10.5",
+            "es6-symbol": "~2.0.1"
+          }
+        },
+        "es6-symbol": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
+          "integrity": "sha1-dhtcZ8/U8dGK+yNPaR1nhoLLO/M=",
+          "dev": true,
+          "requires": {
+            "d": "~0.1.1",
+            "es5-ext": "~0.10.5"
+          }
+        }
       }
     },
     "escape-string-regexp": {
@@ -4002,6 +4367,34 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      },
+      "dependencies": {
+        "d": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+          "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+          "dev": true,
+          "requires": {
+            "es5-ext": "^0.10.50",
+            "type": "^1.0.1"
+          }
+        }
+      }
+    },
+    "eventie": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/eventie/-/eventie-1.0.6.tgz",
+      "integrity": "sha1-1P/IsMK15JPCqhsiy+kY067nRDc=",
+      "dev": true
+    },
     "exec-sh": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.4.tgz",
@@ -4233,6 +4626,23 @@
       "integrity": "sha512-6Ey4Xy2xvmuQu7z7YQtMsaMV0EHJRpVxIDOd5GRrm04/I3nkTKIutELfECsLp6le+b3SSa3cXhPiw6PgqzxYWA==",
       "dev": true
     },
+    "ext": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+      "dev": true,
+      "requires": {
+        "type": "^2.0.0"
+      },
+      "dependencies": {
+        "type": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
+          "integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA==",
+          "dev": true
+        }
+      }
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -4374,6 +4784,18 @@
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
+    },
+    "fancy-log": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.3.tgz",
+      "integrity": "sha512-k9oEhlyc0FrVh25qYuSELjr8oxsCoc4/LEZfg2iJJrfEk/tZL9bCoJE47gqAvI2m/AUjluCS4+3I0eTx8n3AEw==",
+      "dev": true,
+      "requires": {
+        "ansi-gray": "^0.1.1",
+        "color-support": "^1.1.3",
+        "parse-node-version": "^1.0.0",
+        "time-stamp": "^1.0.0"
+      }
     },
     "fast-deep-equal": {
       "version": "3.1.1",
@@ -4566,6 +4988,16 @@
       "dev": true,
       "requires": {
         "semver-regex": "^2.0.0"
+      }
+    },
+    "fizzy-ui-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fizzy-ui-utils/-/fizzy-ui-utils-1.0.1.tgz",
+      "integrity": "sha1-qkEGZB51O8ilzqAQMVskiYyTRAw=",
+      "dev": true,
+      "requires": {
+        "desandro-matches-selector": "~1.0.2",
+        "doc-ready": "~1.0.3"
       }
     },
     "flat-cache": {
@@ -5261,6 +5693,15 @@
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
       "dev": true
     },
+    "get-size": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/get-size/-/get-size-1.2.2.tgz",
+      "integrity": "sha1-v8PvHQGeNFCMmU+jJ9GDwoddYuY=",
+      "dev": true,
+      "requires": {
+        "desandro-get-style-property": "^1"
+      }
+    },
     "get-stdin": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
@@ -5377,6 +5818,15 @@
         "slash": "^3.0.0"
       }
     },
+    "glogg": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.2.tgz",
+      "integrity": "sha512-5mwUoSuBk44Y4EshyiqcH95ZntbDdTQqA3QYSrxmzj28Ai0vXBGMH1ApSANH14j2sIRtqCEyg6PfsuP7ElOEDA==",
+      "dev": true,
+      "requires": {
+        "sparkles": "^1.0.0"
+      }
+    },
     "glur": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/glur/-/glur-1.1.2.tgz",
@@ -5395,6 +5845,104 @@
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true,
       "optional": true
+    },
+    "gulp-minify-html": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/gulp-minify-html/-/gulp-minify-html-1.0.6.tgz",
+      "integrity": "sha1-+Ufz8TlHW74bCP/+cUxHKfH/Bwo=",
+      "dev": true,
+      "requires": {
+        "gulp-util": "^3.0.3",
+        "minimize": "^1.5.0",
+        "through2": "^0.6.1"
+      }
+    },
+    "gulp-util": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+      "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
+      "dev": true,
+      "requires": {
+        "array-differ": "^1.0.0",
+        "array-uniq": "^1.0.2",
+        "beeper": "^1.0.0",
+        "chalk": "^1.0.0",
+        "dateformat": "^2.0.0",
+        "fancy-log": "^1.1.0",
+        "gulplog": "^1.0.0",
+        "has-gulplog": "^0.1.0",
+        "lodash._reescape": "^3.0.0",
+        "lodash._reevaluate": "^3.0.0",
+        "lodash._reinterpolate": "^3.0.0",
+        "lodash.template": "^3.0.0",
+        "minimist": "^1.1.0",
+        "multipipe": "^0.1.2",
+        "object-assign": "^3.0.0",
+        "replace-ext": "0.0.1",
+        "through2": "^2.0.0",
+        "vinyl": "^0.5.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        },
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
+          }
+        }
+      }
+    },
+    "gulplog": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+      "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+      "dev": true,
+      "requires": {
+        "glogg": "^1.0.0"
+      }
     },
     "har-schema": {
       "version": "2.0.0",
@@ -5443,6 +5991,15 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
+    },
+    "has-gulplog": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+      "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+      "dev": true,
+      "requires": {
+        "sparkles": "^1.0.0"
+      }
     },
     "has-symbols": {
       "version": "1.0.1",
@@ -5539,6 +6096,28 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "htmlparser2": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
+      "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "^1.3.0",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.2"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+          "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+          "dev": true
+        }
+      }
     },
     "http-signature": {
       "version": "1.2.0",
@@ -5674,6 +6253,16 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
       "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
       "dev": true
+    },
+    "imagesloaded": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/imagesloaded/-/imagesloaded-3.2.0.tgz",
+      "integrity": "sha1-MffAhA3udxhM5v+ega5Rk29OU4Q=",
+      "dev": true,
+      "requires": {
+        "eventie": "~1.0.4",
+        "wolfy87-eventemitter": ">=4.2 <5.0"
+      }
     },
     "import-fresh": {
       "version": "3.2.1",
@@ -9120,6 +9709,12 @@
         }
       }
     },
+    "jquery": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.2.4.tgz",
+      "integrity": "sha1-LInWiJterFIqfuoywUUhVZxsvwI=",
+      "dev": true
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -9350,10 +9945,25 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
+    "kuler": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-0.0.0.tgz",
+      "integrity": "sha1-tmu0a5NOVQ9Z2BiEjgq7pPf1VTw=",
+      "dev": true,
+      "requires": {
+        "colornames": "0.0.2"
+      }
+    },
     "lazy-cache": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+      "dev": true
+    },
+    "lazysizes": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lazysizes/-/lazysizes-1.5.0.tgz",
+      "integrity": "sha1-Zk36hucIU3i6iTiKTOuGCkPyupk=",
       "dev": true
     },
     "left-pad": {
@@ -9618,10 +10228,102 @@
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "dev": true
+    },
+    "lodash._basetostring": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+      "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+      "dev": true
+    },
+    "lodash._basevalues": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+      "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
+      "dev": true
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+      "dev": true
+    },
+    "lodash._reescape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+      "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
+      "dev": true
+    },
+    "lodash._reevaluate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+      "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
+      "dev": true
+    },
+    "lodash._reinterpolate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+      "dev": true
+    },
+    "lodash._root": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+      "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
+      "dev": true
+    },
+    "lodash.escape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+      "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
+      "dev": true,
+      "requires": {
+        "lodash._root": "^3.0.0"
+      }
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
+      }
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+      "dev": true
+    },
+    "lodash.restparam": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
       "dev": true
     },
     "lodash.sortby": {
@@ -9629,6 +10331,33 @@
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
+    },
+    "lodash.template": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+      "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "^3.0.0",
+        "lodash._basetostring": "^3.0.0",
+        "lodash._basevalues": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0",
+        "lodash._reinterpolate": "^3.0.0",
+        "lodash.escape": "^3.0.0",
+        "lodash.keys": "^3.0.0",
+        "lodash.restparam": "^3.0.0",
+        "lodash.templatesettings": "^3.0.0"
+      }
+    },
+    "lodash.templatesettings": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+      "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+      "dev": true,
+      "requires": {
+        "lodash._reinterpolate": "^3.0.0",
+        "lodash.escape": "^3.0.0"
+      }
     },
     "log-symbols": {
       "version": "4.0.0",
@@ -9756,6 +10485,15 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
+    "lru-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+      "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
+      "dev": true,
+      "requires": {
+        "es5-ext": "~0.10.2"
+      }
+    },
     "magic-string": {
       "version": "0.25.6",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.6.tgz",
@@ -9764,6 +10502,12 @@
       "requires": {
         "sourcemap-codec": "^1.4.4"
       }
+    },
+    "magnific-popup": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/magnific-popup/-/magnific-popup-1.1.0.tgz",
+      "integrity": "sha1-PnNixb0Y9nhf6Z5Z0BPiCvM9MEk=",
+      "dev": true
     },
     "make-dir": {
       "version": "3.0.2",
@@ -9802,6 +10546,40 @@
       "dev": true,
       "requires": {
         "object-visit": "^1.0.0"
+      }
+    },
+    "masonry-layout": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/masonry-layout/-/masonry-layout-3.3.2.tgz",
+      "integrity": "sha1-uQwMClCaXtKoBrvIqBEokKdjQbo=",
+      "dev": true,
+      "requires": {
+        "fizzy-ui-utils": "^1.0.1",
+        "get-size": "~1.2.2",
+        "outlayer": "~1.4.0"
+      }
+    },
+    "memoizee": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.10.tgz",
+      "integrity": "sha1-TsoNiu057J0Bf0xcLy9kMvQuXI8=",
+      "dev": true,
+      "requires": {
+        "d": "~0.1.1",
+        "es5-ext": "~0.10.11",
+        "es6-weak-map": "~0.1.4",
+        "event-emitter": "~0.3.4",
+        "lru-queue": "0.1",
+        "next-tick": "~0.2.2",
+        "timers-ext": "0.1"
+      },
+      "dependencies": {
+        "next-tick": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
+          "integrity": "sha1-ddpKkn7liH45BliABltzNkE7MQ0=",
+          "dev": true
+        }
       }
     },
     "memorystream": {
@@ -9902,6 +10680,29 @@
       "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw==",
       "dev": true
     },
+    "minimize": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/minimize/-/minimize-1.8.1.tgz",
+      "integrity": "sha1-o2dK3pPyinX/ojuODzZc3CPWnYs=",
+      "dev": true,
+      "requires": {
+        "argh": "~0.1.4",
+        "async": "~1.5.2",
+        "cli-color": "~1.1.0",
+        "diagnostics": "~1.0.1",
+        "emits": "~3.0.0",
+        "htmlparser2": "~3.9.0",
+        "node-uuid": "~1.4.7"
+      },
+      "dependencies": {
+        "node-uuid": {
+          "version": "1.4.8",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
+          "dev": true
+        }
+      }
+    },
     "mixin-deep": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
@@ -9985,6 +10786,15 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "multipipe": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+      "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+      "dev": true,
+      "requires": {
+        "duplexer2": "0.0.2"
+      }
+    },
     "mxgraph": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/mxgraph/-/mxgraph-4.1.0.tgz",
@@ -10026,6 +10836,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
     "nice-try": {
@@ -10157,6 +10973,12 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+      "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
       "dev": true
     },
     "object-copy": {
@@ -10314,6 +11136,21 @@
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
+    "outlayer": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/outlayer/-/outlayer-1.4.2.tgz",
+      "integrity": "sha1-bT81+QeMLLdyqb7JOLXqL8dSv0M=",
+      "dev": true,
+      "requires": {
+        "desandro-get-style-property": "~1.0.4",
+        "desandro-matches-selector": "~1.0.2",
+        "doc-ready": "1.0.x",
+        "eventie": "~1.0.3",
+        "fizzy-ui-utils": "~1.0.1",
+        "get-size": "~1.2.2",
+        "wolfy87-eventemitter": ">=4.2 <5"
+      }
+    },
     "p-each-series": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.1.0.tgz",
@@ -10374,6 +11211,12 @@
         "lines-and-columns": "^1.1.6"
       }
     },
+    "parse-node-version": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz",
+      "integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==",
+      "dev": true
+    },
     "parse-passwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
@@ -10391,6 +11234,11 @@
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
+    },
+    "path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w=="
     },
     "path-exists": {
       "version": "4.0.0",
@@ -10508,6 +11356,20 @@
       "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
       "dev": true
     },
+    "points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="
+    },
+    "points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "requires": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
+      }
+    },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -10573,6 +11435,12 @@
           "dev": true
         }
       }
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
     },
     "progress": {
       "version": "2.0.3",
@@ -10817,6 +11685,12 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "replace-ext": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+      "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
       "dev": true
     },
     "request": {
@@ -11254,6 +12128,31 @@
       "dev": true,
       "requires": {
         "estree-walker": "^0.6.1"
+      }
+    },
+    "rough": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rough/-/rough-3.0.1.tgz",
+      "integrity": "sha1-NJqAs8dNFlMzQHbvEwzoONR4SLc=",
+      "dev": true,
+      "requires": {
+        "gulp-minify-html": "^1.0.4",
+        "imagesloaded": "^3.1.8",
+        "jquery": "^2.1.4",
+        "lazysizes": "^1.3.1",
+        "magnific-popup": "^1.0.0",
+        "masonry-layout": "^3.3.2",
+        "susy": "^2.2.6"
+      }
+    },
+    "roughjs": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.3.1.tgz",
+      "integrity": "sha512-m42+OBaBR7x5UhIKyjBCnWqqkaEkBKLkXvHv4pOWJXPofvMnQY4ZcFEQlqf3coKKyZN2lfWMyx7QXSg2GD7SGA==",
+      "requires": {
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
       }
     },
     "rsvp": {
@@ -11831,6 +12730,12 @@
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
     },
+    "sparkles": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
+      "integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==",
+      "dev": true
+    },
     "spawnd": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/spawnd/-/spawnd-4.4.0.tgz",
@@ -12114,6 +13019,12 @@
         }
       }
     },
+    "susy": {
+      "version": "2.2.14",
+      "resolved": "https://registry.npmjs.org/susy/-/susy-2.2.14.tgz",
+      "integrity": "sha512-4I7Cb4Cjw2TF6ZEMxT8W9/Ap35Kn/r6y3LIO+NzaMRBxfbmT+w2KvbrANG/JCqJjlPgqvwLfLF9vmndSMGZuLg==",
+      "dev": true
+    },
     "symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -12256,6 +13167,12 @@
         "minimatch": "^3.0.4"
       }
     },
+    "text-hex": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-0.0.0.tgz",
+      "integrity": "sha1-V4+8haapJjbkLdF7QdAhjM6esrM=",
+      "dev": true
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -12273,6 +13190,58 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
+    },
+    "through2": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+      "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+      "dev": true,
+      "requires": {
+        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
+    "time-stamp": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+      "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
+      "dev": true
+    },
+    "timers-ext": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
+      "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
+      "dev": true,
+      "requires": {
+        "es5-ext": "~0.10.46",
+        "next-tick": "1"
+      }
     },
     "tmpl": {
       "version": "1.0.4",
@@ -12419,6 +13388,12 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
+    },
+    "type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
       "dev": true
     },
     "type-check": {
@@ -12628,6 +13603,17 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "vinyl": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+      "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+      "dev": true,
+      "requires": {
+        "clone": "^1.0.0",
+        "clone-stats": "^0.0.1",
+        "replace-ext": "0.0.1"
+      }
+    },
     "w3c-hr-time": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
@@ -12763,6 +13749,12 @@
       "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
       "dev": true
     },
+    "wolfy87-eventemitter": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/wolfy87-eventemitter/-/wolfy87-eventemitter-4.3.0.tgz",
+      "integrity": "sha1-ZJc5bJXnQ1nwa241QJM5MY2Nlk8=",
+      "dev": true
+    },
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -12862,6 +13854,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "dev": true
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -34,11 +34,6 @@
       "git add"
     ]
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "tsc --noEmit && lint-staged"
-    }
-  },
   "devDependencies": {
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "rollup-plugin-serve": "^1.0.3",
     "rollup-plugin-terser": "^7.0.1",
     "rollup-plugin-typescript2": "^0.26.0",
-    "rough": "^3.0.1",
     "ts-jest": "^26.2.0",
     "ts-mxgraph": "git+https://github.com/process-analytics/ts-mxgraph.git#v1.0.1",
     "typescript": "^3.9.7"

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "rollup-plugin-serve": "^1.0.3",
     "rollup-plugin-terser": "^7.0.1",
     "rollup-plugin-typescript2": "^0.26.0",
+    "rough": "^3.0.1",
     "ts-jest": "^26.2.0",
     "ts-mxgraph": "git+https://github.com/process-analytics/ts-mxgraph.git#v1.0.1",
     "typescript": "^3.9.7"
@@ -79,6 +80,7 @@
   "dependencies": {
     "entities": "^2.0.0",
     "fast-xml-parser": "^3.17.4",
-    "mxgraph": "4.1.0"
+    "mxgraph": "4.1.0",
+    "roughjs": "^4.3.1"
   }
 }

--- a/src/component/BpmnVisualization.ts
+++ b/src/component/BpmnVisualization.ts
@@ -17,21 +17,30 @@ import MxGraphConfigurator from './mxgraph/MxGraphConfigurator';
 import { mxgraph } from 'ts-mxgraph';
 import { defaultMxGraphRenderer } from './mxgraph/MxGraphRenderer';
 import { defaultBpmnParser } from './parser/BpmnParser';
+import BpmnVisualizationOptions, { LoadOptions, PanType, ZoomType } from './BpmnVisualizationOptions';
+import SvgExporter from './mxgraph/extension/SvgExporter';
+import Logger from './Logger';
 
 // TODO unable to load mxClient from mxgraph-type-definitions@1.0.2
 declare const mxClient: typeof mxgraph.mxClient;
 
 export default class BpmnVisualization {
   public readonly graph: mxGraph;
+  private mainConfigLogger = new Logger('bpmn.main#config');
 
-  constructor(protected container: HTMLElement) {
+  constructor(protected container: HTMLElement, options?: BpmnVisualizationOptions) {
     try {
       if (!mxClient.isBrowserSupported()) {
         mxUtils.error('Browser is not supported!', 200, false);
       }
       // Instantiate and configure Graph
       const configurator = new MxGraphConfigurator(this.container);
-      this.graph = configurator.configure();
+
+      // TODO make activation/deactivation configurable
+      this.configureMouseEvent(true);
+
+      this.graph = configurator.configure(options);
+      this.configureKeyHandler();
     } catch (e) {
       // TODO error handling
       mxUtils.alert('Cannot start application: ' + e.message);
@@ -39,15 +48,298 @@ export default class BpmnVisualization {
     }
   }
 
-  public load(xml: string): void {
+  // Changes the zoom / panning on mouseWheel events
+  // TODO this should be done in another class
+  /* eslint-disable no-console */
+  private configureMouseEvent(activated: boolean): void {
+    if (!activated) {
+      return;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const self = this; // TODO replace with array function to access to this directly
+    mxEvent.addMouseWheelListener(function (event: Event, up: boolean) {
+      if (!(event instanceof MouseEvent)) {
+        console.info('[MouseWheelListener] event is not a MouseEvent', event);
+        return;
+      }
+
+      // TODO review type: this hack is due to the introduction of mxgraph-type-definitions
+      const evt = (event as unknown) as MouseEvent;
+      const mxMouseEvent = (evt as unknown) as mxMouseEvent;
+      if (!mxEvent.isConsumed(mxMouseEvent)) {
+        // console.info('[MouseWheelListener] evt: up: %s / altkey: %s / ctrlKey: %s / shiftKey: %s', up, evt.altKey, evt.ctrlKey, evt.shiftKey);
+        // console.info('[MouseWheelListener] evt: x: %s / y: %s', evt.clientX, evt.clientY);
+        // console.info('MouseWheelListener mxMouseEvent: graphX: %s / graphY: %s', mxMouseEvent.graphX, mxMouseEvent.graphY);
+
+        let isEventRelatedToGraphContainer = false;
+        let source = mxEvent.getSource(evt);
+        console.info('[MouseWheelListener] Checking source');
+        while (source != null) {
+          // console.info('[MouseWheelListener] source', source);
+          if (source == self.graph.container) {
+            // console.info('[MouseWheelListener] is graph container!!');
+            isEventRelatedToGraphContainer = true;
+            break;
+          }
+          source = source.parentNode;
+        }
+        console.info('[MouseWheelListener] event related to the graph container?', isEventRelatedToGraphContainer);
+        if (!isEventRelatedToGraphContainer) {
+          return;
+        }
+
+        // only the ctrl key or the meta key on mac
+        const isZoomWheelEvent = (evt.ctrlKey || (mxClient.IS_MAC && evt.metaKey)) && !evt.altKey && !evt.shiftKey;
+
+        if (isZoomWheelEvent) {
+          console.info('[MouseWheelListener] zooming');
+          // TODO pass the point coordinate to use as center
+          const cursorPosition = new mxPoint(mxEvent.getClientX(evt), mxEvent.getClientY(evt));
+          // TODO we could have an option to ignoreCursorPosition
+          console.info('[MouseWheelListener] cursor position', cursorPosition);
+          self.zoom(up ? ZoomType.In : ZoomType.Out);
+          mxEvent.consume(evt);
+
+          // console.info('[MouseWheelListener] after zoom - scrolling to cursorPosition');
+          // // https://github.com/jgraph/drawio/blob/051eed36389f5bebe487663097f340e59940d87a/src/main/webapp/js/mxgraph/EditorUi.js#L2216
+          // // const sp = new mxPoint(self.graph.container.scrollLeft, self.graph.container.scrollTop);
+          // const offset = mxUtils.getOffset(self.graph.container);
+          // console.info('[MouseWheelListener] after zoom - offset', offset);
+          // // const prev = self.graph.view.scale;
+          // let dx = 0;
+          // let dy = 0;
+          //
+          // dx = self.graph.container.offsetWidth / 2 - cursorPosition.x + offset.x;
+          // dy = self.graph.container.offsetHeight / 2 - cursorPosition.y + offset.y;
+          // console.info('[MouseWheelListener] after zoom - dx', dx);
+          // console.info('[MouseWheelListener] after zoom - dy', dy);
+          //
+          // self.graph.container.scrollLeft -= dx;
+          // self.graph.container.scrollTop -= dy;
+          // console.info('[MouseWheelListener] after zoom - scrolling done');
+        }
+        // shift only
+        const isPanningHorizontalWheelEvent = evt.shiftKey && !evt.altKey && !evt.ctrlKey && !evt.metaKey;
+        // no key
+        const isPanningVerticalWheelEvent = !evt.altKey && !evt.shiftKey && !evt.ctrlKey && !evt.metaKey;
+
+        if (isPanningHorizontalWheelEvent || isPanningVerticalWheelEvent) {
+          let panType: PanType;
+          if (isPanningHorizontalWheelEvent) {
+            panType = up ? PanType.HorizontalLeft : PanType.HorizontalRight;
+          } else {
+            panType = up ? PanType.VerticalUp : PanType.VerticalDown;
+          }
+          self.pan(panType);
+          mxEvent.consume(evt);
+        }
+      }
+    }, null);
+  }
+
+  /* eslint-enable no-console */
+
+  private keyHandlerLogger = new Logger('KeyHandler');
+
+  private configureKeyHandler(): void {
+    this.mainConfigLogger.info('Configuring key handler');
+    const keyHandler = new mxKeyHandler(this.graph);
+
+    // TODO for panning with arrow, configure shift + key for smaller or larger panning
+    const panningKeys = new Map<number, PanType>([
+      [37, PanType.HorizontalLeft], // left arrow
+      [38, PanType.VerticalUp], // up arrow
+      [39, PanType.HorizontalRight], // right arrow
+      [40, PanType.VerticalDown], // down arrow
+    ]);
+    panningKeys.forEach((panType: PanType, code: number) => {
+      keyHandler.bindKey(code, (event: KeyboardEvent): void => {
+        this.keyHandlerLogger.info('key pressed: ' + event.code);
+        this.pan(panType);
+        this.keyHandlerLogger.info('End of key management: ' + event.code);
+      });
+    });
+    this.mainConfigLogger.info('Key handler configured');
+  }
+
+  private loadLogger: Logger = new Logger('bpmn.main#load');
+
+  public load(xml: string, options?: LoadOptions): void {
+    this.loadLogger.info('Start loading BPMN');
+    const initialStartTime = performance.now();
     try {
       // TODO the BpmnParser should be a field and injected (see #110)
+      let startTime = performance.now();
       const bpmnModel = defaultBpmnParser().parse(xml);
-      defaultMxGraphRenderer(this.graph).render(bpmnModel);
+      let endTime = performance.now();
+      this.loadLogger.info(`Parsing done in ${endTime - startTime} ms`);
+      startTime = endTime;
+      defaultMxGraphRenderer(this.graph).configure(options?.rendererOptions).render(bpmnModel);
+      endTime = performance.now();
+      this.loadLogger.info(`Rendering done in ${endTime - startTime} ms`);
+      this.loadLogger.info(`BPMN loaded in ${endTime - initialStartTime} ms`);
     } catch (e) {
       // TODO error handling
       mxUtils.alert('Cannot load bpmn diagram: ' + e.message);
       throw e;
     }
+  }
+
+  private zoomLogger: Logger = new Logger('bpmn.main#zoom');
+
+  private fit(zoomType: ZoomType): void {
+    let ignoreWidth = false;
+    let ignoreHeight = false;
+    switch (zoomType) {
+      case ZoomType.FitHorizontal:
+        ignoreHeight = true;
+        break;
+      case ZoomType.FitVertical:
+        ignoreWidth = true;
+        break;
+    }
+
+    this.graph.fit(0, false, 0, true, ignoreWidth, ignoreHeight);
+  }
+
+  // TODO zoom factor should be configurable (in global BpmnVisualizationOptions)
+  // TODO see lazyZoom of draw.io
+  public zoom(zoomType: ZoomType): void {
+    const startTime = performance.now();
+    this.zoomLogger.info(`Start Zooming, type: ${ZoomType[zoomType]}`);
+
+    // TODO add an option to center without zooming
+    //this.graph.center(true, true);
+    switch (zoomType) {
+      case ZoomType.Actual:
+        this.graph.zoomActual();
+        break;
+      case ZoomType.Fit:
+      case ZoomType.FitHorizontal:
+      case ZoomType.FitVertical:
+        this.fit(zoomType);
+        break;
+      case ZoomType.In:
+        this.graph.zoomIn();
+        break;
+      case ZoomType.Out:
+        this.graph.zoomOut();
+        break;
+      default:
+        throw new Error('Unsupported zoom option ' + zoomType);
+    }
+    this.zoomLogger.info(`Zoom completed in ${performance.now() - startTime} ms`);
+  }
+  private panLogger: Logger = new Logger('bpmn.main#pan');
+
+  public pan(panType: PanType): void {
+    const startTime = performance.now();
+    this.panLogger.info(`Panning in direction ${PanType[panType]}`);
+    const view = this.graph.getView();
+    const panValue = 40 / view.scale;
+
+    // inspired from https://github.com/jgraph/drawio/blob/c6a423432912165e9d9e67a21dad22c8a27e8e8e/src/main/webapp/js/mxgraph/EditorUi.js#L2391
+    const translatePoint = view.getTranslate();
+
+    switch (panType) {
+      case PanType.VerticalUp:
+        view.setTranslate(translatePoint.x, translatePoint.y + panValue);
+        break;
+      case PanType.VerticalDown:
+        view.setTranslate(translatePoint.x, translatePoint.y - panValue);
+        break;
+      case PanType.HorizontalLeft:
+        view.setTranslate(translatePoint.x + panValue, translatePoint.y);
+        break;
+      case PanType.HorizontalRight:
+        view.setTranslate(translatePoint.x - panValue, translatePoint.y);
+        break;
+      default:
+        throw new Error('Unsupported pan option ' + panType);
+    }
+    this.panLogger.info(`Panning done in ${performance.now() - startTime} ms`);
+  }
+
+  public preview(): void {
+    const preview = new mxPrintPreview(this.graph, 1, undefined, undefined);
+    preview.open(undefined, undefined, undefined, undefined);
+  }
+
+  /* eslint-disable no-console */
+  public exportAsSvg(): string {
+    console.info('Starting svg export');
+    const svg = new SvgExporter(this.graph).exportSvg();
+    console.info('Svg export completed');
+    console.info(svg);
+    return svg;
+  }
+  /* eslint-enable no-console */
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  ///////////////////////////////////////// OVERVIEW ///////////////////////////////////////////////////////////////////
+  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  // adapted from https://github.com/jgraph/mxgraph2/blob/a15684d7c8b71074e4c73d89c9192459288e0bf4/javascript/src/js/editor/mxEditor.js#L2779-L2823
+
+  private overviewLogger = new Logger('bpmn.overview');
+  private overview: mxOutline;
+  private isOverviewShown = false;
+
+  // TODO find a better way to pass the overview container (only needed for overview init)
+  public toggleOverview(container: HTMLElement): void {
+    this.overviewLogger.info('Toggle overview in progress');
+    this.ensureOverviewInstanceInitialized(container);
+
+    this.overview.suspended = !this.overview.suspended;
+    if (!this.overview.suspended) {
+      this.overview.update(true);
+    }
+
+    this.overviewLogger.info('Toggle completed');
+  }
+
+  private ensureOverviewInstanceInitialized(container: HTMLElement): void {
+    if (this.overview == null) {
+      this.overviewLogger.info('Initializing overview');
+
+      // TODO restore mxGraph outline settings defaults after creating the instance
+      mxConstants.OUTLINE_COLOR = 'Orange';
+      mxConstants.OUTLINE_STROKEWIDTH = 2;
+
+      // TODO this seems requesting expanded.gif images from mxgraph assets
+      // eslint-disable-next-line @typescript-eslint/no-use-before-define
+      const outline = new CustomMxOutline(this.graph, container);
+      // outline.showViewport = false;
+      // TODO review carefully as this can impact performance
+      outline.setZoomEnabled(false); // TODO this function only hidde the square (aka handle), but zooming is still available
+      //outline.graphRenderHint = 'fastest'; // have no effect on svg browser
+      outline.updateOnPan = false; // when true, probably too much impact on rendering performance and not really usefull
+      outline.labelsVisible = false; // TODO see how we can make it work (may not work when isHtmlLabel is true in the main graph) BUT do we need it?
+
+      // mark it suspended on creation, to make toggling work
+      outline.suspended = true;
+
+      this.overview = outline;
+      this.overviewLogger.info('Overview initialization completed');
+    }
+  }
+}
+
+// TODO attempt to have labels, they not show even when htmlLabels is false in the source graph
+class CustomMxOutline extends mxOutline {
+  constructor(source: mxGraph, container: HTMLElement) {
+    super(source, container);
+  }
+
+  createGraph(container: HTMLElement): mxGraph {
+    const graph = super.createGraph(container);
+
+    const htmlLabels = this.source.htmlLabels;
+    console.warn('CustomOutline - source graph htmllabels?', htmlLabels);
+    console.warn('CustomOutline - outline graph htmllabels?', graph.htmlLabels);
+    graph.htmlLabels = htmlLabels;
+
+    return graph;
   }
 }

--- a/src/component/BpmnVisualizationOptions.ts
+++ b/src/component/BpmnVisualizationOptions.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export default interface BpmnVisualizationOptions {
+  activatePanning?: boolean;
+  activateOutline?: boolean;
+  activateKeysHandler?: boolean;
+}
+
+export enum ZoomType {
+  In,
+  Out,
+  Actual,
+  Fit,
+  FitHorizontal,
+  FitVertical,
+}
+
+export enum PanType {
+  VerticalUp,
+  VerticalDown,
+  HorizontalLeft,
+  HorizontalRight,
+}
+
+export interface RendererOptions {
+  /** If set to `true`, ignore the label styles (font size, family, ...) defined in the BPMN source */
+  ignoreLabelStyles?: boolean;
+}
+
+export interface LoadOptions {
+  rendererOptions?: RendererOptions;
+}

--- a/src/component/BpmnVisualizationOptions.ts
+++ b/src/component/BpmnVisualizationOptions.ts
@@ -36,8 +36,14 @@ export enum PanType {
 }
 
 export interface RendererOptions {
-  /** If set to `true`, ignore the label styles (font size, family, ...) defined in the BPMN source */
+  label?: LabelStyleOptions;
+}
+
+export interface LabelStyleOptions {
+  /** If set to `true`, ignore all label styles (font size, family, ...) defined in the BPMN source */
   ignoreLabelStyles?: boolean;
+  /** If set to `true`, ignore the label font family defined in the BPMN source */
+  ignoreLabelFontFamily?: boolean;
 }
 
 export interface LoadOptions {

--- a/src/component/Logger.ts
+++ b/src/component/Logger.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export default class Logger {
+  constructor(readonly topic: string) {}
+  info(msg: string): void {
+    // eslint-disable-next-line no-console
+    console.info(`[${this.topic}]`, msg);
+  }
+}

--- a/src/component/mxgraph/MxGraphConfigurator.ts
+++ b/src/component/mxgraph/MxGraphConfigurator.ts
@@ -17,6 +17,7 @@ import StyleConfigurator from './config/StyleConfigurator';
 import ShapeConfigurator from './config/ShapeConfigurator';
 import MarkerConfigurator from './config/MarkerConfigurator';
 import MxClientConfigurator from './config/MxClientConfigurator';
+import BpmnVisualizationOptions from '../BpmnVisualizationOptions';
 
 /**
  * Configure the mxGraph graph that can be used by the lib
@@ -32,8 +33,8 @@ export default class MxGraphConfigurator {
     this.graph = new mxGraph(container);
   }
 
-  public configure(): mxGraph {
-    this.configureGraph();
+  public configure(options?: BpmnVisualizationOptions): mxGraph {
+    this.configureGraph(options);
     new StyleConfigurator(this.graph).configureStyles();
     new ShapeConfigurator().configureShapes();
     new MarkerConfigurator().configureMarkers();
@@ -41,10 +42,13 @@ export default class MxGraphConfigurator {
     return this.graph;
   }
 
-  private configureGraph(): void {
-    this.graph.setCellsLocked(true);
-    this.graph.setCellsSelectable(false);
+  private configureGraph(options?: BpmnVisualizationOptions): void {
     this.graph.setEdgeLabelsMovable(false);
+    this.graph.setVertexLabelsMovable(false);
+    this.graph.setCellsLocked(false); // true value prevents panning to work
+    // the following is needed when cells are not locked for panning
+    this.graph.setCellsSelectable(false);
+    this.graph.setCellsMovable(false);
 
     this.graph.setHtmlLabels(true); // required for wrapping
 
@@ -55,5 +59,58 @@ export default class MxGraphConfigurator {
     // Disable folding for container mxCell (pool, lane, sub process, call activity) because we don't need it.
     // This also prevents requesting unavailable images (see #185) as we don't override mxGraph folding default images.
     this.graph.foldingEnabled = false;
+
+    this.applyDefaultGraphConfiguration();
+
+    // TODO dynamic option to move elsewhere
+    if (options?.activatePanning) {
+      // eslint-disable-next-line no-console
+      console.info('activate panning');
+      this.graph.setPanning(true);
+    }
+  }
+
+  private applyDefaultGraphConfiguration(): void {
+    this.applyDefaultGraphConfigurationForPanning();
+    this.applyDefaultConfigurationForZoom();
+  }
+
+  private applyDefaultGraphConfigurationForPanning(): void {
+    this.graph.panningHandler.useLeftButtonForPanning = true;
+    this.graph.panningHandler.ignoreCell = true; // Specifies if panning should be active even if there is a cell under the mouse pointer
+    // TODO experiment this settings because currently panning increases makes scrollbars to appears when going right and/or bottom
+    // Specifies if the size of the graph should be automatically extended if the mouse goes near the container edge while dragging.
+    // This is only taken into account if the container has scrollbars.  Default is true.  See autoScroll.
+    //this.graph.autoExtend = false;
+
+    // Specifies if scrollbars should be used for panning in panGraph if any scrollbars are available.  If scrollbars are
+    // enabled in CSS, but no scrollbars appear because the graph is smaller than the container size, then no panning occurs if this is true.
+    // Default is true.
+    // this.graph.useScrollbarsForPanning = false;
+
+    // this.graph.scrollAutoExtend = false;
+    // this.graph.translateToScrollPosition = false;
+
+    // Specifies if the graph should automatically scroll if the mouse goes near the container edge while dragging.  This is only taken into account if the container has scrollbars.  Default is true.
+    //
+    // If you need this to work without scrollbars then set ignoreScrollbars to true.  Please consult the ignoreScrollbars for details.  In general, with no scrollbars, the use of allowAutoPanning is recommended.
+    // this.graph.autoscroll = true;
+
+    // ignoreScrollbars
+    // Specifies if the graph should automatically scroll regardless of the scrollbars.  This will scroll the container using positive values for scroll positions (ie usually only rightwards and downwards).  To avoid possible conflicts with panning, set translateToScrollPosition to true.
+    // this.graph.ignoreScrollbars = true;
+
+    // allowAutoPanning
+    // Specifies if panning via panGraph should be allowed to implement autoscroll if no scrollbars are available in scrollPointToVisible.  To enable panning inside the container, near the edge, set mxPanningManager.border to a positive value.  Default is false.
+  }
+
+  private applyDefaultConfigurationForZoom(): void {
+    // zoomFactor
+    // Specifies the factor used for zoomIn and zoomOut.  Default is 1.2 (120%).
+    // keepSelectionVisibleOnZoom
+    // Specifies if the viewport should automatically contain the selection cells after a zoom operation.  Default is false.
+    // centerZoom
+    // Specifies if the zoom operations should go into the center of the actual diagram rather than going from top, left.  Default is true.
+    // this.graph.centerZoom = true;
   }
 }

--- a/src/component/mxgraph/MxGraphRenderer.ts
+++ b/src/component/mxgraph/MxGraphRenderer.ts
@@ -72,8 +72,7 @@ export default class MxGraphRenderer {
   }
 
   private computeStyle(bpmnCell: Shape | Edge, labelBounds: Bounds): string {
-    const ignoreLabelFont = this.config?.ignoreLabelStyles;
-    return this.styleConfigurator.computeStyle(bpmnCell, labelBounds, ignoreLabelFont);
+    return this.styleConfigurator.computeStyle(bpmnCell, labelBounds, this.config?.label);
   }
 
   private insertShape(shape: Shape): void {

--- a/src/component/mxgraph/config/ShapeConfigurator.ts
+++ b/src/component/mxgraph/config/ShapeConfigurator.ts
@@ -15,12 +15,13 @@
  */
 import { mxgraph } from 'ts-mxgraph';
 import { ShapeBpmnElementKind } from '../../../model/bpmn/shape/ShapeBpmnElementKind';
-import { EndEventShape, StartEventShape, ThrowIntermediateEventShape, CatchIntermediateEventShape, BoundaryEventShape } from '../shape/event-shapes';
-import { ExclusiveGatewayShape, ParallelGatewayShape, InclusiveGatewayShape } from '../shape/gateway-shapes';
-import { SubProcessShape, ReceiveTaskShape, ServiceTaskShape, TaskShape, UserTaskShape, CallActivityShape, SendTaskShape } from '../shape/activity-shapes';
+import { BoundaryEventShape, CatchIntermediateEventShape, EndEventShape, StartEventShape, ThrowIntermediateEventShape } from '../shape/event-shapes';
+import { ExclusiveGatewayShape, InclusiveGatewayShape, ParallelGatewayShape } from '../shape/gateway-shapes';
+import { CallActivityShape, ReceiveTaskShape, SendTaskShape, ServiceTaskShape, SubProcessShape, TaskShape, UserTaskShape } from '../shape/activity-shapes';
 import { TextAnnotationShape } from '../shape/text-annotation-shapes';
 import { MessageFlowIconShape } from '../shape/flow-shapes';
 import { StyleIdentifier } from '../StyleUtils';
+import { SketchySvgCanvas } from '../extension/SketchySvgCanvas';
 
 // TODO unable to load mxClient from mxgraph-type-definitions@1.0.2
 declare const mxClient: typeof mxgraph.mxClient;
@@ -61,7 +62,7 @@ export default class ShapeConfigurator {
   private initMxShapePrototype(isFF: boolean): void {
     // this change is needed for adding the custom attributes that permits identification of the BPMN elements
     mxShape.prototype.createSvgCanvas = function () {
-      const canvas = new mxSvgCanvas2D(this.node, false);
+      const canvas = ShapeConfigurator.newSvgCanvas(this.node, this);
       canvas.strokeTolerance = this.pointerEvents ? this.svgStrokeTolerance : 0;
       canvas.pointerEventsValue = this.svgPointerEvents;
       // TODO existed in mxgraph-type-definitions@1.0.2, no more in mxgraph-type-definitions@1.0.3
@@ -91,6 +92,147 @@ export default class ShapeConfigurator {
       }
 
       return canvas;
+    };
+
+    // TODO understand why we would need this (comes from draw.io)
+    ShapeConfigurator.overrideMxShapePaint(false);
+    ShapeConfigurator.overrideMxRectangleShapePaintBackground(false);
+    ShapeConfigurator.overrideMxRectangleShapePaintForeground(false);
+  }
+
+  private static isCustomizationRequiredForSketchStyle(shape: mxShape): boolean {
+    if (shape.outline) return false;
+    return mxUtils.getValue(shape.style, 'sketch', 'false') == 'true';
+  }
+
+  // private static newSvgCanvas(node: HTMLElement, style: { [key: string]: unknown }): mxSvgCanvas2D {
+  private static newSvgCanvas(node: HTMLElement, shape: mxShape): mxSvgCanvas2D {
+    if (ShapeConfigurator.isCustomizationRequiredForSketchStyle(shape)) {
+      // console.error('Create SketchySvgCanvas');
+      return new SketchySvgCanvas(node, shape);
+    }
+    return new mxSvgCanvas2D(node, false);
+  }
+
+  private static overrideMxShapePaint(activate: boolean): void {
+    if (!activate) return;
+
+    // TODO see if we need this (already adapted to TS and our code)
+    // TODO only when sketch is on!!!!
+    // Overrides for event handling on transparent background for sketch style
+    const shapePaint = mxShape.prototype.paint;
+    mxShape.prototype.paint = function (c): void {
+      let fillStyle = null;
+      let events = true;
+
+      if (this.style != null) {
+        events = mxUtils.getValue(this.style, mxConstants.STYLE_POINTER_EVENTS, '1') == '1';
+        fillStyle = mxUtils.getValue(this.style, 'fillStyle', 'auto');
+
+        if (this.state != null && fillStyle == 'auto') {
+          //var bg = this.state.view.graph.defaultPageBackgroundColor;
+
+          // if (this.fill != null && (this.gradient != null || (bg != null && this.fill.toLowerCase() == bg.toLowerCase()))) {
+          if (this.style.fill != null && this.gradient != null) {
+            fillStyle = 'solid';
+          }
+        }
+      }
+
+      if (events && c instanceof SketchySvgCanvas && !this.outline && (this.fill == null || this.fill == mxConstants.NONE || fillStyle != 'solid')) {
+        console.error('$$$$$ use specific shape.paint override!');
+        // if (events && c.handJiggle != null && c.handJiggle.constructor == RoughCanvas &&
+        //   !this.outline && (this.fill == null || this.fill == mxConstants.NONE ||
+        //     fillStyle != 'solid'))
+        // Save needed for possible transforms applied during paint
+        c.save();
+        const fill = this.fill;
+        const stroke = this.stroke;
+        this.fill = null;
+        this.stroke = null;
+        c.passThrough = true;
+
+        shapePaint.apply(this, [c]);
+
+        c.passThrough = false;
+        this.fill = fill;
+        this.stroke = stroke;
+        c.restore();
+      }
+
+      shapePaint.apply(this, [c]);
+    };
+  }
+
+  private static overrideMxRectangleShapePaintBackground(activate: boolean): void {
+    if (!activate) return;
+
+    // from Draw.io
+    // Overrides to avoid call to rect
+    const mxRectangleShapePaintBackground0 = mxRectangleShape.prototype.paintBackground;
+    mxRectangleShape.prototype.paintBackground = function (c, x, y, w, h): void {
+      if (!(c instanceof SketchySvgCanvas)) {
+        mxRectangleShapePaintBackground0.apply(this, [c, x, y, w, h]);
+      } else {
+        let events = true;
+
+        if (this.style != null) {
+          events = mxUtils.getValue(this.style, mxConstants.STYLE_POINTER_EVENTS, '1') == '1';
+        }
+
+        if (events || (this.fill != null && this.fill != mxConstants.NONE) || (this.stroke != null && this.stroke != mxConstants.NONE)) {
+          if (!events && (this.fill == null || this.fill == mxConstants.NONE)) {
+            c.pointerEvents = false;
+          }
+
+          c.begin();
+
+          if (this.isRounded) {
+            let r = 0;
+
+            if (mxUtils.getValue(this.style, mxConstants.STYLE_ABSOLUTE_ARCSIZE, 0) == '1') {
+              r = Math.min(w / 2, Math.min(h / 2, mxUtils.getValue(this.style, mxConstants.STYLE_ARCSIZE, mxConstants.LINE_ARCSIZE) / 2));
+            } else {
+              const f = mxUtils.getValue(this.style, mxConstants.STYLE_ARCSIZE, mxConstants.RECTANGLE_ROUNDING_FACTOR * 100) / 100;
+              r = Math.min(w * f, h * f);
+            }
+
+            c.moveTo(x + r, y);
+            c.lineTo(x + w - r, y);
+            c.quadTo(x + w, y, x + w, y + r);
+            c.lineTo(x + w, y + h - r);
+            c.quadTo(x + w, y + h, x + w - r, y + h);
+            c.lineTo(x + r, y + h);
+            c.quadTo(x, y + h, x, y + h - r);
+            c.lineTo(x, y + r);
+            c.quadTo(x, y, x + r, y);
+          } else {
+            c.moveTo(x, y);
+            c.lineTo(x + w, y);
+            c.lineTo(x + w, y + h);
+            c.lineTo(x, y + h);
+            c.lineTo(x, y);
+          }
+
+          // LATER: Check if close is needed here
+          c.close();
+          c.end();
+
+          c.fillAndStroke();
+        }
+      }
+    };
+  }
+
+  private static overrideMxRectangleShapePaintForeground(activate: boolean): void {
+    if (!activate) return;
+
+    // from draw.io: Disables glass effect with hand jiggle.
+    const mxRectangleShapePaintForeground0 = mxRectangleShape.prototype.paintForeground;
+    mxRectangleShape.prototype.paintForeground = function (c, x, y, w, h): void {
+      if (!(c instanceof SketchySvgCanvas)) {
+        mxRectangleShapePaintForeground0.apply(this, [c, x, y, w, h]);
+      }
     };
   }
 }

--- a/src/component/mxgraph/config/StyleConfigurator.ts
+++ b/src/component/mxgraph/config/StyleConfigurator.ts
@@ -33,6 +33,7 @@ import { FlowKind } from '../../../model/bpmn/edge/FlowKind';
 import { AssociationFlow, SequenceFlow } from '../../../model/bpmn/edge/Flow';
 import { AssociationDirectionKind } from '../../../model/bpmn/edge/AssociationDirectionKind';
 import { ShapeBpmnMarkerKind } from '../../../model/bpmn/shape/ShapeBpmnMarkerKind';
+import { LabelStyleOptions } from '../../BpmnVisualizationOptions';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export default class StyleConfigurator {
@@ -287,7 +288,7 @@ export default class StyleConfigurator {
     this.configureAssociationFlowStyles();
   }
 
-  computeStyle(bpmnCell: Shape | Edge, labelBounds: Bounds, ignoreLabelFont = false): string {
+  computeStyle(bpmnCell: Shape | Edge, labelBounds: Bounds, labelStyleOptions: LabelStyleOptions): string {
     const styleValues = new Map<string, string | number>();
     const styles: string[] = [bpmnCell.bpmnElement?.kind as string];
 
@@ -324,10 +325,12 @@ export default class StyleConfigurator {
       }
     }
 
-    if (!ignoreLabelFont) {
+    if (!(labelStyleOptions.ignoreLabelStyles === true)) {
       const font = bpmnCell.label?.font;
       if (font) {
-        styleValues.set(mxConstants.STYLE_FONTFAMILY, font.name);
+        if (!(labelStyleOptions.ignoreLabelFontFamily === true)) {
+          styleValues.set(mxConstants.STYLE_FONTFAMILY, font.name);
+        }
         styleValues.set(mxConstants.STYLE_FONTSIZE, font.size);
         styleValues.set(mxConstants.STYLE_FONTSTYLE, StyleConfigurator.getFontStyleValue(font));
       }

--- a/src/component/mxgraph/config/StyleConfigurator.ts
+++ b/src/component/mxgraph/config/StyleConfigurator.ts
@@ -179,6 +179,10 @@ export default class StyleConfigurator {
     style[mxConstants.STYLE_ALIGN] = mxConstants.ALIGN_CENTER;
 
     style[mxConstants.STYLE_SWIMLANE_LINE] = 0; // hide the line between the title region and the content area
+    // TODO check lane fill color (none or fill, relevant for image export)
+    // const fillColor = 'none'; // StyleConstant.DEFAULT_FILL_COLOR
+    style[mxConstants.STYLE_FILLCOLOR] = 'swimlane';
+    // style[this.mxConstants.STYLE_SWIMLANE_FILLCOLOR] = StyleConstant.DEFAULT_FILL_COLOR;
 
     // TODO manage lane text area rendering. there is no Label neither the size available (we have only attribute name="Text of the Label")
     // perhaps it can be calculated as a difference of starting point (either x or y) between pool, lane, sub-lane ?
@@ -283,7 +287,7 @@ export default class StyleConfigurator {
     this.configureAssociationFlowStyles();
   }
 
-  computeStyle(bpmnCell: Shape | Edge, labelBounds: Bounds): string {
+  computeStyle(bpmnCell: Shape | Edge, labelBounds: Bounds, ignoreLabelFont = false): string {
     const styleValues = new Map<string, string | number>();
     const styles: string[] = [bpmnCell.bpmnElement?.kind as string];
 
@@ -320,11 +324,13 @@ export default class StyleConfigurator {
       }
     }
 
-    const font = bpmnCell.label?.font;
-    if (font) {
-      styleValues.set(mxConstants.STYLE_FONTFAMILY, font.name);
-      styleValues.set(mxConstants.STYLE_FONTSIZE, font.size);
-      styleValues.set(mxConstants.STYLE_FONTSTYLE, StyleConfigurator.getFontStyleValue(font));
+    if (!ignoreLabelFont) {
+      const font = bpmnCell.label?.font;
+      if (font) {
+        styleValues.set(mxConstants.STYLE_FONTFAMILY, font.name);
+        styleValues.set(mxConstants.STYLE_FONTSIZE, font.size);
+        styleValues.set(mxConstants.STYLE_FONTSTYLE, StyleConfigurator.getFontStyleValue(font));
+      }
     }
 
     if (labelBounds) {

--- a/src/component/mxgraph/extension/RoughJsAdaptor.ts
+++ b/src/component/mxgraph/extension/RoughJsAdaptor.ts
@@ -1,0 +1,451 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Config, Drawable, OpSet, Options, ResolvedOptions } from 'roughjs/bin/core';
+import { SketchySvgCanvas } from './SketchySvgCanvas';
+import { RoughGenerator } from 'roughjs/bin/generator';
+
+// choose to use RoughCanvas to inherit from the general drawing method
+// + get access to Drawable object
+export class RoughJsAdaptor {
+  private gen: RoughGenerator;
+
+  // constructor(readonly c: mxSvgCanvas2D, config?: Config) {
+  constructor(readonly c: SketchySvgCanvas, readonly config?: Config) {
+    this.gen = new RoughGenerator(config);
+  }
+
+  // implementation taken from the draw.io adaptation
+  draw(drawable: Drawable): void {
+    const sets = drawable.sets || [];
+    const o = drawable.options || this.getDefaultOptions();
+
+    for (let i = 0; i < sets.length; i++) {
+      const drawing = sets[i];
+
+      switch (drawing.type) {
+        case 'path':
+          if (o.stroke != null) {
+            this._drawToContext(drawing, o);
+          }
+          break;
+        case 'fillPath':
+          this._drawToContext(drawing, o);
+          break;
+        case 'fillSketch':
+          this._fillSketch(drawing, o);
+          break;
+      }
+    }
+  }
+
+  // draw.io
+  private _fillSketch(drawing: OpSet, o: ResolvedOptions): void {
+    const strokeColor = this.c.state.strokeColor;
+    const strokeWidth = this.c.state.strokeWidth;
+    const strokeAlpha = this.c.state.strokeAlpha;
+    const dashed = this.c.state.dashed;
+    const fixDash = this.c.state.fixDash;
+
+    let fweight = o.fillWeight;
+    if (fweight < 0) {
+      fweight = o.strokeWidth / 2;
+    }
+
+    this.c.setStrokeAlpha(this.c.state.fillAlpha);
+    this.c.setStrokeColor(o.fill || '');
+    this.c.setStrokeWidth(fweight);
+    this.c.setDashed(false, fixDash);
+
+    this._drawToContext(drawing, o);
+    // this._drawToContext(ctx, drawing, o);
+
+    this.c.setDashed(dashed, fixDash);
+    this.c.setStrokeWidth(strokeWidth);
+    this.c.setStrokeColor(strokeColor);
+    this.c.setStrokeAlpha(strokeAlpha);
+  }
+
+  //RoughCanvas
+  // private fillSketch(ctx: CanvasRenderingContext2D, drawing: OpSet, o: ResolvedOptions) {
+  //   let fweight = o.fillWeight;
+  //   if (fweight < 0) {
+  //     fweight = o.strokeWidth / 2;
+  //   }
+  //   ctx.save();
+  //   if (o.fillLineDash) {
+  //     ctx.setLineDash(o.fillLineDash);
+  //   }
+  //   if (o.fillLineDashOffset) {
+  //     ctx.lineDashOffset = o.fillLineDashOffset;
+  //   }
+  //   ctx.strokeStyle = o.fill || '';
+  //   ctx.lineWidth = fweight;
+  //   this._drawToContext(ctx, drawing);
+  //   ctx.restore();
+  // }
+
+  private _drawToContext(drawing: OpSet, o: ResolvedOptions): void {
+    this.c.begin();
+
+    for (let i = 0; i < drawing.ops.length; i++) {
+      const item = drawing.ops[i];
+      const data = item.data;
+
+      switch (item.op) {
+        case 'move':
+          this.c.moveTo(data[0], data[1]);
+          break;
+        case 'bcurveTo':
+          this.c.curveTo(data[0], data[1], data[2], data[3], data[4], data[5]);
+          break;
+        case 'lineTo':
+          this.c.lineTo(data[0], data[1]);
+          break;
+      }
+    }
+
+    this.c.end();
+
+    if (drawing.type === 'fillPath' && o.fill) {
+      this.c.fill();
+    } else {
+      this.c.stroke();
+    }
+  }
+
+  // copied from RoughCanvas 4.X.X
+
+  get generator(): RoughGenerator {
+    return this.gen;
+  }
+
+  getDefaultOptions(): ResolvedOptions {
+    return this.gen.defaultOptions;
+  }
+
+  // line(x1: number, y1: number, x2: number, y2: number, options?: Options): Drawable {
+  //   const d = this.gen.line(x1, y1, x2, y2, options);
+  //   this.draw(d);
+  //   return d;
+  // }
+  //
+  // rectangle(x: number, y: number, width: number, height: number, options?: Options): Drawable {
+  //   const d = this.gen.rectangle(x, y, width, height, options);
+  //   this.draw(d);
+  //   return d;
+  // }
+  //
+  // ellipse(x: number, y: number, width: number, height: number, options?: Options): Drawable {
+  //   const d = this.gen.ellipse(x, y, width, height, options);
+  //   this.draw(d);
+  //   return d;
+  // }
+  //
+  // circle(x: number, y: number, diameter: number, options?: Options): Drawable {
+  //   const d = this.gen.circle(x, y, diameter, options);
+  //   this.draw(d);
+  //   return d;
+  // }
+  //
+  // linearPath(points: Point[], options?: Options): Drawable {
+  //   const d = this.gen.linearPath(points, options);
+  //   this.draw(d);
+  //   return d;
+  // }
+  //
+  // polygon(points: Point[], options?: Options): Drawable {
+  //   const d = this.gen.polygon(points, options);
+  //   this.draw(d);
+  //   return d;
+  // }
+  //
+  // arc(x: number, y: number, width: number, height: number, start: number, stop: number, closed: boolean = false, options?: Options): Drawable {
+  //   const d = this.gen.arc(x, y, width, height, start, stop, closed, options);
+  //   this.draw(d);
+  //   return d;
+  // }
+  //
+  // curve(points: Point[], options?: Options): Drawable {
+  //   const d = this.gen.curve(points, options);
+  //   this.draw(d);
+  //   return d;
+  // }
+  //
+  path(d: string, options?: Options): Drawable {
+    const drawing = this.gen.path(d, options);
+    this.draw(drawing);
+    return drawing;
+  }
+}
+
+/*
+
+Editor.createRoughCanvas = function(c)
+{
+  var rc = rough.canvas(
+    {
+      // Provides expected function but return value is not used
+      getContext: function()
+      {
+        return c;
+      }
+    });
+
+  rc.draw = function(drawable)
+  {
+    var sets = drawable.sets || [];
+    var o = drawable.options || this.getDefaultOptions();
+
+    for (var i = 0; i < sets.length; i++)
+    {
+      var drawing = sets[i];
+
+      switch (drawing.type)
+      {
+        case 'path':
+          if (o.stroke != null)
+          {
+            this._drawToContext(c, drawing, o);
+          }
+          break;
+        case 'fillPath':
+          this._drawToContext(c, drawing, o);
+          break;
+        case 'fillSketch':
+          this.fillSketch(c, drawing, o);
+          break;
+      }
+    }
+  };
+*/
+
+/*
+  rc.fillSketch = function(ctx, drawing, o)
+  {
+    var strokeColor = this.c.state.strokeColor;
+    var strokeWidth = this.c.state.strokeWidth;
+    var strokeAlpha = this.c.state.strokeAlpha;
+    var dashed = this.c.state.dashed;
+
+    var fweight = o.fillWeight;
+    if (fweight < 0)
+    {
+      fweight = o.strokeWidth / 2;
+    }
+
+    this.c.setStrokeAlpha(c.state.fillAlpha);
+    this.c.setStrokeColor(o.fill || '');
+    this.c.setStrokeWidth(fweight);
+    this.c.setDashed(false);
+
+    this._drawToContext(ctx, drawing, o);
+
+    this.c.setDashed(dashed);
+    this.c.setStrokeWidth(strokeWidth);
+    this.c.setStrokeColor(strokeColor);
+    this.c.setStrokeAlpha(strokeAlpha);
+  };
+
+  rc._drawToContext = function(ctx, drawing, o)
+  {
+    ctx.begin();
+
+    for (var i = 0; i < drawing.ops.length; i++)
+    {
+      var item = drawing.ops[i];
+      var data = item.data;
+
+      switch (item.op)
+      {
+        case 'move':
+          ctx.moveTo(data[0], data[1]);
+          break;
+        case 'bcurveTo':
+          ctx.curveTo(data[0], data[1], data[2], data[3], data[4], data[5]);
+          break;
+        case 'lineTo':
+          ctx.lineTo(data[0], data[1]);
+          break;
+      }
+    };
+
+    ctx.end();
+
+    if (drawing.type === 'fillPath' && o.filled)
+    {
+      ctx.fill();
+    }
+    else
+    {
+      ctx.stroke();
+    }
+  };
+
+  return rc;
+};
+*/
+
+/*
+  private gen: RoughGenerator;
+  private canvas: HTMLCanvasElement;
+  private ctx: CanvasRenderingContext2D;
+
+  constructor(canvas: HTMLCanvasElement, config?: Config) {
+    this.canvas = canvas;
+    this.ctx = this.canvas.getContext('2d')!;
+    this.gen = new RoughGenerator(config);
+  }
+
+  draw(drawable: Drawable) {
+    const sets = drawable.sets || [];
+    const o = drawable.options || this.getDefaultOptions();
+    const ctx = this.ctx;
+    for (const drawing of sets) {
+      switch (drawing.type) {
+        case 'path':
+          ctx.save();
+          ctx.strokeStyle = o.stroke === 'none' ? 'transparent' : o.stroke;
+          ctx.lineWidth = o.strokeWidth;
+          if (o.strokeLineDash) {
+            ctx.setLineDash(o.strokeLineDash);
+          }
+          if (o.strokeLineDashOffset) {
+            ctx.lineDashOffset = o.strokeLineDashOffset;
+          }
+          this._drawToContext(ctx, drawing);
+          ctx.restore();
+          break;
+        case 'fillPath':
+          ctx.save();
+          ctx.fillStyle = o.fill || '';
+          const fillRule: CanvasFillRule = (drawable.shape === 'curve' || drawable.shape === 'polygon') ? 'evenodd' : 'nonzero';
+          this._drawToContext(ctx, drawing, fillRule);
+          ctx.restore();
+          break;
+        case 'fillSketch':
+          this.fillSketch(ctx, drawing, o);
+          break;
+      }
+    }
+  }
+
+  private fillSketch(ctx: CanvasRenderingContext2D, drawing: OpSet, o: ResolvedOptions) {
+    let fweight = o.fillWeight;
+    if (fweight < 0) {
+      fweight = o.strokeWidth / 2;
+    }
+    ctx.save();
+    if (o.fillLineDash) {
+      ctx.setLineDash(o.fillLineDash);
+    }
+    if (o.fillLineDashOffset) {
+      ctx.lineDashOffset = o.fillLineDashOffset;
+    }
+    ctx.strokeStyle = o.fill || '';
+    ctx.lineWidth = fweight;
+    this._drawToContext(ctx, drawing);
+    ctx.restore();
+  }
+
+  private _drawToContext(ctx: CanvasRenderingContext2D, drawing: OpSet, rule: CanvasFillRule = 'nonzero') {
+    ctx.beginPath();
+    for (const item of drawing.ops) {
+      const data = item.data;
+      switch (item.op) {
+        case 'move':
+          ctx.moveTo(data[0], data[1]);
+          break;
+        case 'bcurveTo':
+          ctx.bezierCurveTo(data[0], data[1], data[2], data[3], data[4], data[5]);
+          break;
+        case 'lineTo':
+          ctx.lineTo(data[0], data[1]);
+          break;
+      }
+    }
+    if (drawing.type === 'fillPath') {
+      ctx.fill(rule);
+    } else {
+      ctx.stroke();
+    }
+  }
+
+  get generator(): RoughGenerator {
+    return this.gen;
+  }
+
+  getDefaultOptions(): ResolvedOptions {
+    return this.gen.defaultOptions;
+  }
+
+  line(x1: number, y1: number, x2: number, y2: number, options?: Options): Drawable {
+    const d = this.gen.line(x1, y1, x2, y2, options);
+    this.draw(d);
+    return d;
+  }
+
+  rectangle(x: number, y: number, width: number, height: number, options?: Options): Drawable {
+    const d = this.gen.rectangle(x, y, width, height, options);
+    this.draw(d);
+    return d;
+  }
+
+  ellipse(x: number, y: number, width: number, height: number, options?: Options): Drawable {
+    const d = this.gen.ellipse(x, y, width, height, options);
+    this.draw(d);
+    return d;
+  }
+
+  circle(x: number, y: number, diameter: number, options?: Options): Drawable {
+    const d = this.gen.circle(x, y, diameter, options);
+    this.draw(d);
+    return d;
+  }
+
+  linearPath(points: Point[], options?: Options): Drawable {
+    const d = this.gen.linearPath(points, options);
+    this.draw(d);
+    return d;
+  }
+
+  polygon(points: Point[], options?: Options): Drawable {
+    const d = this.gen.polygon(points, options);
+    this.draw(d);
+    return d;
+  }
+
+  arc(x: number, y: number, width: number, height: number, start: number, stop: number, closed: boolean = false, options?: Options): Drawable {
+    const d = this.gen.arc(x, y, width, height, start, stop, closed, options);
+    this.draw(d);
+    return d;
+  }
+
+  curve(points: Point[], options?: Options): Drawable {
+    const d = this.gen.curve(points, options);
+    this.draw(d);
+    return d;
+  }
+
+  path(d: string, options?: Options): Drawable {
+    const drawing = this.gen.path(d, options);
+    this.draw(drawing);
+    return drawing;
+  }
+
+
+
+ */

--- a/src/component/mxgraph/extension/SketchySvgCanvas.ts
+++ b/src/component/mxgraph/extension/SketchySvgCanvas.ts
@@ -1,0 +1,338 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Drawable, Options } from 'roughjs/bin/core';
+import { RoughJsAdaptor } from './RoughJsAdaptor';
+
+export class SketchySvgCanvas extends mxSvgCanvas2D {
+  passThrough = false;
+  private nextShape: Drawable;
+  private readonly roughJS: RoughJsAdaptor;
+
+  constructor(node: HTMLElement, readonly shape: mxShape) {
+    super(node);
+    this.roughJS = new RoughJsAdaptor(this);
+
+
+    // TODO is this needed? from draw.io
+    // Avoids "spikes" in the output
+    // this.canvas.setLineJoin('round');
+    // this.canvas.setLineCap('round');
+  }
+
+  // TODO rename toRoughJsStyle
+  // TODO rename arguments?
+  private getStyle(stroke: boolean, fill: boolean): Options {
+    // TODO seed to ensure that there is no randomness for a given cell: same rendering after translation, scale or accross reload
+    //  if we want to introduce this feature, let's defined a style entry to make this configurable 'roughjsSeedActivated'
+    // See https://roughjs.com/posts/release-4.0/
+
+    // implementation from draw.io based on the cell ID
+    // // Random seed created from cell ID
+    // var seed = 1;
+    //
+    // if (this.shape.state != null)
+    // {
+    //   var str = this.shape.state.cell.id;
+    //
+    //   if (str != null)
+    //   {
+    //     for (var i = 0; i < str.length; i++)
+    //     {
+    //       seed = ((seed << 5) - seed + str.charCodeAt(i)) << 0;
+    //     }
+    //   }
+    // }
+
+    const style: Options = { strokeWidth: this.state.strokeWidth };
+    // TODO rename into roughDefaultOptions
+    const defs = this.roughJS.getDefaultOptions();
+
+    if (stroke) {
+      style.stroke = this.state.strokeColor === 'none' ? 'transparent' : this.state.strokeColor;
+    } else {
+      delete style.stroke;
+    }
+
+    let gradient = null;
+    if (fill) {
+      style.fill = this.state.fillColor === 'none' ? '' : this.state.fillColor;
+      gradient = this.state.gradientColor === 'none' ? null : this.state.gradientColor;
+    }
+
+    // Applies cell style
+    style['bowing'] = mxUtils.getValue(this.shape.style, 'bowing', defs['bowing']);
+    style['hachureAngle'] = mxUtils.getValue(this.shape.style, 'hachureAngle', defs['hachureAngle']);
+    style['curveFitting'] = mxUtils.getValue(this.shape.style, 'curveFitting', defs['curveFitting']);
+    style['roughness'] = mxUtils.getValue(this.shape.style, 'roughness', defs['roughness']);
+    style['simplification'] = mxUtils.getValue(this.shape.style, 'simplification', defs['simplification']);
+    style['disableMultiStroke'] = mxUtils.getValue(this.shape.style, 'disableMultiStroke', defs['disableMultiStroke']);
+    style['disableMultiStrokeFill'] = mxUtils.getValue(this.shape.style, 'disableMultiStrokeFill', defs['disableMultiStrokeFill']);
+
+    const hachureGap = mxUtils.getValue(this.shape.style, 'hachureGap', -1);
+    style['hachureGap'] = hachureGap == 'auto' ? -1 : hachureGap;
+    style['dashGap'] = mxUtils.getValue(this.shape.style, 'dashGap', hachureGap);
+    style['dashOffset'] = mxUtils.getValue(this.shape.style, 'dashOffset', hachureGap);
+    style['zigzagOffset'] = mxUtils.getValue(this.shape.style, 'zigzagOffset', hachureGap);
+
+    const fillWeight = mxUtils.getValue(this.shape.style, 'fillWeight', -1);
+    style['fillWeight'] = fillWeight == 'auto' ? -1 : fillWeight;
+
+    let fillStyle = mxUtils.getValue(this.shape.style, 'fillStyle', 'auto');
+
+    if (fillStyle == 'auto') {
+      // defaultPageBackgroundColor is draw.io specific
+      fillStyle = style.fill != null && gradient != null ? 'solid' : defs['fillStyle'];
+    }
+
+    style['fillStyle'] = fillStyle;
+
+    return style;
+  }
+
+  begin(): void {
+    if (this.passThrough) {
+      super.begin();
+    } else {
+      this.path = [];
+      // TODO in super, lastX and lastY set to 0: no changes when adding that
+      // this.lastX = 0;
+      // this.lastY = 0;
+    }
+  }
+
+  // end(): void {
+  //   if (this.passThrough) {
+  //     super.end();
+  //   } else {
+  //     // do nothing
+  //   }
+  // }
+
+  // internal method
+  // TODO rename into addOp (signature is wrong in mxgraph-type-definitions 1.0.4)
+  // TODO remove custom implementation for action except the one that directly call roughjs
+  // They are not needed because the addOp will behave correctly regarding translation/scaling with the new implementation below
+  // that acts correctly whether we are in 'passthrough' or not
+  private _addOp(actions: unknown[]): void {
+    if (this.path != null) {
+      // console.error('@@custom addOp - not null path');
+      this.path.push(actions[0] as string);
+
+      if (actions.length > 2) {
+        const s = this.state;
+
+        for (let i = 2; i < actions.length; i += 2) {
+          this.lastX = actions[i - 1] as number;
+          this.lastY = actions[i] as number;
+
+          // from the mxAbstractCanvas2D.prototype.addOp implementation
+          if (this.passThrough) {
+            // manage translation and scaling
+            this.path.push(String(this.format(String((this.lastX + s.dx) * s.scale))));
+            this.path.push(String(this.format(String((this.lastY + s.dy) * s.scale))));
+          } else {
+            this.path.push(String(this.format(String(this.lastX))));
+            this.path.push(String(this.format(String(this.lastY))));
+          }
+        }
+      }
+    }
+  }
+
+  lineTo(x: number, y: number): void {
+    if (this.passThrough) {
+      // console.error('#### custom lineTo - passThrough');
+      super.lineTo(x, y);
+    } else {
+      // console.error('#### custom lineTo - manual');
+      this._addOp([this.lineOp, x, y]);
+      // console.error(`#### custom lineTo - after - this.lastX: ${this.lastX} / this.lastY: ${this.lastY} / x: ${x} / y: ${y}`);
+
+      // in original draw.io implem but managed by _addOp
+      // this.lastX = x;
+      // this.lastY = y;
+      // console.error(`#### custom lineTo - after extra 'last coordinates' set`);
+    }
+  }
+
+  moveTo(x: number, y: number): void {
+    if (this.passThrough) {
+      // console.error('#### custom moveTo - passThrough');
+      super.moveTo(x, y);
+    } else {
+      // console.error('#### custom moveTo - manual');
+      this._addOp([this.moveOp, x, y]);
+      // this.lastX = x;
+      // this.lastY = y;
+      // TODO is this really needed, never called later + don't exist in super class
+      // this.firstX = x;
+      // this.firstY = y;
+    }
+  }
+
+  close(): void {
+    if (this.passThrough) {
+      // console.error('#### custom close - passThrough');
+      super.close();
+    } else {
+      // console.error('#### custom close - manual');
+      // super.close();
+      this._addOp([this.closeOp]);
+    }
+  }
+  //
+  quadTo(x1: number, y1: number, x2: number, y2: number): void {
+    if (this.passThrough) {
+      super.quadTo(x1, y1, x2, y2);
+    } else {
+      this._addOp([this.quadOp, x1, y1, x2, y2]);
+      // super.quadTo(x1, y1, x2, y2);
+      // this.lastX = x2;
+      // this.lastY = y2;
+    }
+  }
+
+  curveTo(x1: number, y1: number, x2: number, y2: number, x3: number, y3: number): void {
+    if (this.passThrough) {
+      super.curveTo(x1, y1, x2, y2, x3, y3);
+    } else {
+      this._addOp([this.curveOp, x1, y1, x2, y2, x3, y3]);
+      // super.curveTo(x1, y1, x2, y2, x3, y3);
+      // this.lastX = x3;
+      // this.lastY = y3;
+    }
+  }
+
+  // arcTo(rx: number, ry: number, angle: number, largeArcFlag: number, sweepFlag: number, x: number, y: number): void {
+  //   if (this.passThrough) {
+  //     super.arcTo(rx, ry, angle, largeArcFlag, sweepFlag, x, y);
+  //   } else {
+  //     // var curves = mxUtils.arcToCurves(this.lastX, this.lastY, rx, ry, angle, largeArcFlag, sweepFlag, x, y);
+  //     //
+  //     // if (curves != null)
+  //     // {
+  //     //   for (var i = 0; i < curves.length; i += 6)
+  //     //   {
+  //     //     this.curveTo(curves[i], curves[i + 1], curves[i + 2],
+  //     //       curves[i + 3], curves[i + 4], curves[i + 5]);
+  //     //   }
+  //     // }
+  //     super.arcTo(rx, ry, angle, largeArcFlag, sweepFlag, x, y);
+  //
+  //     this.lastX = x;
+  //     this.lastY = y;
+  //   }
+  // }
+
+  rect(x: number, y: number, w: number, h: number): void {
+    if (this.passThrough) {
+      // console.error('#### custom rect - passThrough');
+      super.rect(x, y, w, h);
+    } else {
+      // console.error('#### custom rect - manual');
+      this.path = [];
+      this.nextShape = this.roughJS.generator.rectangle(x, y, w, h, this.getStyle(true, true));
+    }
+  }
+
+  ellipse(x: number, y: number, w: number, h: number): void {
+    if (this.passThrough) {
+      // console.error('#### custom ellipse - passThrough');
+      super.ellipse(x, y, w, h);
+    } else {
+      // console.error('#### custom ellipse - manual');
+      this.path = [];
+      this.nextShape = this.roughJS.generator.ellipse(x + w / 2, y + h / 2, w, h, this.getStyle(true, true));
+    }
+  }
+
+  // Redefine the implementation because
+  // the original one applies scaling on dx/dy and scaling must be applied after roughjs processing
+  // we need that the rounded parts goes through roughjs
+  roundrect(x: number, y: number, w: number, h: number, dx: number, dy: number): void {
+    if (this.passThrough) {
+      // console.error('#### custom RoundRect - passThrough');
+      super.roundrect(x, y, w, h, dx, dy);
+    } else {
+      // console.error('#### custom RoundRect - manual');
+      this.begin();
+      this.moveTo(x + dx, y);
+      this.lineTo(x + w - dx, y);
+      this.quadTo(x + w, y, x + w, y + dy);
+      this.lineTo(x + w, y + h - dy);
+      this.quadTo(x + w, y + h, x + w - dx, y + h);
+      this.lineTo(x + dx, y + h);
+      this.quadTo(x, y + h, x, y + h - dy);
+      this.lineTo(x, y + dy);
+      this.quadTo(x, y, x + dx, y);
+    }
+  }
+
+  private drawPath(style: Options): void {
+    if (this.path.length > 0) {
+      this.passThrough = true;
+      try {
+        this.roughJS.path(this.path.join(' '), style);
+      } catch (e) {
+        // ignore
+      }
+      this.passThrough = false;
+    } else if (this.nextShape != null) {
+      for (const key in style) {
+        // here we know this is a valid operation
+        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+        // @ts-ignore
+        this.nextShape.options[key] = style[key];
+      }
+
+      if (style['stroke'] == null) {
+        delete this.nextShape.options['stroke'];
+      }
+
+      if (!style.fill) {
+        delete this.nextShape.options['fill'];
+      }
+
+      this.passThrough = true;
+      this.roughJS.draw(this.nextShape);
+      this.passThrough = false;
+    }
+  }
+
+  stroke(): void {
+    if (this.passThrough) {
+      super.stroke();
+    } else {
+      this.drawPath(this.getStyle(true, false));
+    }
+  }
+
+  fill(): void {
+    if (this.passThrough) {
+      super.fill();
+    } else {
+      this.drawPath(this.getStyle(false, true));
+    }
+  }
+
+  fillAndStroke(): void {
+    if (this.passThrough) {
+      super.fillAndStroke();
+    } else {
+      this.drawPath(this.getStyle(true, true));
+    }
+  }
+}

--- a/src/component/mxgraph/extension/SvgExporter.ts
+++ b/src/component/mxgraph/extension/SvgExporter.ts
@@ -1,0 +1,311 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mxgraph } from 'ts-mxgraph';
+
+// TODO missing in mxgraph-type-definitions@1.0.2
+declare const mxImageExport: typeof mxgraph.mxImageExport;
+// missing 'intersects' method in mxgraph-type-definitions@1.0.2
+declare const mxUtils: typeof mxgraph.mxUtils;
+
+// https://github.com/jgraph/drawio/blob/v13.2.3/src/main/webapp/js/diagramly/EditorUi.js#L1756
+// https://github.com/jgraph/drawio/blob/v13.2.3/src/main/webapp/js/mxgraph/Graph.js#L7780
+export default class SvgExporter {
+  constructor(readonly graph: mxGraph) {}
+
+  public exportSvg(): string {
+    const svgRoot = this.getSvg(1, 0, true, false, true, true, null, null, false);
+    return (
+      '<?xml version="1.0" encoding="UTF-8"?>\n' + '<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">\n' + mxUtils.getXml(svgRoot)
+    );
+  }
+
+  private createSvgImageExport(): mxgraph.mxImageExport {
+    return new mxImageExport();
+    // const exp = new mxImageExport();
+
+    // Adds hyperlinks (experimental)
+    // exp.getLinkForCellState = mxUtils.bind(this, function(state, canvas)
+    // {
+    //     return this.getLinkForCell(state.cell);
+    // });
+
+    // return exp;
+  }
+
+  private getSvg(
+    // background: string,
+    scale: number,
+    border: number,
+    nocrop: boolean,
+    crisp: boolean,
+    ignoreSelection: boolean,
+    showText: boolean,
+    imgExport: mxgraph.mxImageExport,
+    linkTarget: string,
+    hasShadow: boolean,
+  ): Element {
+    //Disable Css Transforms if it is used
+    // const origUseCssTrans = this.useCssTransforms;
+    //
+    // if (origUseCssTrans) {
+    //     this.useCssTransforms = false;
+    //     this.view.revalidate();
+    //     this.sizeDidChange();
+    // }
+
+    try {
+      scale = scale != null ? scale : 1;
+      border = border != null ? border : 0;
+      crisp = crisp != null ? crisp : true;
+      ignoreSelection = ignoreSelection != null ? ignoreSelection : true;
+      showText = showText != null ? showText : true;
+
+      const bounds = ignoreSelection || nocrop ? this.graph.getGraphBounds() : this.graph.getBoundingBox(this.graph.getSelectionCells());
+
+      if (bounds == null) {
+        throw Error('drawing is empty');
+      }
+
+      const vs = this.graph.view.scale;
+
+      // Prepares SVG document that holds the output
+      const svgDoc: XMLDocument = mxUtils.createXmlDocument();
+      const root = svgDoc.createElementNS != null ? svgDoc.createElementNS(mxConstants.NS_SVG, 'svg') : svgDoc.createElement('svg');
+
+      // if (background != null) {
+      //   if (root.style != null) {
+      //     root.style.backgroundColor = background;
+      //   } else {
+      //     root.setAttribute('style', 'background-color:' + background);
+      //   }
+      // }
+
+      if (svgDoc.createElementNS == null) {
+        root.setAttribute('xmlns', mxConstants.NS_SVG);
+        root.setAttribute('xmlns:xlink', mxConstants.NS_XLINK);
+      } else {
+        // KNOWN: Ignored in IE9-11, adds namespace for each image element instead. No workaround.
+        root.setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:xlink', mxConstants.NS_XLINK);
+      }
+
+      const s = scale / vs;
+      const w = Math.max(1, Math.ceil(bounds.width * s) + 2 * border) + (hasShadow ? 5 : 0);
+      const h = Math.max(1, Math.ceil(bounds.height * s) + 2 * border) + (hasShadow ? 5 : 0);
+
+      root.setAttribute('version', '1.1');
+      root.setAttribute('width', w + 'px');
+      root.setAttribute('height', h + 'px');
+      root.setAttribute('viewBox', (crisp ? '-0.5 -0.5' : '0 0') + ' ' + w + ' ' + h);
+      svgDoc.appendChild(root);
+
+      // Renders graph. Offset will be multiplied with state's scale when painting state.
+      // TextOffset only seems to affect FF output but used everywhere for consistency.
+      const group = svgDoc.createElementNS != null ? svgDoc.createElementNS(mxConstants.NS_SVG, 'g') : svgDoc.createElement('g');
+      root.appendChild(group);
+
+      const svgCanvas = this.createSvgCanvas(group);
+      svgCanvas.foOffset = crisp ? -0.5 : 0;
+      svgCanvas.textOffset = crisp ? -0.5 : 0;
+      svgCanvas.imageOffset = crisp ? -0.5 : 0;
+      svgCanvas.translate(Math.floor((border / scale - bounds.x) / vs), Math.floor((border / scale - bounds.y) / vs));
+
+      // Convert HTML entities
+      // const htmlConverter = document.createElement('div');
+
+      // Adds simple text fallback for viewers with no support for foreignObjects
+      // const getAlternateText = svgCanvas.getAlternateText;
+      // svgCanvas.getAlternateText = function(fo, x, y, w, h, str, align, valign, wrap, format, overflow, clip, rotation) {
+      //   // Assumes a max character width of 0.5em
+      //   if (str != null && this.state.fontSize > 0) {
+      //     try {
+      //       if (mxUtils.isNode(str)) {
+      //         str = str.innerText;
+      //       } else {
+      //         htmlConverter.innerHTML = str;
+      //         str = mxUtils.extractTextWithWhitespace(htmlConverter.childNodes);
+      //       }
+      //
+      //       // Workaround for substring breaking double byte UTF
+      //       const exp = Math.ceil((2 * w) / this.state.fontSize);
+      //       const result = [];
+      //       let length = 0;
+      //       let index = 0;
+      //
+      //       while ((exp == 0 || length < exp) && index < str.length) {
+      //         const char = str.charCodeAt(index);
+      //
+      //         if (char == 10 || char == 13) {
+      //           if (length > 0) {
+      //             break;
+      //           }
+      //         } else {
+      //           result.push(str.charAt(index));
+      //
+      //           if (char < 255) {
+      //             length++;
+      //           }
+      //         }
+      //
+      //         index++;
+      //       }
+      //
+      //       // Uses result and adds ellipsis if more than 1 char remains
+      //       if (result.length < str.length && str.length - result.length > 1) {
+      //         str = mxUtils.trim(result.join('')) + '...';
+      //       }
+      //
+      //       return str;
+      //     } catch (e) {
+      //       return getAlternateText.apply(this, arguments);
+      //     }
+      //   } else {
+      //     return getAlternateText.apply(this, arguments);
+      //   }
+      // };
+
+      // Paints background image
+      const bgImg = this.graph.backgroundImage;
+
+      if (bgImg != null) {
+        const s2 = vs / scale;
+        const tr = this.graph.view.translate;
+        const tmp = new mxRectangle(tr.x * s2, tr.y * s2, bgImg.width * s2, bgImg.height * s2);
+
+        // Checks if visible
+        if (mxUtils.intersects(bounds, tmp)) {
+          svgCanvas.image(tr.x, tr.y, bgImg.width, bgImg.height, bgImg.src, true, undefined, undefined);
+        }
+      }
+
+      svgCanvas.scale(s);
+      svgCanvas.textEnabled = showText;
+
+      imgExport = imgExport != null ? imgExport : this.createSvgImageExport();
+      const imgExportDrawCellState = imgExport.drawCellState;
+
+      // Ignores custom links
+      const imgExportGetLinkForCellState = imgExport.getLinkForCellState;
+
+      imgExport.getLinkForCellState = function(state, canvas) {
+        const result = imgExportGetLinkForCellState.apply(this, [state, canvas]);
+
+        return result != null && !state.view.graph.isCustomLink(result) ? result : null;
+      };
+
+      // Implements ignoreSelection flag
+      imgExport.drawCellState = function(state, canvas) {
+        const graph = state.view.graph;
+        let selected = graph.isCellSelected(state.cell);
+        let parent = graph.model.getParent(state.cell);
+
+        // Checks if parent cell is selected
+        while (!ignoreSelection && !selected && parent != null) {
+          selected = graph.isCellSelected(parent);
+          parent = graph.model.getParent(parent);
+        }
+
+        if (ignoreSelection || selected) {
+          imgExportDrawCellState.apply(this, [state, canvas]);
+        }
+      };
+
+      imgExport.drawState(this.graph.getView().getState(this.graph.model.root), svgCanvas);
+      this.updateSvgLinks(root, linkTarget, true);
+      // this.addForeignObjectWarning(svgCanvas, root);
+
+      return root;
+    } finally {
+      // if (origUseCssTrans) {
+      //   this.useCssTransforms = true;
+      //   this.view.revalidate();
+      //   this.sizeDidChange();
+      // }
+    }
+  }
+
+  /**
+   * Hook for creating the canvas used in getSvg.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  private updateSvgLinks(node: Element, target: string, removeCustom: boolean): void {
+    const links = node.getElementsByTagName('a');
+
+    for (let i = 0; i < links.length; i++) {
+      let href = links[i].getAttribute('href');
+
+      if (href == null) {
+        href = links[i].getAttribute('xlink:href');
+      }
+
+      if (href != null) {
+        if (target != null && /^https?:\/\//.test(href)) {
+          links[i].setAttribute('target', target);
+        }
+        // else if (removeCustom && this.isCustomLink(href)) {
+        //   links[i].setAttribute('href', 'javascript:void(0);');
+        // }
+      }
+    }
+  }
+
+  /**
+   * Hook for creating the canvas used in getSvg.
+   */
+  createSvgCanvas(node: Element): mxSvgCanvas2D {
+    const canvas = new mxSvgCanvas2D(node);
+
+    // TODO why do we need to handle events here
+    canvas.pointerEvents = true;
+
+    return canvas;
+  }
+}
+
+// /**
+//  * Adds warning for truncated labels in older viewers.
+//  */
+// Graph.prototype.addForeignObjectWarning = function(canvas, root) {
+//   if (root.getElementsByTagName('foreignObject').length > 0) {
+//     const sw = canvas.createElement('switch');
+//     const g1 = canvas.createElement('g');
+//     g1.setAttribute('requiredFeatures', 'http://www.w3.org/TR/SVG11/feature#Extensibility');
+//     const a = canvas.createElement('a');
+//     a.setAttribute('transform', 'translate(0,-5)');
+//
+//     // Workaround for implicit namespace handling in HTML5 export, IE adds NS1 namespace so use code below
+//     // in all IE versions except quirks mode. KNOWN: Adds xlink namespace to each image tag in output.
+//     if (a.setAttributeNS == null || (root.ownerDocument != document && document.documentMode == null)) {
+//       a.setAttribute('xlink:href', Graph.foreignObjectWarningLink);
+//       a.setAttribute('target', '_blank');
+//     } else {
+//       a.setAttributeNS(mxConstants.NS_XLINK, 'xlink:href', Graph.foreignObjectWarningLink);
+//       a.setAttributeNS(mxConstants.NS_XLINK, 'target', '_blank');
+//     }
+//
+//     const text = canvas.createElement('text');
+//     text.setAttribute('text-anchor', 'middle');
+//     text.setAttribute('font-size', '10px');
+//     text.setAttribute('x', '50%');
+//     text.setAttribute('y', '100%');
+//     mxUtils.write(text, Graph.foreignObjectWarningText);
+//
+//     sw.appendChild(g1);
+//     a.appendChild(text);
+//     sw.appendChild(a);
+//     root.appendChild(sw);
+//   }
+// };

--- a/src/component/parser/BpmnParser.ts
+++ b/src/component/parser/BpmnParser.ts
@@ -16,13 +16,163 @@
 import BpmnModel from '../../model/bpmn/BpmnModel';
 import BpmnXmlParser from './xml/BpmnXmlParser';
 import BpmnJsonParser, { defaultBpmnJsonParser } from './json/BpmnJsonParser';
+import Logger from '../Logger';
+import ShapeUtil from '../../model/bpmn/shape/ShapeUtil';
+import ShapeBpmnElement from '../../model/bpmn/shape/ShapeBpmnElement';
+import { FlowKind } from '../../model/bpmn/edge/FlowKind';
+import Edge from '../../model/bpmn/edge/Edge';
+
+class FlowNodesStatistics {
+  private activities = 0;
+  private events = 0;
+  private gateways = 0;
+  private others = 0;
+
+  addActivity(element: ShapeBpmnElement): void {
+    this.activities++;
+  }
+
+  addEvent(element: ShapeBpmnElement): void {
+    this.events++;
+  }
+
+  addGateway(element: ShapeBpmnElement): void {
+    this.gateways++;
+  }
+
+  addOther(element: ShapeBpmnElement): void {
+    this.others++;
+  }
+}
+
+class EdgeTypeStatistics {
+  elements = 0;
+  wayPoints = 0;
+}
+
+class EdgesStatistics {
+  private associations = new EdgeTypeStatistics();
+  private messageFlows = new EdgeTypeStatistics();
+  private sequenceFlows = new EdgeTypeStatistics();
+  private undefined = 0;
+
+  addAssociation(edge: Edge): void {
+    this.associations.elements++;
+    this.associations.wayPoints += EdgesStatistics.getWayPointsNumber(edge);
+  }
+
+  addMessageFlow(edge: Edge): void {
+    this.messageFlows.elements++;
+    this.messageFlows.wayPoints += EdgesStatistics.getWayPointsNumber(edge);
+  }
+
+  addSequenceFlow(edge: Edge): void {
+    this.sequenceFlows.elements++;
+    this.sequenceFlows.wayPoints += EdgesStatistics.getWayPointsNumber(edge);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  addUndefined(edge: Edge): void {
+    this.undefined++;
+  }
+
+  private static getWayPointsNumber(edge: Edge): number {
+    if (!edge.waypoints) {
+      const length = edge?.waypoints?.length;
+      console.error('@@@@@undefined waypoints:', length);
+    }
+
+    return edge?.waypoints?.length; // || 0;
+  }
+}
+
+class ModelStatistics {
+  private readonly globals: {
+    pools: number;
+    lanes: number;
+    flowNodes: number;
+    edges: number;
+  };
+  private readonly flowNodes = new FlowNodesStatistics();
+  private readonly edges = new EdgesStatistics();
+
+  constructor(bpmnModel: BpmnModel) {
+    this.globals = {
+      pools: bpmnModel.pools.length,
+      lanes: bpmnModel.lanes.length,
+      flowNodes: bpmnModel.flowNodes.length,
+      edges: bpmnModel.edges.length,
+    };
+
+    this.computeFlowNodesStatistics(bpmnModel);
+    this.computeEdgesStatistics(bpmnModel);
+  }
+
+  log(logger: Logger): void {
+    const msg = `BpmnModel Statistics: ${JSON.stringify(this, undefined, 2)}`;
+    logger.info(msg);
+  }
+
+  private computeFlowNodesStatistics(bpmnModel: BpmnModel): void {
+    // const activityKinds = ShapeUtil.activityKinds();
+    // const eventTypes = ShapeUtil.topLevelBpmnEventKinds();
+    // Object.values(ShapeBpmnEventKind)
+    bpmnModel.flowNodes.forEach(flowNode => {
+      const bpmnElement = flowNode.bpmnElement;
+      const kind = bpmnElement.kind;
+      if (ShapeUtil.isActivity(kind)) {
+        this.flowNodes.addActivity(bpmnElement);
+      } else if (ShapeUtil.isEvent(kind)) {
+        this.flowNodes.addEvent(bpmnElement);
+      } else if (ShapeUtil.isGateway(kind)) {
+        this.flowNodes.addGateway(bpmnElement);
+      } else {
+        this.flowNodes.addOther(bpmnElement);
+      }
+    });
+  }
+
+  private computeEdgesStatistics(bpmnModel: BpmnModel): void {
+    bpmnModel.edges.forEach(edge => {
+      const bpmnElement = edge.bpmnElement;
+      if (!bpmnElement) {
+        this.edges.addUndefined(edge);
+        return;
+      }
+      switch (bpmnElement.kind) {
+        case FlowKind.ASSOCIATION_FLOW:
+          this.edges.addAssociation(edge);
+          break;
+        case FlowKind.MESSAGE_FLOW:
+          this.edges.addMessageFlow(edge);
+          break;
+        case FlowKind.SEQUENCE_FLOW:
+          this.edges.addSequenceFlow(edge);
+          break;
+      }
+    });
+  }
+}
 
 class BpmnParser {
+  private log: Logger = new Logger('bpmn.parser');
+
   constructor(readonly jsonParser: BpmnJsonParser, readonly xmlParser: BpmnXmlParser) {}
 
   parse(bpmnAsXml: string): BpmnModel {
+    const initialStartTime = performance.now();
+    this.log.info(`Start xml parsing, string length ${bpmnAsXml.length}`);
+
     const json = this.xmlParser.parse(bpmnAsXml);
-    return this.jsonParser.parse(json);
+    this.log.info(`Xml parsing done in ${performance.now() - initialStartTime} ms`);
+
+    const jsonStartTime = performance.now();
+    const bpmnModel = this.jsonParser.parse(json);
+    this.log.info(`Json parsing done in ${performance.now() - jsonStartTime} ms`);
+
+    this.log.info(`Full parsing done in ${performance.now() - initialStartTime} ms`);
+    new ModelStatistics(bpmnModel).log(this.log);
+    return bpmnModel;
   }
 }
 

--- a/src/demo/component/download.ts
+++ b/src/demo/component/download.ts
@@ -1,0 +1,138 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { logDownload } from '../helper';
+
+// inspired from https://ourcodeworld.com/articles/read/189/how-to-create-a-file-and-generate-a-download-with-javascript-in-the-browser-without-a-server
+function download(filename: string, contentType: string, text: string): void {
+  const element = document.createElement('a');
+  // only for svg
+  if (contentType.startsWith('data:image/svg+xml')) {
+    text = encodeURIComponent(text);
+    contentType += ',';
+  }
+
+  element.setAttribute('href', contentType + text);
+  element.setAttribute('download', filename);
+  // TODO find a way to stay on the page to keep console logs when downloading (same issue with demo.bpmn.io), opening the file in the browser is ok
+  // element.setAttribute('target', '_blank');
+
+  element.style.display = 'none';
+  document.body.appendChild(element);
+
+  element.click();
+  // TODO do this in a finally block
+  document.body.removeChild(element);
+}
+
+export function downloadAsSvg(svg: string): void {
+  // TODO add ;charset=utf-8 ?
+  download('diagram.svg', 'data:image/svg+xml', svg);
+}
+
+// adapted from ES6 code from https://stackoverflow.com/a/23451803/3180025
+//
+// const input = "https://restcountries.eu/data/afg.svg"
+// new SvgToPngConverter().convertFromInput(input, function(imgData){
+//   // You now have your png data in base64 (imgData).
+//   // Do what ever you wish with it here.
+// });
+// class SvgToPngConverter {
+//   private canvas: HTMLCanvasElement;
+//   private readonly imgPreview: HTMLImageElement;
+//   private canvasCtx: CanvasRenderingContext2D;
+//
+//   constructor() {
+//     this.canvas = document.createElement('canvas');
+//     this.imgPreview = document.createElement('img');
+//     this.imgPreview.setAttribute('style', 'position: absolute; top: -9999px');
+//
+//     document.body.appendChild(this.imgPreview);
+//     this.canvasCtx = this.canvas.getContext('2d');
+//   }
+//
+//   private cleanUp(): void {
+//     document.body.removeChild(this.imgPreview);
+//   }
+//
+//   public convertFromInput(input, callback): void {
+//     // eslint-disable-next-line @typescript-eslint/no-this-alias
+//     const _this = this;
+//     this.imgPreview.onload = function() {
+//       const img = new Image();
+//       _this.canvas.width = _this.imgPreview.clientWidth;
+//       _this.canvas.height = _this.imgPreview.clientHeight;
+//       img.crossOrigin = 'anonymous';
+//       img.src = _this.imgPreview.src;
+//       img.onload = function() {
+//         _this.canvasCtx.drawImage(img, 0, 0);
+//         const imgData = _this.canvas.toDataURL('image/png');
+//         if (typeof callback == 'function') {
+//           callback(imgData);
+//         }
+//         // TODO do this in a finally block
+//         _this.cleanUp();
+//       };
+//     };
+//
+//     this.imgPreview.src = input;
+//   }
+// }
+
+//  Create svg blob and draw on canvas using .drawImage():
+//
+//     make canvas element
+//     make a svgBlob object from the svg xml
+//     make a url object from domUrl.createObjectURL(svgBlob);
+//     create an Image object and assign url to image src
+//     draw image into canvas
+//     get png data string from canvas: canvas.toDataURL();
+//
+// see also https://stackoverflow.com/a/38019175/3180025
+export function downloadAsPng(svg: string): string {
+  const canvas = document.createElement('canvas');
+
+  const svgBlob = new Blob([svg], { type: 'image/svg+xml;charset=utf-8' });
+  const svgUrl = URL.createObjectURL(svgBlob);
+
+  const imgPreview = document.createElement('img');
+  imgPreview.setAttribute('style', 'position: absolute; top: -9999px');
+  imgPreview.src = svgUrl;
+  document.body.appendChild(imgPreview);
+  const canvasCtx = canvas.getContext('2d');
+
+  let pngInBase64 = 'not set';
+  imgPreview.onload = function() {
+    logDownload('call imgPreview.onload');
+
+    const img = new Image();
+    canvas.width = imgPreview.clientWidth;
+    canvas.height = imgPreview.clientHeight;
+    // img.crossOrigin = 'anonymous';
+    img.src = imgPreview.src;
+    img.onload = function() {
+      logDownload('call img.onload');
+      canvasCtx.drawImage(img, 0, 0);
+      // TODO find a way to improve quality of the export that is currently fuzzy
+      pngInBase64 = canvas.toDataURL('image/png');
+      // TODO do this in a finally block
+      document.body.removeChild(imgPreview);
+      logDownload('image data:', pngInBase64);
+      download('diagram.png', '', pngInBase64);
+    };
+  };
+
+  return pngInBase64;
+}

--- a/src/demo/helper.ts
+++ b/src/demo/helper.ts
@@ -34,3 +34,7 @@ export function logStartup(message?: string, ...optionalParams: unknown[]): void
 export function log(message?: string, ...optionalParams: unknown[]): void {
   _log('[DEMO]', message, ...optionalParams);
 }
+
+export function logDownload(message?: unknown, ...optionalParams: unknown[]): void {
+  _log('[DEMO DOWNLOAD]', message, ...optionalParams);
+}

--- a/src/demo/index.ts
+++ b/src/demo/index.ts
@@ -320,11 +320,9 @@ export function configureExportButtons(): void {
 // =====================================================================================================================
 // Global Rendering
 // =====================================================================================================================
-const btnSketch = document.getElementById('btn-sketch') as HTMLInputElement;
-btnSketch.onclick = function () {
-  const initialStartTime = performance.now();
-  const sketchActivated = btnSketch.checked;
 
+export function applySketchStyle(sketchActivated: boolean): void {
+  const initialStartTime = performance.now();
   log(`Sketch style management, sketch: ${sketchActivated}`);
   statusRendering(`New rendering in progress, sketch mode: ${sketchActivated}`);
 
@@ -392,19 +390,103 @@ btnSketch.onclick = function () {
   graph.refresh();
   log(`mxgraph.graph refreshed in ${performance.now() - startTime} ms`);
   statusRendered(`Rendering completed in ${performance.now() - initialStartTime} ms, sketch mode: ${sketchActivated}`);
-};
+}
 
-const btnFitOnLoad = document.getElementById('btn-fit-on-load') as HTMLInputElement;
-btnFitOnLoad.onclick = function () {
-  fitOnLoad = btnFitOnLoad.checked;
+// const btnSketch = document.getElementById('btn-sketch') as HTMLInputElement;
+// btnSketch.onclick = function () {
+//   const sketchActivated = btnSketch.checked;
+//   applySketchStyle(sketchActivated);
+//   // const initialStartTime = performance.now();
+//   // log(`Sketch style management, sketch: ${sketchActivated}`);
+//   // statusRendering(`New rendering in progress, sketch mode: ${sketchActivated}`);
+//   //
+//   // const graph = bpmnVisualization.graph;
+//   // const styleSheet = graph.getStylesheet();
+//   //
+//   // styleSheet.getDefaultEdgeStyle()['sketch'] = String(sketchActivated);
+//   // styleSheet.getDefaultVertexStyle()['sketch'] = String(sketchActivated);
+//   //
+//   // // only to demonstrate various fill capacity with rough.js
+//   // ShapeUtil.taskKinds().forEach(kind => {
+//   //   const style = styleSheet.styles[kind];
+//   //
+//   //   switch (kind) {
+//   //     case ShapeBpmnElementKind.TASK_USER:
+//   //       style['fillStyle'] = 'zigzag';
+//   //       style[mxConstants.STYLE_FILLCOLOR] = 'purple';
+//   //       style[mxConstants.STYLE_FILL_OPACITY] = '20';
+//   //       break;
+//   //     case ShapeBpmnElementKind.TASK:
+//   //       style['roughness'] = '2';
+//   //       style['fillStyle'] = 'cross-hatch';
+//   //       style[mxConstants.STYLE_FILLCOLOR] = 'Orange';
+//   //       style[mxConstants.STYLE_FILL_OPACITY] = '40';
+//   //       break;
+//   //     case ShapeBpmnElementKind.TASK_SERVICE:
+//   //       style['roughness'] = '1.5';
+//   //       style[mxConstants.STYLE_FILLCOLOR] = mxConstants.NONE;
+//   //       break;
+//   //   }
+//   //
+//   //   if (!sketchActivated) {
+//   //     style[mxConstants.STYLE_FILLCOLOR] = StyleDefault.DEFAULT_FILL_COLOR;
+//   //     style[mxConstants.STYLE_FILL_OPACITY] = '100';
+//   //   }
+//   // });
+//   //
+//   // // ensure throw icon are fill more than with the default style
+//   // ShapeUtil.topLevelBpmnEventKinds().forEach(kind => {
+//   //   const style = styleSheet.styles[kind];
+//   //   // style['fillStyle'] = 'zigzag';
+//   //   // style['zigzagOffset'] = '12';
+//   //   style['hachureAngle'] = '60';
+//   //   style['hachureGap'] = '3';
+//   //   style['fillWeight'] = '2';
+//   // });
+//   //
+//   // const availableSketchFonts = ['Gloria Hallelujah, cursive', 'Permanent Marker, cursive'];
+//   // // hack as we currently configured all properties in all styles, instead of only override what is defined in the default
+//   // (Object.values(ShapeBpmnElementKind) as string[]).concat(Object.values(SequenceFlowKind) as string[]).forEach(kind => {
+//   //   const style = styleSheet.styles[kind];
+//   //   if (!sketchActivated) {
+//   //     style[mxConstants.STYLE_FONTFAMILY] = StyleDefault.DEFAULT_FONT_FAMILY;
+//   //     style[mxConstants.STYLE_FONTSIZE] = StyleDefault.DEFAULT_FONT_SIZE;
+//   //   } else {
+//   //     const font = availableSketchFonts[Math.floor(Math.random() * availableSketchFonts.length)];
+//   //     // log(`Use custom font for ${kind}: ${font}`);
+//   //     style[mxConstants.STYLE_FONTSIZE] = 12;
+//   //     style[mxConstants.STYLE_FONTFAMILY] = font;
+//   //   }
+//   // });
+//   //
+//   // const startTime = performance.now();
+//   // log('Refreshing the mxgraph.graph to consider style updates');
+//   // graph.refresh();
+//   // log(`mxgraph.graph refreshed in ${performance.now() - startTime} ms`);
+//   // statusRendered(`Rendering completed in ${performance.now() - initialStartTime} ms, sketch mode: ${sketchActivated}`);
+// };
+
+// const btnFitOnLoad = document.getElementById('btn-fit-on-load') as HTMLInputElement;
+// btnFitOnLoad.onclick = function () {
+//   fitOnLoad = btnFitOnLoad.checked;
+//   log(`Fit On Load is now '${fitOnLoad}'`);
+// };
+//
+// const btnIgnoreBpmnLabelStyles = document.getElementById('btn-ignore-bpmn-label-styles') as HTMLInputElement;
+// btnIgnoreBpmnLabelStyles.onclick = function () {
+//   rendererOptions = { ...rendererOptions, ignoreLabelStyles: btnIgnoreBpmnLabelStyles.checked };
+//   log(`RenderOptions 'ignoreLabelStyles' is now '${rendererOptions.ignoreLabelStyles}'`);
+// };
+
+export function configureFitOnLoad(activate: boolean): void {
+  fitOnLoad = activate;
   log(`Fit On Load is now '${fitOnLoad}'`);
-};
+}
 
-const btnIgnoreBpmnLabelStyles = document.getElementById('btn-ignore-bpmn-label-styles') as HTMLInputElement;
-btnIgnoreBpmnLabelStyles.onclick = function () {
-  rendererOptions = { ...rendererOptions, ignoreLabelStyles: btnIgnoreBpmnLabelStyles.checked };
+export function configureIgnoreBpmnLabelStyles(activate: boolean): void {
+  rendererOptions = { ...rendererOptions, ignoreLabelStyles: activate };
   log(`RenderOptions 'ignoreLabelStyles' is now '${rendererOptions.ignoreLabelStyles}'`);
-};
+}
 
 function loadBpmnFromUrl(url: string, statusFetchKoNotifier: (errorMsg: string) => void): void {
   fetchBpmnContent(url)

--- a/src/demo/index.ts
+++ b/src/demo/index.ts
@@ -19,7 +19,7 @@ import { PanType, RendererOptions, ZoomType } from '../component/BpmnVisualizati
 import { log, logStartup } from './helper';
 import { downloadAsPng, downloadAsSvg } from './component/download';
 import ShapeUtil from '../model/bpmn/shape/ShapeUtil';
-import { StyleDefault } from '..';
+import { StyleDefault } from '../component/mxgraph/StyleUtils';
 import { ShapeBpmnElementKind } from '../model/bpmn/shape';
 import { SequenceFlowKind } from '../model/bpmn/edge/SequenceFlowKind';
 

--- a/src/demo/index.ts
+++ b/src/demo/index.ts
@@ -137,11 +137,6 @@ export function handleFileSelect(evt: any): void {
   readAndLoadFile(f);
 }
 
-// document.getElementById('btn-open-input-file').addEventListener('change', handleFileSelect, false);
-// document.getElementById('btn-open').addEventListener('click', () => {
-//   document.getElementById('btn-open-input-file').click();
-// });
-
 document.getElementById('btn-clean').onclick = function () {
   cleanStatus();
 
@@ -208,30 +203,6 @@ export function openFromUrl(url: string): void {
   });
 }
 
-// // DISABLED
-// // document.getElementById('btn-open-url').onclick = function () {
-// //   const url = (document.getElementById('input-open-url') as HTMLInputElement).value;
-// //   openFromUrl(url);
-// // };
-//
-// document.getElementById('select-open-migw').onchange = function () {
-//   const fileName = (document.getElementById('select-open-migw') as HTMLSelectElement).value;
-//   if (fileName) {
-//     log('Start opening MIGW file %s', fileName);
-//     const url = `https://raw.githubusercontent.com/bpmn-miwg/bpmn-miwg-test-suite/master/Reference/${fileName}`;
-//     openFromUrl(url);
-//   }
-// };
-//
-// document.getElementById('select-open-bpmn-visualization-example').onchange = function () {
-//   const fileName = (document.getElementById('select-open-bpmn-visualization-example') as HTMLSelectElement).value;
-//   if (fileName) {
-//     log('Start opening bpmn-visualization-example file %s', fileName);
-//     const url = `https://raw.githubusercontent.com/process-analytics/bpmn-visualization-examples/master/bpmn-files/${fileName}`;
-//     openFromUrl(url);
-//   }
-// };
-//
 // =====================================================================================================================
 // ZOOM
 // =====================================================================================================================
@@ -275,18 +246,6 @@ export function configureNavigationButtons(): void {
     bpmnVisualization.pan(PanType.HorizontalRight);
   };
 }
-
-// // =====================================================================================================================
-// // General
-// // =====================================================================================================================
-//
-// export function configureGeneraButtons(): void {
-//   document.getElementById('btn-help').onclick = function () {
-//     log('click btn-help');
-//     // TODO implement a more convenient popup/modal
-//     window.alert('Keyboard Shortcuts\nPanning: use arrow');
-//   };
-// }
 
 // =====================================================================================================================
 // General graph
@@ -391,92 +350,6 @@ export function applySketchStyle(sketchActivated: boolean): void {
   log(`mxgraph.graph refreshed in ${performance.now() - startTime} ms`);
   statusRendered(`Rendering completed in ${performance.now() - initialStartTime} ms, sketch mode: ${sketchActivated}`);
 }
-
-// const btnSketch = document.getElementById('btn-sketch') as HTMLInputElement;
-// btnSketch.onclick = function () {
-//   const sketchActivated = btnSketch.checked;
-//   applySketchStyle(sketchActivated);
-//   // const initialStartTime = performance.now();
-//   // log(`Sketch style management, sketch: ${sketchActivated}`);
-//   // statusRendering(`New rendering in progress, sketch mode: ${sketchActivated}`);
-//   //
-//   // const graph = bpmnVisualization.graph;
-//   // const styleSheet = graph.getStylesheet();
-//   //
-//   // styleSheet.getDefaultEdgeStyle()['sketch'] = String(sketchActivated);
-//   // styleSheet.getDefaultVertexStyle()['sketch'] = String(sketchActivated);
-//   //
-//   // // only to demonstrate various fill capacity with rough.js
-//   // ShapeUtil.taskKinds().forEach(kind => {
-//   //   const style = styleSheet.styles[kind];
-//   //
-//   //   switch (kind) {
-//   //     case ShapeBpmnElementKind.TASK_USER:
-//   //       style['fillStyle'] = 'zigzag';
-//   //       style[mxConstants.STYLE_FILLCOLOR] = 'purple';
-//   //       style[mxConstants.STYLE_FILL_OPACITY] = '20';
-//   //       break;
-//   //     case ShapeBpmnElementKind.TASK:
-//   //       style['roughness'] = '2';
-//   //       style['fillStyle'] = 'cross-hatch';
-//   //       style[mxConstants.STYLE_FILLCOLOR] = 'Orange';
-//   //       style[mxConstants.STYLE_FILL_OPACITY] = '40';
-//   //       break;
-//   //     case ShapeBpmnElementKind.TASK_SERVICE:
-//   //       style['roughness'] = '1.5';
-//   //       style[mxConstants.STYLE_FILLCOLOR] = mxConstants.NONE;
-//   //       break;
-//   //   }
-//   //
-//   //   if (!sketchActivated) {
-//   //     style[mxConstants.STYLE_FILLCOLOR] = StyleDefault.DEFAULT_FILL_COLOR;
-//   //     style[mxConstants.STYLE_FILL_OPACITY] = '100';
-//   //   }
-//   // });
-//   //
-//   // // ensure throw icon are fill more than with the default style
-//   // ShapeUtil.topLevelBpmnEventKinds().forEach(kind => {
-//   //   const style = styleSheet.styles[kind];
-//   //   // style['fillStyle'] = 'zigzag';
-//   //   // style['zigzagOffset'] = '12';
-//   //   style['hachureAngle'] = '60';
-//   //   style['hachureGap'] = '3';
-//   //   style['fillWeight'] = '2';
-//   // });
-//   //
-//   // const availableSketchFonts = ['Gloria Hallelujah, cursive', 'Permanent Marker, cursive'];
-//   // // hack as we currently configured all properties in all styles, instead of only override what is defined in the default
-//   // (Object.values(ShapeBpmnElementKind) as string[]).concat(Object.values(SequenceFlowKind) as string[]).forEach(kind => {
-//   //   const style = styleSheet.styles[kind];
-//   //   if (!sketchActivated) {
-//   //     style[mxConstants.STYLE_FONTFAMILY] = StyleDefault.DEFAULT_FONT_FAMILY;
-//   //     style[mxConstants.STYLE_FONTSIZE] = StyleDefault.DEFAULT_FONT_SIZE;
-//   //   } else {
-//   //     const font = availableSketchFonts[Math.floor(Math.random() * availableSketchFonts.length)];
-//   //     // log(`Use custom font for ${kind}: ${font}`);
-//   //     style[mxConstants.STYLE_FONTSIZE] = 12;
-//   //     style[mxConstants.STYLE_FONTFAMILY] = font;
-//   //   }
-//   // });
-//   //
-//   // const startTime = performance.now();
-//   // log('Refreshing the mxgraph.graph to consider style updates');
-//   // graph.refresh();
-//   // log(`mxgraph.graph refreshed in ${performance.now() - startTime} ms`);
-//   // statusRendered(`Rendering completed in ${performance.now() - initialStartTime} ms, sketch mode: ${sketchActivated}`);
-// };
-
-// const btnFitOnLoad = document.getElementById('btn-fit-on-load') as HTMLInputElement;
-// btnFitOnLoad.onclick = function () {
-//   fitOnLoad = btnFitOnLoad.checked;
-//   log(`Fit On Load is now '${fitOnLoad}'`);
-// };
-//
-// const btnIgnoreBpmnLabelStyles = document.getElementById('btn-ignore-bpmn-label-styles') as HTMLInputElement;
-// btnIgnoreBpmnLabelStyles.onclick = function () {
-//   rendererOptions = { ...rendererOptions, ignoreLabelStyles: btnIgnoreBpmnLabelStyles.checked };
-//   log(`RenderOptions 'ignoreLabelStyles' is now '${rendererOptions.ignoreLabelStyles}'`);
-// };
 
 export function configureFitOnLoad(activate: boolean): void {
   fitOnLoad = activate;

--- a/src/demo/index.ts
+++ b/src/demo/index.ts
@@ -19,13 +19,14 @@ import { PanType, RendererOptions, ZoomType } from '../component/BpmnVisualizati
 import { log, logStartup } from './helper';
 import { downloadAsPng, downloadAsSvg } from './component/download';
 import ShapeUtil from '../model/bpmn/shape/ShapeUtil';
-import { StyleDefault } from '../component/mxgraph/StyleUtils';
-import { ShapeBpmnElementKind } from '../model/bpmn/shape/ShapeBpmnElementKind';
+import { StyleDefault } from '..';
+import { ShapeBpmnElementKind } from '../model/bpmn/shape';
 import { SequenceFlowKind } from '../model/bpmn/edge/SequenceFlowKind';
 
 export * from './helper';
 
-let bpmnVisualization: BpmnVisualization;
+// export for demo improvements
+export let bpmnVisualization: BpmnVisualization;
 
 let fitOnLoad = false;
 let rendererOptions: RendererOptions;
@@ -136,10 +137,10 @@ export function handleFileSelect(evt: any): void {
   readAndLoadFile(f);
 }
 
-document.getElementById('btn-open-input-file').addEventListener('change', handleFileSelect, false);
-document.getElementById('btn-open').addEventListener('click', () => {
-  document.getElementById('btn-open-input-file').click();
-});
+// document.getElementById('btn-open-input-file').addEventListener('change', handleFileSelect, false);
+// document.getElementById('btn-open').addEventListener('click', () => {
+//   document.getElementById('btn-open-input-file').click();
+// });
 
 document.getElementById('btn-clean').onclick = function () {
   cleanStatus();
@@ -199,7 +200,7 @@ function fetchBpmnContent(url: string): Promise<string> {
     });
 }
 
-function openFromUrl(url: string): void {
+export function openFromUrl(url: string): void {
   cleanStatus();
   fetchBpmnContent(url).then(bpmn => {
     loadBpmn(bpmn);
@@ -207,101 +208,114 @@ function openFromUrl(url: string): void {
   });
 }
 
-// DISABLED
-// document.getElementById('btn-open-url').onclick = function () {
-//   const url = (document.getElementById('input-open-url') as HTMLInputElement).value;
-//   openFromUrl(url);
+// // DISABLED
+// // document.getElementById('btn-open-url').onclick = function () {
+// //   const url = (document.getElementById('input-open-url') as HTMLInputElement).value;
+// //   openFromUrl(url);
+// // };
+//
+// document.getElementById('select-open-migw').onchange = function () {
+//   const fileName = (document.getElementById('select-open-migw') as HTMLSelectElement).value;
+//   if (fileName) {
+//     log('Start opening MIGW file %s', fileName);
+//     const url = `https://raw.githubusercontent.com/bpmn-miwg/bpmn-miwg-test-suite/master/Reference/${fileName}`;
+//     openFromUrl(url);
+//   }
 // };
-
-document.getElementById('select-open-migw').onchange = function () {
-  const fileName = (document.getElementById('select-open-migw') as HTMLSelectElement).value;
-  if (fileName) {
-    log('Start opening MIGW file %s', fileName);
-    const url = `https://raw.githubusercontent.com/bpmn-miwg/bpmn-miwg-test-suite/master/Reference/${fileName}`;
-    openFromUrl(url);
-  }
-};
-
-document.getElementById('select-open-bpmn-visualization-example').onchange = function () {
-  const fileName = (document.getElementById('select-open-bpmn-visualization-example') as HTMLSelectElement).value;
-  if (fileName) {
-    log('Start opening bpmn-visualization-example file %s', fileName);
-    const url = `https://raw.githubusercontent.com/process-analytics/bpmn-visualization-examples/master/bpmn-files/${fileName}`;
-    openFromUrl(url);
-  }
-};
-
+//
+// document.getElementById('select-open-bpmn-visualization-example').onchange = function () {
+//   const fileName = (document.getElementById('select-open-bpmn-visualization-example') as HTMLSelectElement).value;
+//   if (fileName) {
+//     log('Start opening bpmn-visualization-example file %s', fileName);
+//     const url = `https://raw.githubusercontent.com/process-analytics/bpmn-visualization-examples/master/bpmn-files/${fileName}`;
+//     openFromUrl(url);
+//   }
+// };
+//
 // =====================================================================================================================
 // ZOOM
 // =====================================================================================================================
-document.getElementById('btn-zoom-in').onclick = function () {
-  bpmnVisualization.zoom(ZoomType.In);
-};
-document.getElementById('btn-zoom-out').onclick = function () {
-  bpmnVisualization.zoom(ZoomType.Out);
-};
-document.getElementById('btn-zoom-actual').onclick = function () {
-  bpmnVisualization.zoom(ZoomType.Actual);
-};
-document.getElementById('btn-zoom-fit').onclick = function () {
-  bpmnVisualization.zoom(ZoomType.Fit);
-};
-document.getElementById('btn-zoom-fit-horizontal').onclick = function () {
-  bpmnVisualization.zoom(ZoomType.FitHorizontal);
-};
-document.getElementById('btn-zoom-fit-vertical').onclick = function () {
-  bpmnVisualization.zoom(ZoomType.FitVertical);
-};
+
+export function configureZoomButtons(): void {
+  document.getElementById('btn-zoom-in').onclick = function () {
+    bpmnVisualization.zoom(ZoomType.In);
+  };
+  document.getElementById('btn-zoom-out').onclick = function () {
+    bpmnVisualization.zoom(ZoomType.Out);
+  };
+  document.getElementById('btn-zoom-actual').onclick = function () {
+    bpmnVisualization.zoom(ZoomType.Actual);
+  };
+  document.getElementById('btn-zoom-fit').onclick = function () {
+    bpmnVisualization.zoom(ZoomType.Fit);
+  };
+  document.getElementById('btn-zoom-fit-horizontal').onclick = function () {
+    bpmnVisualization.zoom(ZoomType.FitHorizontal);
+  };
+  document.getElementById('btn-zoom-fit-vertical').onclick = function () {
+    bpmnVisualization.zoom(ZoomType.FitVertical);
+  };
+}
 
 // =====================================================================================================================
 // PAN
 // =====================================================================================================================
-document.getElementById('btn-pan-up').onclick = function () {
-  bpmnVisualization.pan(PanType.VerticalUp);
-};
-document.getElementById('btn-pan-down').onclick = function () {
-  bpmnVisualization.pan(PanType.VerticalDown);
-};
-document.getElementById('btn-pan-left').onclick = function () {
-  bpmnVisualization.pan(PanType.HorizontalLeft);
-};
-document.getElementById('btn-pan-right').onclick = function () {
-  bpmnVisualization.pan(PanType.HorizontalRight);
-};
 
-// =====================================================================================================================
-// General
-// =====================================================================================================================
+export function configureNavigationButtons(): void {
+  document.getElementById('btn-pan-up').onclick = function () {
+    bpmnVisualization.pan(PanType.VerticalUp);
+  };
+  document.getElementById('btn-pan-down').onclick = function () {
+    bpmnVisualization.pan(PanType.VerticalDown);
+  };
+  document.getElementById('btn-pan-left').onclick = function () {
+    bpmnVisualization.pan(PanType.HorizontalLeft);
+  };
+  document.getElementById('btn-pan-right').onclick = function () {
+    bpmnVisualization.pan(PanType.HorizontalRight);
+  };
+}
 
-document.getElementById('btn-help').onclick = function () {
-  log('click btn-help');
-  // TODO implement a more convenient popup/modal
-  window.alert('Keyboard Shortcuts\nPanning: use arrow');
-};
+// // =====================================================================================================================
+// // General
+// // =====================================================================================================================
+//
+// export function configureGeneraButtons(): void {
+//   document.getElementById('btn-help').onclick = function () {
+//     log('click btn-help');
+//     // TODO implement a more convenient popup/modal
+//     window.alert('Keyboard Shortcuts\nPanning: use arrow');
+//   };
+// }
 
 // =====================================================================================================================
 // General graph
 // =====================================================================================================================
 
-const overviewElement = document.getElementById('graph-overview');
-document.getElementById('btn-overview').onclick = function () {
-  overviewElement.classList.toggle('hidden');
-  bpmnVisualization.toggleOverview(overviewElement);
-};
+export function configureGeneralGraphButtons(): void {
+  const overviewElement = document.getElementById('graph-overview');
+  document.getElementById('btn-overview').onclick = function () {
+    overviewElement.classList.toggle('hidden');
+    bpmnVisualization.toggleOverview(overviewElement);
+  };
+}
 
 // =====================================================================================================================
 // Export/Download
 // =====================================================================================================================
-document.getElementById('btn-export-preview').onclick = function () {
-  bpmnVisualization.preview();
-};
-document.getElementById('btn-export-svg').onclick = function () {
-  downloadAsSvg(bpmnVisualization.exportAsSvg());
-};
 
-document.getElementById('btn-export-png').onclick = function () {
-  downloadAsPng(bpmnVisualization.exportAsSvg());
-};
+export function configureExportButtons(): void {
+  document.getElementById('btn-export-preview').onclick = function () {
+    bpmnVisualization.preview();
+  };
+  document.getElementById('btn-export-svg').onclick = function () {
+    downloadAsSvg(bpmnVisualization.exportAsSvg());
+  };
+
+  document.getElementById('btn-export-png').onclick = function () {
+    downloadAsPng(bpmnVisualization.exportAsSvg());
+  };
+}
 
 // =====================================================================================================================
 // Global Rendering

--- a/src/demo/index.ts
+++ b/src/demo/index.ts
@@ -22,6 +22,7 @@ import ShapeUtil from '../model/bpmn/shape/ShapeUtil';
 import { StyleDefault } from '../component/mxgraph/StyleUtils';
 import { ShapeBpmnElementKind } from '../model/bpmn/shape';
 import { SequenceFlowKind } from '../model/bpmn/edge/SequenceFlowKind';
+import { FlowKind } from '../model/bpmn/edge/FlowKind';
 
 export * from './helper';
 
@@ -331,18 +332,21 @@ export function applySketchStyle(sketchActivated: boolean): void {
 
   const availableSketchFonts = ['Gloria Hallelujah, cursive', 'Permanent Marker, cursive'];
   // hack as we currently configured all properties in all styles, instead of only override what is defined in the default
-  (Object.values(ShapeBpmnElementKind) as string[]).concat(Object.values(SequenceFlowKind) as string[]).forEach(kind => {
-    const style = styleSheet.styles[kind];
-    if (!sketchActivated) {
-      style[mxConstants.STYLE_FONTFAMILY] = StyleDefault.DEFAULT_FONT_FAMILY;
-      style[mxConstants.STYLE_FONTSIZE] = StyleDefault.DEFAULT_FONT_SIZE;
-    } else {
-      const font = availableSketchFonts[Math.floor(Math.random() * availableSketchFonts.length)];
-      // log(`Use custom font for ${kind}: ${font}`);
-      style[mxConstants.STYLE_FONTSIZE] = 12;
-      style[mxConstants.STYLE_FONTFAMILY] = font;
-    }
-  });
+  (Object.values(ShapeBpmnElementKind) as string[])
+    .concat(Object.values(FlowKind) as string[]) // message flows
+    .concat(Object.values(SequenceFlowKind) as string[]) // sequence flows
+    .forEach(kind => {
+      const style = styleSheet.styles[kind];
+      if (!sketchActivated) {
+        style[mxConstants.STYLE_FONTFAMILY] = StyleDefault.DEFAULT_FONT_FAMILY;
+        style[mxConstants.STYLE_FONTSIZE] = StyleDefault.DEFAULT_FONT_SIZE;
+      } else {
+        const font = availableSketchFonts[Math.floor(Math.random() * availableSketchFonts.length)];
+        // log(`Use custom font for ${kind}: ${font}`);
+        style[mxConstants.STYLE_FONTSIZE] = 12;
+        style[mxConstants.STYLE_FONTFAMILY] = font;
+      }
+    });
 
   const startTime = performance.now();
   log('Refreshing the mxgraph.graph to consider style updates');

--- a/src/demo/index.ts
+++ b/src/demo/index.ts
@@ -30,7 +30,7 @@ export * from './helper';
 export let bpmnVisualization: BpmnVisualization;
 
 let fitOnLoad = false;
-let rendererOptions: RendererOptions;
+const rendererOptions: RendererOptions = { label: {} };
 
 // =====================================================================================================================
 // LOAD BPMN STATUS AREA
@@ -361,8 +361,13 @@ export function configureFitOnLoad(activate: boolean): void {
 }
 
 export function configureIgnoreBpmnLabelStyles(activate: boolean): void {
-  rendererOptions = { ...rendererOptions, ignoreLabelStyles: activate };
-  log(`RenderOptions 'ignoreLabelStyles' is now '${rendererOptions.ignoreLabelStyles}'`);
+  rendererOptions.label.ignoreLabelStyles = activate;
+  log(`RenderOptions 'ignoreLabelStyles' is now '${rendererOptions.label.ignoreLabelStyles}'`);
+}
+
+export function configureIgnoreBpmnLabelFont(activate: boolean): void {
+  rendererOptions.label.ignoreLabelFontFamily = activate;
+  log(`RenderOptions 'ignoreLabelFont' is now '${rendererOptions.label.ignoreLabelFontFamily}'`);
 }
 
 function loadBpmnFromUrl(url: string, statusFetchKoNotifier: (errorMsg: string) => void): void {

--- a/src/demo/index.ts
+++ b/src/demo/index.ts
@@ -16,28 +16,112 @@
 import BpmnVisualization from '../component/BpmnVisualization';
 import { log, logStartup } from './helper';
 import { DropFileUserInterface } from './component/DropFileUserInterface';
+import { PanType, RendererOptions, ZoomType } from '../component/BpmnVisualizationOptions';
+import { documentReady, log, logStartup } from './helper';
+import { downloadAsPng, downloadAsSvg } from './component/download';
+import ShapeUtil from '../model/bpmn/shape/ShapeUtil';
+import { StyleDefault } from '../component/mxgraph/StyleUtils';
+import { ShapeBpmnElementKind } from '../model/bpmn/shape/ShapeBpmnElementKind';
+import { SequenceFlowKind } from '../model/bpmn/edge/SequenceFlowKind';
 
 export * from './helper';
 
 let bpmnVisualization: BpmnVisualization;
 
 let fitOnLoad = false;
+let rendererOptions: RendererOptions;
+
+// =====================================================================================================================
+// LOAD BPMN STATUS AREA
+// =====================================================================================================================
+
+function getStatusElement(): HTMLElement {
+  return document.getElementById('status');
+}
+
+function statusLoaded(msg: string): void {
+  const statusElt = getStatusElement();
+
+  let innerText = statusElt.innerText;
+  if (innerText) {
+    innerText += '<br>';
+  }
+  statusElt.innerHTML = innerText + msg;
+
+  statusElt.className = 'status-ok';
+
+  // clean status area after a few seconds
+  // setTimeout(function() {
+  //   statusElt.innerText = '';
+  // }, 3000);
+}
+
+function cleanStatus(): void {
+  getStatusElement().innerText = ``;
+}
+
+function statusFetching(url: string): void {
+  const statusElt = getStatusElement();
+  statusElt.innerText = 'Fetching ' + url;
+  statusElt.className = ' status-pending';
+}
+
+function statusFetched(url: string, duration: number): void {
+  const statusElt = getStatusElement();
+  // only display file name to keep the status content small
+  const urlParts = url.split('/');
+  const fileName = urlParts[urlParts.length - 1];
+  statusElt.innerText = `Fetch OK (${duration} ms): ${fileName}`;
+  statusElt.className = 'status-ok';
+}
+
+function statusFetchKO(url: string, error: unknown): void {
+  const statusElt = getStatusElement();
+  statusElt.innerText = `Unable to fetch ${url}. ${error}`;
+  statusElt.className = 'status-ko';
+}
+
+function statusRendering(msg: string): void {
+  const statusElt = getStatusElement();
+  statusElt.innerText = msg;
+  statusElt.className = ' status-pending';
+}
+
+function statusRendered(msg: string): void {
+  const statusElt = getStatusElement();
+  statusElt.innerText = msg;
+  statusElt.className = 'status-ok';
+}
+
+// =====================================================================================================================
+// LOAD BPMN
+// =====================================================================================================================
+
 function loadBpmn(bpmn: string): void {
+  const initialStartTime = performance.now();
   log('Loading bpmn....');
-  bpmnVisualization.load(bpmn);
+  bpmnVisualization.load(bpmn, { rendererOptions: rendererOptions });
   log('BPMN loaded');
 
+  // TODO this should be an option of the load function to improve rendering performance
+  // the current solution, 1st render the using the actual size, then render it with fit
+  // mxgraph performs 2 rendering operations, the 1st one is useless
+  // on large file, the extra rendering can take more than 500ms
   if (fitOnLoad) {
-    log('Fitting....');
-    bpmnVisualization.graph.fit(0);
-    log('Fit completed');
+    log('Start performing Fit after load');
+    const startTime = performance.now();
+    bpmnVisualization.zoom(ZoomType.Fit);
+    log(`Fit on load rendering done in ${performance.now() - startTime} ms`);
   }
+
+  statusLoaded(`BPMN loaded in ${performance.now() - initialStartTime} ms`);
 }
 
 // callback function for opening | dropping the file to be loaded
 function readAndLoadFile(f: File): void {
   const reader = new FileReader();
   reader.onload = () => {
+    cleanStatus();
     loadBpmn(reader.result as string);
   };
   reader.readAsText(f);
@@ -53,6 +137,261 @@ export function handleFileSelect(evt: any): void {
   readAndLoadFile(f);
 }
 
+document.getElementById('btn-open-input-file').addEventListener('change', handleFileSelect, false);
+document.getElementById('btn-open').addEventListener('click', () => {
+  document.getElementById('btn-open-input-file').click();
+});
+
+document.getElementById('btn-clean').onclick = function () {
+  cleanStatus();
+
+  log('clearing mxgraph model');
+  const model = bpmnVisualization.graph.getModel();
+  model.clear();
+  log('mxgraph model cleared');
+
+  // hacky way: clean the graph by loading an empty BPMN file
+  //   loadBpmn(`<definitions
+  //   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  //   xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+  //   targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  //   id="Definitions_1"
+  //   exporter="bpmn-visualization" exporterVersion="N/A">
+  //   <process id="Process_1" isExecutable="false"/>
+  //   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+  //     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1"/>
+  //   </bpmndi:BPMNDiagram>
+  // </definitions>`);
+};
+
+// =====================================================================================================================
+// BPMN from remote url
+// =====================================================================================================================
+
+function fetchBpmnContent(url: string): Promise<string> {
+  log('Fetching BPMN content from url <%s>', url);
+  const startTime = performance.now();
+  statusFetching(url);
+  return fetch(url)
+    .then(response => {
+      // log(response);
+      if (!response.ok) {
+        throw Error(String(response.status));
+      }
+      return response.text();
+    })
+    .then(responseBody => {
+      // log('retrieved content: %s', responseBody);
+      log('BPMN content fetched');
+      const duration = performance.now() - startTime;
+      statusFetched(url, duration);
+      return responseBody;
+    })
+    .catch(error => {
+      statusFetchKO(url, error);
+      throw new Error(`Unable to fetch ${url}. ${error}`);
+    })
+    .finally(() => {
+      // clean status area after a few seconds
+      // setTimeout(function() {
+      //   const statusElt = getStatusElement();
+      //   statusElt.innerText = '';
+      // }, 3000);
+    });
+}
+
+function openFromUrl(url: string): void {
+  cleanStatus();
+  fetchBpmnContent(url).then(bpmn => {
+    loadBpmn(bpmn);
+    log('Bpmn loaded from url <%s>', url);
+  });
+}
+
+// DISABLED
+// document.getElementById('btn-open-url').onclick = function () {
+//   const url = (document.getElementById('input-open-url') as HTMLInputElement).value;
+//   openFromUrl(url);
+// };
+
+document.getElementById('select-open-migw').onchange = function () {
+  const fileName = (document.getElementById('select-open-migw') as HTMLSelectElement).value;
+  if (fileName) {
+    log('Start opening MIGW file %s', fileName);
+    const url = `https://raw.githubusercontent.com/bpmn-miwg/bpmn-miwg-test-suite/master/Reference/${fileName}`;
+    openFromUrl(url);
+  }
+};
+
+document.getElementById('select-open-bpmn-visualization-example').onchange = function () {
+  const fileName = (document.getElementById('select-open-bpmn-visualization-example') as HTMLSelectElement).value;
+  if (fileName) {
+    log('Start opening bpmn-visualization-example file %s', fileName);
+    const url = `https://raw.githubusercontent.com/process-analytics/bpmn-visualization-examples/master/bpmn-files/${fileName}`;
+    openFromUrl(url);
+  }
+};
+
+// =====================================================================================================================
+// ZOOM
+// =====================================================================================================================
+document.getElementById('btn-zoom-in').onclick = function () {
+  bpmnVisualization.zoom(ZoomType.In);
+};
+document.getElementById('btn-zoom-out').onclick = function () {
+  bpmnVisualization.zoom(ZoomType.Out);
+};
+document.getElementById('btn-zoom-actual').onclick = function () {
+  bpmnVisualization.zoom(ZoomType.Actual);
+};
+document.getElementById('btn-zoom-fit').onclick = function () {
+  bpmnVisualization.zoom(ZoomType.Fit);
+};
+document.getElementById('btn-zoom-fit-horizontal').onclick = function () {
+  bpmnVisualization.zoom(ZoomType.FitHorizontal);
+};
+document.getElementById('btn-zoom-fit-vertical').onclick = function () {
+  bpmnVisualization.zoom(ZoomType.FitVertical);
+};
+
+// =====================================================================================================================
+// PAN
+// =====================================================================================================================
+document.getElementById('btn-pan-up').onclick = function () {
+  bpmnVisualization.pan(PanType.VerticalUp);
+};
+document.getElementById('btn-pan-down').onclick = function () {
+  bpmnVisualization.pan(PanType.VerticalDown);
+};
+document.getElementById('btn-pan-left').onclick = function () {
+  bpmnVisualization.pan(PanType.HorizontalLeft);
+};
+document.getElementById('btn-pan-right').onclick = function () {
+  bpmnVisualization.pan(PanType.HorizontalRight);
+};
+
+// =====================================================================================================================
+// General
+// =====================================================================================================================
+
+document.getElementById('btn-help').onclick = function () {
+  log('click btn-help');
+  // TODO implement a more convenient popup/modal
+  window.alert('Keyboard Shortcuts\nPanning: use arrow');
+};
+
+// =====================================================================================================================
+// General graph
+// =====================================================================================================================
+
+const overviewElement = document.getElementById('graph-overview');
+document.getElementById('btn-overview').onclick = function () {
+  overviewElement.classList.toggle('hidden');
+  bpmnVisualization.toggleOverview(overviewElement);
+};
+
+// =====================================================================================================================
+// Export/Download
+// =====================================================================================================================
+document.getElementById('btn-export-preview').onclick = function () {
+  bpmnVisualization.preview();
+};
+document.getElementById('btn-export-svg').onclick = function () {
+  downloadAsSvg(bpmnVisualization.exportAsSvg());
+};
+
+document.getElementById('btn-export-png').onclick = function () {
+  downloadAsPng(bpmnVisualization.exportAsSvg());
+};
+
+// =====================================================================================================================
+// Global Rendering
+// =====================================================================================================================
+const btnSketch = document.getElementById('btn-sketch') as HTMLInputElement;
+btnSketch.onclick = function () {
+  const initialStartTime = performance.now();
+  const sketchActivated = btnSketch.checked;
+
+  log(`Sketch style management, sketch: ${sketchActivated}`);
+  statusRendering(`New rendering in progress, sketch mode: ${sketchActivated}`);
+
+  const graph = bpmnVisualization.graph;
+  const styleSheet = graph.getStylesheet();
+
+  styleSheet.getDefaultEdgeStyle()['sketch'] = String(sketchActivated);
+  styleSheet.getDefaultVertexStyle()['sketch'] = String(sketchActivated);
+
+  // only to demonstrate various fill capacity with rough.js
+  ShapeUtil.taskKinds().forEach(kind => {
+    const style = styleSheet.styles[kind];
+
+    switch (kind) {
+      case ShapeBpmnElementKind.TASK_USER:
+        style['fillStyle'] = 'zigzag';
+        style[mxConstants.STYLE_FILLCOLOR] = 'purple';
+        style[mxConstants.STYLE_FILL_OPACITY] = '20';
+        break;
+      case ShapeBpmnElementKind.TASK:
+        style['roughness'] = '2';
+        style['fillStyle'] = 'cross-hatch';
+        style[mxConstants.STYLE_FILLCOLOR] = 'Orange';
+        style[mxConstants.STYLE_FILL_OPACITY] = '40';
+        break;
+      case ShapeBpmnElementKind.TASK_SERVICE:
+        style['roughness'] = '1.5';
+        style[mxConstants.STYLE_FILLCOLOR] = mxConstants.NONE;
+        break;
+    }
+
+    if (!sketchActivated) {
+      style[mxConstants.STYLE_FILLCOLOR] = StyleDefault.DEFAULT_FILL_COLOR;
+      style[mxConstants.STYLE_FILL_OPACITY] = '100';
+    }
+  });
+
+  // ensure throw icon are fill more than with the default style
+  ShapeUtil.topLevelBpmnEventKinds().forEach(kind => {
+    const style = styleSheet.styles[kind];
+    // style['fillStyle'] = 'zigzag';
+    // style['zigzagOffset'] = '12';
+    style['hachureAngle'] = '60';
+    style['hachureGap'] = '3';
+    style['fillWeight'] = '2';
+  });
+
+  const availableSketchFonts = ['Gloria Hallelujah, cursive', 'Permanent Marker, cursive'];
+  // hack as we currently configured all properties in all styles, instead of only override what is defined in the default
+  (Object.values(ShapeBpmnElementKind) as string[]).concat(Object.values(SequenceFlowKind) as string[]).forEach(kind => {
+    const style = styleSheet.styles[kind];
+    if (!sketchActivated) {
+      style[mxConstants.STYLE_FONTFAMILY] = StyleDefault.DEFAULT_FONT_FAMILY;
+      style[mxConstants.STYLE_FONTSIZE] = StyleDefault.DEFAULT_FONT_SIZE;
+    } else {
+      const font = availableSketchFonts[Math.floor(Math.random() * availableSketchFonts.length)];
+      // log(`Use custom font for ${kind}: ${font}`);
+      style[mxConstants.STYLE_FONTSIZE] = 12;
+      style[mxConstants.STYLE_FONTFAMILY] = font;
+    }
+  });
+
+  const startTime = performance.now();
+  log('Refreshing the mxgraph.graph to consider style updates');
+  graph.refresh();
+  log(`mxgraph.graph refreshed in ${performance.now() - startTime} ms`);
+  statusRendered(`Rendering completed in ${performance.now() - initialStartTime} ms, sketch mode: ${sketchActivated}`);
+};
+
+const btnFitOnLoad = document.getElementById('btn-fit-on-load') as HTMLInputElement;
+btnFitOnLoad.onclick = function () {
+  fitOnLoad = btnFitOnLoad.checked;
+  log(`Fit On Load is now '${fitOnLoad}'`);
+};
+
+const btnIgnoreBpmnLabelStyles = document.getElementById('btn-ignore-bpmn-label-styles') as HTMLInputElement;
+btnIgnoreBpmnLabelStyles.onclick = function () {
+  rendererOptions = { ...rendererOptions, ignoreLabelStyles: btnIgnoreBpmnLabelStyles.checked };
+  log(`RenderOptions 'ignoreLabelStyles' is now '${rendererOptions.ignoreLabelStyles}'`);
+};
 function fetchBpmnContent(url: string): Promise<string> {
   log(`Fetching BPMN content from url ${url}`);
   return fetch(url).then(response => {
@@ -90,6 +429,24 @@ function defaultStatusFetchKoNotifier(errorMsg: string): void {
 }
 
 export function startBpmnVisualization(config: BpmnVisualizationDemoConfiguration): void {
+////////////////////////////////////////////////////////////////////////////////
+// if bpmn passed as request parameter, try to load it directly
+////////////////////////////////////////////////////////////////////////////////
+
+// TODO     auto open ?url=diagram-url
+//
+//     (function() {
+//       var str = window.location.search;
+//       var match = /(?:\&|\?)url=([^&]+)/.exec(str);
+//
+//       if (match) {
+//         var url = decodeURIComponent(match[1]);
+//         $('#input-open-url').val(url);
+//         openFromUrl(url);
+//       }
+//     })();
+
+documentReady(function () {
   const log = logStartup;
   const container = config.container;
 

--- a/src/demo/index.ts
+++ b/src/demo/index.ts
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 import BpmnVisualization from '../component/BpmnVisualization';
-import { log, logStartup } from './helper';
 import { DropFileUserInterface } from './component/DropFileUserInterface';
 import { PanType, RendererOptions, ZoomType } from '../component/BpmnVisualizationOptions';
-import { documentReady, log, logStartup } from './helper';
+import { log, logStartup } from './helper';
 import { downloadAsPng, downloadAsSvg } from './component/download';
 import ShapeUtil from '../model/bpmn/shape/ShapeUtil';
 import { StyleDefault } from '../component/mxgraph/StyleUtils';
@@ -169,7 +168,7 @@ document.getElementById('btn-clean').onclick = function () {
 // =====================================================================================================================
 
 function fetchBpmnContent(url: string): Promise<string> {
-  log('Fetching BPMN content from url <%s>', url);
+  log(`Fetching BPMN content from url ${url}`);
   const startTime = performance.now();
   statusFetching(url);
   return fetch(url)
@@ -392,15 +391,6 @@ btnIgnoreBpmnLabelStyles.onclick = function () {
   rendererOptions = { ...rendererOptions, ignoreLabelStyles: btnIgnoreBpmnLabelStyles.checked };
   log(`RenderOptions 'ignoreLabelStyles' is now '${rendererOptions.ignoreLabelStyles}'`);
 };
-function fetchBpmnContent(url: string): Promise<string> {
-  log(`Fetching BPMN content from url ${url}`);
-  return fetch(url).then(response => {
-    if (!response.ok) {
-      throw Error(String(response.status));
-    }
-    return response.text();
-  });
-}
 
 function loadBpmnFromUrl(url: string, statusFetchKoNotifier: (errorMsg: string) => void): void {
   fetchBpmnContent(url)
@@ -429,24 +419,6 @@ function defaultStatusFetchKoNotifier(errorMsg: string): void {
 }
 
 export function startBpmnVisualization(config: BpmnVisualizationDemoConfiguration): void {
-////////////////////////////////////////////////////////////////////////////////
-// if bpmn passed as request parameter, try to load it directly
-////////////////////////////////////////////////////////////////////////////////
-
-// TODO     auto open ?url=diagram-url
-//
-//     (function() {
-//       var str = window.location.search;
-//       var match = /(?:\&|\?)url=([^&]+)/.exec(str);
-//
-//       if (match) {
-//         var url = decodeURIComponent(match[1]);
-//         $('#input-open-url').val(url);
-//         openFromUrl(url);
-//       }
-//     })();
-
-documentReady(function () {
   const log = logStartup;
   const container = config.container;
 

--- a/src/index.html
+++ b/src/index.html
@@ -80,6 +80,7 @@ left: 15px !important;"></div>
       <label for="btn-sketch">Sketch</label><input type="checkbox" id="btn-sketch">
       <div style="position: relative; float: right; left: 20px">
         <input type="checkbox" id="btn-ignore-bpmn-label-styles"><label for="btn-ignore-bpmn-label-styles" title="Load Time Only. When activated, the Label styles in the BPMN Diagram are ignored and default font settings apply">Ignore Label Styles</label>
+        <input type="checkbox" id="btn-ignore-bpmn-label-font"><label for="btn-ignore-bpmn-label-font" title="Load Time Only. When activated, the font family of Label styles in the BPMN Diagram are ignored and default font family settings apply">Ignore Label Font Family</label>
         <br>
         <input type="checkbox" id="btn-fit-on-load"><label for="btn-fit-on-load" title="When activated, the BPMN diagram fits the whole viewport after load time">Fit On Load</label>
       </div>

--- a/src/index.html
+++ b/src/index.html
@@ -20,7 +20,6 @@ left: 15px !important;"></div>
         <input type="button" class="btn-common btn-settings" id="btn-settings" title="Configure"/>
         <input type="button" class="btn-common btn-help" id="btn-help" title="Getting Help"/>
     </div>
-    <!-- TODO restore drag&drop support -->
     <div id="btn-group-import" class="btn-group btn-group-import">
       <input type="button" class="btn-common btn-clean" id="btn-clean" title="Clean the BPMN Diagram"/>
       <input type="file" id="btn-open-input-file" name="btn-open-input-file"/>

--- a/src/index.html
+++ b/src/index.html
@@ -4,17 +4,125 @@
     <meta charset="UTF-8">
     <title>BPMN Visualization Demo</title>
     <link href="./static/css/main.css" rel="stylesheet">
+    <link href="./static/css/extended-demo.css" rel="stylesheet">
     <link rel="shortcut icon" href="./static/img/favicon.ico">
+    <!-- sketchy font -->
+    <link href="https://fonts.googleapis.com/css2?family=Gloria+Hallelujah&family=Permanent+Marker&display=swap" rel="stylesheet">
 </head>
 <body>
-    <div id="file-selector" class="hidden">
-        <input type="file" id="bpmn-file" name="file"/>
-        <label for="bpmn-file" class="btn"><span>open BPMN file</span></label>
-    </div>
-    <div class="info-centered"><p>(either drop a file here)</p></div>
-    <div id="graph"></div>
+<!-- TODO currently manage via style attribute as all classes are removed when fetching -->
+<div id="status" style="position: absolute;
+top: 60px !important;
+left: 15px !important;"></div>
 
-    <!-- load global settings -->
+<div id="btn-container">
+    <div id="btn-group-general" class="btn-group btn-group-general">
+        <input type="button" class="btn-common btn-settings" id="btn-settings" title="Configure"/>
+        <input type="button" class="btn-common btn-help" id="btn-help" title="Getting Help"/>
+    </div>
+    <!-- TODO restore drag&drop support -->
+    <div id="btn-group-import" class="btn-group btn-group-import">
+      <input type="button" class="btn-common btn-clean" id="btn-clean" title="Clean the BPMN Diagram"/>
+      <input type="file" id="btn-open-input-file" name="btn-open-input-file"/>
+      <input type="button" class="btn-common btn-open" id="btn-open" title="Open a local BPMN Diagram"/>
+      <select name="select-open-migw" id="select-open-migw" title="Open remote BPMN diagram MIGW Reference">
+        <option value="">...</option>
+        <option value="A.1.0.bpmn">A.1.0</option>
+        <option value="A.2.0.bpmn" selected>A.2.0</option>
+        <option value="A.2.1.bpmn">A.2.1</option>
+        <option value="A.3.0.bpmn">A.3.0</option>
+        <option value="A.4.0.bpmn">A.4.0</option>
+        <option value="A.4.1.bpmn">A.4.1</option>
+        <option value="B.1.0.bpmn">B.1.0</option>
+        <option value="B.2.0.bpmn">B.2.0</option>
+        <option value="C.1.0.bpmn">C.1.0</option>
+        <option value="C.1.1.bpmn">C.1.1</option>
+        <option value="C.2.0.bpmn">C.2.0</option>
+        <option value="C.3.0.bpmn">C.3.0</option>
+        <option value="C.3.0.bpmn">C.4.0</option>
+        <option value="C.3.0.bpmn">C.5.0</option>
+        <option value="C.6.0.bpmn">C.6.0</option>
+        <option value="D.3.0-unknown.bpmn">D.3.0</option>
+      </select>
+      <select name="select-open-bpmn-visualization-example" id="select-open-bpmn-visualization-example" title="Open remote BPMN diagram bpmn-visualization examples">
+        <option value="">...</option>
+        <option value="all_activity_types.bpmn">activities</option>
+        <option value="artifacts_and_data_reference.bpmn">artifacts and data reference</option>
+        <option value="all_event_boundaries.bpmn">boundary events</option>
+        <option value="all_event_types.bpmn" selected>events</option>
+        <option value="all_event_types_on_top.bpmn">events (top element)</option>
+        <option value="all_gateway_types.bpmn">gateways</option>
+        <option value="all_message_flow_types.bpmn">message flows</option>
+        <option value="all_sequence_flow_types.bpmn">sequence flows (various types)</option>
+        <option value="label_sequence_flows.bpmn">sequence flows (label)</option>
+        <option value="subprocesses.bpmn">subprocesses</option>
+        <option value="subprocesses_event_and_transaction.bpmn">subprocesses event and transaction</option>
+        <option value="does-not-exist.bpmn">unknown</option>
+      </select>
+    </div>
+
+    <div id="btn-group-export" class="btn-group btn-group-export">
+      <input type="button" class="btn-common btn-download-svg" id="btn-export-svg" title="Download as SVG image"/>
+      <input type="button" class="btn-common btn-download-png" id="btn-export-png" title="Download as PNG image"/>
+      <input type="button" class="btn-common btn-print" id="btn-export-preview" title="Print Preview">
+    </div>
+
+    <div id="btn-group-zoom" style="position: absolute;
+  top: 110px !important;
+  left: 15px !important;">
+        <button id="btn-zoom-in">+</button>
+        <button id="btn-zoom-out">-</button>
+        <button id="btn-zoom-actual">Reset to Actual</button>
+        <button id="btn-zoom-fit">Fit</button>
+        <button id="btn-zoom-fit-horizontal">Horizontal Fit</button>
+        <button id="btn-zoom-fit-vertical">Vertical Fit</button>
+    </div>
+    <div id="btn-group-renderer" style="position: absolute; top: 110px; left: 650px;">
+      <label for="btn-sketch">Sketch</label><input type="checkbox" id="btn-sketch">
+      <div style="position: relative; float: right; left: 20px">
+        <input type="checkbox" id="btn-ignore-bpmn-label-styles"><label for="btn-ignore-bpmn-label-styles" title="Load Time Only. When activated, the Label styles in the BPMN Diagram are ignored and default font settings apply">Ignore Label Styles</label>
+        <br>
+        <input type="checkbox" id="btn-fit-on-load"><label for="btn-fit-on-load" title="When activated, the BPMN diagram fits the whole viewport after load time">Fit On Load</label>
+      </div>
+    </div>
+
+
+    <div id="btn-group-navigation" style="position: absolute;
+  top: 150px !important;
+  left: 15px !important;">
+        <input type="button" class="btn-common btn-overview" id="btn-overview" title="Display the Diagram Overview"/>
+        <button id="btn-pan-up" title="Pan/Scroll Up">
+            Up
+        </button>
+        <button id="btn-pan-down" title="Pan/Scroll Down">
+            <!-- https://icons.getbootstrap.com/icons/arrow-down/ -->
+            <svg class="bi bi-arrow-down" width="1em" height="1em" viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                <path fill-rule="evenodd" d="M4.646 9.646a.5.5 0 0 1 .708 0L8 12.293l2.646-2.647a.5.5 0 0 1 .708.708l-3 3a.5.5 0 0 1-.708 0l-3-3a.5.5 0 0 1 0-.708z"/>
+                <path fill-rule="evenodd" d="M8 2.5a.5.5 0 0 1 .5.5v9a.5.5 0 0 1-1 0V3a.5.5 0 0 1 .5-.5z"/>
+            </svg>
+        </button>
+        <button id="btn-pan-left" title="Pan/Scroll Left">
+            <!-- https://icons.getbootstrap.com/icons/arrow-left-circle-fill/ -->
+            <svg class="bi bi-arrow-left-circle-fill" width="1em" height="1em" viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                <path fill-rule="evenodd" d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zm-7.646 2.646a.5.5 0 0 1-.708.708l-3-3a.5.5 0 0 1 0-.708l3-3a.5.5 0 1 1 .708.708L6.207 7.5H11a.5.5 0 0 1 0 1H6.207l2.147 2.146z"/>
+            </svg>
+        </button>
+        <button id="btn-pan-right" title="Pan/Scroll Right">
+            <!-- https://icons.getbootstrap.com/icons/arrow-right-circle/ -->
+            <svg class="bi bi-arrow-right-circle" width="1em" height="1em" viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                <path fill-rule="evenodd" d="M8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>
+                <path fill-rule="evenodd" d="M7.646 11.354a.5.5 0 0 1 0-.708L10.293 8 7.646 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708 0z"/>
+                <path fill-rule="evenodd" d="M4.5 8a.5.5 0 0 1 .5-.5h5a.5.5 0 0 1 0 1H5a.5.5 0 0 1-.5-.5z"/>
+            </svg>
+        </button>
+    </div>
+</div>
+<div id="graph" class="graph-container">
+</div>
+<div id="graph-overview" class="hidden graph-overview">
+</div>
+
+<!-- load global settings -->
     <script src="./static/js/configureMxGraphGlobals.js"></script>
     <!-- load mxGraph client library -->
     <script src="./static/js/mxClient.min.js"></script>

--- a/src/index.html
+++ b/src/index.html
@@ -38,9 +38,10 @@ left: 15px !important;"></div>
         <option value="C.1.1.bpmn">C.1.1</option>
         <option value="C.2.0.bpmn">C.2.0</option>
         <option value="C.3.0.bpmn">C.3.0</option>
-        <option value="C.3.0.bpmn">C.4.0</option>
-        <option value="C.3.0.bpmn">C.5.0</option>
+        <option value="C.4.0.bpmn">C.4.0</option>
+        <option value="C.5.0.bpmn">C.5.0</option>
         <option value="C.6.0.bpmn">C.6.0</option>
+        <option value="C.7.0.bpmn">C.7.0</option>
         <option value="D.3.0-unknown.bpmn">D.3.0</option>
       </select>
       <select name="select-open-bpmn-visualization-example" id="select-open-bpmn-visualization-example" title="Open remote BPMN diagram bpmn-visualization examples">

--- a/src/model/bpmn/shape/ShapeUtil.ts
+++ b/src/model/bpmn/shape/ShapeUtil.ts
@@ -54,6 +54,10 @@ export default class ShapeUtil {
     return this.EVENT_KINDS.includes(kind);
   }
 
+  public static isGateway(kind: ShapeBpmnElementKind): boolean {
+    return this.GATEWAY_KINDS.includes(kind);
+  }
+
   public static isCallActivity(kind: ShapeBpmnElementKind): boolean {
     return ShapeBpmnElementKind.CALL_ACTIVITY === kind;
   }

--- a/src/static/css/extended-demo.css
+++ b/src/static/css/extended-demo.css
@@ -1,0 +1,117 @@
+.graph-container {
+  /*element*/
+  /*    margin: 20px 20px 40px 70px;*/
+  top: 220px;
+  bottom: 20px;
+  left: 40px;
+  right: 40px;
+  /*touch-action: none;*/
+  /*div.base#graph*/
+  border-style: solid;
+  border-color: #F2F2F2;
+  border-width: 1px;
+  /*background: url('images/grid.gif');*/
+  /*div.base*/
+  position: absolute;
+  overflow: hidden;
+  /*font-family: Arial;*/
+  /*font-size: 8pt;*/
+}
+.btn-group {
+  background: #FAFAFA;
+  border: solid 1px black;
+  border-radius: 2px;
+
+  position: absolute;
+  box-sizing: border-box;
+  /*left: 20px;*/
+  /*top: 20px;*/
+  /*width: 48px;*/
+  /*height: 60px;*/
+}
+.btn-group-general {
+  top: 15px !important;
+  left: 15px !important;
+}
+.btn-group-import {
+  top: 15px !important;
+  left: 120px !important;
+}
+.btn-group-export {
+  top: 15px !important;
+  left: 650px !important;
+}
+.btn-common {
+  z-index: 2;
+  display: inline-block;
+  content: "";
+  background-repeat: no-repeat;
+  background-size: 1rem 1rem;
+  /*height: 32px;*/
+  width: 32px;
+  margin: 5px;
+}
+.btn-help {
+  /* https://icons.getbootstrap.com/icons/question-circle/ */
+  background-image: url("data:image/svg+xml,<svg viewBox='0 0 16 16' fill='%23333' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' d='M8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z'/><path d='M5.25 6.033h1.32c0-.781.458-1.384 1.36-1.384.685 0 1.313.343 1.313 1.168 0 .635-.374.927-.965 1.371-.673.489-1.206 1.06-1.168 1.987l.007.463h1.307v-.355c0-.718.273-.927 1.01-1.486.609-.463 1.244-.977 1.244-2.056 0-1.511-1.276-2.241-2.673-2.241-1.326 0-2.786.647-2.754 2.533zm1.562 5.516c0 .533.425.927 1.01.927.609 0 1.028-.394 1.028-.927 0-.552-.42-.94-1.029-.94-.584 0-1.009.388-1.009.94z'/></svg>");
+}
+.btn-settings {
+  /* https://icons.getbootstrap.com/icons/gear-fill/ */
+  background-image: url("data:image/svg+xml,<svg viewBox='0 0 16 16' fill='%23333' xmlns='http://www.w3.org/2000/svg'> <path fill-rule='evenodd' d='M9.405 1.05c-.413-1.4-2.397-1.4-2.81 0l-.1.34a1.464 1.464 0 0 1-2.105.872l-.31-.17c-1.283-.698-2.686.705-1.987 1.987l.169.311c.446.82.023 1.841-.872 2.105l-.34.1c-1.4.413-1.4 2.397 0 2.81l.34.1a1.464 1.464 0 0 1 .872 2.105l-.17.31c-.698 1.283.705 2.686 1.987 1.987l.311-.169a1.464 1.464 0 0 1 2.105.872l.1.34c.413 1.4 2.397 1.4 2.81 0l.1-.34a1.464 1.464 0 0 1 2.105-.872l.31.17c1.283.698 2.686-.705 1.987-1.987l-.169-.311a1.464 1.464 0 0 1 .872-2.105l.34-.1c1.4-.413 1.4-2.397 0-2.81l-.34-.1a1.464 1.464 0 0 1-.872-2.105l.17-.31c.698-1.283-.705-2.686-1.987-1.987l-.311.169a1.464 1.464 0 0 1-2.105-.872l-.1-.34zM8 10.93a2.929 2.929 0 1 0 0-5.86 2.929 2.929 0 0 0 0 5.858z'/>></svg>");
+}
+.btn-clean {
+  /*https://icons.getbootstrap.com/icons/trash-fill/*/
+  background-image: url("data:image/svg+xml,<svg viewBox='0 0 16 16' class='bi bi-trash-fill' fill='currentColor' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' d='M2.5 1a1 1 0 0 0-1 1v1a1 1 0 0 0 1 1H3v9a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2V4h.5a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1H10a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1H2.5zm3 4a.5.5 0 0 1 .5.5v7a.5.5 0 0 1-1 0v-7a.5.5 0 0 1 .5-.5zM8 5a.5.5 0 0 1 .5.5v7a.5.5 0 0 1-1 0v-7A.5.5 0 0 1 8 5zm3 .5a.5.5 0 0 0-1 0v7a.5.5 0 0 0 1 0v-7z'/></svg>");
+}
+.btn-open {
+  /* https://icons.getbootstrap.com/icons/file-earmark/ */
+  background-image: url("data:image/svg+xml,<svg width='1em' height='1em' viewBox='0 0 16 16' class='bi bi-file-earmark' fill='currentColor' xmlns='http://www.w3.org/2000/svg'><path d='M4 1h5v1H4a1 1 0 0 0-1 1v10a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V6h1v7a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V3a2 2 0 0 1 2-2z'/><path d='M9 4.5V1l5 5h-3.5A1.5 1.5 0 0 1 9 4.5z'/></svg>");
+}
+.btn-overview {
+  /* https://www.flaticon.com/free-icon/map_1010816
+  Icons made by <a href="https://www.flaticon.com/authors/vitaly-gorbachev" title="Vitaly Gorbachev">Vitaly Gorbachev</a> from <a href="https://www.flaticon.com/" title="Flaticon"> www.flaticon.com</a> */
+  background-image: url("data:image/svg+xml,<svg version='1.1' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 384.528 384.528' style='enable-background:new 0 0 384.528 384.528;'><path d='M256.664,7.024l-128,48L0.264,0v144v46.936v131.88l127.6,54.688l128-48l128.4,55.024v-153.56v-46.704V61.712 L256.664,7.024z M112.264,336l-80-34.288V192.528l80,34.288V336z M112.264,192l-80-34.288V48.528l80,34.288V192z M240.264,301.176 l-96,36V227.352l96-36V301.176z M240.264,157.176l-96,36V83.352l96-36V157.176z M352.264,336l-80-34.288V190.968l80,28.568V336z M352.264,184.264v1.296l-80-28.576V48.528l80,34.288V184.264z'/></svg>");
+}
+.btn-download-svg {
+  /* https://icons.getbootstrap.com/icons/download/ */
+  background-image: url("data:image/svg+xml,<svg viewBox='0 0 16 16' fill='%23333' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' d='M.5 8a.5.5 0 0 1 .5.5V12a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V8.5a.5.5 0 0 1 1 0V12a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V8.5A.5.5 0 0 1 .5 8z'/><path fill-rule='evenodd' d='M5 7.5a.5.5 0 0 1 .707 0L8 9.793 10.293 7.5a.5.5 0 1 1 .707.707l-2.646 2.647a.5.5 0 0 1-.708 0L5 8.207A.5.5 0 0 1 5 7.5z'/><path fill-rule='evenodd' d='M8 1a.5.5 0 0 1 .5.5v8a.5.5 0 0 1-1 0v-8A.5.5 0 0 1 8 1z'/></svg>");
+}
+.btn-download-png {
+  /* https://icons.getbootstrap.com/icons/image/ */
+  background-image: url("data:image/svg+xml,<svg viewBox='0 0 16 16' fill='%23333' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' d='M14.002 2h-12a1 1 0 0 0-1 1v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V3a1 1 0 0 0-1-1zm-12-1a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V3a2 2 0 0 0-2-2h-12z'/><path d='M10.648 7.646a.5.5 0 0 1 .577-.093L15.002 9.5V14h-14v-2l2.646-2.354a.5.5 0 0 1 .63-.062l2.66 1.773 3.71-3.71z'/><path fill-rule='evenodd' d='M4.502 7a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3z'/> </svg>");
+}
+.btn-print {
+  /* https://icons.getbootstrap.com/icons/printer/ */
+  background-image: url("data:image/svg+xml,<svg viewBox='0 0 16 16' class='bi bi-printer' fill='currentColor' xmlns='http://www.w3.org/2000/svg'><path d='M11 2H5a1 1 0 0 0-1 1v2H3V3a2 2 0 0 1 2-2h6a2 2 0 0 1 2 2v2h-1V3a1 1 0 0 0-1-1zm3 4H2a1 1 0 0 0-1 1v3a1 1 0 0 0 1 1h1v1H2a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2h-1v-1h1a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1z'/><path fill-rule='evenodd' d='M11 9H5a1 1 0 0 0-1 1v3a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1v-3a1 1 0 0 0-1-1zM5 8a2 2 0 0 0-2 2v3a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2v-3a2 2 0 0 0-2-2H5z'/><path d='M3 7.5a.5.5 0 1 1-1 0 .5.5 0 0 1 1 0z'/></svg>");
+}
+
+.status-pending {
+  color: blueviolet;
+  font-style: italic;
+}
+.status-ok {
+  color: #2ecc71;
+}
+.status-ko {
+  color: red;
+  font-weight: bold;
+}
+
+
+.graph-overview {
+  /* TODO activate when/if we implement setting the main graph center by clicking somewhere on the overview outside of the overview rectangle border
+  cursor: crosshair;*/
+  overflow: hidden;
+  position: absolute;
+  top: 20px;
+  right: 40px;
+  width: 320px;
+  height: 180px;
+  /*position: relative;*/
+  /*width: 100%;*/
+  /*height: 100%;*/
+  background-color: rgba(255, 255, 255, .8); /* white with transparency*/
+  /*cursor: move;*/
+  border: 2px solid #ccc;
+  border-radius: 2px;
+}

--- a/src/static/js/demo.js
+++ b/src/static/js/demo.js
@@ -14,8 +14,11 @@
  * limitations under the License.
  */
 import {
+  applySketchStyle,
   configureExportButtons,
+  configureFitOnLoad,
   configureGeneralGraphButtons,
+  configureIgnoreBpmnLabelStyles,
   configureNavigationButtons,
   configureZoomButtons,
   documentReady,
@@ -58,6 +61,24 @@ function configureOpenButtons() {
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+function configureRenderingButtons() {
+  const btnSketch = document.getElementById('btn-sketch');
+  btnSketch.onclick = function () {
+    applySketchStyle(btnSketch.checked);
+  };
+
+  const btnFitOnLoad = document.getElementById('btn-fit-on-load');
+  btnFitOnLoad.onclick = function () {
+    configureFitOnLoad(btnFitOnLoad.checked);
+  };
+
+  const btnIgnoreBpmnLabelStyles = document.getElementById('btn-ignore-bpmn-label-styles');
+  btnIgnoreBpmnLabelStyles.onclick = function () {
+    configureIgnoreBpmnLabelStyles(btnIgnoreBpmnLabelStyles.checked);
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 function startDemo() {
   startBpmnVisualization({ container: 'graph' });
 
@@ -68,6 +89,7 @@ function startDemo() {
   };
 
   configureGeneralGraphButtons();
+  configureRenderingButtons();
 
   configureOpenButtons();
 

--- a/src/static/js/demo.js
+++ b/src/static/js/demo.js
@@ -18,6 +18,7 @@ import {
   configureExportButtons,
   configureFitOnLoad,
   configureGeneralGraphButtons,
+  configureIgnoreBpmnLabelFont,
   configureIgnoreBpmnLabelStyles,
   configureNavigationButtons,
   configureZoomButtons,
@@ -75,6 +76,11 @@ function configureRenderingButtons() {
   const btnIgnoreBpmnLabelStyles = document.getElementById('btn-ignore-bpmn-label-styles');
   btnIgnoreBpmnLabelStyles.onclick = function () {
     configureIgnoreBpmnLabelStyles(btnIgnoreBpmnLabelStyles.checked);
+  };
+
+  const btnIgnoreBpmnLabelFont = document.getElementById('btn-ignore-bpmn-label-font');
+  btnIgnoreBpmnLabelFont.onclick = function () {
+    configureIgnoreBpmnLabelFont(btnIgnoreBpmnLabelFont.checked);
   };
 }
 

--- a/src/static/js/demo.js
+++ b/src/static/js/demo.js
@@ -13,13 +13,67 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { documentReady, handleFileSelect, startBpmnVisualization } from '../../index.es.js';
+import {
+  configureExportButtons,
+  configureGeneralGraphButtons,
+  configureNavigationButtons,
+  configureZoomButtons,
+  documentReady,
+  handleFileSelect,
+  log,
+  openFromUrl,
+  startBpmnVisualization,
+} from '../../index.es.js';
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+function configureOpenButtons() {
+  document.getElementById('btn-open-input-file').addEventListener('change', handleFileSelect, false);
+  document.getElementById('btn-open').addEventListener('click', () => {
+    document.getElementById('btn-open-input-file').click();
+  });
+
+  // DISABLED
+  // document.getElementById('btn-open-url').onclick = function () {
+  //   const url = (document.getElementById('input-open-url') as HTMLInputElement).value;
+  //   openFromUrl(url);
+  // };
+
+  document.getElementById('select-open-migw').onchange = function () {
+    const fileName = document.getElementById('select-open-migw').value;
+    if (fileName) {
+      log('Start opening MIGW file %s', fileName);
+      const url = `https://raw.githubusercontent.com/bpmn-miwg/bpmn-miwg-test-suite/master/Reference/${fileName}`;
+      openFromUrl(url);
+    }
+  };
+
+  document.getElementById('select-open-bpmn-visualization-example').onchange = function () {
+    const fileName = document.getElementById('select-open-bpmn-visualization-example').value;
+    if (fileName) {
+      log('Start opening bpmn-visualization-example file %s', fileName);
+      const url = `https://raw.githubusercontent.com/process-analytics/bpmn-visualization-examples/master/bpmn-files/${fileName}`;
+      openFromUrl(url);
+    }
+  };
+}
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 function startDemo() {
   startBpmnVisualization({ container: 'graph' });
-  document.getElementById('bpmn-file').addEventListener('change', handleFileSelect, false);
-  document.getElementById('file-selector').classList.remove('hidden');
+
+  document.getElementById('btn-help').onclick = function () {
+    log('click btn-help');
+    // TODO implement a more convenient popup/modal
+    window.alert('Keyboard Shortcuts\nPanning: use arrow');
+  };
+
+  configureGeneralGraphButtons();
+
+  configureOpenButtons();
+
+  configureExportButtons();
+  configureNavigationButtons();
+  configureZoomButtons();
 }
 
 documentReady(startDemo());

--- a/test/e2e/config/jest.globals.ts
+++ b/test/e2e/config/jest.globals.ts
@@ -22,6 +22,7 @@ const {
   mxConstants,
   mxCodec,
   mxCodecRegistry,
+  mxEvent,
   mxSvgCanvas2D,
   mxCellRenderer,
   mxGeometry,
@@ -47,6 +48,7 @@ globalAny.mxUtils = mxUtils;
 globalAny.mxConstants = mxConstants;
 globalAny.mxCodec = mxCodec;
 globalAny.mxCodecRegistry = mxCodecRegistry;
+globalAny.mxEvent = mxEvent;
 globalAny.mxSvgCanvas2D = mxSvgCanvas2D;
 globalAny.mxCellRenderer = mxCellRenderer;
 globalAny.mxGeometry = mxGeometry;


### PR DESCRIPTION
This is the latest part of the series about demo poc (see #361 and #555 for previous versions).
There won't be new poc on that topic
- navigation is going to be implemented directly in the library. For instance, in version `0.6.0`, we already have: zoom and pan using the mouse, fit on load including a new `fit+center` option
- this poc has served as base for examples (remote file loading, fit)
- sketchy BPMN will be demonstrated with examples when the [mxgraph-sketch](https://github.com/process-analytics/mxgraph-sketch) extension will be more mature

### General information

You can run the demo locally by using [demo-a604752d.zip](https://github.com/process-analytics/bpmn-visualization-js/files/5505202/demo-a604752d.zip)
- unzip it
- serve it with an http server (this is required because it uses ES module script)
- access to the index.html page


### Sketch improvements
- roughjs dependencies cleaning
- allow to only ignore font family in addition to all label styles: we only need to be able to choose a sketchy font, we can keep font size and alterations (italic, bold, ...)
- apply sketch style to messages flows

![sketch_improvements](https://user-images.githubusercontent.com/27200110/98447496-81325c80-2125-11eb-919f-c05214d3e3aa.gif)


### `miwg-test-suite` files list
Fix the list and add C.7.0

![image](https://user-images.githubusercontent.com/27200110/98447533-c6568e80-2125-11eb-9596-f6f90c988d09.png)

