### PR TITLE
[REFACTOR] Prepare the demo page for the fit after load

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -11,7 +11,7 @@
       <div id="options-panel">
         <div>
           <h3>Options</h3>
-          <label>Fit on load
+          <label>Fit type
             <select name="fitTypes" id="fitType-selected">
               <option value="None" selected="yes">None</option>
               <option value="HorizontalVertical">Horizontal-Vertical</option>

--- a/test/e2e/helpers/visu-utils.ts
+++ b/test/e2e/helpers/visu-utils.ts
@@ -109,7 +109,7 @@ export class BpmnDiagramPreparation {
     loadOptions: LoadOptions = { fit: { type: FitType.HorizontalVertical } },
   ) {
     const params = targetedPage.queryParams?.join('&') ?? '';
-    this.baseUrl = `http://localhost:10002/${targetedPage.name}.html?fitType=${FitType[loadOptions?.fit?.type]}&fitMargin=${loadOptions?.fit?.margin}&${params}`;
+    this.baseUrl = `http://localhost:10002/${targetedPage.name}.html?fitTypeOnLoad=${FitType[loadOptions?.fit?.type]}&fitMargin=${loadOptions?.fit?.margin}&${params}`;
   }
 
   /**


### PR DESCRIPTION
- introduce functions to configure fit on load options from url parameters (all pages)
- introduce functions to configure demo elements (buttons and inputs)
- rename url parameter from `fitType` to `fitTypeOnLoad`
- debug: always log 'load options' after loading the diagram (previously, this was only done at configuration time)

Covers #738 