### PR TITLE
[INFRA] more visible remaining manual edits in release-drafter template

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -45,13 +45,15 @@ exclude-labels:
   - reverted
   - wontfix
 template: |
+  **TODO: review the contributors list (remove our bot and avoid duplicates)**
   Thanks to all the contributors of this release 🌈: $CONTRIBUTORS
 
-  <!-- TODO: add milestone id when publishing -->
+  **TODO: add milestone id when publishing**
   See [milestone $NEXT_PATCH_VERSION](https://github.com/process-analytics/bpmn-visualization-js/milestone/x?closed=1) to get the list of issues covered by this release.
 
   # Highlights
-  <!-- TODO: add screenshots and user oriented info -->
+
+  **TODO: add screenshots and user oriented info**
 
   # What's Changed
   $CHANGES


### PR DESCRIPTION
Previously, guidelines for release-notes remaining edits were provided as
comments, so they weren't visible in the displayed draft.
They are now visible in the rendered DRAFT to help not forgetting what has to
be done at release time.