### PR TITLE
[INFRA] Avoid extra html documentation rebuild

### DIFF
--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -5,14 +5,14 @@ on:
     branches:
       - master
     paths:
-      - 'docs/**'
+      - 'docs/users/**'
       - 'scripts/docs.js'
       - '.github/workflows/generate-documentation.yml'
   pull_request:
     branches:
       - master
     paths:
-      - 'docs/**'
+      - 'docs/users/**'
       - 'scripts/docs.js'
       - '.github/workflows/generate-documentation.yml'
 


### PR DESCRIPTION
Only rebuild the documentation when the `users` content changes and not when the `contributors` content changes as it is not part of the sources used to build the HTML documentation.