### PR TITLE
[INFRA] Don't run 'tsc' in pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "tsc --noEmit && lint-staged"
+      "pre-commit": "lint-staged"
     }
   }
 }


### PR DESCRIPTION
The pre-commit hook for linting is very useful because we always forget to run
it, especially when pushing.

Running 'tsc' seems also a good idea at the beginning of the project, but now,
it takes several seconds to complete which makes the commit experience boring.
This is particularly annoying for people that work with baby steps and commit
very frequently.
The gain of the of compilation check versus the time to wait before moving
forward don't worth the price: IDE or command line allows to run incremental
compilation fast and we almost never push code that don't compile.