### PR TITLE
[FEAT] Add API to search elements by BPMN Kinds

### DIFF
--- a/src/component/registry/bpmn-elements-registry.ts
+++ b/src/component/registry/bpmn-elements-registry.ts
@@ -138,8 +138,7 @@ export class BpmnQuerySelectors {
   }
 
   elementsOfKind(kind: string): string {
-    // style is NOT empty in g node that hold the label i.e. the one with a foreignObject
-    return `#${this.containerId} > svg > g > g > g.${kind}:not([style=""])`;
+    return `#${this.containerId} > svg > g > g > g.${kind}:not(.bpmn-label)`;
   }
 }
 

--- a/src/component/registry/bpmn-elements-registry.ts
+++ b/src/component/registry/bpmn-elements-registry.ts
@@ -38,9 +38,9 @@ export class BpmnElementsRegistry {
       .map(bpmnSemantic => ({ bpmnSemantic: bpmnSemantic, htmlElement: this.htmlElementRegistry.getBpmnHtmlElement(bpmnSemantic.id) }));
   }
 
-  getElementsByKinds(bpmnKinds: BpmnKind | BpmnKind[]): BpmnElement[] {
+  getElementsByKinds(bpmnKinds: BpmnElementKind | BpmnElementKind[]): BpmnElement[] {
     const bpmnElements: BpmnElement[] = [];
-    ensureIsArray<BpmnKind>(bpmnKinds)
+    ensureIsArray<BpmnElementKind>(bpmnKinds)
       .map(kind =>
         // TODO when implementing #953, use the model to search for Bpmn elements matching kinds instead of css selectors
         this.htmlElementRegistry.getBpmnHtmlElements(kind).map(
@@ -58,14 +58,14 @@ export class BpmnElementsRegistry {
   }
 }
 
-export type BpmnKind = FlowKind | ShapeBpmnElementKind;
+export type BpmnElementKind = FlowKind | ShapeBpmnElementKind;
 
 export interface BpmnSemantic {
   id: string;
   name: string;
   /** `true` when relates to a BPMN Shape, `false` when relates to a BPMN Edge. */
   isShape: boolean;
-  // TODO use a more 'type oriented' BpmnKind (as part of #929)
+  // TODO use a more 'type oriented' BpmnElementKind (as part of #929)
   kind: string;
 }
 
@@ -154,7 +154,7 @@ class HtmlElementRegistry {
     return document.querySelector<HTMLElement>(this.selectors.element(bpmnElementId));
   }
 
-  getBpmnHtmlElements(bpmnElementKind: BpmnKind): HTMLElement[] {
+  getBpmnHtmlElements(bpmnElementKind: BpmnElementKind): HTMLElement[] {
     const selectors = this.selectors.elementsOfKind(computeBpmnBaseClassName(bpmnElementKind));
     return [...document.querySelectorAll<HTMLElement>(selectors)];
   }

--- a/src/component/registry/bpmn-elements-registry.ts
+++ b/src/component/registry/bpmn-elements-registry.ts
@@ -137,8 +137,8 @@ export class BpmnQuerySelectors {
     return `#${this.containerId} > svg > g > g > g[data-bpmn-id="${bpmnElementId}"].bpmn-label > g > foreignObject`;
   }
 
-  elementsOfKind(kind: string): string {
-    return `#${this.containerId} > svg > g > g > g.${kind}:not(.bpmn-label)`;
+  elementsOfKind(bpmnKindCssClassname: string): string {
+    return `#${this.containerId} > svg > g > g > g.${bpmnKindCssClassname}:not(.bpmn-label)`;
   }
 }
 
@@ -154,8 +154,8 @@ class HtmlElementRegistry {
     return document.querySelector<HTMLElement>(this.selectors.element(bpmnElementId));
   }
 
-  getBpmnHtmlElements(kind: BpmnKind): HTMLElement[] {
-    const selectors = this.selectors.elementsOfKind(computeBpmnBaseClassName(kind));
+  getBpmnHtmlElements(bpmnElementKind: BpmnKind): HTMLElement[] {
+    const selectors = this.selectors.elementsOfKind(computeBpmnBaseClassName(bpmnElementKind));
     return [...document.querySelectorAll<HTMLElement>(selectors)];
   }
 }

--- a/src/demo/index.ts
+++ b/src/demo/index.ts
@@ -17,7 +17,7 @@ import BpmnVisualization from '../component/BpmnVisualization';
 import { GlobalOptions, FitOptions, FitType, LoadOptions } from '../component/options';
 import { log, logStartup } from './helper';
 import { DropFileUserInterface } from './component/DropFileUserInterface';
-import { BpmnElement, BpmnKind } from '../component/registry/bpmn-elements-registry';
+import { BpmnElement, BpmnElementKind } from '../component/registry/bpmn-elements-registry';
 
 export * from './helper';
 
@@ -53,7 +53,7 @@ export function fit(fitOptions: FitOptions): void {
   log('Fit done with configuration', stringify(fitOptions));
 }
 
-export function getElementsByKinds(bpmnKinds: BpmnKind | BpmnKind[]): BpmnElement[] {
+export function getElementsByKinds(bpmnKinds: BpmnElementKind | BpmnElementKind[]): BpmnElement[] {
   return bpmnVisualization.bpmnElementsRegistry.getElementsByKinds(bpmnKinds);
 }
 

--- a/src/demo/index.ts
+++ b/src/demo/index.ts
@@ -17,6 +17,7 @@ import BpmnVisualization from '../component/BpmnVisualization';
 import { GlobalOptions, FitOptions, FitType, LoadOptions } from '../component/options';
 import { log, logStartup } from './helper';
 import { DropFileUserInterface } from './component/DropFileUserInterface';
+import { BpmnElement, BpmnKind } from '../component/registry/bpmn-elements-registry';
 
 export * from './helper';
 
@@ -50,6 +51,10 @@ export function fit(fitOptions: FitOptions): void {
   log('Fitting....');
   bpmnVisualization.fit(fitOptions);
   log('Fit done with configuration', stringify(fitOptions));
+}
+
+export function getElementsByKinds(bpmnKinds: BpmnKind | BpmnKind[]): BpmnElement[] {
+  return bpmnVisualization.bpmnElementsRegistry.getElementsByKinds(bpmnKinds);
 }
 
 // callback function for opening | dropping the file to be loaded

--- a/src/elements-identification.html
+++ b/src/elements-identification.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>BPMN Visualization Non Regression</title>
+    <link rel="shortcut icon" href="./static/img/favicon.ico">
+    <style>
+      #main-container {
+        top: 140px;
+        bottom: 10px;
+        left: 10px;
+        right: 10px;
+        position: absolute;
+      }
+      #bpmn-container {
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
+
+        border-style: solid;
+        border-color: #B0B0B0;
+        border-width: 1px;
+
+        position: absolute;
+        overflow: hidden;
+      }
+
+      textarea {
+        resize: none;
+        height: 100px;
+        right: 10px;
+        position: absolute;
+        width: 70%;
+      }
+    </style>
+</head>
+<body>
+    <div id="controls">
+      <label for="bpmn-kinds-select">Select by Kinds:</label><select id="bpmn-kinds-select">
+        <option value="task">Abstract Task</option>
+        <option value="userTask">User Task</option>
+        <option value="scriptTask">Script Task</option>
+        <option value="serviceTask">Service Task</option>
+        <option value="startEvent">Start Event</option>
+        <option value="endEvent">End Event</option>
+        <option value="intermediateCatchEvent">Catch Event</option>
+        <option value="intermediateThrowEvent">Throw Event</option>
+        <option value="lane">Lane</option>
+      </select>
+      <button id="bpmn-kinds-textarea-clean-btn">Clear</button>
+      <textarea id="elements-result"></textarea>
+    </div>
+
+    <div id="main-container">
+      <div id="bpmn-container"></div>
+    </div>
+
+    <!-- load global settings -->
+    <script src="./static/js/configureMxGraphGlobals.js"></script>
+    <!-- load mxGraph client library -->
+    <script src="./static/js/mxClient.min.js"></script>
+    <!-- load app -->
+    <script src="./static/js/elements-identification.js" type="module"></script>
+</body>
+</html>

--- a/src/static/js/elements-identification.js
+++ b/src/static/js/elements-identification.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { documentReady, FitType, getElementsByKinds, log, startBpmnVisualization, updateLoadOptions } from '../../index.es.js';
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+function configureControls() {
+  const textArea = document.getElementById('elements-result');
+
+  document.getElementById('bpmn-kinds-select').onchange = function (ev) {
+    const bpmnKind = ev.target.value;
+    log(`Searching for Bpmn elements of '${bpmnKind}' kind`);
+    const elementsByKinds = getElementsByKinds(bpmnKind);
+
+    const textHeader = `Found ${elementsByKinds.length} ${bpmnKind}(s)`;
+    log(textHeader);
+    const lines = elementsByKinds.map(elt => `  - ${elt.bpmnSemantic.id}: '${elt.bpmnSemantic.name}'`).join('\n');
+
+    textArea.value += [textHeader, lines].join('\n') + '\n';
+    textArea.scrollTop = textArea.scrollHeight;
+  };
+
+  document.getElementById('bpmn-kinds-textarea-clean-btn').onclick = function () {
+    textArea.value = '';
+  };
+}
+
+documentReady(() => {
+  startBpmnVisualization({
+    container: 'bpmn-container',
+    globalOptions: {
+      mouseNavigationSupport: true,
+    },
+  });
+  updateLoadOptions({ type: FitType.Center, margin: 20 });
+  configureControls();
+});

--- a/test/e2e/mxGraph.dom.test.ts
+++ b/test/e2e/mxGraph.dom.test.ts
@@ -13,10 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import BpmnVisualization from '../../src/component/BpmnVisualization';
 import { readFileSync } from '../helpers/file-helper';
-import { HtmlElementLookup } from './helpers/visu-utils';
-import { ShapeBpmnElementKind } from '../../src/model/bpmn/internal/shape';
+import { expectSvgEvent, expectSvgPool, expectSvgSequenceFlow, expectSvgTask, HtmlElementLookup } from './helpers/visu-utils';
+import { BpmnElement, BpmnVisualization, ShapeBpmnElementKind } from '../../src/bpmn-visualization';
 import { FlowKind } from '../../src/model/bpmn/internal/edge/FlowKind';
 
 const bpmnContainerId = 'bpmn-visualization-container';
@@ -43,29 +42,123 @@ describe('DOM only checks', () => {
   });
 });
 
+interface ExpectedBaseBpmnElement {
+  id: string;
+  name?: string;
+}
+
+function expectShapeBpmnElement(bpmnElement: BpmnElement, expected: ExpectedBaseBpmnElement): void {
+  const bpmnSemantic = bpmnElement.bpmnSemantic;
+  expect(bpmnSemantic.id).toEqual(expected.id);
+  expect(bpmnSemantic.name).toEqual(expected.name);
+  expect(bpmnSemantic.isShape).toBeTruthy();
+}
+
+function expectStartEventBpmnElement(bpmnElement: BpmnElement, expected: ExpectedBaseBpmnElement): void {
+  expectShapeBpmnElement(bpmnElement, expected);
+  expect(bpmnElement.bpmnSemantic.kind).toEqual(ShapeBpmnElementKind.EVENT_START);
+
+  expectSvgEvent(bpmnElement.htmlElement);
+}
+
+function expectEndEventBpmnElement(bpmnElement: BpmnElement, expected: ExpectedBaseBpmnElement): void {
+  expectShapeBpmnElement(bpmnElement, expected);
+  expect(bpmnElement.bpmnSemantic.kind).toEqual(ShapeBpmnElementKind.EVENT_END);
+
+  expectSvgEvent(bpmnElement.htmlElement);
+}
+
+function expectSequenceFlowBpmnElement(bpmnElement: BpmnElement, expected: ExpectedBaseBpmnElement): void {
+  const bpmnSemantic = bpmnElement.bpmnSemantic;
+  expect(bpmnSemantic.id).toEqual(expected.id);
+  expect(bpmnSemantic.name).toEqual(expected.name);
+  expect(bpmnSemantic.isShape).toBeFalsy();
+  expect(bpmnSemantic.kind).toEqual(FlowKind.SEQUENCE_FLOW);
+
+  expectSvgSequenceFlow(bpmnElement.htmlElement);
+}
+
+function expectTaskBpmnElement(bpmnElement: BpmnElement, expected: ExpectedBaseBpmnElement): void {
+  expectShapeBpmnElement(bpmnElement, expected);
+  expect(bpmnElement.bpmnSemantic.kind).toEqual(ShapeBpmnElementKind.TASK);
+
+  expectSvgTask(bpmnElement.htmlElement);
+}
+
+function expectServiceTaskBpmnElement(bpmnElement: BpmnElement, expected: ExpectedBaseBpmnElement): void {
+  expectShapeBpmnElement(bpmnElement, expected);
+  expect(bpmnElement.bpmnSemantic.kind).toEqual(ShapeBpmnElementKind.TASK_SERVICE);
+
+  expectSvgTask(bpmnElement.htmlElement);
+}
+
+function expectPoolBpmnElement(bpmnElement: BpmnElement, expected: ExpectedBaseBpmnElement): void {
+  expectShapeBpmnElement(bpmnElement, expected);
+  expect(bpmnElement.bpmnSemantic.kind).toEqual(ShapeBpmnElementKind.POOL);
+
+  expectSvgPool(bpmnElement.htmlElement);
+}
+
 describe('Bpmn Elements registry', () => {
-  it('Look for several BPMN elements by ids', async () => {
-    bpmnVisualization.load(readFileSync('../fixtures/bpmn/simple-start-task-end.bpmn'));
+  describe('Get by ids', () => {
+    it('Pass several existing ids', async () => {
+      bpmnVisualization.load(readFileSync('../fixtures/bpmn/simple-start-task-end.bpmn'));
 
-    const bpmnElements = bpmnVisualization.bpmnElementsRegistry.getElementsByIds(['StartEvent_1', 'Flow_2']);
-    expect(bpmnElements).toHaveLength(2);
+      const bpmnElements = bpmnVisualization.bpmnElementsRegistry.getElementsByIds(['StartEvent_1', 'Flow_2']);
+      expect(bpmnElements).toHaveLength(2);
 
-    const startEventBpmnSemantic = bpmnElements[0].bpmnSemantic;
-    expect(startEventBpmnSemantic.id).toEqual('StartEvent_1');
-    expect(startEventBpmnSemantic.isShape).toBeTruthy();
-    expect(startEventBpmnSemantic.kind).toEqual(ShapeBpmnElementKind.EVENT_START);
-    expect(startEventBpmnSemantic.name).toEqual('Start Event 1');
+      expectStartEventBpmnElement(bpmnElements[0], { id: 'StartEvent_1', name: 'Start Event 1' });
+      expectSequenceFlowBpmnElement(bpmnElements[1], { id: 'Flow_2' });
+    });
 
-    const sequenceFlow2BpmnSemantic = bpmnElements[1].bpmnSemantic;
-    expect(sequenceFlow2BpmnSemantic.id).toEqual('Flow_2');
-    expect(sequenceFlow2BpmnSemantic.isShape).toBeFalsy();
-    expect(sequenceFlow2BpmnSemantic.kind).toEqual(FlowKind.SEQUENCE_FLOW);
-    expect(sequenceFlow2BpmnSemantic.name).toBeUndefined();
+    it('Pass a single non existing id', async () => {
+      bpmnVisualization.load(readFileSync('../fixtures/bpmn/simple-start-task-end.bpmn'));
+      const bpmnElements = bpmnVisualization.bpmnElementsRegistry.getElementsByIds('unknown');
+      expect(bpmnElements).toHaveLength(0);
+    });
   });
 
-  it('Look for unknown BPMN elements by ids', async () => {
-    bpmnVisualization.load(readFileSync('../fixtures/bpmn/simple-start-task-end.bpmn'));
-    const bpmnElements = bpmnVisualization.bpmnElementsRegistry.getElementsByIds('unknown');
-    expect(bpmnElements).toHaveLength(0);
+  describe('Get by kinds', () => {
+    it('Pass a single kind related to a single existing element', async () => {
+      bpmnVisualization.load(readFileSync('../fixtures/bpmn/simple-start-task-end.bpmn'));
+      const bpmnElements = bpmnVisualization.bpmnElementsRegistry.getElementsByKinds(ShapeBpmnElementKind.TASK);
+      expect(bpmnElements).toHaveLength(1);
+
+      expectTaskBpmnElement(bpmnElements[0], { id: 'Activity_1', name: 'Task 1' });
+    });
+
+    it('Pass a single kind related to several existing elements', async () => {
+      bpmnVisualization.load(readFileSync('../fixtures/bpmn/simple-start-task-end.bpmn'));
+      const bpmnElements = bpmnVisualization.bpmnElementsRegistry.getElementsByKinds(FlowKind.SEQUENCE_FLOW);
+      expect(bpmnElements).toHaveLength(2);
+
+      expectSequenceFlowBpmnElement(bpmnElements[0], { id: 'Flow_1', name: 'Sequence Flow 1' });
+      expectSequenceFlowBpmnElement(bpmnElements[1], { id: 'Flow_2' });
+    });
+
+    it('No elements for this kind', async () => {
+      bpmnVisualization.load(readFileSync('../fixtures/bpmn/simple-start-task-end.bpmn'));
+      const bpmnElements = bpmnVisualization.bpmnElementsRegistry.getElementsByKinds(ShapeBpmnElementKind.SUB_PROCESS);
+      expect(bpmnElements).toHaveLength(0);
+    });
+
+    it('Pass a several kinds that all match existing elements', async () => {
+      bpmnVisualization.load(readFileSync('../fixtures/bpmn/registry/1-pool-3-lanes-message-start-end-intermediate-events.bpmn'));
+      const bpmnElements = bpmnVisualization.bpmnElementsRegistry.getElementsByKinds([ShapeBpmnElementKind.EVENT_END, ShapeBpmnElementKind.POOL]);
+      expect(bpmnElements).toHaveLength(3);
+
+      expectEndEventBpmnElement(bpmnElements[0], { id: 'endEvent_terminate_1', name: 'terminate end 1' });
+      expectEndEventBpmnElement(bpmnElements[1], { id: 'endEvent_message_1', name: 'message end 2' });
+      expectPoolBpmnElement(bpmnElements[2], { id: 'Participant_1', name: 'Pool 1' });
+    });
+
+    it('Pass a several kinds that match existing and non-existing elements', async () => {
+      bpmnVisualization.load(readFileSync('../fixtures/bpmn/registry/1-pool-3-lanes-message-start-end-intermediate-events.bpmn'));
+      const bpmnElements = bpmnVisualization.bpmnElementsRegistry.getElementsByKinds([ShapeBpmnElementKind.CALL_ACTIVITY, ShapeBpmnElementKind.TASK_SERVICE]);
+      expect(bpmnElements).toHaveLength(2);
+
+      expectServiceTaskBpmnElement(bpmnElements[0], { id: 'serviceTask_1_2', name: 'Service Task 1.2' });
+      expectServiceTaskBpmnElement(bpmnElements[1], { id: 'serviceTask_2_1', name: 'Service Task 2.1' });
+    });
   });
 });

--- a/test/e2e/mxGraph.view.test.ts
+++ b/test/e2e/mxGraph.view.test.ts
@@ -24,13 +24,13 @@ async function expectLabel(bpmnId: string, expectedText?: string): Promise<void>
   if (!expectedText) {
     return;
   }
-  const svgElementHandle = await page.waitForSelector(bpmnQuerySelectors.labelOfFirstAvailableElement(bpmnId));
+  const svgElementHandle = await page.waitForSelector(bpmnQuerySelectors.labelOfElement(bpmnId));
   // contains 3 div
   expect(await svgElementHandle.evaluate(node => (node.firstChild.firstChild.firstChild as HTMLElement).innerHTML)).toBe(expectedText);
 }
 
 async function expectEvent(bpmnId: string, expectedText: string, isStartEvent = true): Promise<void> {
-  const svgElementHandle = await page.waitForSelector(bpmnQuerySelectors.firstAvailableElement(bpmnId));
+  const svgElementHandle = await page.waitForSelector(bpmnQuerySelectors.element(bpmnId));
   await expectClassName(svgElementHandle, isStartEvent ? 'bpmn-start-event' : 'bpmn-end-event');
   await expectFirstChildNodeName(svgElementHandle, 'ellipse');
   await expectFirstChildAttribute(svgElementHandle, 'rx', '18');
@@ -56,7 +56,7 @@ async function expectFirstChildAttribute(svgElementHandle: ElementHandle, attrib
 }
 
 async function expectTask(bpmnId: string, expectedText: string): Promise<void> {
-  const svgElementHandle = await page.waitForSelector(bpmnQuerySelectors.firstAvailableElement(bpmnId));
+  const svgElementHandle = await page.waitForSelector(bpmnQuerySelectors.element(bpmnId));
   await expectClassName(svgElementHandle, 'bpmn-task');
   await expectFirstChildNodeName(svgElementHandle, 'rect');
   await expectFirstChildAttribute(svgElementHandle, 'width', '100');
@@ -65,7 +65,7 @@ async function expectTask(bpmnId: string, expectedText: string): Promise<void> {
 }
 
 async function expectSequenceFlow(bpmnId: string, expectedText?: string): Promise<void> {
-  const svgElementHandle = await page.waitForSelector(bpmnQuerySelectors.firstAvailableElement(bpmnId));
+  const svgElementHandle = await page.waitForSelector(bpmnQuerySelectors.element(bpmnId));
   await expectClassName(svgElementHandle, 'bpmn-sequence-flow');
   await expectFirstChildNodeName(svgElementHandle, 'path');
   await expectLabel(bpmnId, expectedText);

--- a/test/fixtures/bpmn/registry/1-pool-3-lanes-message-start-end-intermediate-events.bpmn
+++ b/test/fixtures/bpmn/registry/1-pool-3-lanes-message-start-end-intermediate-events.bpmn
@@ -1,0 +1,259 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0jsncq9" targetNamespace="http://example.bpmn.com/schema/bpmn">
+  <bpmn:collaboration id="Collaboration_03068dc">
+    <bpmn:participant id="Participant_1" name="Pool 1" processRef="Process_0vbjbkf" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_0vbjbkf" isExecutable="false">
+    <bpmn:laneSet id="LaneSet_1e2wb07">
+      <bpmn:lane id="Lane_0xke7q1" name="Lane 3">
+        <bpmn:flowNodeRef>Activity_0gsh2b6</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_1s7095g</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_1wihmdr</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_1q818hp</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_1dunul0" name="Lane 2">
+        <bpmn:flowNodeRef>Gateway_1hq21li</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Activity_1c0vze1</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>serviceTask_2_1</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>endEvent_message_1</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_13kpaun" name="Lane 1">
+        <bpmn:flowNodeRef>Activity_1sn3x37</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_05sspdt</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>endEvent_terminate_1</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Activity_1s8cug0</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Activity_06pc14u</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>serviceTask_1_2</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>StartEvent_0av7pgo</bpmn:flowNodeRef>
+      </bpmn:lane>
+    </bpmn:laneSet>
+    <bpmn:userTask id="Activity_1sn3x37" name="User Task 0">
+      <bpmn:incoming>Flow_1ueepp9</bpmn:incoming>
+      <bpmn:outgoing>Flow_1bewc4s</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:exclusiveGateway id="Gateway_05sspdt" name="gateway 1">
+      <bpmn:incoming>Flow_1noi0ay</bpmn:incoming>
+      <bpmn:outgoing>Flow_0i9h5sw</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0ule9dn</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:endEvent id="endEvent_terminate_1" name="terminate end 1">
+      <bpmn:incoming>Flow_1dmga1h</bpmn:incoming>
+      <bpmn:terminateEventDefinition />
+    </bpmn:endEvent>
+    <bpmn:userTask id="Activity_1s8cug0" name="User Task 1.1">
+      <bpmn:incoming>Flow_0ule9dn</bpmn:incoming>
+      <bpmn:outgoing>Flow_1ceafgv</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:parallelGateway id="Gateway_1hq21li" name="gateway 2">
+      <bpmn:incoming>Flow_0sqwsrw</bpmn:incoming>
+      <bpmn:incoming>Flow_0g017tm</bpmn:incoming>
+      <bpmn:outgoing>Flow_09zytr1</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:userTask id="Activity_1c0vze1" name="User Task 2.2">
+      <bpmn:incoming>Flow_1hvyo7b</bpmn:incoming>
+      <bpmn:outgoing>Flow_0sqwsrw</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Activity_0gsh2b6" name="User Task 3.1">
+      <bpmn:incoming>Flow_1wwy4bv</bpmn:incoming>
+      <bpmn:outgoing>Flow_08z7uoy</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_08z7uoy" sourceRef="Activity_0gsh2b6" targetRef="Event_1wihmdr" />
+    <bpmn:sequenceFlow id="Flow_1wwy4bv" sourceRef="Event_1s7095g" targetRef="Activity_0gsh2b6" />
+    <bpmn:sequenceFlow id="Flow_1ueepp9" sourceRef="StartEvent_0av7pgo" targetRef="Activity_1sn3x37" />
+    <bpmn:sequenceFlow id="Flow_1bewc4s" name="link" sourceRef="Activity_1sn3x37" targetRef="Activity_06pc14u" />
+    <bpmn:sequenceFlow id="Flow_0i9h5sw" name="rejected" sourceRef="Gateway_05sspdt" targetRef="serviceTask_2_1" />
+    <bpmn:sequenceFlow id="Flow_0ule9dn" name="accepted" sourceRef="Gateway_05sspdt" targetRef="Activity_1s8cug0" />
+    <bpmn:sequenceFlow id="Flow_1ceafgv" sourceRef="Activity_1s8cug0" targetRef="serviceTask_1_2" />
+    <bpmn:sequenceFlow id="Flow_1dmga1h" sourceRef="serviceTask_1_2" targetRef="endEvent_terminate_1" />
+    <bpmn:sequenceFlow id="Flow_1hvyo7b" sourceRef="serviceTask_2_1" targetRef="Activity_1c0vze1" />
+    <bpmn:sequenceFlow id="Flow_09zytr1" sourceRef="Gateway_1hq21li" targetRef="endEvent_message_1" />
+    <bpmn:sequenceFlow id="Flow_1noi0ay" sourceRef="Activity_06pc14u" targetRef="Gateway_05sspdt" />
+    <bpmn:sequenceFlow id="Flow_0sqwsrw" sourceRef="Activity_1c0vze1" targetRef="Gateway_1hq21li" />
+    <bpmn:task id="Activity_06pc14u" name="Task 1">
+      <bpmn:incoming>Flow_1bewc4s</bpmn:incoming>
+      <bpmn:outgoing>Flow_1noi0ay</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:serviceTask id="serviceTask_2_1" name="Service Task 2.1">
+      <bpmn:incoming>Flow_0i9h5sw</bpmn:incoming>
+      <bpmn:outgoing>Flow_1hvyo7b</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="serviceTask_1_2" name="Service Task 1.2">
+      <bpmn:incoming>Flow_1ceafgv</bpmn:incoming>
+      <bpmn:outgoing>Flow_1dmga1h</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="endEvent_message_1" name="message end 2">
+      <bpmn:incoming>Flow_09zytr1</bpmn:incoming>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0kuujqg" />
+    </bpmn:endEvent>
+    <bpmn:startEvent id="StartEvent_0av7pgo" name="message start 1">
+      <bpmn:outgoing>Flow_1ueepp9</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_17xfjtr" />
+    </bpmn:startEvent>
+    <bpmn:startEvent id="Event_1s7095g" name="start 2">
+      <bpmn:outgoing>Flow_1wwy4bv</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0t8djvo" sourceRef="Event_1wihmdr" targetRef="Event_1q818hp" />
+    <bpmn:intermediateCatchEvent id="Event_1wihmdr" name="message catch intermediate 1">
+      <bpmn:incoming>Flow_08z7uoy</bpmn:incoming>
+      <bpmn:outgoing>Flow_0t8djvo</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_077j2qu" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_0g017tm" sourceRef="Event_1q818hp" targetRef="Gateway_1hq21li" />
+    <bpmn:intermediateThrowEvent id="Event_1q818hp" name="message throw intermediate 1">
+      <bpmn:incoming>Flow_0t8djvo</bpmn:incoming>
+      <bpmn:outgoing>Flow_0g017tm</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_11kxj5k" />
+    </bpmn:intermediateThrowEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_03068dc">
+      <bpmndi:BPMNShape id="Participant_1_di" bpmnElement="Participant_1" isHorizontal="true">
+        <dc:Bounds x="158" y="50" width="1062" height="430" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_13kpaun_di" bpmnElement="Lane_13kpaun" isHorizontal="true">
+        <dc:Bounds x="188" y="50" width="1032" height="125" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_1dunul0_di" bpmnElement="Lane_1dunul0" isHorizontal="true">
+        <dc:Bounds x="188" y="175" width="1032" height="185" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_0xke7q1_di" bpmnElement="Lane_0xke7q1" isHorizontal="true">
+        <dc:Bounds x="188" y="360" width="1032" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0sqwsrw_di" bpmnElement="Flow_0sqwsrw">
+        <di:waypoint x="890" y="270" />
+        <di:waypoint x="955" y="270" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1noi0ay_di" bpmnElement="Flow_1noi0ay">
+        <di:waypoint x="600" y="110" />
+        <di:waypoint x="675" y="110" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_09zytr1_di" bpmnElement="Flow_09zytr1">
+        <di:waypoint x="1005" y="270" />
+        <di:waypoint x="1042" y="270" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1hvyo7b_di" bpmnElement="Flow_1hvyo7b">
+        <di:waypoint x="750" y="270" />
+        <di:waypoint x="790" y="270" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1dmga1h_di" bpmnElement="Flow_1dmga1h">
+        <di:waypoint x="1040" y="110" />
+        <di:waypoint x="1102" y="110" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ceafgv_di" bpmnElement="Flow_1ceafgv">
+        <di:waypoint x="890" y="110" />
+        <di:waypoint x="940" y="110" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ule9dn_di" bpmnElement="Flow_0ule9dn">
+        <di:waypoint x="725" y="110" />
+        <di:waypoint x="790" y="110" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="735" y="92" width="46" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0i9h5sw_di" bpmnElement="Flow_0i9h5sw">
+        <di:waypoint x="700" y="135" />
+        <di:waypoint x="700" y="230" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="710" y="143" width="40" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1bewc4s_di" bpmnElement="Flow_1bewc4s">
+        <di:waypoint x="412" y="110" />
+        <di:waypoint x="500" y="110" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="448" y="92" width="17" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ueepp9_di" bpmnElement="Flow_1ueepp9">
+        <di:waypoint x="270" y="110" />
+        <di:waypoint x="312" y="110" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1wwy4bv_di" bpmnElement="Flow_1wwy4bv">
+        <di:waypoint x="330" y="420" />
+        <di:waypoint x="462" y="420" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_08z7uoy_di" bpmnElement="Flow_08z7uoy">
+        <di:waypoint x="562" y="420" />
+        <di:waypoint x="632" y="420" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0t8djvo_di" bpmnElement="Flow_0t8djvo">
+        <di:waypoint x="668" y="420" />
+        <di:waypoint x="812" y="420" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0g017tm_di" bpmnElement="Flow_0g017tm">
+        <di:waypoint x="848" y="420" />
+        <di:waypoint x="980" y="420" />
+        <di:waypoint x="980" y="295" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_0ifu0xr_di" bpmnElement="Activity_1sn3x37">
+        <dc:Bounds x="312" y="70" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_05sspdt_di" bpmnElement="Gateway_05sspdt" isMarkerVisible="true">
+        <dc:Bounds x="675" y="85" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="673" y="63" width="53" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="endEvent_terminate_1_di" bpmnElement="endEvent_terminate_1">
+        <dc:Bounds x="1102" y="92" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1106" y="135" width="28" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0tufvfp_di" bpmnElement="Activity_1s8cug0">
+        <dc:Bounds x="790" y="70" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0m423t9_di" bpmnElement="Gateway_1hq21li">
+        <dc:Bounds x="955" y="245" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="954" y="223" width="53" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0jljuyk_di" bpmnElement="Activity_1c0vze1">
+        <dc:Bounds x="790" y="230" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1wcuws6_di" bpmnElement="Activity_0gsh2b6">
+        <dc:Bounds x="462" y="380" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1u44j4q_di" bpmnElement="Activity_06pc14u">
+        <dc:Bounds x="500" y="70" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0iznnsm_di" bpmnElement="serviceTask_2_1">
+        <dc:Bounds x="650" y="230" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_02k08fd_di" bpmnElement="serviceTask_1_2">
+        <dc:Bounds x="940" y="70" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0bpyu2c_di" bpmnElement="endEvent_message_1">
+        <dc:Bounds x="1042" y="252" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1022" y="295" width="76" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1kkb8ww_di" bpmnElement="StartEvent_0av7pgo">
+        <dc:Bounds x="234" y="92" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="213" y="135" width="79" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0q6nq79_di" bpmnElement="Event_1s7095g">
+        <dc:Bounds x="294" y="402" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="297" y="445" width="31" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_00seehq_di" bpmnElement="Event_1wihmdr">
+        <dc:Bounds x="632" y="402" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="613" y="445" width="74" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_14o73vn_di" bpmnElement="Event_1q818hp">
+        <dc:Bounds x="812" y="402" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="793" y="445" width="75" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
Let pass one or several BPMN Kinds to get BpmnElements.
This implementation relies on CSS selectors for searching elements. It will be
possible to avoid this when the BpmnModel will be available and will provide
search capabilities (see #953).

closes #927 