### PR TITLE
[POC] Replace MxGraph by Cytoscapejs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6613,9 +6613,9 @@
       }
     },
     "cytoscape": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.17.0.tgz",
-      "integrity": "sha512-zPAB2UVV4QWArs+0UEq0ojYn7riFfz8CjivL67wibE/zdnAE8TTvDO5bFxsShSTutmG+1NkCnTXJjOxfosDMwA==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.18.0.tgz",
+      "integrity": "sha512-9GeAWkcy8gzecNyUGqFe2P42JgA8O+pJ4bFxr85jyXmH92042e/e9ERMqwfM1UWGMfIDasMoe7dvKMLGlF5vzQ==",
       "requires": {
         "heap": "^0.2.6",
         "lodash.debounce": "^4.0.8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3637,6 +3637,12 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
+    "@types/cytoscape": {
+      "version": "3.14.10",
+      "resolved": "https://registry.npmjs.org/@types/cytoscape/-/cytoscape-3.14.10.tgz",
+      "integrity": "sha512-lRZfaUSf334b84cvRAre14iJkMHgE7hj5ld3zg4TedMn3mBx/AuCVf4J6xxWImmkzBN7j+oB3ROtzRJv3OAQzQ==",
+      "dev": true
+    },
     "@types/dateformat": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/dateformat/-/dateformat-3.0.1.tgz",
@@ -6606,6 +6612,15 @@
         "fs-exists-sync": "^0.1.0"
       }
     },
+    "cytoscape": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.17.0.tgz",
+      "integrity": "sha512-zPAB2UVV4QWArs+0UEq0ojYn7riFfz8CjivL67wibE/zdnAE8TTvDO5bFxsShSTutmG+1NkCnTXJjOxfosDMwA==",
+      "requires": {
+        "heap": "^0.2.6",
+        "lodash.debounce": "^4.0.8"
+      }
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -8801,6 +8816,11 @@
           }
         }
       }
+    },
+    "heap": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.6.tgz",
+      "integrity": "sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw="
     },
     "hex-color-regex": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "postversion": "node scripts/manage-version-suffix.mjs && git commit --no-verify -a -m \"[RELEASE] prepare version for new developments\""
   },
   "dependencies": {
-    "cytoscape": "^3.16.3",
+    "cytoscape": "3.18.0",
     "entities": "^2.2.0",
     "fast-xml-parser": "^3.17.6",
     "lodash.debounce": "^4.0.8",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "postversion": "node scripts/manage-version-suffix.mjs && git commit --no-verify -a -m \"[RELEASE] prepare version for new developments\""
   },
   "dependencies": {
+    "cytoscape": "^3.16.3",
     "entities": "^2.2.0",
     "fast-xml-parser": "^3.17.6",
     "lodash.debounce": "^4.0.8",
@@ -88,6 +89,7 @@
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^11.1.1",
     "@typed-mxgraph/typed-mxgraph": "^1.0.0-2",
+    "@types/cytoscape": "^3.14.9",
     "@types/debug": "^4.1.5",
     "@types/jest": "^26.0.20",
     "@types/jest-environment-puppeteer": "^4.3.2",

--- a/src/component/CytoBpmnVisualization.ts
+++ b/src/component/CytoBpmnVisualization.ts
@@ -1,0 +1,329 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import cytoscape, { NodeSingular } from 'cytoscape';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+// import * as math from 'cytoscape/src/math.js';
+import customRenderer from './cytoscape/renderer/index';
+import { newBpmnParser } from './parser/BpmnParser';
+
+export default class CytoBpmnVisualization {
+  constructor(readonly container: string) {
+    document.getElementById(container);
+  }
+
+  // private extendCytoscape(cy: cytoscape.Core): cytoscape.Core {
+  //   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  //   // @ts-ignore
+  //   const CanvasRenderer = cy.extension('renderer', 'canvas');
+  //   CanvasRenderer.prototype.nodeShapeImpl = function (name: any, context: any, centerX: any, centerY: any, width: any, height: any, points: any) {
+  //     // eslint-disable-next-line no-console
+  //     console.log('____________________________________EXTENDED___________________________________');
+  //     switch (name) {
+  //       case 'ellipse':
+  //         return this.drawEllipsePath(context, centerX, centerY, width, height);
+  //       case 'polygon':
+  //         return this.drawPolygonPath(context, centerX, centerY, width, height, points);
+  //       case 'round-polygon':
+  //         return this.drawRoundPolygonPath(context, centerX, centerY, width, height, points);
+  //       case 'roundrectangle':
+  //       case 'round-rectangle':
+  //         return this.drawRoundRectanglePath(context, centerX, centerY, width, height);
+  //       case 'cutrectangle':
+  //       case 'cut-rectangle':
+  //         return this.drawCutRectanglePath(context, centerX, centerY, width, height);
+  //       case 'bottomroundrectangle':
+  //       case 'bottom-round-rectangle':
+  //         return this.drawBottomRoundRectanglePath(context, centerX, centerY, width, height);
+  //       case 'barrel':
+  //         return this.drawBarrelPath(context, centerX, centerY, width, height);
+  //       case 'newShape':
+  //         return this.drawBarrelPath(context, centerX, centerY, width, height);
+  //     }
+  //   };
+  //   // CanvasRenderer.prototype.nodeShapes['newShape'] = {
+  //   //   renderer: this,
+  //   //   name: 'barrel',
+  //   //   points: math.generateUnitNgonPointsFitToSquare(4, 0),
+  //   //   draw: function (context: any, centerX: any, centerY: any, width: any, height: any) {
+  //   //     this.renderer.nodeShapeImpl(this.name, context, centerX, centerY, width, height);
+  //   //   },
+  //   //   intersectLine: function (nodeX: any, nodeY: any, width: number, height: number, x: any, y: any, padding: number) {
+  //   //     // use two fixed t values for the bezier curve approximation
+  //   //
+  //   //     const t0 = 0.15;
+  //   //     const t1 = 0.5;
+  //   //     const t2 = 0.85;
+  //   //
+  //   //     const bPts = this.generateBarrelBezierPts(width + 2 * padding, height + 2 * padding, nodeX, nodeY);
+  //   //
+  //   //     const approximateBarrelCurvePts = (pts: number[]) => {
+  //   //       // approximate curve pts based on the two t values
+  //   //       const m0 = math.qbezierPtAt({ x: pts[0], y: pts[1] }, { x: pts[2], y: pts[3] }, { x: pts[4], y: pts[5] }, t0);
+  //   //       const m1 = math.qbezierPtAt({ x: pts[0], y: pts[1] }, { x: pts[2], y: pts[3] }, { x: pts[4], y: pts[5] }, t1);
+  //   //       const m2 = math.qbezierPtAt({ x: pts[0], y: pts[1] }, { x: pts[2], y: pts[3] }, { x: pts[4], y: pts[5] }, t2);
+  //   //
+  //   //       return [pts[0], pts[1], m0.x, m0.y, m1.x, m1.y, m2.x, m2.y, pts[4], pts[5]];
+  //   //     };
+  //   //
+  //   //     const pts = [].concat(
+  //   //       approximateBarrelCurvePts(bPts.topLeft),
+  //   //       approximateBarrelCurvePts(bPts.topRight),
+  //   //       approximateBarrelCurvePts(bPts.bottomRight),
+  //   //       approximateBarrelCurvePts(bPts.bottomLeft),
+  //   //     );
+  //   //
+  //   //     return math.polygonIntersectLine(x, y, pts, nodeX, nodeY);
+  //   //   },
+  //   //
+  //   //   generateBarrelBezierPts: function (width: number, height: number, centerX: number, centerY: number) {
+  //   //     const hh = height / 2;
+  //   //     const hw = width / 2;
+  //   //     const xBegin = centerX - hw;
+  //   //     const xEnd = centerX + hw;
+  //   //     const yBegin = centerY - hh;
+  //   //     const yEnd = centerY + hh;
+  //   //
+  //   //     const curveConstants = math.getBarrelCurveConstants(width, height);
+  //   //     const hOffset = curveConstants.heightOffset;
+  //   //     const wOffset = curveConstants.widthOffset;
+  //   //     const ctrlPtXOffset = curveConstants.ctrlPtOffsetPct * width;
+  //   //
+  //   //     // points are in clockwise order, inner (imaginary) control pt on [4, 5]
+  //   //     const pts = {
+  //   //       topLeft: [xBegin, yBegin + hOffset, xBegin + ctrlPtXOffset, yBegin, xBegin + wOffset, yBegin],
+  //   //       topRight: [xEnd - wOffset, yBegin, xEnd - ctrlPtXOffset, yBegin, xEnd, yBegin + hOffset],
+  //   //       bottomRight: [xEnd, yEnd - hOffset, xEnd - ctrlPtXOffset, yEnd, xEnd - wOffset, yEnd],
+  //   //       bottomLeft: [xBegin + wOffset, yEnd, xBegin + ctrlPtXOffset, yEnd, xBegin, yEnd - hOffset],
+  //   //     };
+  //   //
+  //   //     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  //   //     // @ts-ignore
+  //   //     pts.topLeft.isTop = true;
+  //   //     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  //   //     // @ts-ignore
+  //   //     pts.topRight.isTop = true;
+  //   //     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  //   //     // @ts-ignore
+  //   //     pts.bottomLeft.isBottom = true;
+  //   //     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  //   //     // @ts-ignore
+  //   //     pts.bottomRight.isBottom = true;
+  //   //
+  //   //     return pts;
+  //   //   },
+  //   //
+  //   //   checkPoint: function (x: any, y: number, padding: any, width: number, height: number, centerX: any, centerY: any) {
+  //   //     const curveConstants = math.getBarrelCurveConstants(width, height);
+  //   //     const hOffset = curveConstants.heightOffset;
+  //   //     const wOffset = curveConstants.widthOffset;
+  //   //
+  //   //     // Check hBox
+  //   //     if (math.pointInsidePolygon(x, y, this.points, centerX, centerY, width, height - 2 * hOffset, [0, -1], padding)) {
+  //   //       return true;
+  //   //     }
+  //   //
+  //   //     // Check vBox
+  //   //     if (math.pointInsidePolygon(x, y, this.points, centerX, centerY, width - 2 * wOffset, height, [0, -1], padding)) {
+  //   //       return true;
+  //   //     }
+  //   //
+  //   //     const barrelCurvePts = this.generateBarrelBezierPts(width, height, centerX, centerY);
+  //   //
+  //   //     const getCurveT = function (x: number, y: number, curvePts: any[]) {
+  //   //       const x0 = curvePts[4];
+  //   //       const x1 = curvePts[2];
+  //   //       const x2 = curvePts[0];
+  //   //       const y0 = curvePts[5];
+  //   //       // var y1 = curvePts[ 3 ];
+  //   //       const y2 = curvePts[1];
+  //   //
+  //   //       const xMin = Math.min(x0, x2);
+  //   //       const xMax = Math.max(x0, x2);
+  //   //       const yMin = Math.min(y0, y2);
+  //   //       const yMax = Math.max(y0, y2);
+  //   //
+  //   //       if (xMin <= x && x <= xMax && yMin <= y && y <= yMax) {
+  //   //         const coeff = math.bezierPtsToQuadCoeff(x0, x1, x2);
+  //   //         const roots = math.solveQuadratic(coeff[0], coeff[1], coeff[2], x);
+  //   //
+  //   //         const validRoots = roots.filter(function (r: number) {
+  //   //           return 0 <= r && r <= 1;
+  //   //         });
+  //   //
+  //   //         if (validRoots.length > 0) {
+  //   //           return validRoots[0];
+  //   //         }
+  //   //       }
+  //   //       return null;
+  //   //     };
+  //   //
+  //   //     const curveRegions = Object.keys(barrelCurvePts);
+  //   //     for (let i = 0; i < curveRegions.length; i++) {
+  //   //       const corner = curveRegions[i];
+  //   //       const cornerPts = barrelCurvePts[corner];
+  //   //       const t = getCurveT(x, y, cornerPts);
+  //   //
+  //   //       if (t == null) {
+  //   //         continue;
+  //   //       }
+  //   //
+  //   //       const y0 = cornerPts[5];
+  //   //       const y1 = cornerPts[3];
+  //   //       const y2 = cornerPts[1];
+  //   //       const bezY = math.qbezierAt(y0, y1, y2, t);
+  //   //
+  //   //       if (cornerPts.isTop && bezY <= y) {
+  //   //         return true;
+  //   //       }
+  //   //       if (cornerPts.isBottom && y <= bezY) {
+  //   //         return true;
+  //   //       }
+  //   //     }
+  //   //     return false;
+  //   //   },
+  //   // };
+  //   return cy;
+  // }
+
+  public load(xml: string) {
+    const bpmnModel = newBpmnParser().parse(xml);
+    // eslint-disable-next-line no-console
+    console.log('____________________BPMN MODEL___________________', bpmnModel);
+    // cytoscape.use(anywherePanning);
+    cytoscape.use(customRenderer);
+    const cy = cytoscape({
+      container: document.getElementById('graph-cyto'),
+      renderer: {
+        name: 'custom',
+      },
+      style: [
+        {
+          selector: 'node',
+          style: {
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            shape: function (ele: NodeSingular) {
+              // eslint-disable-next-line no-console,prefer-rest-params
+              console.log(arguments);
+              const kind = ele.data().kind;
+              // eslint-disable-next-line no-console,prefer-rest-params
+              console.log(kind);
+              if (kind && kind.endsWith('Event')) {
+                return 'ellipse';
+              } else if (kind && kind.indexOf('Gateway') !== -1) {
+                return 'new-shape';
+              }
+              return 'round-rectangle';
+            },
+            'background-color': '#FFF',
+            'background-opacity': 0,
+            'border-color': '#000',
+            'border-width': '3',
+            'border-style': 'solid',
+            label: 'data(label)',
+            height: 'data(height)',
+            width: 'data(width)',
+          },
+        },
+        {
+          selector: 'edge',
+          style: {
+            width: 2,
+            'line-color': '#059',
+            'target-arrow-color': '#059',
+            'target-arrow-shape': 'triangle',
+            'curve-style': 'straight',
+          },
+        },
+      ],
+      layout: {
+        name: 'grid',
+        rows: 1,
+      },
+    });
+
+    // const newCy = this.extendCytoscape(cy);
+    // // eslint-disable-next-line no-console
+    // console.log(newCy);
+    cy.add(
+      bpmnModel.flowNodes.map(function (flowNode) {
+        return {
+          group: 'nodes',
+          data: {
+            id: flowNode.bpmnElement.id,
+            label: flowNode.bpmnElement.name,
+            kind: flowNode.bpmnElement.kind,
+            height: flowNode.bounds.height,
+            width: flowNode.bounds.width,
+          },
+          position: { x: flowNode.bounds.x, y: flowNode.bounds.y },
+        };
+      }),
+    );
+    cy.add(
+      bpmnModel.edges.map(function (edge) {
+        return { group: 'edges', data: { id: edge.id, label: edge.bpmnElement.name, source: edge.bpmnElement.sourceRefId, target: edge.bpmnElement.targetRefId } };
+      }),
+    );
+    // eslint-disable-next-line no-console
+    console.log('_______________________CY_____________________', cy);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    // eslint-disable-next-line no-console
+    console.log('_______________________CY_____________________', cy._private.renderer);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    // eslint-disable-next-line no-console
+    console.log('_______________________CY_____________________', cy._private.renderer.nodeShapes);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    // eslint-disable-next-line no-console
+    console.log('_______________________CY_____________________', cy._private.style.properties.shape);
+
+    // TODO: this hack is needed as for any additional style properties there is a check on predefined set of allowed properties @see Style.parseImplWarn
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    cy._private.style.properties.shape.type.enums.push('new-shape');
+
+    // cy._private.renderer.nodeShapes.test = function () {
+    //
+    // };
+
+    // cy.anywherePanning();
+    //
+    // // An event which is emitted when panning has started.
+    // // The second argument is an event for "vmousedown".
+    // cy.on('awpanstart', function (evt, evt2) {
+    //   // eslint-disable-next-line no-console
+    //   console.log('_____PANNING______started');
+    // });
+    //
+    // // An event which is emitted when the cursor has moved during panning.
+    // // The second argument is an event for "vmousemove".
+    // cy.on('awpanmove', function (evt, evt2) {
+    //   // eslint-disable-next-line no-console
+    //   console.log('_____PANNING______moving');
+    // });
+    //
+    // // An event which is emitted when the panning has ended.
+    // // The second argument is an event for "vmouseup".
+    // cy.on('awpanend', function (evt, evt2) {
+    //   // eslint-disable-next-line no-console
+    //   console.log('_____PANNING______ended');
+    // });
+  }
+}

--- a/src/component/cytoscape/renderer/core/canvas/arrow-shapes.js
+++ b/src/component/cytoscape/renderer/core/canvas/arrow-shapes.js
@@ -1,0 +1,109 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+var CRp = {};
+
+var impl;
+
+function polygon(context, points) {
+  for (var i = 0; i < points.length; i++) {
+    var pt = points[i];
+
+    context.lineTo(pt.x, pt.y);
+  }
+}
+
+function triangleBackcurve(context, points, controlPoint) {
+  var firstPt;
+
+  for (var i = 0; i < points.length; i++) {
+    var pt = points[i];
+
+    if (i === 0) {
+      firstPt = pt;
+    }
+
+    context.lineTo(pt.x, pt.y);
+  }
+
+  context.quadraticCurveTo(controlPoint.x, controlPoint.y, firstPt.x, firstPt.y);
+}
+
+function triangleTee(context, trianglePoints, teePoints) {
+  if (context.beginPath) {
+    context.beginPath();
+  }
+
+  var triPts = trianglePoints;
+  for (var i = 0; i < triPts.length; i++) {
+    var pt = triPts[i];
+
+    context.lineTo(pt.x, pt.y);
+  }
+
+  var teePts = teePoints;
+  var firstTeePt = teePoints[0];
+  context.moveTo(firstTeePt.x, firstTeePt.y);
+
+  for (var i = 1; i < teePts.length; i++) {
+    var pt = teePts[i];
+
+    context.lineTo(pt.x, pt.y);
+  }
+
+  if (context.closePath) {
+    context.closePath();
+  }
+}
+
+function circleTriangle(context, trianglePoints, rx, ry, r) {
+  if (context.beginPath) {
+    context.beginPath();
+  }
+  context.arc(rx, ry, r, 0, Math.PI * 2, false);
+  var triPts = trianglePoints;
+  var firstTrPt = triPts[0];
+  context.moveTo(firstTrPt.x, firstTrPt.y);
+  for (var i = 0; i < triPts.length; i++) {
+    var pt = triPts[i];
+    context.lineTo(pt.x, pt.y);
+  }
+  if (context.closePath) {
+    context.closePath();
+  }
+}
+
+function circle(context, rx, ry, r) {
+  context.arc(rx, ry, r, 0, Math.PI * 2, false);
+}
+
+CRp.arrowShapeImpl = function (name) {
+  return (impl ||
+    (impl = {
+      polygon: polygon,
+
+      'triangle-backcurve': triangleBackcurve,
+
+      'triangle-tee': triangleTee,
+
+      'circle-triangle': circleTriangle,
+
+      'triangle-cross': triangleTee,
+
+      circle: circle,
+    }))[name];
+};
+
+export default CRp;

--- a/src/component/cytoscape/renderer/core/canvas/drawing-edges.js
+++ b/src/component/cytoscape/renderer/core/canvas/drawing-edges.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as util from '../../../../../../node_modules/cytoscape/src/util';
+import * as util from 'cytoscape/src/util';
 
 let CRp = {};
 

--- a/src/component/cytoscape/renderer/core/canvas/drawing-edges.js
+++ b/src/component/cytoscape/renderer/core/canvas/drawing-edges.js
@@ -1,0 +1,358 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as util from '../../../../../../node_modules/cytoscape/src/util';
+
+let CRp = {};
+
+CRp.drawEdge = function (context, edge, shiftToOriginWithBb, drawLabel = true, shouldDrawOverlay = true, shouldDrawOpacity = true) {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  let r = this;
+  let rs = edge._private.rscratch;
+
+  if (shouldDrawOpacity && !edge.visible()) {
+    return;
+  }
+
+  // if bezier ctrl pts can not be calculated, then die
+  if (rs.badLine || rs.allpts == null || isNaN(rs.allpts[0])) {
+    // isNaN in case edge is impossible and browser bugs (e.g. safari)
+    return;
+  }
+
+  let bb;
+  if (shiftToOriginWithBb) {
+    bb = shiftToOriginWithBb;
+
+    context.translate(-bb.x1, -bb.y1);
+  }
+
+  let opacity = shouldDrawOpacity ? edge.pstyle('opacity').value : 1;
+  let lineOpacity = shouldDrawOpacity ? edge.pstyle('line-opacity').value : 1;
+
+  let lineStyle = edge.pstyle('line-style').value;
+  let edgeWidth = edge.pstyle('width').pfValue;
+  let lineCap = edge.pstyle('line-cap').value;
+
+  let effectiveLineOpacity = opacity * lineOpacity;
+  // separate arrow opacity would require arrow-opacity property
+  let effectiveArrowOpacity = opacity * lineOpacity;
+
+  let drawLine = (strokeOpacity = effectiveLineOpacity) => {
+    context.lineWidth = edgeWidth;
+    context.lineCap = lineCap;
+
+    r.eleStrokeStyle(context, edge, strokeOpacity);
+    r.drawEdgePath(edge, context, rs.allpts, lineStyle);
+
+    context.lineCap = 'butt'; // reset for other drawing functions
+  };
+
+  let drawOverlay = () => {
+    if (!shouldDrawOverlay) {
+      return;
+    }
+
+    r.drawEdgeOverlay(context, edge);
+  };
+
+  let drawArrows = (arrowOpacity = effectiveArrowOpacity) => {
+    r.drawArrowheads(context, edge, arrowOpacity);
+  };
+
+  let drawText = () => {
+    r.drawElementText(context, edge, null, drawLabel);
+  };
+
+  context.lineJoin = 'round';
+
+  let ghost = edge.pstyle('ghost').value === 'yes';
+
+  if (ghost) {
+    let gx = edge.pstyle('ghost-offset-x').pfValue;
+    let gy = edge.pstyle('ghost-offset-y').pfValue;
+    let ghostOpacity = edge.pstyle('ghost-opacity').value;
+    let effectiveGhostOpacity = effectiveLineOpacity * ghostOpacity;
+
+    context.translate(gx, gy);
+
+    drawLine(effectiveGhostOpacity);
+    drawArrows(effectiveGhostOpacity);
+
+    context.translate(-gx, -gy);
+  }
+
+  drawLine();
+  drawArrows();
+  drawOverlay();
+  drawText();
+
+  if (shiftToOriginWithBb) {
+    context.translate(bb.x1, bb.y1);
+  }
+};
+
+CRp.drawEdgeOverlay = function (context, edge) {
+  if (!edge.visible()) {
+    return;
+  }
+
+  let overlayOpacity = edge.pstyle('overlay-opacity').value;
+
+  if (overlayOpacity === 0) {
+    return;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  let r = this;
+  let usePaths = r.usePaths();
+  let rs = edge._private.rscratch;
+
+  let overlayPadding = edge.pstyle('overlay-padding').pfValue;
+  let overlayWidth = 2 * overlayPadding;
+  let overlayColor = edge.pstyle('overlay-color').value;
+
+  context.lineWidth = overlayWidth;
+
+  if (rs.edgeType === 'self' && !usePaths) {
+    context.lineCap = 'butt';
+  } else {
+    context.lineCap = 'round';
+  }
+
+  r.colorStrokeStyle(context, overlayColor[0], overlayColor[1], overlayColor[2], overlayOpacity);
+
+  r.drawEdgePath(edge, context, rs.allpts, 'solid');
+};
+
+CRp.drawEdgePath = function (edge, context, pts, type) {
+  let rs = edge._private.rscratch;
+  let canvasCxt = context;
+  let path;
+  let pathCacheHit = false;
+  let usePaths = this.usePaths();
+  let lineDashPattern = edge.pstyle('line-dash-pattern').pfValue;
+  let lineDashOffset = edge.pstyle('line-dash-offset').pfValue;
+
+  if (usePaths) {
+    let pathCacheKey = pts.join('$');
+    let keyMatches = rs.pathCacheKey && rs.pathCacheKey === pathCacheKey;
+
+    if (keyMatches) {
+      path = context = rs.pathCache;
+      pathCacheHit = true;
+    } else {
+      path = context = new Path2D();
+      rs.pathCacheKey = pathCacheKey;
+      rs.pathCache = path;
+    }
+  }
+
+  if (canvasCxt.setLineDash) {
+    // for very outofdate browsers
+    switch (type) {
+      case 'dotted':
+        canvasCxt.setLineDash([1, 1]);
+        break;
+
+      case 'dashed':
+        canvasCxt.setLineDash(lineDashPattern);
+        canvasCxt.lineDashOffset = lineDashOffset;
+        break;
+
+      case 'solid':
+        canvasCxt.setLineDash([]);
+        break;
+    }
+  }
+
+  if (!pathCacheHit && !rs.badLine) {
+    if (context.beginPath) {
+      context.beginPath();
+    }
+    context.moveTo(pts[0], pts[1]);
+
+    switch (rs.edgeType) {
+      case 'bezier':
+      case 'self':
+      case 'compound':
+      case 'multibezier':
+        for (let i = 2; i + 3 < pts.length; i += 4) {
+          context.quadraticCurveTo(pts[i], pts[i + 1], pts[i + 2], pts[i + 3]);
+        }
+        break;
+
+      case 'straight':
+      case 'segments':
+      case 'haystack':
+        for (let i = 2; i + 1 < pts.length; i += 2) {
+          context.lineTo(pts[i], pts[i + 1]);
+        }
+        break;
+    }
+  }
+
+  context = canvasCxt;
+  if (usePaths) {
+    context.stroke(path);
+  } else {
+    context.stroke();
+  }
+
+  // reset any line dashes
+  if (context.setLineDash) {
+    // for very outofdate browsers
+    context.setLineDash([]);
+  }
+};
+
+CRp.drawArrowheads = function (context, edge, opacity) {
+  let rs = edge._private.rscratch;
+  let isHaystack = rs.edgeType === 'haystack';
+
+  if (!isHaystack) {
+    this.drawArrowhead(context, edge, 'source', rs.arrowStartX, rs.arrowStartY, rs.srcArrowAngle, opacity);
+  }
+
+  this.drawArrowhead(context, edge, 'mid-target', rs.midX, rs.midY, rs.midtgtArrowAngle, opacity);
+
+  this.drawArrowhead(context, edge, 'mid-source', rs.midX, rs.midY, rs.midsrcArrowAngle, opacity);
+
+  if (!isHaystack) {
+    this.drawArrowhead(context, edge, 'target', rs.arrowEndX, rs.arrowEndY, rs.tgtArrowAngle, opacity);
+  }
+};
+
+CRp.drawArrowhead = function (context, edge, prefix, x, y, angle, opacity) {
+  if (isNaN(x) || x == null || isNaN(y) || y == null || isNaN(angle) || angle == null) {
+    return;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  let self = this;
+  let arrowShape = edge.pstyle(prefix + '-arrow-shape').value;
+  if (arrowShape === 'none') {
+    return;
+  }
+
+  let arrowClearFill = edge.pstyle(prefix + '-arrow-fill').value === 'hollow' ? 'both' : 'filled';
+  let arrowFill = edge.pstyle(prefix + '-arrow-fill').value;
+  let edgeWidth = edge.pstyle('width').pfValue;
+  let edgeOpacity = edge.pstyle('opacity').value;
+
+  if (opacity === undefined) {
+    opacity = edgeOpacity;
+  }
+
+  let gco = context.globalCompositeOperation;
+
+  if (opacity !== 1 || arrowFill === 'hollow') {
+    // then extra clear is needed
+    context.globalCompositeOperation = 'destination-out';
+
+    self.colorFillStyle(context, 255, 255, 255, 1);
+    self.colorStrokeStyle(context, 255, 255, 255, 1);
+
+    self.drawArrowShape(edge, context, arrowClearFill, edgeWidth, arrowShape, x, y, angle);
+
+    context.globalCompositeOperation = gco;
+  } // otherwise, the opaque arrow clears it for free :)
+
+  let color = edge.pstyle(prefix + '-arrow-color').value;
+  self.colorFillStyle(context, color[0], color[1], color[2], opacity);
+  self.colorStrokeStyle(context, color[0], color[1], color[2], opacity);
+
+  self.drawArrowShape(edge, context, arrowFill, edgeWidth, arrowShape, x, y, angle);
+};
+
+CRp.drawArrowShape = function (edge, context, fill, edgeWidth, shape, x, y, angle) {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  let r = this;
+  let usePaths = this.usePaths() && shape !== 'triangle-cross';
+  let pathCacheHit = false;
+  let path;
+  let canvasContext = context;
+  let translation = { x, y };
+  let scale = edge.pstyle('arrow-scale').value;
+  let size = this.getArrowWidth(edgeWidth, scale);
+  let shapeImpl = r.arrowShapes[shape];
+
+  if (usePaths) {
+    let cache = (r.arrowPathCache = r.arrowPathCache || []);
+    let key = util.hashString(shape);
+    let cachedPath = cache[key];
+
+    if (cachedPath != null) {
+      path = context = cachedPath;
+      pathCacheHit = true;
+    } else {
+      path = context = new Path2D();
+      cache[key] = path;
+    }
+  }
+
+  if (!pathCacheHit) {
+    if (context.beginPath) {
+      context.beginPath();
+    }
+    if (usePaths) {
+      // store in the path cache with values easily manipulated later
+      shapeImpl.draw(context, 1, 0, { x: 0, y: 0 }, 1);
+    } else {
+      shapeImpl.draw(context, size, angle, translation, edgeWidth);
+    }
+    if (context.closePath) {
+      context.closePath();
+    }
+  }
+
+  context = canvasContext;
+
+  if (usePaths) {
+    // set transform to arrow position/orientation
+    context.translate(x, y);
+    context.rotate(angle);
+    context.scale(size, size);
+  }
+
+  if (fill === 'filled' || fill === 'both') {
+    if (usePaths) {
+      context.fill(path);
+    } else {
+      context.fill();
+    }
+  }
+
+  if (fill === 'hollow' || fill === 'both') {
+    context.lineWidth = (shapeImpl.matchEdgeWidth ? edgeWidth : 1) / (usePaths ? size : 1);
+    context.lineJoin = 'miter';
+
+    if (usePaths) {
+      context.stroke(path);
+    } else {
+      context.stroke();
+    }
+  }
+
+  if (usePaths) {
+    // reset transform by applying inverse
+    context.scale(1 / size, 1 / size);
+    context.rotate(-angle);
+    context.translate(-x, -y);
+  }
+};
+
+export default CRp;

--- a/src/component/cytoscape/renderer/core/canvas/drawing-elements.js
+++ b/src/component/cytoscape/renderer/core/canvas/drawing-elements.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as math from '../../../../../../node_modules/cytoscape/src/math';
+import * as math from 'cytoscape/src/math';
 
 let CRp = {};
 

--- a/src/component/cytoscape/renderer/core/canvas/drawing-elements.js
+++ b/src/component/cytoscape/renderer/core/canvas/drawing-elements.js
@@ -1,0 +1,244 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as math from '../../../../../../node_modules/cytoscape/src/math';
+
+let CRp = {};
+
+CRp.drawElement = function (context, ele, shiftToOriginWithBb, showLabel, showOverlay, showOpacity) {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  let r = this;
+
+  if (ele.isNode()) {
+    r.drawNode(context, ele, shiftToOriginWithBb, showLabel, showOverlay, showOpacity);
+  } else {
+    r.drawEdge(context, ele, shiftToOriginWithBb, showLabel, showOverlay, showOpacity);
+  }
+};
+
+CRp.drawElementOverlay = function (context, ele) {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  let r = this;
+
+  if (ele.isNode()) {
+    r.drawNodeOverlay(context, ele);
+  } else {
+    r.drawEdgeOverlay(context, ele);
+  }
+};
+
+CRp.drawCachedElementPortion = function (context, ele, eleTxrCache, pxRatio, lvl, reason, getRotation, getOpacity) {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  let r = this;
+  let bb = eleTxrCache.getBoundingBox(ele);
+
+  if (bb.w === 0 || bb.h === 0) {
+    return;
+  } // ignore zero size case
+
+  let eleCache = eleTxrCache.getElement(ele, bb, pxRatio, lvl, reason);
+
+  if (eleCache != null) {
+    let opacity = getOpacity(r, ele);
+
+    if (opacity === 0) {
+      return;
+    }
+
+    let theta = getRotation(r, ele);
+    let { x1, y1, w, h } = bb;
+    let x, y, sx, sy, smooth;
+
+    if (theta !== 0) {
+      let rotPt = eleTxrCache.getRotationPoint(ele);
+
+      sx = rotPt.x;
+      sy = rotPt.y;
+
+      context.translate(sx, sy);
+      context.rotate(theta);
+
+      smooth = r.getImgSmoothing(context);
+
+      if (!smooth) {
+        r.setImgSmoothing(context, true);
+      }
+
+      let off = eleTxrCache.getRotationOffset(ele);
+
+      x = off.x;
+      y = off.y;
+    } else {
+      x = x1;
+      y = y1;
+    }
+
+    let oldGlobalAlpha;
+
+    if (opacity !== 1) {
+      oldGlobalAlpha = context.globalAlpha;
+      context.globalAlpha = oldGlobalAlpha * opacity;
+    }
+
+    context.drawImage(eleCache.texture.canvas, eleCache.x, 0, eleCache.width, eleCache.height, x, y, w, h);
+
+    if (opacity !== 1) {
+      context.globalAlpha = oldGlobalAlpha;
+    }
+
+    if (theta !== 0) {
+      context.rotate(-theta);
+      context.translate(-sx, -sy);
+
+      if (!smooth) {
+        r.setImgSmoothing(context, false);
+      }
+    }
+  } else {
+    eleTxrCache.drawElement(context, ele); // direct draw fallback
+  }
+};
+
+const getZeroRotation = () => 0;
+const getLabelRotation = (r, ele) => r.getTextAngle(ele, null);
+const getSourceLabelRotation = (r, ele) => r.getTextAngle(ele, 'source');
+const getTargetLabelRotation = (r, ele) => r.getTextAngle(ele, 'target');
+const getOpacity = (r, ele) => ele.effectiveOpacity();
+const getTextOpacity = (e, ele) => ele.pstyle('text-opacity').pfValue * ele.effectiveOpacity();
+
+CRp.drawCachedElement = function (context, ele, pxRatio, extent, lvl, requestHighQuality) {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  let r = this;
+  let { eleTxrCache, lblTxrCache, slbTxrCache, tlbTxrCache } = r.data;
+
+  let bb = ele.boundingBox();
+  let reason = requestHighQuality === true ? eleTxrCache.reasons.highQuality : null;
+
+  if (bb.w === 0 || bb.h === 0 || !ele.visible()) {
+    return;
+  }
+
+  if (!extent || math.boundingBoxesIntersect(bb, extent)) {
+    let isEdge = ele.isEdge();
+    let badLine = ele.element()._private.rscratch.badLine;
+
+    r.drawCachedElementPortion(context, ele, eleTxrCache, pxRatio, lvl, reason, getZeroRotation, getOpacity);
+
+    if (!isEdge || !badLine) {
+      r.drawCachedElementPortion(context, ele, lblTxrCache, pxRatio, lvl, reason, getLabelRotation, getTextOpacity);
+    }
+
+    if (isEdge && !badLine) {
+      r.drawCachedElementPortion(context, ele, slbTxrCache, pxRatio, lvl, reason, getSourceLabelRotation, getTextOpacity);
+      r.drawCachedElementPortion(context, ele, tlbTxrCache, pxRatio, lvl, reason, getTargetLabelRotation, getTextOpacity);
+    }
+
+    r.drawElementOverlay(context, ele);
+  }
+};
+
+CRp.drawElements = function (context, eles) {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  let r = this;
+
+  for (let i = 0; i < eles.length; i++) {
+    let ele = eles[i];
+
+    r.drawElement(context, ele);
+  }
+};
+
+CRp.drawCachedElements = function (context, eles, pxRatio, extent) {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  let r = this;
+
+  for (let i = 0; i < eles.length; i++) {
+    let ele = eles[i];
+
+    r.drawCachedElement(context, ele, pxRatio, extent);
+  }
+};
+
+CRp.drawCachedNodes = function (context, eles, pxRatio, extent) {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  let r = this;
+
+  for (let i = 0; i < eles.length; i++) {
+    let ele = eles[i];
+
+    if (!ele.isNode()) {
+      continue;
+    }
+
+    r.drawCachedElement(context, ele, pxRatio, extent);
+  }
+};
+
+CRp.drawLayeredElements = function (context, eles, pxRatio, extent) {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  let r = this;
+
+  let layers = r.data.lyrTxrCache.getLayers(eles, pxRatio);
+
+  if (layers) {
+    for (let i = 0; i < layers.length; i++) {
+      let layer = layers[i];
+      let bb = layer.bb;
+
+      if (bb.w === 0 || bb.h === 0) {
+        continue;
+      }
+
+      context.drawImage(layer.canvas, bb.x1, bb.y1, bb.w, bb.h);
+    }
+  } else {
+    // fall back on plain caching if no layers
+    r.drawCachedElements(context, eles, pxRatio, extent);
+  }
+};
+
+// if (process.env.NODE_ENV !== 'production') {
+//   CRp.drawDebugPoints = function (context, eles) {
+//     let draw = function (x, y, color) {
+//       context.fillStyle = color;
+//       context.fillRect(x - 1, y - 1, 3, 3);
+//     };
+//
+//     for (let i = 0; i < eles.length; i++) {
+//       let ele = eles[i];
+//       let rs = ele._private.rscratch;
+//
+//       if (ele.isNode()) {
+//         let p = ele.position();
+//
+//         draw(rs.labelX, rs.labelY, 'red');
+//         draw(p.x, p.y, 'magenta');
+//       } else {
+//         let pts = rs.allpts;
+//
+//         for (let j = 0; j + 1 < pts.length; j += 2) {
+//           let x = pts[j];
+//           let y = pts[j + 1];
+//
+//           draw(x, y, 'cyan');
+//         }
+//
+//         draw(rs.midX, rs.midY, 'yellow');
+//       }
+//     }
+//   };
+// }
+
+export default CRp;

--- a/src/component/cytoscape/renderer/core/canvas/drawing-images.js
+++ b/src/component/cytoscape/renderer/core/canvas/drawing-images.js
@@ -1,0 +1,173 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+var CRp = {};
+
+CRp.safeDrawImage = function (context, img, ix, iy, iw, ih, x, y, w, h) {
+  // detect problematic cases for old browsers with bad images (cheaper than try-catch)
+  if (iw <= 0 || ih <= 0 || w <= 0 || h <= 0) {
+    return;
+  }
+
+  context.drawImage(img, ix, iy, iw, ih, x, y, w, h);
+};
+
+CRp.drawInscribedImage = function (context, img, node, index, nodeOpacity) {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  var r = this;
+  var pos = node.position();
+  var nodeX = pos.x;
+  var nodeY = pos.y;
+  var styleObj = node.cy().style();
+  var getIndexedStyle = styleObj.getIndexedStyle.bind(styleObj);
+  var fit = getIndexedStyle(node, 'background-fit', 'value', index);
+  var repeat = getIndexedStyle(node, 'background-repeat', 'value', index);
+  var nodeW = node.width();
+  var nodeH = node.height();
+  var paddingX2 = node.padding() * 2;
+  var nodeTW = nodeW + (getIndexedStyle(node, 'background-width-relative-to', 'value', index) === 'inner' ? 0 : paddingX2);
+  var nodeTH = nodeH + (getIndexedStyle(node, 'background-height-relative-to', 'value', index) === 'inner' ? 0 : paddingX2);
+  var rs = node._private.rscratch;
+  var clip = getIndexedStyle(node, 'background-clip', 'value', index);
+  var shouldClip = clip === 'node';
+  var imgOpacity = getIndexedStyle(node, 'background-image-opacity', 'value', index) * nodeOpacity;
+
+  var imgW = img.width || img.cachedW;
+  var imgH = img.height || img.cachedH;
+
+  // workaround for broken browsers like ie
+  if (null == imgW || null == imgH) {
+    document.body.appendChild(img); // eslint-disable-line no-undef
+
+    imgW = img.cachedW = img.width || img.offsetWidth;
+    imgH = img.cachedH = img.height || img.offsetHeight;
+
+    document.body.removeChild(img); // eslint-disable-line no-undef
+  }
+
+  var w = imgW;
+  var h = imgH;
+
+  if (getIndexedStyle(node, 'background-width', 'value', index) !== 'auto') {
+    if (getIndexedStyle(node, 'background-width', 'units', index) === '%') {
+      w = getIndexedStyle(node, 'background-width', 'pfValue', index) * nodeTW;
+    } else {
+      w = getIndexedStyle(node, 'background-width', 'pfValue', index);
+    }
+  }
+
+  if (getIndexedStyle(node, 'background-height', 'value', index) !== 'auto') {
+    if (getIndexedStyle(node, 'background-height', 'units', index) === '%') {
+      h = getIndexedStyle(node, 'background-height', 'pfValue', index) * nodeTH;
+    } else {
+      h = getIndexedStyle(node, 'background-height', 'pfValue', index);
+    }
+  }
+
+  if (w === 0 || h === 0) {
+    return; // no point in drawing empty image (and chrome is broken in this case)
+  }
+
+  if (fit === 'contain') {
+    var scale = Math.min(nodeTW / w, nodeTH / h);
+
+    w *= scale;
+    h *= scale;
+  } else if (fit === 'cover') {
+    var scale = Math.max(nodeTW / w, nodeTH / h);
+
+    w *= scale;
+    h *= scale;
+  }
+
+  var x = nodeX - nodeTW / 2; // left
+  var posXUnits = getIndexedStyle(node, 'background-position-x', 'units', index);
+  var posXPfVal = getIndexedStyle(node, 'background-position-x', 'pfValue', index);
+  if (posXUnits === '%') {
+    x += (nodeTW - w) * posXPfVal;
+  } else {
+    x += posXPfVal;
+  }
+
+  var offXUnits = getIndexedStyle(node, 'background-offset-x', 'units', index);
+  var offXPfVal = getIndexedStyle(node, 'background-offset-x', 'pfValue', index);
+  if (offXUnits === '%') {
+    x += (nodeTW - w) * offXPfVal;
+  } else {
+    x += offXPfVal;
+  }
+
+  var y = nodeY - nodeTH / 2; // top
+  var posYUnits = getIndexedStyle(node, 'background-position-y', 'units', index);
+  var posYPfVal = getIndexedStyle(node, 'background-position-y', 'pfValue', index);
+  if (posYUnits === '%') {
+    y += (nodeTH - h) * posYPfVal;
+  } else {
+    y += posYPfVal;
+  }
+
+  var offYUnits = getIndexedStyle(node, 'background-offset-y', 'units', index);
+  var offYPfVal = getIndexedStyle(node, 'background-offset-y', 'pfValue', index);
+  if (offYUnits === '%') {
+    y += (nodeTH - h) * offYPfVal;
+  } else {
+    y += offYPfVal;
+  }
+
+  if (rs.pathCache) {
+    x -= nodeX;
+    y -= nodeY;
+
+    nodeX = 0;
+    nodeY = 0;
+  }
+
+  var gAlpha = context.globalAlpha;
+
+  context.globalAlpha = imgOpacity;
+
+  if (repeat === 'no-repeat') {
+    if (shouldClip) {
+      context.save();
+
+      if (rs.pathCache) {
+        context.clip(rs.pathCache);
+      } else {
+        r.nodeShapes[r.getNodeShape(node)].draw(context, nodeX, nodeY, nodeTW, nodeTH);
+
+        context.clip();
+      }
+    }
+
+    r.safeDrawImage(context, img, 0, 0, imgW, imgH, x, y, w, h);
+
+    if (shouldClip) {
+      context.restore();
+    }
+  } else {
+    var pattern = context.createPattern(img, repeat);
+    context.fillStyle = pattern;
+
+    r.nodeShapes[r.getNodeShape(node)].draw(context, nodeX, nodeY, nodeTW, nodeTH);
+
+    context.translate(x, y);
+    context.fill();
+    context.translate(-x, -y);
+  }
+
+  context.globalAlpha = gAlpha;
+};
+
+export default CRp;

--- a/src/component/cytoscape/renderer/core/canvas/drawing-label-text.js
+++ b/src/component/cytoscape/renderer/core/canvas/drawing-label-text.js
@@ -1,0 +1,405 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as util from '../../../../../../node_modules/cytoscape/src/util';
+import * as math from '../../../../../../node_modules/cytoscape/src/math';
+
+let CRp = {};
+
+CRp.eleTextBiggerThanMin = function (ele, scale) {
+  if (!scale) {
+    let zoom = ele.cy().zoom();
+    let pxRatio = this.getPixelRatio();
+    let lvl = Math.ceil(math.log2(zoom * pxRatio)); // the effective texture level
+
+    scale = Math.pow(2, lvl);
+  }
+
+  let computedSize = ele.pstyle('font-size').pfValue * scale;
+  let minSize = ele.pstyle('min-zoomed-font-size').pfValue;
+
+  if (computedSize < minSize) {
+    return false;
+  }
+
+  return true;
+};
+
+CRp.drawElementText = function (context, ele, shiftToOriginWithBb, force, prefix, useEleOpacity = true) {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  let r = this;
+
+  if (force == null) {
+    if (useEleOpacity && !r.eleTextBiggerThanMin(ele)) {
+      return;
+    }
+  } else if (force === false) {
+    return;
+  }
+
+  if (ele.isNode()) {
+    let label = ele.pstyle('label');
+
+    if (!label || !label.value) {
+      return;
+    }
+
+    let justification = r.getLabelJustification(ele);
+
+    context.textAlign = justification;
+    context.textBaseline = 'bottom';
+  } else {
+    let badLine = ele.element()._private.rscratch.badLine;
+    let label = ele.pstyle('label');
+    let srcLabel = ele.pstyle('source-label');
+    let tgtLabel = ele.pstyle('target-label');
+
+    if (badLine || ((!label || !label.value) && (!srcLabel || !srcLabel.value) && (!tgtLabel || !tgtLabel.value))) {
+      return;
+    }
+
+    context.textAlign = 'center';
+    context.textBaseline = 'bottom';
+  }
+
+  let applyRotation = !shiftToOriginWithBb;
+
+  let bb;
+  if (shiftToOriginWithBb) {
+    bb = shiftToOriginWithBb;
+
+    context.translate(-bb.x1, -bb.y1);
+  }
+
+  if (prefix == null) {
+    r.drawText(context, ele, null, applyRotation, useEleOpacity);
+
+    if (ele.isEdge()) {
+      r.drawText(context, ele, 'source', applyRotation, useEleOpacity);
+
+      r.drawText(context, ele, 'target', applyRotation, useEleOpacity);
+    }
+  } else {
+    r.drawText(context, ele, prefix, applyRotation, useEleOpacity);
+  }
+
+  if (shiftToOriginWithBb) {
+    context.translate(bb.x1, bb.y1);
+  }
+};
+
+CRp.getFontCache = function (context) {
+  let cache;
+
+  this.fontCaches = this.fontCaches || [];
+
+  for (let i = 0; i < this.fontCaches.length; i++) {
+    cache = this.fontCaches[i];
+
+    if (cache.context === context) {
+      return cache;
+    }
+  }
+
+  cache = {
+    context: context,
+  };
+  this.fontCaches.push(cache);
+
+  return cache;
+};
+
+// set up canvas context with font
+// returns transformed text string
+CRp.setupTextStyle = function (context, ele, useEleOpacity = true) {
+  // Font style
+  let labelStyle = ele.pstyle('font-style').strValue;
+  let labelSize = ele.pstyle('font-size').pfValue + 'px';
+  let labelFamily = ele.pstyle('font-family').strValue;
+  let labelWeight = ele.pstyle('font-weight').strValue;
+  let opacity = useEleOpacity ? ele.effectiveOpacity() * ele.pstyle('text-opacity').value : 1;
+  let outlineOpacity = ele.pstyle('text-outline-opacity').value * opacity;
+  let color = ele.pstyle('color').value;
+  let outlineColor = ele.pstyle('text-outline-color').value;
+
+  context.font = labelStyle + ' ' + labelWeight + ' ' + labelSize + ' ' + labelFamily;
+
+  context.lineJoin = 'round'; // so text outlines aren't jagged
+
+  this.colorFillStyle(context, color[0], color[1], color[2], opacity);
+
+  this.colorStrokeStyle(context, outlineColor[0], outlineColor[1], outlineColor[2], outlineOpacity);
+};
+
+// TODO ensure re-used
+function roundRect(ctx, x, y, width, height, radius = 5) {
+  ctx.beginPath();
+  ctx.moveTo(x + radius, y);
+  ctx.lineTo(x + width - radius, y);
+  ctx.quadraticCurveTo(x + width, y, x + width, y + radius);
+  ctx.lineTo(x + width, y + height - radius);
+  ctx.quadraticCurveTo(x + width, y + height, x + width - radius, y + height);
+  ctx.lineTo(x + radius, y + height);
+  ctx.quadraticCurveTo(x, y + height, x, y + height - radius);
+  ctx.lineTo(x, y + radius);
+  ctx.quadraticCurveTo(x, y, x + radius, y);
+  ctx.closePath();
+  ctx.fill();
+}
+
+CRp.getTextAngle = function (ele, prefix) {
+  let theta;
+  let _p = ele._private;
+  let rscratch = _p.rscratch;
+  let pdash = prefix ? prefix + '-' : '';
+  let rotation = ele.pstyle(pdash + 'text-rotation');
+  let textAngle = util.getPrefixedProperty(rscratch, 'labelAngle', prefix);
+
+  if (rotation.strValue === 'autorotate') {
+    theta = ele.isEdge() ? textAngle : 0;
+  } else if (rotation.strValue === 'none') {
+    theta = 0;
+  } else {
+    theta = rotation.pfValue;
+  }
+
+  return theta;
+};
+
+CRp.drawText = function (context, ele, prefix, applyRotation = true, useEleOpacity = true) {
+  let _p = ele._private;
+  let rscratch = _p.rscratch;
+  let parentOpacity = useEleOpacity ? ele.effectiveOpacity() : 1;
+
+  if (useEleOpacity && (parentOpacity === 0 || ele.pstyle('text-opacity').value === 0)) {
+    return;
+  }
+
+  // use 'main' as an alias for the main label (i.e. null prefix)
+  if (prefix === 'main') {
+    prefix = null;
+  }
+
+  let textX = util.getPrefixedProperty(rscratch, 'labelX', prefix);
+  let textY = util.getPrefixedProperty(rscratch, 'labelY', prefix);
+  let orgTextX, orgTextY; // used for rotation
+  let text = this.getLabelText(ele, prefix);
+
+  if (text != null && text !== '' && !isNaN(textX) && !isNaN(textY)) {
+    this.setupTextStyle(context, ele, useEleOpacity);
+
+    let pdash = prefix ? prefix + '-' : '';
+    let textW = util.getPrefixedProperty(rscratch, 'labelWidth', prefix);
+    let textH = util.getPrefixedProperty(rscratch, 'labelHeight', prefix);
+    let marginX = ele.pstyle(pdash + 'text-margin-x').pfValue;
+    let marginY = ele.pstyle(pdash + 'text-margin-y').pfValue;
+
+    let isEdge = ele.isEdge();
+
+    let halign = ele.pstyle('text-halign').value;
+    let valign = ele.pstyle('text-valign').value;
+
+    if (isEdge) {
+      halign = 'center';
+      valign = 'center';
+    }
+
+    textX += marginX;
+    textY += marginY;
+
+    let theta;
+
+    if (!applyRotation) {
+      theta = 0;
+    } else {
+      theta = this.getTextAngle(ele, prefix);
+    }
+
+    if (theta !== 0) {
+      orgTextX = textX;
+      orgTextY = textY;
+
+      context.translate(orgTextX, orgTextY);
+      context.rotate(theta);
+
+      textX = 0;
+      textY = 0;
+    }
+
+    switch (valign) {
+      case 'top':
+        break;
+      case 'center':
+        textY += textH / 2;
+        break;
+      case 'bottom':
+        textY += textH;
+        break;
+    }
+
+    let backgroundOpacity = ele.pstyle('text-background-opacity').value;
+    let borderOpacity = ele.pstyle('text-border-opacity').value;
+    let textBorderWidth = ele.pstyle('text-border-width').pfValue;
+    let backgroundPadding = ele.pstyle('text-background-padding').pfValue;
+
+    if (backgroundOpacity > 0 || (textBorderWidth > 0 && borderOpacity > 0)) {
+      let bgX = textX - backgroundPadding;
+
+      switch (halign) {
+        case 'left':
+          bgX -= textW;
+          break;
+        case 'center':
+          bgX -= textW / 2;
+          break;
+        case 'right':
+          break;
+      }
+
+      let bgY = textY - textH - backgroundPadding;
+      let bgW = textW + 2 * backgroundPadding;
+      let bgH = textH + 2 * backgroundPadding;
+
+      if (backgroundOpacity > 0) {
+        let textFill = context.fillStyle;
+        let textBackgroundColor = ele.pstyle('text-background-color').value;
+
+        context.fillStyle = 'rgba(' + textBackgroundColor[0] + ',' + textBackgroundColor[1] + ',' + textBackgroundColor[2] + ',' + backgroundOpacity * parentOpacity + ')';
+        let styleShape = ele.pstyle('text-background-shape').strValue;
+        if (styleShape.indexOf('round') === 0) {
+          roundRect(context, bgX, bgY, bgW, bgH, 2);
+        } else {
+          context.fillRect(bgX, bgY, bgW, bgH);
+        }
+        context.fillStyle = textFill;
+      }
+
+      if (textBorderWidth > 0 && borderOpacity > 0) {
+        let textStroke = context.strokeStyle;
+        let textLineWidth = context.lineWidth;
+        let textBorderColor = ele.pstyle('text-border-color').value;
+        let textBorderStyle = ele.pstyle('text-border-style').value;
+
+        context.strokeStyle = 'rgba(' + textBorderColor[0] + ',' + textBorderColor[1] + ',' + textBorderColor[2] + ',' + borderOpacity * parentOpacity + ')';
+        context.lineWidth = textBorderWidth;
+
+        if (context.setLineDash) {
+          // for very outofdate browsers
+          switch (textBorderStyle) {
+            case 'dotted':
+              context.setLineDash([1, 1]);
+              break;
+            case 'dashed':
+              context.setLineDash([4, 2]);
+              break;
+            case 'double':
+              context.lineWidth = textBorderWidth / 4; // 50% reserved for white between the two borders
+              context.setLineDash([]);
+              break;
+            case 'solid':
+              context.setLineDash([]);
+              break;
+          }
+        }
+
+        context.strokeRect(bgX, bgY, bgW, bgH);
+
+        if (textBorderStyle === 'double') {
+          let whiteWidth = textBorderWidth / 2;
+
+          context.strokeRect(bgX + whiteWidth, bgY + whiteWidth, bgW - whiteWidth * 2, bgH - whiteWidth * 2);
+        }
+
+        if (context.setLineDash) {
+          // for very outofdate browsers
+          context.setLineDash([]);
+        }
+        context.lineWidth = textLineWidth;
+        context.strokeStyle = textStroke;
+      }
+    }
+
+    let lineWidth = 2 * ele.pstyle('text-outline-width').pfValue; // *2 b/c the stroke is drawn centred on the middle
+
+    if (lineWidth > 0) {
+      context.lineWidth = lineWidth;
+    }
+
+    if (ele.pstyle('text-wrap').value === 'wrap') {
+      let lines = util.getPrefixedProperty(rscratch, 'labelWrapCachedLines', prefix);
+      let lineHeight = util.getPrefixedProperty(rscratch, 'labelLineHeight', prefix);
+      let halfTextW = textW / 2;
+      let justification = this.getLabelJustification(ele);
+
+      if (justification === 'auto') {
+        // then it's already ok, so skip all the other ifs
+      } else if (halign === 'left') {
+        // auto justification : right
+        if (justification === 'left') {
+          textX += -textW;
+        } else if (justification === 'center') {
+          textX += -halfTextW;
+        } // else same as auto
+      } else if (halign === 'center') {
+        // auto justfication : center
+        if (justification === 'left') {
+          textX += -halfTextW;
+        } else if (justification === 'right') {
+          textX += halfTextW;
+        } // else same as auto
+      } else if (halign === 'right') {
+        // auto justification : left
+        if (justification === 'center') {
+          textX += halfTextW;
+        } else if (justification === 'right') {
+          textX += textW;
+        } // else same as auto
+      }
+
+      switch (valign) {
+        case 'top':
+          textY -= (lines.length - 1) * lineHeight;
+          break;
+        case 'center':
+        case 'bottom':
+          textY -= (lines.length - 1) * lineHeight;
+          break;
+      }
+
+      for (let l = 0; l < lines.length; l++) {
+        if (lineWidth > 0) {
+          context.strokeText(lines[l], textX, textY);
+        }
+
+        context.fillText(lines[l], textX, textY);
+
+        textY += lineHeight;
+      }
+    } else {
+      if (lineWidth > 0) {
+        context.strokeText(text, textX, textY);
+      }
+
+      context.fillText(text, textX, textY);
+    }
+
+    if (theta !== 0) {
+      context.rotate(-theta);
+      context.translate(-orgTextX, -orgTextY);
+    }
+  }
+};
+
+export default CRp;

--- a/src/component/cytoscape/renderer/core/canvas/drawing-label-text.js
+++ b/src/component/cytoscape/renderer/core/canvas/drawing-label-text.js
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as util from '../../../../../../node_modules/cytoscape/src/util';
-import * as math from '../../../../../../node_modules/cytoscape/src/math';
+import * as util from 'cytoscape/src/util';
+import * as math from 'cytoscape/src/math';
 
 let CRp = {};
 

--- a/src/component/cytoscape/renderer/core/canvas/drawing-nodes.js
+++ b/src/component/cytoscape/renderer/core/canvas/drawing-nodes.js
@@ -1,0 +1,403 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as is from '../../../../../../node_modules/cytoscape/src/is';
+import * as util from '../../../../../../node_modules/cytoscape/src/util';
+
+let CRp = {};
+
+CRp.drawNode = function (context, node, shiftToOriginWithBb, drawLabel = true, shouldDrawOverlay = true, shouldDrawOpacity = true) {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  let r = this;
+  let nodeWidth, nodeHeight;
+  let _p = node._private;
+  let rs = _p.rscratch;
+  let pos = node.position();
+
+  if (!is.number(pos.x) || !is.number(pos.y)) {
+    return; // can't draw node with undefined position
+  }
+
+  if (shouldDrawOpacity && !node.visible()) {
+    return;
+  }
+
+  let eleOpacity = shouldDrawOpacity ? node.effectiveOpacity() : 1;
+
+  let usePaths = r.usePaths();
+  let path;
+  let pathCacheHit = false;
+
+  let padding = node.padding();
+
+  nodeWidth = node.width() + 2 * padding;
+  nodeHeight = node.height() + 2 * padding;
+
+  //
+  // setup shift
+
+  let bb;
+  if (shiftToOriginWithBb) {
+    bb = shiftToOriginWithBb;
+
+    context.translate(-bb.x1, -bb.y1);
+  }
+
+  //
+  // load bg image
+
+  let bgImgProp = node.pstyle('background-image');
+  let urls = bgImgProp.value;
+  let urlDefined = new Array(urls.length);
+  let image = new Array(urls.length);
+  let numImages = 0;
+  for (let i = 0; i < urls.length; i++) {
+    let url = urls[i];
+    let defd = (urlDefined[i] = url != null && url !== 'none');
+
+    if (defd) {
+      let bgImgCrossOrigin = node.cy().style().getIndexedStyle(node, 'background-image-crossorigin', 'value', i);
+
+      numImages++;
+
+      // get image, and if not loaded then ask to redraw when later loaded
+      image[i] = r.getCachedImage(url, bgImgCrossOrigin, function () {
+        _p.backgroundTimestamp = Date.now();
+
+        node.emitAndNotify('background');
+      });
+    }
+  }
+
+  //
+  // setup styles
+
+  let darkness = node.pstyle('background-blacken').value;
+  let borderWidth = node.pstyle('border-width').pfValue;
+  let bgOpacity = node.pstyle('background-opacity').value * eleOpacity;
+  let borderColor = node.pstyle('border-color').value;
+  let borderStyle = node.pstyle('border-style').value;
+  let borderOpacity = node.pstyle('border-opacity').value * eleOpacity;
+
+  context.lineJoin = 'miter'; // so borders are square with the node shape
+
+  let setupShapeColor = (bgOpy = bgOpacity) => {
+    r.eleFillStyle(context, node, bgOpy);
+  };
+
+  let setupBorderColor = (bdrOpy = borderOpacity) => {
+    r.colorStrokeStyle(context, borderColor[0], borderColor[1], borderColor[2], bdrOpy);
+  };
+
+  //
+  // setup shape
+
+  let styleShape = node.pstyle('shape').strValue;
+  let shapePts = node.pstyle('shape-polygon-points').pfValue;
+
+  if (usePaths) {
+    context.translate(pos.x, pos.y);
+
+    let pathCache = (r.nodePathCache = r.nodePathCache || []);
+
+    let key = util.hashStrings(styleShape === 'polygon' ? styleShape + ',' + shapePts.join(',') : styleShape, '' + nodeHeight, '' + nodeWidth);
+
+    let cachedPath = pathCache[key];
+
+    if (cachedPath != null) {
+      path = cachedPath;
+      pathCacheHit = true;
+      rs.pathCache = path;
+    } else {
+      path = new Path2D();
+      pathCache[key] = rs.pathCache = path;
+    }
+  }
+
+  let drawShape = () => {
+    if (!pathCacheHit) {
+      let npos = pos;
+
+      if (usePaths) {
+        npos = {
+          x: 0,
+          y: 0,
+        };
+      }
+
+      r.nodeShapes[r.getNodeShape(node)].draw(path || context, npos.x, npos.y, nodeWidth, nodeHeight);
+    }
+
+    if (usePaths) {
+      context.fill(path);
+    } else {
+      context.fill();
+    }
+  };
+
+  let drawImages = (nodeOpacity = eleOpacity) => {
+    let prevBging = _p.backgrounding;
+    let totalCompleted = 0;
+
+    for (let i = 0; i < image.length; i++) {
+      if (urlDefined[i] && image[i].complete && !image[i].error) {
+        totalCompleted++;
+        r.drawInscribedImage(context, image[i], node, i, nodeOpacity);
+      }
+    }
+
+    _p.backgrounding = !(totalCompleted === numImages);
+    if (prevBging !== _p.backgrounding) {
+      // update style b/c :backgrounding state changed
+      node.updateStyle(false);
+    }
+  };
+
+  let drawPie = (redrawShape = false, pieOpacity = eleOpacity) => {
+    if (r.hasPie(node)) {
+      r.drawPie(context, node, pieOpacity);
+
+      // redraw/restore path if steps after pie need it
+      if (redrawShape) {
+        if (!usePaths) {
+          r.nodeShapes[r.getNodeShape(node)].draw(context, pos.x, pos.y, nodeWidth, nodeHeight);
+        }
+      }
+    }
+  };
+
+  let darken = (darkenOpacity = eleOpacity) => {
+    let opacity = (darkness > 0 ? darkness : -darkness) * darkenOpacity;
+    let c = darkness > 0 ? 0 : 255;
+
+    if (darkness !== 0) {
+      r.colorFillStyle(context, c, c, c, opacity);
+
+      if (usePaths) {
+        context.fill(path);
+      } else {
+        context.fill();
+      }
+    }
+  };
+
+  let drawBorder = () => {
+    if (borderWidth > 0) {
+      context.lineWidth = borderWidth;
+      context.lineCap = 'butt';
+
+      if (context.setLineDash) {
+        // for very outofdate browsers
+        switch (borderStyle) {
+          case 'dotted':
+            context.setLineDash([1, 1]);
+            break;
+
+          case 'dashed':
+            context.setLineDash([4, 2]);
+            break;
+
+          case 'solid':
+          case 'double':
+            context.setLineDash([]);
+            break;
+        }
+      }
+
+      if (usePaths) {
+        context.stroke(path);
+      } else {
+        context.stroke();
+      }
+
+      if (borderStyle === 'double') {
+        context.lineWidth = borderWidth / 3;
+
+        let gco = context.globalCompositeOperation;
+        context.globalCompositeOperation = 'destination-out';
+
+        if (usePaths) {
+          context.stroke(path);
+        } else {
+          context.stroke();
+        }
+
+        context.globalCompositeOperation = gco;
+      }
+
+      // reset in case we changed the border style
+      if (context.setLineDash) {
+        // for very outofdate browsers
+        context.setLineDash([]);
+      }
+    }
+  };
+
+  let drawOverlay = () => {
+    if (shouldDrawOverlay) {
+      r.drawNodeOverlay(context, node, pos, nodeWidth, nodeHeight);
+    }
+  };
+
+  let drawText = () => {
+    r.drawElementText(context, node, null, drawLabel);
+  };
+
+  let ghost = node.pstyle('ghost').value === 'yes';
+
+  if (ghost) {
+    let gx = node.pstyle('ghost-offset-x').pfValue;
+    let gy = node.pstyle('ghost-offset-y').pfValue;
+    let ghostOpacity = node.pstyle('ghost-opacity').value;
+    let effGhostOpacity = ghostOpacity * eleOpacity;
+
+    context.translate(gx, gy);
+
+    setupShapeColor(ghostOpacity * bgOpacity);
+    drawShape();
+    drawImages(effGhostOpacity);
+    drawPie(darkness !== 0 || borderWidth !== 0);
+    darken(effGhostOpacity);
+    setupBorderColor(ghostOpacity * borderOpacity);
+    drawBorder();
+
+    context.translate(-gx, -gy);
+  }
+
+  setupShapeColor();
+  drawShape();
+  drawImages();
+  drawPie(darkness !== 0 || borderWidth !== 0);
+  darken();
+  setupBorderColor();
+  drawBorder();
+
+  if (usePaths) {
+    context.translate(-pos.x, -pos.y);
+  }
+
+  drawText();
+
+  drawOverlay();
+
+  //
+  // clean up shift
+
+  if (shiftToOriginWithBb) {
+    context.translate(bb.x1, bb.y1);
+  }
+};
+
+CRp.drawNodeOverlay = function (context, node, pos, nodeWidth, nodeHeight) {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  let r = this;
+
+  if (!node.visible()) {
+    return;
+  }
+
+  let overlayPadding = node.pstyle('overlay-padding').pfValue;
+  let overlayOpacity = node.pstyle('overlay-opacity').value;
+  let overlayColor = node.pstyle('overlay-color').value;
+
+  if (overlayOpacity > 0) {
+    pos = pos || node.position();
+
+    if (nodeWidth == null || nodeHeight == null) {
+      let padding = node.padding();
+
+      nodeWidth = node.width() + 2 * padding;
+      nodeHeight = node.height() + 2 * padding;
+    }
+
+    r.colorFillStyle(context, overlayColor[0], overlayColor[1], overlayColor[2], overlayOpacity);
+
+    r.nodeShapes['roundrectangle'].draw(context, pos.x, pos.y, nodeWidth + overlayPadding * 2, nodeHeight + overlayPadding * 2);
+
+    context.fill();
+  }
+};
+
+// does the node have at least one pie piece?
+CRp.hasPie = function (node) {
+  node = node[0]; // ensure ele ref
+
+  return node._private.hasPie;
+};
+
+CRp.drawPie = function (context, node, nodeOpacity, pos) {
+  node = node[0]; // ensure ele ref
+  pos = pos || node.position();
+
+  let cyStyle = node.cy().style();
+  let pieSize = node.pstyle('pie-size');
+  let x = pos.x;
+  let y = pos.y;
+  let nodeW = node.width();
+  let nodeH = node.height();
+  let radius = Math.min(nodeW, nodeH) / 2; // must fit in node
+  let lastPercent = 0; // what % to continue drawing pie slices from on [0, 1]
+  let usePaths = this.usePaths();
+
+  if (usePaths) {
+    x = 0;
+    y = 0;
+  }
+
+  if (pieSize.units === '%') {
+    radius = radius * pieSize.pfValue;
+  } else if (pieSize.pfValue !== undefined) {
+    radius = pieSize.pfValue / 2;
+  }
+
+  for (let i = 1; i <= cyStyle.pieBackgroundN; i++) {
+    // 1..N
+    let size = node.pstyle('pie-' + i + '-background-size').value;
+    let color = node.pstyle('pie-' + i + '-background-color').value;
+    let opacity = node.pstyle('pie-' + i + '-background-opacity').value * nodeOpacity;
+    let percent = size / 100; // map integer range [0, 100] to [0, 1]
+
+    // percent can't push beyond 1
+    if (percent + lastPercent > 1) {
+      percent = 1 - lastPercent;
+    }
+
+    let angleStart = 1.5 * Math.PI + 2 * Math.PI * lastPercent; // start at 12 o'clock and go clockwise
+    let angleDelta = 2 * Math.PI * percent;
+    let angleEnd = angleStart + angleDelta;
+
+    // ignore if
+    // - zero size
+    // - we're already beyond the full circle
+    // - adding the current slice would go beyond the full circle
+    if (size === 0 || lastPercent >= 1 || lastPercent + percent > 1) {
+      continue;
+    }
+
+    context.beginPath();
+    context.moveTo(x, y);
+    context.arc(x, y, radius, angleStart, angleEnd);
+    context.closePath();
+
+    this.colorFillStyle(context, color[0], color[1], color[2], opacity);
+
+    context.fill();
+
+    lastPercent += percent;
+  }
+};
+
+export default CRp;

--- a/src/component/cytoscape/renderer/core/canvas/drawing-nodes.js
+++ b/src/component/cytoscape/renderer/core/canvas/drawing-nodes.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as is from '../../../../../../node_modules/cytoscape/src/is';
-import * as util from '../../../../../../node_modules/cytoscape/src/util';
+import * as is from 'cytoscape/src/is';
+import * as util from 'cytoscape/src/util';
 
 let CRp = {};
 

--- a/src/component/cytoscape/renderer/core/canvas/drawing-redraw.js
+++ b/src/component/cytoscape/renderer/core/canvas/drawing-redraw.js
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as util from '../../../../../../node_modules/cytoscape/src/util';
-import * as math from '../../../../../../node_modules/cytoscape/src/math';
+import * as util from 'cytoscape/src/util';
+import * as math from 'cytoscape/src/math';
 
 var CRp = {};
 

--- a/src/component/cytoscape/renderer/core/canvas/drawing-redraw.js
+++ b/src/component/cytoscape/renderer/core/canvas/drawing-redraw.js
@@ -1,0 +1,721 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as util from '../../../../../../node_modules/cytoscape/src/util';
+import * as math from '../../../../../../node_modules/cytoscape/src/math';
+
+var CRp = {};
+
+var motionBlurDelay = 100;
+
+// var isFirefox = typeof InstallTrigger !== 'undefined';
+
+CRp.getPixelRatio = function () {
+  var context = this.data.contexts[0];
+
+  if (this.forcedPixelRatio != null) {
+    return this.forcedPixelRatio;
+  }
+
+  var backingStore =
+    context.backingStorePixelRatio ||
+    context.webkitBackingStorePixelRatio ||
+    context.mozBackingStorePixelRatio ||
+    context.msBackingStorePixelRatio ||
+    context.oBackingStorePixelRatio ||
+    context.backingStorePixelRatio ||
+    1;
+
+  return (window.devicePixelRatio || 1) / backingStore; // eslint-disable-line no-undef
+};
+
+CRp.paintCache = function (context) {
+  var caches = (this.paintCaches = this.paintCaches || []);
+  var needToCreateCache = true;
+  var cache;
+
+  for (var i = 0; i < caches.length; i++) {
+    cache = caches[i];
+
+    if (cache.context === context) {
+      needToCreateCache = false;
+      break;
+    }
+  }
+
+  if (needToCreateCache) {
+    cache = {
+      context: context,
+    };
+    caches.push(cache);
+  }
+
+  return cache;
+};
+
+CRp.createGradientStyleFor = function (context, shapeStyleName, ele, fill, opacity) {
+  let gradientStyle;
+  let usePaths = this.usePaths();
+
+  let colors = ele.pstyle(shapeStyleName + '-gradient-stop-colors').value,
+    positions = ele.pstyle(shapeStyleName + '-gradient-stop-positions').pfValue;
+
+  if (fill === 'radial-gradient') {
+    if (ele.isEdge()) {
+      let start = ele.sourceEndpoint(),
+        end = ele.targetEndpoint(),
+        mid = ele.midpoint();
+
+      let d1 = math.dist(start, mid);
+      let d2 = math.dist(end, mid);
+
+      gradientStyle = context.createRadialGradient(mid.x, mid.y, 0, mid.x, mid.y, Math.max(d1, d2));
+    } else {
+      let pos = usePaths ? { x: 0, y: 0 } : ele.position(),
+        width = ele.paddedWidth(),
+        height = ele.paddedHeight();
+      gradientStyle = context.createRadialGradient(pos.x, pos.y, 0, pos.x, pos.y, Math.max(width, height));
+    }
+  } else {
+    if (ele.isEdge()) {
+      let start = ele.sourceEndpoint(),
+        end = ele.targetEndpoint();
+
+      gradientStyle = context.createLinearGradient(start.x, start.y, end.x, end.y);
+    } else {
+      let pos = usePaths ? { x: 0, y: 0 } : ele.position(),
+        width = ele.paddedWidth(),
+        height = ele.paddedHeight(),
+        halfWidth = width / 2,
+        halfHeight = height / 2;
+      let direction = ele.pstyle('background-gradient-direction').value;
+
+      switch (direction) {
+        case 'to-bottom':
+          gradientStyle = context.createLinearGradient(pos.x, pos.y - halfHeight, pos.x, pos.y + halfHeight);
+          break;
+        case 'to-top':
+          gradientStyle = context.createLinearGradient(pos.x, pos.y + halfHeight, pos.x, pos.y - halfHeight);
+          break;
+        case 'to-left':
+          gradientStyle = context.createLinearGradient(pos.x + halfWidth, pos.y, pos.x - halfWidth, pos.y);
+          break;
+        case 'to-right':
+          gradientStyle = context.createLinearGradient(pos.x - halfWidth, pos.y, pos.x + halfWidth, pos.y);
+          break;
+        case 'to-bottom-right':
+        case 'to-right-bottom':
+          gradientStyle = context.createLinearGradient(pos.x - halfWidth, pos.y - halfHeight, pos.x + halfWidth, pos.y + halfHeight);
+          break;
+        case 'to-top-right':
+        case 'to-right-top':
+          gradientStyle = context.createLinearGradient(pos.x - halfWidth, pos.y + halfHeight, pos.x + halfWidth, pos.y - halfHeight);
+          break;
+        case 'to-bottom-left':
+        case 'to-left-bottom':
+          gradientStyle = context.createLinearGradient(pos.x + halfWidth, pos.y - halfHeight, pos.x - halfWidth, pos.y + halfHeight);
+          break;
+        case 'to-top-left':
+        case 'to-left-top':
+          gradientStyle = context.createLinearGradient(pos.x + halfWidth, pos.y + halfHeight, pos.x - halfWidth, pos.y - halfHeight);
+          break;
+      }
+    }
+  }
+  if (!gradientStyle) return null; // invalid gradient style
+
+  let hasPositions = positions.length === colors.length;
+
+  let length = colors.length;
+  for (let i = 0; i < length; i++) {
+    gradientStyle.addColorStop(hasPositions ? positions[i] : i / (length - 1), 'rgba(' + colors[i][0] + ',' + colors[i][1] + ',' + colors[i][2] + ',' + opacity + ')');
+  }
+
+  return gradientStyle;
+};
+
+CRp.gradientFillStyle = function (context, ele, fill, opacity) {
+  const gradientStyle = this.createGradientStyleFor(context, 'background', ele, fill, opacity);
+  if (!gradientStyle) return null; // error
+  context.fillStyle = gradientStyle;
+};
+
+CRp.colorFillStyle = function (context, r, g, b, a) {
+  context.fillStyle = 'rgba(' + r + ',' + g + ',' + b + ',' + a + ')';
+  // turn off for now, seems context does its own caching
+
+  // var cache = this.paintCache(context);
+
+  // var fillStyle = 'rgba(' + r + ',' + g + ',' + b + ',' + a + ')';
+
+  // if( cache.fillStyle !== fillStyle ){
+  //   context.fillStyle = cache.fillStyle = fillStyle;
+  // }
+};
+
+CRp.eleFillStyle = function (context, ele, opacity) {
+  let backgroundFill = ele.pstyle('background-fill').value;
+
+  if (backgroundFill === 'linear-gradient' || backgroundFill === 'radial-gradient') {
+    this.gradientFillStyle(context, ele, backgroundFill, opacity);
+  } else {
+    let backgroundColor = ele.pstyle('background-color').value;
+    this.colorFillStyle(context, backgroundColor[0], backgroundColor[1], backgroundColor[2], opacity);
+  }
+};
+
+CRp.gradientStrokeStyle = function (context, ele, fill, opacity) {
+  const gradientStyle = this.createGradientStyleFor(context, 'line', ele, fill, opacity);
+  if (!gradientStyle) return null; // error
+  context.strokeStyle = gradientStyle;
+};
+
+CRp.colorStrokeStyle = function (context, r, g, b, a) {
+  context.strokeStyle = 'rgba(' + r + ',' + g + ',' + b + ',' + a + ')';
+  // turn off for now, seems context does its own caching
+
+  // var cache = this.paintCache(context);
+
+  // var strokeStyle = 'rgba(' + r + ',' + g + ',' + b + ',' + a + ')';
+
+  // if( cache.strokeStyle !== strokeStyle ){
+  //   context.strokeStyle = cache.strokeStyle = strokeStyle;
+  // }
+};
+
+CRp.eleStrokeStyle = function (context, ele, opacity) {
+  let lineFill = ele.pstyle('line-fill').value;
+
+  if (lineFill === 'linear-gradient' || lineFill === 'radial-gradient') {
+    this.gradientStrokeStyle(context, ele, lineFill, opacity);
+  } else {
+    let lineColor = ele.pstyle('line-color').value;
+    this.colorStrokeStyle(context, lineColor[0], lineColor[1], lineColor[2], opacity);
+  }
+};
+
+// Resize canvas
+CRp.matchCanvasSize = function (container) {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  var r = this;
+  var data = r.data;
+  var bb = r.findContainerClientCoords();
+  var width = bb[2];
+  var height = bb[3];
+  var pixelRatio = r.getPixelRatio();
+  var mbPxRatio = r.motionBlurPxRatio;
+
+  if (container === r.data.bufferCanvases[r.MOTIONBLUR_BUFFER_NODE] || container === r.data.bufferCanvases[r.MOTIONBLUR_BUFFER_DRAG]) {
+    pixelRatio = mbPxRatio;
+  }
+
+  var canvasWidth = width * pixelRatio;
+  var canvasHeight = height * pixelRatio;
+  var canvas;
+
+  if (canvasWidth === r.canvasWidth && canvasHeight === r.canvasHeight) {
+    return; // save cycles if same
+  }
+
+  r.fontCaches = null; // resizing resets the style
+
+  var canvasContainer = data.canvasContainer;
+  canvasContainer.style.width = width + 'px';
+  canvasContainer.style.height = height + 'px';
+
+  for (var i = 0; i < r.CANVAS_LAYERS; i++) {
+    canvas = data.canvases[i];
+
+    canvas.width = canvasWidth;
+    canvas.height = canvasHeight;
+
+    canvas.style.width = width + 'px';
+    canvas.style.height = height + 'px';
+  }
+
+  for (var i = 0; i < r.BUFFER_COUNT; i++) {
+    canvas = data.bufferCanvases[i];
+
+    canvas.width = canvasWidth;
+    canvas.height = canvasHeight;
+
+    canvas.style.width = width + 'px';
+    canvas.style.height = height + 'px';
+  }
+
+  r.textureMult = 1;
+  if (pixelRatio <= 1) {
+    canvas = data.bufferCanvases[r.TEXTURE_BUFFER];
+
+    r.textureMult = 2;
+    canvas.width = canvasWidth * r.textureMult;
+    canvas.height = canvasHeight * r.textureMult;
+  }
+
+  r.canvasWidth = canvasWidth;
+  r.canvasHeight = canvasHeight;
+};
+
+CRp.renderTo = function (cxt, zoom, pan, pxRatio) {
+  this.render({
+    forcedContext: cxt,
+    forcedZoom: zoom,
+    forcedPan: pan,
+    drawAllLayers: true,
+    forcedPxRatio: pxRatio,
+  });
+};
+
+CRp.render = function (options) {
+  options = options || util.staticEmptyObject();
+
+  var forcedContext = options.forcedContext;
+  var drawAllLayers = options.drawAllLayers;
+  var drawOnlyNodeLayer = options.drawOnlyNodeLayer;
+  var forcedZoom = options.forcedZoom;
+  var forcedPan = options.forcedPan;
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  var r = this;
+  var pixelRatio = options.forcedPxRatio === undefined ? this.getPixelRatio() : options.forcedPxRatio;
+  var cy = r.cy;
+  var data = r.data;
+  var needDraw = data.canvasNeedsRedraw;
+  var textureDraw = r.textureOnViewport && !forcedContext && (r.pinching || r.hoverData.dragging || r.swipePanning || r.data.wheelZooming);
+  var motionBlur = options.motionBlur !== undefined ? options.motionBlur : r.motionBlur;
+  var mbPxRatio = r.motionBlurPxRatio;
+  var hasCompoundNodes = cy.hasCompoundNodes();
+  var inNodeDragGesture = r.hoverData.draggingEles;
+  var inBoxSelection = r.hoverData.selecting || r.touchData.selecting ? true : false;
+  motionBlur = motionBlur && !forcedContext && r.motionBlurEnabled && !inBoxSelection;
+  var motionBlurFadeEffect = motionBlur;
+
+  if (!forcedContext) {
+    if (r.prevPxRatio !== pixelRatio) {
+      r.invalidateContainerClientCoordsCache();
+      r.matchCanvasSize(r.container);
+
+      r.redrawHint('eles', true);
+      r.redrawHint('drag', true);
+    }
+
+    r.prevPxRatio = pixelRatio;
+  }
+
+  if (!forcedContext && r.motionBlurTimeout) {
+    clearTimeout(r.motionBlurTimeout);
+  }
+
+  if (motionBlur) {
+    if (r.mbFrames == null) {
+      r.mbFrames = 0;
+    }
+
+    r.mbFrames++;
+
+    if (r.mbFrames < 3) {
+      // need several frames before even high quality motionblur
+      motionBlurFadeEffect = false;
+    }
+
+    // go to lower quality blurry frames when several m/b frames have been rendered (avoids flashing)
+    if (r.mbFrames > r.minMbLowQualFrames) {
+      //r.fullQualityMb = false;
+      r.motionBlurPxRatio = r.mbPxRBlurry;
+    }
+  }
+
+  if (r.clearingMotionBlur) {
+    r.motionBlurPxRatio = 1;
+  }
+
+  // b/c drawToContext() may be async w.r.t. redraw(), keep track of last texture frame
+  // because a rogue async texture frame would clear needDraw
+  if (r.textureDrawLastFrame && !textureDraw) {
+    needDraw[r.NODE] = true;
+    needDraw[r.SELECT_BOX] = true;
+  }
+
+  var style = cy.style();
+
+  var zoom = cy.zoom();
+  var effectiveZoom = forcedZoom !== undefined ? forcedZoom : zoom;
+  var pan = cy.pan();
+  var effectivePan = {
+    x: pan.x,
+    y: pan.y,
+  };
+
+  var vp = {
+    zoom: zoom,
+    pan: {
+      x: pan.x,
+      y: pan.y,
+    },
+  };
+  var prevVp = r.prevViewport;
+  var viewportIsDiff = prevVp === undefined || vp.zoom !== prevVp.zoom || vp.pan.x !== prevVp.pan.x || vp.pan.y !== prevVp.pan.y;
+
+  // we want the low quality motionblur only when the viewport is being manipulated etc (where it's not noticed)
+  if (!viewportIsDiff && !(inNodeDragGesture && !hasCompoundNodes)) {
+    r.motionBlurPxRatio = 1;
+  }
+
+  if (forcedPan) {
+    effectivePan = forcedPan;
+  }
+
+  // apply pixel ratio
+
+  effectiveZoom *= pixelRatio;
+  effectivePan.x *= pixelRatio;
+  effectivePan.y *= pixelRatio;
+
+  var eles = r.getCachedZSortedEles();
+
+  function mbclear(context, x, y, w, h) {
+    var gco = context.globalCompositeOperation;
+
+    context.globalCompositeOperation = 'destination-out';
+    r.colorFillStyle(context, 255, 255, 255, r.motionBlurTransparency);
+    context.fillRect(x, y, w, h);
+
+    context.globalCompositeOperation = gco;
+  }
+
+  function setContextTransform(context, clear) {
+    var ePan, eZoom, w, h;
+
+    if (!r.clearingMotionBlur && (context === data.bufferContexts[r.MOTIONBLUR_BUFFER_NODE] || context === data.bufferContexts[r.MOTIONBLUR_BUFFER_DRAG])) {
+      ePan = {
+        x: pan.x * mbPxRatio,
+        y: pan.y * mbPxRatio,
+      };
+
+      eZoom = zoom * mbPxRatio;
+
+      w = r.canvasWidth * mbPxRatio;
+      h = r.canvasHeight * mbPxRatio;
+    } else {
+      ePan = effectivePan;
+      eZoom = effectiveZoom;
+
+      w = r.canvasWidth;
+      h = r.canvasHeight;
+    }
+
+    context.setTransform(1, 0, 0, 1, 0, 0);
+
+    if (clear === 'motionBlur') {
+      mbclear(context, 0, 0, w, h);
+    } else if (!forcedContext && (clear === undefined || clear)) {
+      context.clearRect(0, 0, w, h);
+    }
+
+    if (!drawAllLayers) {
+      context.translate(ePan.x, ePan.y);
+      context.scale(eZoom, eZoom);
+    }
+    if (forcedPan) {
+      context.translate(forcedPan.x, forcedPan.y);
+    }
+    if (forcedZoom) {
+      context.scale(forcedZoom, forcedZoom);
+    }
+  }
+
+  if (!textureDraw) {
+    r.textureDrawLastFrame = false;
+  }
+
+  if (textureDraw) {
+    r.textureDrawLastFrame = true;
+
+    if (!r.textureCache) {
+      r.textureCache = {};
+
+      r.textureCache.bb = cy.mutableElements().boundingBox();
+
+      r.textureCache.texture = r.data.bufferCanvases[r.TEXTURE_BUFFER];
+
+      var cxt = r.data.bufferContexts[r.TEXTURE_BUFFER];
+
+      cxt.setTransform(1, 0, 0, 1, 0, 0);
+      cxt.clearRect(0, 0, r.canvasWidth * r.textureMult, r.canvasHeight * r.textureMult);
+
+      r.render({
+        forcedContext: cxt,
+        drawOnlyNodeLayer: true,
+        forcedPxRatio: pixelRatio * r.textureMult,
+      });
+
+      var vp = (r.textureCache.viewport = {
+        zoom: cy.zoom(),
+        pan: cy.pan(),
+        width: r.canvasWidth,
+        height: r.canvasHeight,
+      });
+
+      vp.mpan = {
+        x: (0 - vp.pan.x) / vp.zoom,
+        y: (0 - vp.pan.y) / vp.zoom,
+      };
+    }
+
+    needDraw[r.DRAG] = false;
+    needDraw[r.NODE] = false;
+
+    var context = data.contexts[r.NODE];
+
+    var texture = r.textureCache.texture;
+    var vp = r.textureCache.viewport;
+
+    context.setTransform(1, 0, 0, 1, 0, 0);
+
+    if (motionBlur) {
+      mbclear(context, 0, 0, vp.width, vp.height);
+    } else {
+      context.clearRect(0, 0, vp.width, vp.height);
+    }
+
+    var outsideBgColor = style.core('outside-texture-bg-color').value;
+    var outsideBgOpacity = style.core('outside-texture-bg-opacity').value;
+    r.colorFillStyle(context, outsideBgColor[0], outsideBgColor[1], outsideBgColor[2], outsideBgOpacity);
+    context.fillRect(0, 0, vp.width, vp.height);
+
+    var zoom = cy.zoom();
+
+    setContextTransform(context, false);
+
+    context.clearRect(vp.mpan.x, vp.mpan.y, vp.width / vp.zoom / pixelRatio, vp.height / vp.zoom / pixelRatio);
+    context.drawImage(texture, vp.mpan.x, vp.mpan.y, vp.width / vp.zoom / pixelRatio, vp.height / vp.zoom / pixelRatio);
+  } else if (r.textureOnViewport && !forcedContext) {
+    // clear the cache since we don't need it
+    r.textureCache = null;
+  }
+
+  var extent = cy.extent();
+  var vpManip = r.pinching || r.hoverData.dragging || r.swipePanning || r.data.wheelZooming || r.hoverData.draggingEles || r.cy.animated();
+  var hideEdges = r.hideEdgesOnViewport && vpManip;
+
+  var needMbClear = [];
+
+  needMbClear[r.NODE] = (!needDraw[r.NODE] && motionBlur && !r.clearedForMotionBlur[r.NODE]) || r.clearingMotionBlur;
+  if (needMbClear[r.NODE]) {
+    r.clearedForMotionBlur[r.NODE] = true;
+  }
+
+  needMbClear[r.DRAG] = (!needDraw[r.DRAG] && motionBlur && !r.clearedForMotionBlur[r.DRAG]) || r.clearingMotionBlur;
+  if (needMbClear[r.DRAG]) {
+    r.clearedForMotionBlur[r.DRAG] = true;
+  }
+
+  if (needDraw[r.NODE] || drawAllLayers || drawOnlyNodeLayer || needMbClear[r.NODE]) {
+    var useBuffer = motionBlur && !needMbClear[r.NODE] && mbPxRatio !== 1;
+    var context = forcedContext || (useBuffer ? r.data.bufferContexts[r.MOTIONBLUR_BUFFER_NODE] : data.contexts[r.NODE]);
+    var clear = motionBlur && !useBuffer ? 'motionBlur' : undefined;
+
+    setContextTransform(context, clear);
+
+    if (hideEdges) {
+      r.drawCachedNodes(context, eles.nondrag, pixelRatio, extent);
+    } else {
+      r.drawLayeredElements(context, eles.nondrag, pixelRatio, extent);
+    }
+
+    if (r.debug) {
+      r.drawDebugPoints(context, eles.nondrag);
+    }
+
+    if (!drawAllLayers && !motionBlur) {
+      needDraw[r.NODE] = false;
+    }
+  }
+
+  if (!drawOnlyNodeLayer && (needDraw[r.DRAG] || drawAllLayers || needMbClear[r.DRAG])) {
+    var useBuffer = motionBlur && !needMbClear[r.DRAG] && mbPxRatio !== 1;
+    var context = forcedContext || (useBuffer ? r.data.bufferContexts[r.MOTIONBLUR_BUFFER_DRAG] : data.contexts[r.DRAG]);
+
+    setContextTransform(context, motionBlur && !useBuffer ? 'motionBlur' : undefined);
+
+    if (hideEdges) {
+      r.drawCachedNodes(context, eles.drag, pixelRatio, extent);
+    } else {
+      r.drawCachedElements(context, eles.drag, pixelRatio, extent);
+    }
+
+    if (r.debug) {
+      r.drawDebugPoints(context, eles.drag);
+    }
+
+    if (!drawAllLayers && !motionBlur) {
+      needDraw[r.DRAG] = false;
+    }
+  }
+
+  if (r.showFps || (!drawOnlyNodeLayer && needDraw[r.SELECT_BOX] && !drawAllLayers)) {
+    var context = forcedContext || data.contexts[r.SELECT_BOX];
+
+    setContextTransform(context);
+
+    if (r.selection[4] == 1 && (r.hoverData.selecting || r.touchData.selecting)) {
+      var zoom = r.cy.zoom();
+      var borderWidth = style.core('selection-box-border-width').value / zoom;
+
+      context.lineWidth = borderWidth;
+      context.fillStyle =
+        'rgba(' +
+        style.core('selection-box-color').value[0] +
+        ',' +
+        style.core('selection-box-color').value[1] +
+        ',' +
+        style.core('selection-box-color').value[2] +
+        ',' +
+        style.core('selection-box-opacity').value +
+        ')';
+
+      context.fillRect(r.selection[0], r.selection[1], r.selection[2] - r.selection[0], r.selection[3] - r.selection[1]);
+
+      if (borderWidth > 0) {
+        context.strokeStyle =
+          'rgba(' +
+          style.core('selection-box-border-color').value[0] +
+          ',' +
+          style.core('selection-box-border-color').value[1] +
+          ',' +
+          style.core('selection-box-border-color').value[2] +
+          ',' +
+          style.core('selection-box-opacity').value +
+          ')';
+
+        context.strokeRect(r.selection[0], r.selection[1], r.selection[2] - r.selection[0], r.selection[3] - r.selection[1]);
+      }
+    }
+
+    if (data.bgActivePosistion && !r.hoverData.selecting) {
+      var zoom = r.cy.zoom();
+      var pos = data.bgActivePosistion;
+
+      context.fillStyle =
+        'rgba(' +
+        style.core('active-bg-color').value[0] +
+        ',' +
+        style.core('active-bg-color').value[1] +
+        ',' +
+        style.core('active-bg-color').value[2] +
+        ',' +
+        style.core('active-bg-opacity').value +
+        ')';
+
+      context.beginPath();
+      context.arc(pos.x, pos.y, style.core('active-bg-size').pfValue / zoom, 0, 2 * Math.PI);
+      context.fill();
+    }
+
+    var timeToRender = r.lastRedrawTime;
+    if (r.showFps && timeToRender) {
+      timeToRender = Math.round(timeToRender);
+      var fps = Math.round(1000 / timeToRender);
+
+      context.setTransform(1, 0, 0, 1, 0, 0);
+
+      context.fillStyle = 'rgba(255, 0, 0, 0.75)';
+      context.strokeStyle = 'rgba(255, 0, 0, 0.75)';
+      context.lineWidth = 1;
+      context.fillText('1 frame = ' + timeToRender + ' ms = ' + fps + ' fps', 0, 20);
+
+      var maxFps = 60;
+      context.strokeRect(0, 30, 250, 20);
+      context.fillRect(0, 30, 250 * Math.min(fps / maxFps, 1), 20);
+    }
+
+    if (!drawAllLayers) {
+      needDraw[r.SELECT_BOX] = false;
+    }
+  }
+
+  // motionblur: blit rendered blurry frames
+  if (motionBlur && mbPxRatio !== 1) {
+    var cxtNode = data.contexts[r.NODE];
+    var txtNode = r.data.bufferCanvases[r.MOTIONBLUR_BUFFER_NODE];
+
+    var cxtDrag = data.contexts[r.DRAG];
+    var txtDrag = r.data.bufferCanvases[r.MOTIONBLUR_BUFFER_DRAG];
+
+    var drawMotionBlur = function (cxt, txt, needClear) {
+      cxt.setTransform(1, 0, 0, 1, 0, 0);
+
+      if (needClear || !motionBlurFadeEffect) {
+        cxt.clearRect(0, 0, r.canvasWidth, r.canvasHeight);
+      } else {
+        mbclear(cxt, 0, 0, r.canvasWidth, r.canvasHeight);
+      }
+
+      var pxr = mbPxRatio;
+
+      cxt.drawImage(
+        txt, // img
+        0,
+        0, // sx, sy
+        r.canvasWidth * pxr,
+        r.canvasHeight * pxr, // sw, sh
+        0,
+        0, // x, y
+        r.canvasWidth,
+        r.canvasHeight, // w, h
+      );
+    };
+
+    if (needDraw[r.NODE] || needMbClear[r.NODE]) {
+      drawMotionBlur(cxtNode, txtNode, needMbClear[r.NODE]);
+      needDraw[r.NODE] = false;
+    }
+
+    if (needDraw[r.DRAG] || needMbClear[r.DRAG]) {
+      drawMotionBlur(cxtDrag, txtDrag, needMbClear[r.DRAG]);
+      needDraw[r.DRAG] = false;
+    }
+  }
+
+  r.prevViewport = vp;
+
+  if (r.clearingMotionBlur) {
+    r.clearingMotionBlur = false;
+    r.motionBlurCleared = true;
+    r.motionBlur = true;
+  }
+
+  if (motionBlur) {
+    r.motionBlurTimeout = setTimeout(function () {
+      r.motionBlurTimeout = null;
+
+      r.clearedForMotionBlur[r.NODE] = false;
+      r.clearedForMotionBlur[r.DRAG] = false;
+      r.motionBlur = false;
+      r.clearingMotionBlur = !textureDraw;
+      r.mbFrames = 0;
+
+      needDraw[r.NODE] = true;
+      needDraw[r.DRAG] = true;
+
+      r.redraw();
+    }, motionBlurDelay);
+  }
+
+  if (!forcedContext) {
+    cy.emit('render');
+  }
+};
+
+export default CRp;

--- a/src/component/cytoscape/renderer/core/canvas/drawing-shapes.js
+++ b/src/component/cytoscape/renderer/core/canvas/drawing-shapes.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as math from '../../../../../../node_modules/cytoscape/src/math';
+import * as math from 'cytoscape/src/math';
 
 var CRp = {};
 

--- a/src/component/cytoscape/renderer/core/canvas/drawing-shapes.js
+++ b/src/component/cytoscape/renderer/core/canvas/drawing-shapes.js
@@ -1,0 +1,258 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as math from '../../../../../../node_modules/cytoscape/src/math';
+
+var CRp = {};
+
+// @O Polygon drawing
+CRp.drawPolygonPath = function (context, x, y, width, height, points) {
+  var halfW = width / 2;
+  var halfH = height / 2;
+
+  if (context.beginPath) {
+    context.beginPath();
+  }
+
+  context.moveTo(x + halfW * points[0], y + halfH * points[1]);
+
+  for (var i = 1; i < points.length / 2; i++) {
+    context.lineTo(x + halfW * points[i * 2], y + halfH * points[i * 2 + 1]);
+  }
+
+  context.closePath();
+};
+
+CRp.drawRoundPolygonPath = function (context, x, y, width, height, points) {
+  const halfW = width / 2;
+  const halfH = height / 2;
+  const cornerRadius = math.getRoundPolygonRadius(width, height);
+
+  if (context.beginPath) {
+    context.beginPath();
+  }
+
+  for (let i = 0; i < points.length / 4; i++) {
+    let sourceUv, destUv;
+    if (i === 0) {
+      sourceUv = points.length - 2;
+    } else {
+      sourceUv = i * 4 - 2;
+    }
+    destUv = i * 4 + 2;
+
+    const px = x + halfW * points[i * 4];
+    const py = y + halfH * points[i * 4 + 1];
+
+    const cosTheta = -points[sourceUv] * points[destUv] - points[sourceUv + 1] * points[destUv + 1];
+    const offset = cornerRadius / Math.tan(Math.acos(cosTheta) / 2);
+
+    const cp0x = px - offset * points[sourceUv];
+    const cp0y = py - offset * points[sourceUv + 1];
+    const cp1x = px + offset * points[destUv];
+    const cp1y = py + offset * points[destUv + 1];
+
+    if (i === 0) {
+      context.moveTo(cp0x, cp0y);
+    } else {
+      context.lineTo(cp0x, cp0y);
+    }
+
+    context.arcTo(px, py, cp1x, cp1y, cornerRadius);
+  }
+
+  context.closePath();
+};
+
+// Round rectangle drawing
+CRp.drawRoundRectanglePath = function (context, x, y, width, height) {
+  var halfWidth = width / 2;
+  var halfHeight = height / 2;
+  var cornerRadius = math.getRoundRectangleRadius(width, height);
+
+  if (context.beginPath) {
+    context.beginPath();
+  }
+
+  // Start at top middle
+  context.moveTo(x, y - halfHeight);
+  // Arc from middle top to right side
+  context.arcTo(x + halfWidth, y - halfHeight, x + halfWidth, y, cornerRadius);
+  // Arc from right side to bottom
+  context.arcTo(x + halfWidth, y + halfHeight, x, y + halfHeight, cornerRadius);
+  // Arc from bottom to left side
+  context.arcTo(x - halfWidth, y + halfHeight, x - halfWidth, y, cornerRadius);
+  // Arc from left side to topBorder
+  context.arcTo(x - halfWidth, y - halfHeight, x, y - halfHeight, cornerRadius);
+  // Join line
+  context.lineTo(x, y - halfHeight);
+
+  context.closePath();
+};
+
+CRp.drawBottomRoundRectanglePath = function (context, x, y, width, height) {
+  var halfWidth = width / 2;
+  var halfHeight = height / 2;
+  var cornerRadius = math.getRoundRectangleRadius(width, height);
+
+  if (context.beginPath) {
+    context.beginPath();
+  }
+
+  // Start at top middle
+  context.moveTo(x, y - halfHeight);
+  context.lineTo(x + halfWidth, y - halfHeight);
+  context.lineTo(x + halfWidth, y);
+
+  context.arcTo(x + halfWidth, y + halfHeight, x, y + halfHeight, cornerRadius);
+  context.arcTo(x - halfWidth, y + halfHeight, x - halfWidth, y, cornerRadius);
+
+  context.lineTo(x - halfWidth, y - halfHeight);
+  context.lineTo(x, y - halfHeight);
+
+  context.closePath();
+};
+
+CRp.drawCutRectanglePath = function (context, x, y, width, height) {
+  var halfWidth = width / 2;
+  var halfHeight = height / 2;
+  var cornerLength = math.getCutRectangleCornerLength();
+
+  if (context.beginPath) {
+    context.beginPath();
+  }
+
+  context.moveTo(x - halfWidth + cornerLength, y - halfHeight);
+
+  context.lineTo(x + halfWidth - cornerLength, y - halfHeight);
+  context.lineTo(x + halfWidth, y - halfHeight + cornerLength);
+  context.lineTo(x + halfWidth, y + halfHeight - cornerLength);
+  context.lineTo(x + halfWidth - cornerLength, y + halfHeight);
+  context.lineTo(x - halfWidth + cornerLength, y + halfHeight);
+  context.lineTo(x - halfWidth, y + halfHeight - cornerLength);
+  context.lineTo(x - halfWidth, y - halfHeight + cornerLength);
+
+  context.closePath();
+};
+
+CRp.drawBarrelPath = function (context, x, y, width, height) {
+  var halfWidth = width / 2;
+  var halfHeight = height / 2;
+
+  var xBegin = x - halfWidth;
+  var xEnd = x + halfWidth;
+  var yBegin = y - halfHeight;
+  var yEnd = y + halfHeight;
+
+  var barrelCurveConstants = math.getBarrelCurveConstants(width, height);
+  var wOffset = barrelCurveConstants.widthOffset;
+  var hOffset = barrelCurveConstants.heightOffset;
+  var ctrlPtXOffset = barrelCurveConstants.ctrlPtOffsetPct * wOffset;
+
+  if (context.beginPath) {
+    context.beginPath();
+  }
+
+  context.moveTo(xBegin, yBegin + hOffset);
+
+  context.lineTo(xBegin, yEnd - hOffset);
+  context.quadraticCurveTo(xBegin + ctrlPtXOffset, yEnd, xBegin + wOffset, yEnd);
+
+  context.lineTo(xEnd - wOffset, yEnd);
+  context.quadraticCurveTo(xEnd - ctrlPtXOffset, yEnd, xEnd, yEnd - hOffset);
+
+  context.lineTo(xEnd, yBegin + hOffset);
+  context.quadraticCurveTo(xEnd - ctrlPtXOffset, yBegin, xEnd - wOffset, yBegin);
+
+  context.lineTo(xBegin + wOffset, yBegin);
+  context.quadraticCurveTo(xBegin + ctrlPtXOffset, yBegin, xBegin, yBegin + hOffset);
+
+  context.closePath();
+};
+CRp.drawNewShapePath = function (context, x, y, width, height) {
+  var halfWidth = width / 2;
+  var halfHeight = height / 2;
+
+  var xBegin = x - halfWidth;
+  var xEnd = x + halfWidth;
+  var yBegin = y - halfHeight;
+  var yEnd = y + halfHeight;
+
+  var barrelCurveConstants = math.getBarrelCurveConstants(width, height);
+  var wOffset = barrelCurveConstants.widthOffset;
+  var hOffset = barrelCurveConstants.heightOffset;
+  var ctrlPtXOffset = barrelCurveConstants.ctrlPtOffsetPct * wOffset;
+
+  if (context.beginPath) {
+    context.beginPath();
+  }
+
+  context.moveTo(xBegin, yBegin + hOffset);
+
+  context.lineTo(xBegin, yEnd - hOffset);
+  context.quadraticCurveTo(xBegin + ctrlPtXOffset, yEnd, xBegin + wOffset, yEnd);
+
+  context.lineTo(xEnd - wOffset, yEnd);
+  context.quadraticCurveTo(xEnd - ctrlPtXOffset, yEnd, xEnd, yEnd - hOffset);
+
+  context.lineTo(xEnd, yBegin + hOffset);
+  context.quadraticCurveTo(xEnd - ctrlPtXOffset, yBegin, xEnd - wOffset, yBegin);
+
+  context.lineTo(xBegin + wOffset, yBegin);
+  context.quadraticCurveTo(xBegin + ctrlPtXOffset, yBegin, xBegin, yBegin + hOffset);
+
+  context.closePath();
+};
+
+var sin0 = Math.sin(0);
+var cos0 = Math.cos(0);
+
+var sin = {};
+var cos = {};
+
+var ellipseStepSize = Math.PI / 40;
+
+for (var i = 0 * Math.PI; i < 2 * Math.PI; i += ellipseStepSize) {
+  sin[i] = Math.sin(i);
+  cos[i] = Math.cos(i);
+}
+
+CRp.drawEllipsePath = function (context, centerX, centerY, width, height) {
+  if (context.beginPath) {
+    context.beginPath();
+  }
+
+  if (context.ellipse) {
+    context.ellipse(centerX, centerY, width / 2, height / 2, 0, 0, 2 * Math.PI);
+  } else {
+    var xPos, yPos;
+    var rw = width / 2;
+    var rh = height / 2;
+    for (var i = 0 * Math.PI; i < 2 * Math.PI; i += ellipseStepSize) {
+      xPos = centerX - rw * sin[i] * sin0 + rw * cos[i] * cos0;
+      yPos = centerY + rh * cos[i] * sin0 + rh * sin[i] * cos0;
+
+      if (i === 0) {
+        context.moveTo(xPos, yPos);
+      } else {
+        context.lineTo(xPos, yPos);
+      }
+    }
+  }
+
+  context.closePath();
+};
+
+export default CRp;

--- a/src/component/cytoscape/renderer/core/canvas/ele-texture-cache-lookup.js
+++ b/src/component/cytoscape/renderer/core/canvas/ele-texture-cache-lookup.js
@@ -1,0 +1,194 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Map from '../../../../../../node_modules/cytoscape/src/map';
+import Set from '../../../../../../node_modules/cytoscape/src/set';
+import * as util from '../../../../../../node_modules/cytoscape/src/util';
+
+// Allows lookups for (ele, lvl) => cache.
+// Uses keys so elements may share the same cache.
+class ElementTextureCacheLookup {
+  constructor(getKey, doesEleInvalidateKey = util.falsify) {
+    this.idsByKey = new Map();
+    this.keyForId = new Map();
+    this.cachesByLvl = new Map();
+    this.lvls = [];
+    this.getKey = getKey;
+    this.doesEleInvalidateKey = doesEleInvalidateKey;
+  }
+
+  getIdsFor(key) {
+    if (key == null) {
+      util.error(`Can not get id list for null key`);
+    }
+
+    let { idsByKey } = this;
+    let ids = this.idsByKey.get(key);
+
+    if (!ids) {
+      ids = new Set();
+
+      idsByKey.set(key, ids);
+    }
+
+    return ids;
+  }
+
+  addIdForKey(key, id) {
+    if (key != null) {
+      this.getIdsFor(key).add(id);
+    }
+  }
+
+  deleteIdForKey(key, id) {
+    if (key != null) {
+      this.getIdsFor(key).delete(id);
+    }
+  }
+
+  getNumberOfIdsForKey(key) {
+    if (key == null) {
+      return 0;
+    } else {
+      return this.getIdsFor(key).size;
+    }
+  }
+
+  updateKeyMappingFor(ele) {
+    let id = ele.id();
+    let prevKey = this.keyForId.get(id);
+    let currKey = this.getKey(ele);
+
+    this.deleteIdForKey(prevKey, id);
+
+    this.addIdForKey(currKey, id);
+
+    this.keyForId.set(id, currKey);
+  }
+
+  deleteKeyMappingFor(ele) {
+    let id = ele.id();
+    let prevKey = this.keyForId.get(id);
+
+    this.deleteIdForKey(prevKey, id);
+
+    this.keyForId.delete(id);
+  }
+
+  keyHasChangedFor(ele) {
+    let id = ele.id();
+    let prevKey = this.keyForId.get(id);
+    let newKey = this.getKey(ele);
+
+    return prevKey !== newKey;
+  }
+
+  isInvalid(ele) {
+    return this.keyHasChangedFor(ele) || this.doesEleInvalidateKey(ele);
+  }
+
+  getCachesAt(lvl) {
+    let { cachesByLvl, lvls } = this;
+    let caches = cachesByLvl.get(lvl);
+
+    if (!caches) {
+      caches = new Map();
+
+      cachesByLvl.set(lvl, caches);
+      lvls.push(lvl);
+    }
+
+    return caches;
+  }
+
+  getCache(key, lvl) {
+    return this.getCachesAt(lvl).get(key);
+  }
+
+  get(ele, lvl) {
+    let key = this.getKey(ele);
+    let cache = this.getCache(key, lvl);
+
+    // getting for an element may need to add to the id list b/c eles can share keys
+    if (cache != null) {
+      this.updateKeyMappingFor(ele);
+    }
+
+    return cache;
+  }
+
+  getForCachedKey(ele, lvl) {
+    let key = this.keyForId.get(ele.id()); // n.b. use cached key, not newly computed key
+    let cache = this.getCache(key, lvl);
+
+    return cache;
+  }
+
+  hasCache(key, lvl) {
+    return this.getCachesAt(lvl).has(key);
+  }
+
+  has(ele, lvl) {
+    let key = this.getKey(ele);
+
+    return this.hasCache(key, lvl);
+  }
+
+  setCache(key, lvl, cache) {
+    cache.key = key;
+
+    this.getCachesAt(lvl).set(key, cache);
+  }
+
+  set(ele, lvl, cache) {
+    let key = this.getKey(ele);
+
+    this.setCache(key, lvl, cache);
+    this.updateKeyMappingFor(ele);
+  }
+
+  deleteCache(key, lvl) {
+    this.getCachesAt(lvl).delete(key);
+  }
+
+  delete(ele, lvl) {
+    let key = this.getKey(ele);
+
+    this.deleteCache(key, lvl);
+  }
+
+  invalidateKey(key) {
+    this.lvls.forEach(lvl => this.deleteCache(key, lvl));
+  }
+
+  // returns true if no other eles reference the invalidated cache (n.b. other eles may need the cache with the same key)
+  invalidate(ele) {
+    let id = ele.id();
+    let key = this.keyForId.get(id); // n.b. use stored key rather than current (potential key)
+
+    this.deleteKeyMappingFor(ele);
+
+    let entireKeyInvalidated = this.doesEleInvalidateKey(ele);
+
+    if (entireKeyInvalidated) {
+      // clear mapping for current key
+      this.invalidateKey(key);
+    }
+
+    return entireKeyInvalidated || this.getNumberOfIdsForKey(key) === 0;
+  }
+}
+
+export default ElementTextureCacheLookup;

--- a/src/component/cytoscape/renderer/core/canvas/ele-texture-cache-lookup.js
+++ b/src/component/cytoscape/renderer/core/canvas/ele-texture-cache-lookup.js
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Map from '../../../../../../node_modules/cytoscape/src/map';
-import Set from '../../../../../../node_modules/cytoscape/src/set';
-import * as util from '../../../../../../node_modules/cytoscape/src/util';
+import Map from 'cytoscape/src/map';
+import Set from 'cytoscape/src/set';
+import * as util from 'cytoscape/src/util';
 
 // Allows lookups for (ele, lvl) => cache.
 // Uses keys so elements may share the same cache.

--- a/src/component/cytoscape/renderer/core/canvas/ele-texture-cache.js
+++ b/src/component/cytoscape/renderer/core/canvas/ele-texture-cache.js
@@ -1,0 +1,592 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as math from '../../../../../../node_modules/cytoscape/src/math';
+import { trueify, falsify, removeFromArray, clearArray, MAX_INT, assign, defaults } from '../../../../../../node_modules/cytoscape/src/util';
+import Heap from '../../../../../../node_modules/cytoscape/src/heap';
+import defs from './texture-cache-defs';
+import ElementTextureCacheLookup from './ele-texture-cache-lookup';
+
+const minTxrH = 25; // the size of the texture cache for small height eles (special case)
+const txrStepH = 50; // the min size of the regular cache, and the size it increases with each step up
+const minLvl = -4; // when scaling smaller than that we don't need to re-render
+const maxLvl = 3; // when larger than this scale just render directly (caching is not helpful)
+const maxZoom = 7.99; // beyond this zoom level, layered textures are not used
+const eleTxrSpacing = 8; // spacing between elements on textures to avoid blitting overlaps
+const defTxrWidth = 1024; // default/minimum texture width
+const maxTxrW = 1024; // the maximum width of a texture
+const maxTxrH = 1024; // the maximum height of a texture
+const minUtility = 0.2; // if usage of texture is less than this, it is retired
+const maxFullness = 0.8; // fullness of texture after which queue removal is checked
+const maxFullnessChecks = 10; // dequeued after this many checks
+const deqCost = 0.15; // % of add'l rendering cost allowed for dequeuing ele caches each frame
+const deqAvgCost = 0.1; // % of add'l rendering cost compared to average overall redraw time
+const deqNoDrawCost = 0.9; // % of avg frame time that can be used for dequeueing when not drawing
+const deqFastCost = 0.9; // % of frame time to be used when >60fps
+const deqRedrawThreshold = 100; // time to batch redraws together from dequeueing to allow more dequeueing calcs to happen in the meanwhile
+const maxDeqSize = 1; // number of eles to dequeue and render at higher texture in each batch
+
+const getTxrReasons = {
+  dequeue: 'dequeue',
+  downscale: 'downscale',
+  highQuality: 'highQuality',
+};
+
+const initDefaults = defaults({
+  getKey: null,
+  doesEleInvalidateKey: falsify,
+  drawElement: null,
+  getBoundingBox: null,
+  getRotationPoint: null,
+  getRotationOffset: null,
+  isVisible: trueify,
+  allowEdgeTxrCaching: true,
+  allowParentTxrCaching: true,
+});
+
+const ElementTextureCache = function (renderer, initOptions) {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  let self = this;
+
+  self.renderer = renderer;
+  self.onDequeues = [];
+
+  let opts = initDefaults(initOptions);
+
+  assign(self, opts);
+
+  self.lookup = new ElementTextureCacheLookup(opts.getKey, opts.doesEleInvalidateKey);
+
+  self.setupDequeueing();
+};
+
+const ETCp = ElementTextureCache.prototype;
+
+ETCp.reasons = getTxrReasons;
+
+// the list of textures in which new subtextures for elements can be placed
+ETCp.getTextureQueue = function (txrH) {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  let self = this;
+  self.eleImgCaches = self.eleImgCaches || {};
+
+  return (self.eleImgCaches[txrH] = self.eleImgCaches[txrH] || []);
+};
+
+// the list of usused textures which can be recycled (in use in texture queue)
+ETCp.getRetiredTextureQueue = function (txrH) {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  let self = this;
+
+  let rtxtrQs = (self.eleImgCaches.retired = self.eleImgCaches.retired || {});
+  let rtxtrQ = (rtxtrQs[txrH] = rtxtrQs[txrH] || []);
+
+  return rtxtrQ;
+};
+
+// queue of element draw requests at different scale levels
+ETCp.getElementQueue = function () {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  let self = this;
+
+  let q = (self.eleCacheQueue =
+    self.eleCacheQueue ||
+    new Heap(function (a, b) {
+      return b.reqs - a.reqs;
+    }));
+
+  return q;
+};
+
+// queue of element draw requests at different scale levels (element id lookup)
+ETCp.getElementKeyToQueue = function () {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  let self = this;
+
+  let k2q = (self.eleKeyToCacheQueue = self.eleKeyToCacheQueue || {});
+
+  return k2q;
+};
+
+ETCp.getElement = function (ele, bb, pxRatio, lvl, reason) {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  let self = this;
+  let r = this.renderer;
+  let zoom = r.cy.zoom();
+  let lookup = this.lookup;
+
+  if (!bb || bb.w === 0 || bb.h === 0 || isNaN(bb.w) || isNaN(bb.h) || !ele.visible() || !ele.removed()) {
+    return null;
+  }
+
+  if ((!self.allowEdgeTxrCaching && ele.isEdge()) || (!self.allowParentTxrCaching && ele.isParent())) {
+    return null;
+  }
+
+  if (lvl == null) {
+    lvl = Math.ceil(math.log2(zoom * pxRatio));
+  }
+
+  if (lvl < minLvl) {
+    lvl = minLvl;
+  } else if (zoom >= maxZoom || lvl > maxLvl) {
+    return null;
+  }
+
+  let scale = Math.pow(2, lvl);
+  let eleScaledH = bb.h * scale;
+  let eleScaledW = bb.w * scale;
+  let scaledLabelShown = r.eleTextBiggerThanMin(ele, scale);
+
+  if (!this.isVisible(ele, scaledLabelShown)) {
+    return null;
+  }
+
+  let eleCache = lookup.get(ele, lvl);
+
+  // if this get was on an unused/invalidated cache, then restore the texture usage metric
+  if (eleCache && eleCache.invalidated) {
+    eleCache.invalidated = false;
+    eleCache.texture.invalidatedWidth -= eleCache.width;
+  }
+
+  if (eleCache) {
+    return eleCache;
+  }
+
+  let txrH; // which texture height this ele belongs to
+
+  if (eleScaledH <= minTxrH) {
+    txrH = minTxrH;
+  } else if (eleScaledH <= txrStepH) {
+    txrH = txrStepH;
+  } else {
+    txrH = Math.ceil(eleScaledH / txrStepH) * txrStepH;
+  }
+
+  if (eleScaledH > maxTxrH || eleScaledW > maxTxrW) {
+    return null; // caching large elements is not efficient
+  }
+
+  let txrQ = self.getTextureQueue(txrH);
+
+  // first try the second last one in case it has space at the end
+  let txr = txrQ[txrQ.length - 2];
+
+  let addNewTxr = function () {
+    return self.recycleTexture(txrH, eleScaledW) || self.addTexture(txrH, eleScaledW);
+  };
+
+  // try the last one if there is no second last one
+  if (!txr) {
+    txr = txrQ[txrQ.length - 1];
+  }
+
+  // if the last one doesn't exist, we need a first one
+  if (!txr) {
+    txr = addNewTxr();
+  }
+
+  // if there's no room in the current texture, we need a new one
+  if (txr.width - txr.usedWidth < eleScaledW) {
+    txr = addNewTxr();
+  }
+
+  let scalableFrom = function (otherCache) {
+    return otherCache && otherCache.scaledLabelShown === scaledLabelShown;
+  };
+
+  let deqing = reason && reason === getTxrReasons.dequeue;
+  let highQualityReq = reason && reason === getTxrReasons.highQuality;
+  let downscaleReq = reason && reason === getTxrReasons.downscale;
+
+  let higherCache; // the nearest cache with a higher level
+  for (let l = lvl + 1; l <= maxLvl; l++) {
+    let c = lookup.get(ele, l);
+
+    if (c) {
+      higherCache = c;
+      break;
+    }
+  }
+
+  let oneUpCache = higherCache && higherCache.level === lvl + 1 ? higherCache : null;
+
+  let downscale = function () {
+    txr.context.drawImage(oneUpCache.texture.canvas, oneUpCache.x, 0, oneUpCache.width, oneUpCache.height, txr.usedWidth, 0, eleScaledW, eleScaledH);
+  };
+
+  // reset ele area in texture
+  txr.context.setTransform(1, 0, 0, 1, 0, 0);
+  txr.context.clearRect(txr.usedWidth, 0, eleScaledW, txrH);
+
+  if (scalableFrom(oneUpCache)) {
+    // then we can relatively cheaply rescale the existing image w/o rerendering
+    downscale();
+  } else if (scalableFrom(higherCache)) {
+    // then use the higher cache for now and queue the next level down
+    // to cheaply scale towards the smaller level
+
+    if (highQualityReq) {
+      for (let l = higherCache.level; l > lvl; l--) {
+        oneUpCache = self.getElement(ele, bb, pxRatio, l, getTxrReasons.downscale);
+      }
+
+      downscale();
+    } else {
+      self.queueElement(ele, higherCache.level - 1);
+
+      return higherCache;
+    }
+  } else {
+    let lowerCache; // the nearest cache with a lower level
+    if (!deqing && !highQualityReq && !downscaleReq) {
+      for (let l = lvl - 1; l >= minLvl; l--) {
+        let c = lookup.get(ele, l);
+
+        if (c) {
+          lowerCache = c;
+          break;
+        }
+      }
+    }
+
+    if (scalableFrom(lowerCache)) {
+      // then use the lower quality cache for now and queue the better one for later
+
+      self.queueElement(ele, lvl);
+
+      return lowerCache;
+    }
+
+    txr.context.translate(txr.usedWidth, 0);
+    txr.context.scale(scale, scale);
+
+    this.drawElement(txr.context, ele, bb, scaledLabelShown, false);
+
+    txr.context.scale(1 / scale, 1 / scale);
+    txr.context.translate(-txr.usedWidth, 0);
+  }
+
+  eleCache = {
+    x: txr.usedWidth,
+    texture: txr,
+    level: lvl,
+    scale: scale,
+    width: eleScaledW,
+    height: eleScaledH,
+    scaledLabelShown: scaledLabelShown,
+  };
+
+  txr.usedWidth += Math.ceil(eleScaledW + eleTxrSpacing);
+
+  txr.eleCaches.push(eleCache);
+
+  lookup.set(ele, lvl, eleCache);
+
+  self.checkTextureFullness(txr);
+
+  return eleCache;
+};
+
+ETCp.invalidateElements = function (eles) {
+  for (let i = 0; i < eles.length; i++) {
+    this.invalidateElement(eles[i]);
+  }
+};
+
+ETCp.invalidateElement = function (ele) {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  let self = this;
+  let lookup = self.lookup;
+  let caches = [];
+  let invalid = lookup.isInvalid(ele);
+
+  if (!invalid) {
+    return; // override the invalidation request if the element key has not changed
+  }
+
+  for (let lvl = minLvl; lvl <= maxLvl; lvl++) {
+    let cache = lookup.getForCachedKey(ele, lvl);
+
+    if (cache) {
+      caches.push(cache);
+    }
+  }
+
+  let noOtherElesUseCache = lookup.invalidate(ele);
+
+  if (noOtherElesUseCache) {
+    for (let i = 0; i < caches.length; i++) {
+      let cache = caches[i];
+      let txr = cache.texture;
+
+      // remove space from the texture it belongs to
+      txr.invalidatedWidth += cache.width;
+
+      // mark the cache as invalidated
+      cache.invalidated = true;
+
+      // retire the texture if its utility is low
+      self.checkTextureUtility(txr);
+    }
+  }
+
+  // remove from queue since the old req was for the old state
+  self.removeFromQueue(ele);
+};
+
+ETCp.checkTextureUtility = function (txr) {
+  // invalidate all entries in the cache if the cache size is small
+  if (txr.invalidatedWidth >= minUtility * txr.width) {
+    this.retireTexture(txr);
+  }
+};
+
+ETCp.checkTextureFullness = function (txr) {
+  // if texture has been mostly filled and passed over several times, remove
+  // it from the queue so we don't need to waste time looking at it to put new things
+
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  let self = this;
+  let txrQ = self.getTextureQueue(txr.height);
+
+  if (txr.usedWidth / txr.width > maxFullness && txr.fullnessChecks >= maxFullnessChecks) {
+    removeFromArray(txrQ, txr);
+  } else {
+    txr.fullnessChecks++;
+  }
+};
+
+ETCp.retireTexture = function (txr) {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  let self = this;
+  let txrH = txr.height;
+  let txrQ = self.getTextureQueue(txrH);
+  let lookup = this.lookup;
+
+  // retire the texture from the active / searchable queue:
+
+  removeFromArray(txrQ, txr);
+
+  txr.retired = true;
+
+  // remove the refs from the eles to the caches:
+
+  let eleCaches = txr.eleCaches;
+
+  for (let i = 0; i < eleCaches.length; i++) {
+    let eleCache = eleCaches[i];
+
+    lookup.deleteCache(eleCache.key, eleCache.level);
+  }
+
+  clearArray(eleCaches);
+
+  // add the texture to a retired queue so it can be recycled in future:
+
+  let rtxtrQ = self.getRetiredTextureQueue(txrH);
+
+  rtxtrQ.push(txr);
+};
+
+ETCp.addTexture = function (txrH, minW) {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  let self = this;
+  let txrQ = self.getTextureQueue(txrH);
+  let txr = {};
+
+  txrQ.push(txr);
+
+  txr.eleCaches = [];
+
+  txr.height = txrH;
+  txr.width = Math.max(defTxrWidth, minW);
+  txr.usedWidth = 0;
+  txr.invalidatedWidth = 0;
+  txr.fullnessChecks = 0;
+
+  txr.canvas = self.renderer.makeOffscreenCanvas(txr.width, txr.height);
+
+  txr.context = txr.canvas.getContext('2d');
+
+  return txr;
+};
+
+ETCp.recycleTexture = function (txrH, minW) {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  let self = this;
+  let txrQ = self.getTextureQueue(txrH);
+  let rtxtrQ = self.getRetiredTextureQueue(txrH);
+
+  for (let i = 0; i < rtxtrQ.length; i++) {
+    let txr = rtxtrQ[i];
+
+    if (txr.width >= minW) {
+      txr.retired = false;
+
+      txr.usedWidth = 0;
+      txr.invalidatedWidth = 0;
+      txr.fullnessChecks = 0;
+
+      clearArray(txr.eleCaches);
+
+      txr.context.setTransform(1, 0, 0, 1, 0, 0);
+      txr.context.clearRect(0, 0, txr.width, txr.height);
+
+      removeFromArray(rtxtrQ, txr);
+      txrQ.push(txr);
+
+      return txr;
+    }
+  }
+};
+
+ETCp.queueElement = function (ele, lvl) {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  let self = this;
+  let q = self.getElementQueue();
+  let k2q = self.getElementKeyToQueue();
+  let key = this.getKey(ele);
+  let existingReq = k2q[key];
+
+  if (existingReq) {
+    // use the max lvl b/c in between lvls are cheap to make
+    existingReq.level = Math.max(existingReq.level, lvl);
+
+    existingReq.eles.merge(ele);
+
+    existingReq.reqs++;
+
+    q.updateItem(existingReq);
+  } else {
+    let req = {
+      eles: ele.spawn().merge(ele),
+      level: lvl,
+      reqs: 1,
+      key,
+    };
+
+    q.push(req);
+
+    k2q[key] = req;
+  }
+};
+
+ETCp.dequeue = function (pxRatio /*, extent*/) {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  let self = this;
+  let q = self.getElementQueue();
+  let k2q = self.getElementKeyToQueue();
+  let dequeued = [];
+  let lookup = self.lookup;
+
+  for (let i = 0; i < maxDeqSize; i++) {
+    if (q.size() > 0) {
+      let req = q.pop();
+      let key = req.key;
+      let ele = req.eles[0]; // all eles have the same key
+      let cacheExists = lookup.hasCache(ele, req.level);
+
+      // clear out the key to req lookup
+      k2q[key] = null;
+
+      // dequeueing isn't necessary with an existing cache
+      if (cacheExists) {
+        continue;
+      }
+
+      dequeued.push(req);
+
+      let bb = self.getBoundingBox(ele);
+
+      self.getElement(ele, bb, pxRatio, req.level, getTxrReasons.dequeue);
+    } else {
+      break;
+    }
+  }
+
+  return dequeued;
+};
+
+ETCp.removeFromQueue = function (ele) {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  let self = this;
+  let q = self.getElementQueue();
+  let k2q = self.getElementKeyToQueue();
+  let key = this.getKey(ele);
+  let req = k2q[key];
+
+  if (req != null) {
+    if (req.eles.length === 1) {
+      // remove if last ele in the req
+      // bring to front of queue
+      req.reqs = MAX_INT;
+      q.updateItem(req);
+
+      q.pop(); // remove from queue
+
+      k2q[key] = null; // remove from lookup map
+    } else {
+      // otherwise just remove ele from req
+      req.eles.unmerge(ele);
+    }
+  }
+};
+
+ETCp.onDequeue = function (fn) {
+  this.onDequeues.push(fn);
+};
+ETCp.offDequeue = function (fn) {
+  removeFromArray(this.onDequeues, fn);
+};
+
+ETCp.setupDequeueing = defs.setupDequeueing({
+  deqRedrawThreshold: deqRedrawThreshold,
+  deqCost: deqCost,
+  deqAvgCost: deqAvgCost,
+  deqNoDrawCost: deqNoDrawCost,
+  deqFastCost: deqFastCost,
+  deq: function (self, pxRatio, extent) {
+    return self.dequeue(pxRatio, extent);
+  },
+  onDeqd: function (self, deqd) {
+    for (let i = 0; i < self.onDequeues.length; i++) {
+      let fn = self.onDequeues[i];
+
+      fn(deqd);
+    }
+  },
+  shouldRedraw: function (self, deqd, pxRatio, extent) {
+    for (let i = 0; i < deqd.length; i++) {
+      let eles = deqd[i].eles;
+
+      for (let j = 0; j < eles.length; j++) {
+        let bb = eles[j].boundingBox();
+
+        if (math.boundingBoxesIntersect(bb, extent)) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  },
+  priority: function (self) {
+    return self.renderer.beforeRenderPriorities.eleTxrDeq;
+  },
+});
+
+export default ElementTextureCache;

--- a/src/component/cytoscape/renderer/core/canvas/ele-texture-cache.js
+++ b/src/component/cytoscape/renderer/core/canvas/ele-texture-cache.js
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as math from '../../../../../../node_modules/cytoscape/src/math';
-import { trueify, falsify, removeFromArray, clearArray, MAX_INT, assign, defaults } from '../../../../../../node_modules/cytoscape/src/util';
-import Heap from '../../../../../../node_modules/cytoscape/src/heap';
+import * as math from 'cytoscape/src/math';
+import { trueify, falsify, removeFromArray, clearArray, MAX_INT, assign, defaults } from 'cytoscape/src/util';
+import Heap from 'cytoscape/src/heap';
 import defs from './texture-cache-defs';
 import ElementTextureCacheLookup from './ele-texture-cache-lookup';
 

--- a/src/component/cytoscape/renderer/core/canvas/export-image.js
+++ b/src/component/cytoscape/renderer/core/canvas/export-image.js
@@ -1,0 +1,191 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as is from '../../../../../../node_modules/cytoscape/src/is';
+import Promise from '../../../../../../node_modules/cytoscape/src/promise';
+
+var CRp = {};
+
+CRp.createBuffer = function (w, h) {
+  var buffer = document.createElement('canvas'); // eslint-disable-line no-undef
+  buffer.width = w;
+  buffer.height = h;
+
+  return [buffer, buffer.getContext('2d')];
+};
+
+CRp.bufferCanvasImage = function (options) {
+  var cy = this.cy;
+  var eles = cy.mutableElements();
+  var bb = eles.boundingBox();
+  var ctrRect = this.findContainerClientCoords();
+  var width = options.full ? Math.ceil(bb.w) : ctrRect[2];
+  var height = options.full ? Math.ceil(bb.h) : ctrRect[3];
+  var specdMaxDims = is.number(options.maxWidth) || is.number(options.maxHeight);
+  var pxRatio = this.getPixelRatio();
+  var scale = 1;
+
+  if (options.scale !== undefined) {
+    width *= options.scale;
+    height *= options.scale;
+
+    scale = options.scale;
+  } else if (specdMaxDims) {
+    var maxScaleW = Infinity;
+    var maxScaleH = Infinity;
+
+    if (is.number(options.maxWidth)) {
+      maxScaleW = (scale * options.maxWidth) / width;
+    }
+
+    if (is.number(options.maxHeight)) {
+      maxScaleH = (scale * options.maxHeight) / height;
+    }
+
+    scale = Math.min(maxScaleW, maxScaleH);
+
+    width *= scale;
+    height *= scale;
+  }
+
+  if (!specdMaxDims) {
+    width *= pxRatio;
+    height *= pxRatio;
+    scale *= pxRatio;
+  }
+
+  var buffCanvas = document.createElement('canvas'); // eslint-disable-line no-undef
+
+  buffCanvas.width = width;
+  buffCanvas.height = height;
+
+  buffCanvas.style.width = width + 'px';
+  buffCanvas.style.height = height + 'px';
+
+  var buffCxt = buffCanvas.getContext('2d');
+
+  // Rasterize the layers, but only if container has nonzero size
+  if (width > 0 && height > 0) {
+    buffCxt.clearRect(0, 0, width, height);
+
+    buffCxt.globalCompositeOperation = 'source-over';
+
+    var zsortedEles = this.getCachedZSortedEles();
+
+    if (options.full) {
+      // draw the full bounds of the graph
+      buffCxt.translate(-bb.x1 * scale, -bb.y1 * scale);
+      buffCxt.scale(scale, scale);
+
+      this.drawElements(buffCxt, zsortedEles);
+
+      buffCxt.scale(1 / scale, 1 / scale);
+      buffCxt.translate(bb.x1 * scale, bb.y1 * scale);
+    } else {
+      // draw the current view
+      var pan = cy.pan();
+
+      var translation = {
+        x: pan.x * scale,
+        y: pan.y * scale,
+      };
+
+      scale *= cy.zoom();
+
+      buffCxt.translate(translation.x, translation.y);
+      buffCxt.scale(scale, scale);
+
+      this.drawElements(buffCxt, zsortedEles);
+
+      buffCxt.scale(1 / scale, 1 / scale);
+      buffCxt.translate(-translation.x, -translation.y);
+    }
+
+    // need to fill bg at end like this in order to fill cleared transparent pixels in jpgs
+    if (options.bg) {
+      buffCxt.globalCompositeOperation = 'destination-over';
+
+      buffCxt.fillStyle = options.bg;
+      buffCxt.rect(0, 0, width, height);
+      buffCxt.fill();
+    }
+  }
+
+  return buffCanvas;
+};
+
+function b64ToBlob(b64, mimeType) {
+  var bytes = atob(b64);
+  var buff = new ArrayBuffer(bytes.length);
+  var buffUint8 = new Uint8Array(buff);
+
+  for (var i = 0; i < bytes.length; i++) {
+    buffUint8[i] = bytes.charCodeAt(i);
+  }
+
+  return new Blob([buff], { type: mimeType });
+}
+
+function b64UriToB64(b64uri) {
+  var i = b64uri.indexOf(',');
+
+  return b64uri.substr(i + 1);
+}
+
+function output(options, canvas, mimeType) {
+  let getB64Uri = () => canvas.toDataURL(mimeType, options.quality);
+
+  switch (options.output) {
+    case 'blob-promise':
+      return new Promise((resolve, reject) => {
+        try {
+          canvas.toBlob(
+            blob => {
+              if (blob != null) {
+                resolve(blob);
+              } else {
+                reject(new Error('`canvas.toBlob()` sent a null value in its callback'));
+              }
+            },
+            mimeType,
+            options.quality,
+          );
+        } catch (err) {
+          reject(err);
+        }
+      });
+
+    case 'blob':
+      return b64ToBlob(b64UriToB64(getB64Uri()), mimeType);
+
+    case 'base64':
+      return b64UriToB64(getB64Uri());
+
+    case 'base64uri':
+    default:
+      return getB64Uri();
+  }
+}
+
+CRp.png = function (options) {
+  return output(options, this.bufferCanvasImage(options), 'image/png');
+};
+
+CRp.jpg = function (options) {
+  return output(options, this.bufferCanvasImage(options), 'image/jpeg');
+};
+
+export default CRp;

--- a/src/component/cytoscape/renderer/core/canvas/export-image.js
+++ b/src/component/cytoscape/renderer/core/canvas/export-image.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as is from '../../../../../../node_modules/cytoscape/src/is';
-import Promise from '../../../../../../node_modules/cytoscape/src/promise';
+import * as is from 'cytoscape/src/is';
+import Promise from 'cytoscape/src/promise';
 
 var CRp = {};
 

--- a/src/component/cytoscape/renderer/core/canvas/index.js
+++ b/src/component/cytoscape/renderer/core/canvas/index.js
@@ -1,0 +1,499 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* global OffscreenCanvas */
+
+import * as util from '../../../../../../node_modules/cytoscape/src/util';
+import * as is from '../../../../../../node_modules/cytoscape/src/is';
+import * as math from '../../../../../../node_modules/cytoscape/src/math';
+import ElementTextureCache from './ele-texture-cache';
+import LayeredTextureCache from './layered-texture-cache';
+
+import arrowShapes from './arrow-shapes';
+import drawingElements from './drawing-elements';
+import drawingEdges from './drawing-edges';
+import drawingImages from './drawing-images';
+import drawingLabelText from './drawing-label-text';
+import drawingNodes from './drawing-nodes';
+import drawingRedraw from './drawing-redraw';
+import drawingShapes from './drawing-shapes';
+import exportImage from './export-image';
+import nodeShapes from './node-shapes';
+
+var CR = CanvasRenderer;
+var CRp = CanvasRenderer.prototype;
+
+CRp.CANVAS_LAYERS = 3;
+//
+CRp.SELECT_BOX = 0;
+CRp.DRAG = 1;
+CRp.NODE = 2;
+
+CRp.BUFFER_COUNT = 3;
+//
+CRp.TEXTURE_BUFFER = 0;
+CRp.MOTIONBLUR_BUFFER_NODE = 1;
+CRp.MOTIONBLUR_BUFFER_DRAG = 2;
+
+function CanvasRenderer(options) {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  var r = this;
+
+  // eslint-disable-next-line no-console
+  console.log(this.nodeShapes);
+
+  // TODO: this is needed to extend property from BaseRenderer (the property is set while creating the extension Renderer 'custom')
+  this.nodeShapes['new-shape'] = {
+    renderer: this,
+
+    name: 'new-shape',
+
+    points: math.generateUnitNgonPointsFitToSquare(4, 0),
+
+    draw: function (context, centerX, centerY, width, height) {
+      this.renderer.nodeShapeImpl(this.name, context, centerX, centerY, width, height);
+    },
+
+    intersectLine: function (nodeX, nodeY, width, height, x, y, padding) {
+      // use two fixed t values for the bezier curve approximation
+
+      var t0 = 0.15;
+      var t1 = 0.5;
+      var t2 = 0.85;
+
+      var bPts = this.generateBarrelBezierPts(width + 2 * padding, height + 2 * padding, nodeX, nodeY);
+
+      var approximateBarrelCurvePts = pts => {
+        // approximate curve pts based on the two t values
+        var m0 = math.qbezierPtAt({ x: pts[0], y: pts[1] }, { x: pts[2], y: pts[3] }, { x: pts[4], y: pts[5] }, t0);
+        var m1 = math.qbezierPtAt({ x: pts[0], y: pts[1] }, { x: pts[2], y: pts[3] }, { x: pts[4], y: pts[5] }, t1);
+        var m2 = math.qbezierPtAt({ x: pts[0], y: pts[1] }, { x: pts[2], y: pts[3] }, { x: pts[4], y: pts[5] }, t2);
+
+        return [pts[0], pts[1], m0.x, m0.y, m1.x, m1.y, m2.x, m2.y, pts[4], pts[5]];
+      };
+
+      var pts = [].concat(
+        approximateBarrelCurvePts(bPts.topLeft),
+        approximateBarrelCurvePts(bPts.topRight),
+        approximateBarrelCurvePts(bPts.bottomRight),
+        approximateBarrelCurvePts(bPts.bottomLeft),
+      );
+
+      return math.polygonIntersectLine(x, y, pts, nodeX, nodeY);
+    },
+
+    generateBarrelBezierPts: function (width, height, centerX, centerY) {
+      var hh = height / 2;
+      var hw = width / 2;
+      var xBegin = centerX - hw;
+      var xEnd = centerX + hw;
+      var yBegin = centerY - hh;
+      var yEnd = centerY + hh;
+
+      var curveConstants = math.getBarrelCurveConstants(width, height);
+      var hOffset = curveConstants.heightOffset;
+      var wOffset = curveConstants.widthOffset;
+      var ctrlPtXOffset = curveConstants.ctrlPtOffsetPct * width;
+
+      // points are in clockwise order, inner (imaginary) control pt on [4, 5]
+      var pts = {
+        topLeft: [xBegin, yBegin + hOffset, xBegin + ctrlPtXOffset, yBegin, xBegin + wOffset, yBegin],
+        topRight: [xEnd - wOffset, yBegin, xEnd - ctrlPtXOffset, yBegin, xEnd, yBegin + hOffset],
+        bottomRight: [xEnd, yEnd - hOffset, xEnd - ctrlPtXOffset, yEnd, xEnd - wOffset, yEnd],
+        bottomLeft: [xBegin + wOffset, yEnd, xBegin + ctrlPtXOffset, yEnd, xBegin, yEnd - hOffset],
+      };
+
+      pts.topLeft.isTop = true;
+      pts.topRight.isTop = true;
+      pts.bottomLeft.isBottom = true;
+      pts.bottomRight.isBottom = true;
+
+      return pts;
+    },
+
+    checkPoint: function (x, y, padding, width, height, centerX, centerY) {
+      var curveConstants = math.getBarrelCurveConstants(width, height);
+      var hOffset = curveConstants.heightOffset;
+      var wOffset = curveConstants.widthOffset;
+
+      // Check hBox
+      if (math.pointInsidePolygon(x, y, this.points, centerX, centerY, width, height - 2 * hOffset, [0, -1], padding)) {
+        return true;
+      }
+
+      // Check vBox
+      if (math.pointInsidePolygon(x, y, this.points, centerX, centerY, width - 2 * wOffset, height, [0, -1], padding)) {
+        return true;
+      }
+
+      var barrelCurvePts = this.generateBarrelBezierPts(width, height, centerX, centerY);
+
+      var getCurveT = function (x, y, curvePts) {
+        var x0 = curvePts[4];
+        var x1 = curvePts[2];
+        var x2 = curvePts[0];
+        var y0 = curvePts[5];
+        // var y1 = curvePts[ 3 ];
+        var y2 = curvePts[1];
+
+        var xMin = Math.min(x0, x2);
+        var xMax = Math.max(x0, x2);
+        var yMin = Math.min(y0, y2);
+        var yMax = Math.max(y0, y2);
+
+        if (xMin <= x && x <= xMax && yMin <= y && y <= yMax) {
+          var coeff = math.bezierPtsToQuadCoeff(x0, x1, x2);
+          var roots = math.solveQuadratic(coeff[0], coeff[1], coeff[2], x);
+
+          var validRoots = roots.filter(function (r) {
+            return 0 <= r && r <= 1;
+          });
+
+          if (validRoots.length > 0) {
+            return validRoots[0];
+          }
+        }
+        return null;
+      };
+
+      var curveRegions = Object.keys(barrelCurvePts);
+      for (var i = 0; i < curveRegions.length; i++) {
+        var corner = curveRegions[i];
+        var cornerPts = barrelCurvePts[corner];
+        var t = getCurveT(x, y, cornerPts);
+
+        if (t == null) {
+          continue;
+        }
+
+        var y0 = cornerPts[5];
+        var y1 = cornerPts[3];
+        var y2 = cornerPts[1];
+        var bezY = math.qbezierAt(y0, y1, y2, t);
+
+        if (cornerPts.isTop && bezY <= y) {
+          return true;
+        }
+        if (cornerPts.isBottom && y <= bezY) {
+          return true;
+        }
+      }
+      return false;
+    },
+  };
+
+  // eslint-disable-next-line no-console
+  console.log(this.nodeShapes);
+
+  r.data = {
+    canvases: new Array(CRp.CANVAS_LAYERS),
+    contexts: new Array(CRp.CANVAS_LAYERS),
+    canvasNeedsRedraw: new Array(CRp.CANVAS_LAYERS),
+
+    bufferCanvases: new Array(CRp.BUFFER_COUNT),
+    bufferContexts: new Array(CRp.CANVAS_LAYERS),
+  };
+
+  var tapHlOffAttr = '-webkit-tap-highlight-color';
+  var tapHlOffStyle = 'rgba(0,0,0,0)';
+  r.data.canvasContainer = document.createElement('div'); // eslint-disable-line no-undef
+  var containerStyle = r.data.canvasContainer.style;
+  r.data.canvasContainer.style[tapHlOffAttr] = tapHlOffStyle;
+  containerStyle.position = 'relative';
+  containerStyle.zIndex = '0';
+  containerStyle.overflow = 'hidden';
+
+  var container = options.cy.container();
+  container.appendChild(r.data.canvasContainer);
+  container.style[tapHlOffAttr] = tapHlOffStyle;
+
+  var styleMap = {
+    '-webkit-user-select': 'none',
+    '-moz-user-select': '-moz-none',
+    'user-select': 'none',
+    '-webkit-tap-highlight-color': 'rgba(0,0,0,0)',
+    'outline-style': 'none',
+  };
+
+  if (is.ms()) {
+    styleMap['-ms-touch-action'] = 'none';
+    styleMap['touch-action'] = 'none';
+  }
+
+  for (var i = 0; i < CRp.CANVAS_LAYERS; i++) {
+    var canvas = (r.data.canvases[i] = document.createElement('canvas')); // eslint-disable-line no-undef
+    r.data.contexts[i] = canvas.getContext('2d');
+    Object.keys(styleMap).forEach(k => {
+      canvas.style[k] = styleMap[k];
+    });
+    canvas.style.position = 'absolute';
+    canvas.setAttribute('data-id', 'layer' + i);
+    canvas.style.zIndex = String(CRp.CANVAS_LAYERS - i);
+    r.data.canvasContainer.appendChild(canvas);
+
+    r.data.canvasNeedsRedraw[i] = false;
+  }
+  r.data.topCanvas = r.data.canvases[0];
+
+  r.data.canvases[CRp.NODE].setAttribute('data-id', 'layer' + CRp.NODE + '-node');
+  r.data.canvases[CRp.SELECT_BOX].setAttribute('data-id', 'layer' + CRp.SELECT_BOX + '-selectbox');
+  r.data.canvases[CRp.DRAG].setAttribute('data-id', 'layer' + CRp.DRAG + '-drag');
+
+  for (var i = 0; i < CRp.BUFFER_COUNT; i++) {
+    r.data.bufferCanvases[i] = document.createElement('canvas'); // eslint-disable-line no-undef
+    r.data.bufferContexts[i] = r.data.bufferCanvases[i].getContext('2d');
+    r.data.bufferCanvases[i].style.position = 'absolute';
+    r.data.bufferCanvases[i].setAttribute('data-id', 'buffer' + i);
+    r.data.bufferCanvases[i].style.zIndex = String(-i - 1);
+    r.data.bufferCanvases[i].style.visibility = 'hidden';
+    //r.data.canvasContainer.appendChild(r.data.bufferCanvases[i]);
+  }
+
+  r.pathsEnabled = true;
+
+  let emptyBb = math.makeBoundingBox();
+
+  let getBoxCenter = bb => ({ x: (bb.x1 + bb.x2) / 2, y: (bb.y1 + bb.y2) / 2 });
+
+  let getCenterOffset = bb => ({ x: -bb.w / 2, y: -bb.h / 2 });
+
+  let backgroundTimestampHasChanged = ele => {
+    let _p = ele[0]._private;
+    let same = _p.oldBackgroundTimestamp === _p.backgroundTimestamp;
+
+    return !same;
+  };
+
+  let getStyleKey = ele => ele[0]._private.nodeKey;
+  let getLabelKey = ele => ele[0]._private.labelStyleKey;
+  let getSourceLabelKey = ele => ele[0]._private.sourceLabelStyleKey;
+  let getTargetLabelKey = ele => ele[0]._private.targetLabelStyleKey;
+
+  let drawElement = (context, ele, bb, scaledLabelShown, useEleOpacity) => r.drawElement(context, ele, bb, false, false, useEleOpacity);
+  let drawLabel = (context, ele, bb, scaledLabelShown, useEleOpacity) => r.drawElementText(context, ele, bb, scaledLabelShown, 'main', useEleOpacity);
+  let drawSourceLabel = (context, ele, bb, scaledLabelShown, useEleOpacity) => r.drawElementText(context, ele, bb, scaledLabelShown, 'source', useEleOpacity);
+  let drawTargetLabel = (context, ele, bb, scaledLabelShown, useEleOpacity) => r.drawElementText(context, ele, bb, scaledLabelShown, 'target', useEleOpacity);
+
+  let getElementBox = ele => {
+    ele.boundingBox();
+    return ele[0]._private.bodyBounds;
+  };
+  let getLabelBox = ele => {
+    ele.boundingBox();
+    return ele[0]._private.labelBounds.main || emptyBb;
+  };
+  let getSourceLabelBox = ele => {
+    ele.boundingBox();
+    return ele[0]._private.labelBounds.source || emptyBb;
+  };
+  let getTargetLabelBox = ele => {
+    ele.boundingBox();
+    return ele[0]._private.labelBounds.target || emptyBb;
+  };
+
+  let isLabelVisibleAtScale = (ele, scaledLabelShown) => scaledLabelShown;
+
+  let getElementRotationPoint = ele => getBoxCenter(getElementBox(ele));
+
+  let addTextMargin = (prefix, pt, ele) => {
+    let pre = prefix ? prefix + '-' : '';
+
+    return {
+      x: pt.x + ele.pstyle(pre + 'text-margin-x').pfValue,
+      y: pt.y + ele.pstyle(pre + 'text-margin-y').pfValue,
+    };
+  };
+
+  let getRsPt = (ele, x, y) => {
+    let rs = ele[0]._private.rscratch;
+
+    return { x: rs[x], y: rs[y] };
+  };
+
+  let getLabelRotationPoint = ele => addTextMargin('', getRsPt(ele, 'labelX', 'labelY'), ele);
+  let getSourceLabelRotationPoint = ele => addTextMargin('source', getRsPt(ele, 'sourceLabelX', 'sourceLabelY'), ele);
+  let getTargetLabelRotationPoint = ele => addTextMargin('target', getRsPt(ele, 'targetLabelX', 'targetLabelY'), ele);
+
+  let getElementRotationOffset = ele => getCenterOffset(getElementBox(ele));
+  let getSourceLabelRotationOffset = ele => getCenterOffset(getSourceLabelBox(ele));
+  let getTargetLabelRotationOffset = ele => getCenterOffset(getTargetLabelBox(ele));
+
+  let getLabelRotationOffset = ele => {
+    let bb = getLabelBox(ele);
+    let p = getCenterOffset(getLabelBox(ele));
+
+    if (ele.isNode()) {
+      switch (ele.pstyle('text-halign').value) {
+        case 'left':
+          p.x = -bb.w;
+          break;
+        case 'right':
+          p.x = 0;
+          break;
+      }
+
+      switch (ele.pstyle('text-valign').value) {
+        case 'top':
+          p.y = -bb.h;
+          break;
+        case 'bottom':
+          p.y = 0;
+          break;
+      }
+    }
+
+    return p;
+  };
+
+  let eleTxrCache = (r.data.eleTxrCache = new ElementTextureCache(r, {
+    getKey: getStyleKey,
+    doesEleInvalidateKey: backgroundTimestampHasChanged,
+    drawElement: drawElement,
+    getBoundingBox: getElementBox,
+    getRotationPoint: getElementRotationPoint,
+    getRotationOffset: getElementRotationOffset,
+    allowEdgeTxrCaching: false,
+    allowParentTxrCaching: false,
+  }));
+
+  let lblTxrCache = (r.data.lblTxrCache = new ElementTextureCache(r, {
+    getKey: getLabelKey,
+    drawElement: drawLabel,
+    getBoundingBox: getLabelBox,
+    getRotationPoint: getLabelRotationPoint,
+    getRotationOffset: getLabelRotationOffset,
+    isVisible: isLabelVisibleAtScale,
+  }));
+
+  let slbTxrCache = (r.data.slbTxrCache = new ElementTextureCache(r, {
+    getKey: getSourceLabelKey,
+    drawElement: drawSourceLabel,
+    getBoundingBox: getSourceLabelBox,
+    getRotationPoint: getSourceLabelRotationPoint,
+    getRotationOffset: getSourceLabelRotationOffset,
+    isVisible: isLabelVisibleAtScale,
+  }));
+
+  let tlbTxrCache = (r.data.tlbTxrCache = new ElementTextureCache(r, {
+    getKey: getTargetLabelKey,
+    drawElement: drawTargetLabel,
+    getBoundingBox: getTargetLabelBox,
+    getRotationPoint: getTargetLabelRotationPoint,
+    getRotationOffset: getTargetLabelRotationOffset,
+    isVisible: isLabelVisibleAtScale,
+  }));
+
+  let lyrTxrCache = (r.data.lyrTxrCache = new LayeredTextureCache(r));
+
+  r.onUpdateEleCalcs(function invalidateTextureCaches(willDraw, eles) {
+    // each cache should check for sub-key diff to see that the update affects that cache particularly
+    eleTxrCache.invalidateElements(eles);
+    lblTxrCache.invalidateElements(eles);
+    slbTxrCache.invalidateElements(eles);
+    tlbTxrCache.invalidateElements(eles);
+
+    // any change invalidates the layers
+    lyrTxrCache.invalidateElements(eles);
+
+    // update the old bg timestamp so diffs can be done in the ele txr caches
+    for (let i = 0; i < eles.length; i++) {
+      let _p = eles[i]._private;
+
+      _p.oldBackgroundTimestamp = _p.backgroundTimestamp;
+    }
+  });
+
+  let refineInLayers = reqs => {
+    for (var i = 0; i < reqs.length; i++) {
+      lyrTxrCache.enqueueElementRefinement(reqs[i].ele);
+    }
+  };
+
+  eleTxrCache.onDequeue(refineInLayers);
+  lblTxrCache.onDequeue(refineInLayers);
+  slbTxrCache.onDequeue(refineInLayers);
+  tlbTxrCache.onDequeue(refineInLayers);
+}
+
+CRp.redrawHint = function (group, bool) {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  var r = this;
+
+  switch (group) {
+    case 'eles':
+      r.data.canvasNeedsRedraw[CRp.NODE] = bool;
+      break;
+    case 'drag':
+      r.data.canvasNeedsRedraw[CRp.DRAG] = bool;
+      break;
+    case 'select':
+      r.data.canvasNeedsRedraw[CRp.SELECT_BOX] = bool;
+      break;
+  }
+};
+
+// whether to use Path2D caching for drawing
+var pathsImpld = typeof Path2D !== 'undefined';
+
+CRp.path2dEnabled = function (on) {
+  if (on === undefined) {
+    return this.pathsEnabled;
+  }
+
+  this.pathsEnabled = on ? true : false;
+};
+
+CRp.usePaths = function () {
+  return pathsImpld && this.pathsEnabled;
+};
+
+CRp.setImgSmoothing = function (context, bool) {
+  if (context.imageSmoothingEnabled != null) {
+    context.imageSmoothingEnabled = bool;
+  } else {
+    context.webkitImageSmoothingEnabled = bool;
+    context.mozImageSmoothingEnabled = bool;
+    context.msImageSmoothingEnabled = bool;
+  }
+};
+
+CRp.getImgSmoothing = function (context) {
+  if (context.imageSmoothingEnabled != null) {
+    return context.imageSmoothingEnabled;
+  } else {
+    return context.webkitImageSmoothingEnabled || context.mozImageSmoothingEnabled || context.msImageSmoothingEnabled;
+  }
+};
+
+CRp.makeOffscreenCanvas = function (width, height) {
+  let canvas;
+
+  if (typeof OffscreenCanvas !== typeof undefined) {
+    canvas = new OffscreenCanvas(width, height);
+  } else {
+    canvas = document.createElement('canvas'); // eslint-disable-line no-undef
+    canvas.width = width;
+    canvas.height = height;
+  }
+
+  return canvas;
+};
+
+[arrowShapes, drawingElements, drawingEdges, drawingImages, drawingLabelText, drawingNodes, drawingRedraw, drawingShapes, exportImage, nodeShapes].forEach(function (props) {
+  util.extend(CRp, props);
+});
+
+export default CR;

--- a/src/component/cytoscape/renderer/core/canvas/index.js
+++ b/src/component/cytoscape/renderer/core/canvas/index.js
@@ -16,9 +16,9 @@
 
 /* global OffscreenCanvas */
 
-import * as util from '../../../../../../node_modules/cytoscape/src/util';
-import * as is from '../../../../../../node_modules/cytoscape/src/is';
-import * as math from '../../../../../../node_modules/cytoscape/src/math';
+import * as util from 'cytoscape/src/util';
+import * as is from 'cytoscape/src/is';
+import * as math from 'cytoscape/src/math';
 import ElementTextureCache from './ele-texture-cache';
 import LayeredTextureCache from './layered-texture-cache';
 

--- a/src/component/cytoscape/renderer/core/canvas/layered-texture-cache.js
+++ b/src/component/cytoscape/renderer/core/canvas/layered-texture-cache.js
@@ -1,0 +1,719 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as util from '../../../../../../node_modules/cytoscape/src/util';
+import * as math from '../../../../../../node_modules/cytoscape/src/math';
+import Heap from '../../../../../../node_modules/cytoscape/src/heap';
+import * as is from '../../../../../../node_modules/cytoscape/src/is';
+import defs from './texture-cache-defs';
+
+var defNumLayers = 1; // default number of layers to use
+var minLvl = -4; // when scaling smaller than that we don't need to re-render
+var maxLvl = 2; // when larger than this scale just render directly (caching is not helpful)
+var maxZoom = 3.99; // beyond this zoom level, layered textures are not used
+var deqRedrawThreshold = 50; // time to batch redraws together from dequeueing to allow more dequeueing calcs to happen in the meanwhile
+var refineEleDebounceTime = 50; // time to debounce sharper ele texture updates
+var disableEleImgSmoothing = true; // when drawing eles on layers from an ele cache ; crisper and more performant when true
+var deqCost = 0.15; // % of add'l rendering cost allowed for dequeuing ele caches each frame
+var deqAvgCost = 0.1; // % of add'l rendering cost compared to average overall redraw time
+var deqNoDrawCost = 0.9; // % of avg frame time that can be used for dequeueing when not drawing
+var deqFastCost = 0.9; // % of frame time to be used when >60fps
+var maxDeqSize = 1; // number of eles to dequeue and render at higher texture in each batch
+var invalidThreshold = 250; // time threshold for disabling b/c of invalidations
+var maxLayerArea = 4000 * 4000; // layers can't be bigger than this
+var alwaysQueue = true; // never draw all the layers in a level on a frame; draw directly until all dequeued
+var useHighQualityEleTxrReqs = true; // whether to use high quality ele txr requests (generally faster and cheaper in the longterm)
+
+var useEleTxrCaching = true; // whether to use individual ele texture caching underneath this cache
+
+// var log = function(){ console.log.apply( console, arguments ); };
+
+var LayeredTextureCache = function (renderer) {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  var self = this;
+  var r = (self.renderer = renderer);
+  var cy = r.cy;
+
+  self.layersByLevel = {}; // e.g. 2 => [ layer1, layer2, ..., layerN ]
+
+  self.firstGet = true;
+
+  self.lastInvalidationTime = util.performanceNow() - 2 * invalidThreshold;
+
+  self.skipping = false;
+
+  self.eleTxrDeqs = cy.collection();
+
+  self.scheduleElementRefinement = util.debounce(function () {
+    self.refineElementTextures(self.eleTxrDeqs);
+
+    self.eleTxrDeqs.unmerge(self.eleTxrDeqs);
+  }, refineEleDebounceTime);
+
+  r.beforeRender(function (willDraw, now) {
+    if (now - self.lastInvalidationTime <= invalidThreshold) {
+      self.skipping = true;
+    } else {
+      self.skipping = false;
+    }
+  }, r.beforeRenderPriorities.lyrTxrSkip);
+
+  var qSort = function (a, b) {
+    return b.reqs - a.reqs;
+  };
+
+  self.layersQueue = new Heap(qSort);
+
+  self.setupDequeueing();
+};
+
+var LTCp = LayeredTextureCache.prototype;
+
+var layerIdPool = 0;
+var MAX_INT = Math.pow(2, 53) - 1;
+
+LTCp.makeLayer = function (bb, lvl) {
+  var scale = Math.pow(2, lvl);
+
+  var w = Math.ceil(bb.w * scale);
+  var h = Math.ceil(bb.h * scale);
+
+  var canvas = this.renderer.makeOffscreenCanvas(w, h);
+
+  var layer = {
+    id: (layerIdPool = ++layerIdPool % MAX_INT),
+    bb: bb,
+    level: lvl,
+    width: w,
+    height: h,
+    canvas: canvas,
+    context: canvas.getContext('2d'),
+    eles: [],
+    elesQueue: [],
+    reqs: 0,
+  };
+
+  // log('make layer %s with w %s and h %s and lvl %s', layer.id, layer.width, layer.height, layer.level);
+
+  var cxt = layer.context;
+  var dx = -layer.bb.x1;
+  var dy = -layer.bb.y1;
+
+  // do the transform on creation to save cycles (it's the same for all eles)
+  cxt.scale(scale, scale);
+  cxt.translate(dx, dy);
+
+  return layer;
+};
+
+LTCp.getLayers = function (eles, pxRatio, lvl) {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  var self = this;
+  var r = self.renderer;
+  var cy = r.cy;
+  var zoom = cy.zoom();
+  var firstGet = self.firstGet;
+
+  self.firstGet = false;
+
+  // log('--\nget layers with %s eles', eles.length);
+  //log eles.map(function(ele){ return ele.id() }) );
+
+  if (lvl == null) {
+    lvl = Math.ceil(math.log2(zoom * pxRatio));
+
+    if (lvl < minLvl) {
+      lvl = minLvl;
+    } else if (zoom >= maxZoom || lvl > maxLvl) {
+      return null;
+    }
+  }
+
+  self.validateLayersElesOrdering(lvl, eles);
+
+  var layersByLvl = self.layersByLevel;
+  var scale = Math.pow(2, lvl);
+  var layers = (layersByLvl[lvl] = layersByLvl[lvl] || []);
+  var bb;
+
+  var lvlComplete = self.levelIsComplete(lvl, eles);
+  var tmpLayers;
+
+  var checkTempLevels = function () {
+    var canUseAsTmpLvl = function (l) {
+      self.validateLayersElesOrdering(l, eles);
+
+      if (self.levelIsComplete(l, eles)) {
+        tmpLayers = layersByLvl[l];
+        return true;
+      }
+    };
+
+    var checkLvls = function (dir) {
+      if (tmpLayers) {
+        return;
+      }
+
+      for (var l = lvl + dir; minLvl <= l && l <= maxLvl; l += dir) {
+        if (canUseAsTmpLvl(l)) {
+          break;
+        }
+      }
+    };
+
+    checkLvls(+1);
+    checkLvls(-1);
+
+    // remove the invalid layers; they will be replaced as needed later in this function
+    for (var i = layers.length - 1; i >= 0; i--) {
+      var layer = layers[i];
+
+      if (layer.invalid) {
+        util.removeFromArray(layers, layer);
+      }
+    }
+  };
+
+  if (!lvlComplete) {
+    // if the current level is incomplete, then use the closest, best quality layerset temporarily
+    // and later queue the current layerset so we can get the proper quality level soon
+
+    checkTempLevels();
+  } else {
+    // log('level complete, using existing layers\n--');
+    return layers;
+  }
+
+  var getBb = function () {
+    if (!bb) {
+      bb = math.makeBoundingBox();
+
+      for (var i = 0; i < eles.length; i++) {
+        math.updateBoundingBox(bb, eles[i].boundingBox());
+      }
+    }
+
+    return bb;
+  };
+
+  var makeLayer = function (opts) {
+    opts = opts || {};
+
+    var after = opts.after;
+
+    getBb();
+
+    var area = bb.w * scale * (bb.h * scale);
+
+    if (area > maxLayerArea) {
+      return null;
+    }
+
+    var layer = self.makeLayer(bb, lvl);
+
+    if (after != null) {
+      var index = layers.indexOf(after) + 1;
+
+      layers.splice(index, 0, layer);
+    } else if (opts.insert === undefined || opts.insert) {
+      // no after specified => first layer made so put at start
+      layers.unshift(layer);
+    }
+
+    // if( tmpLayers ){
+    //self.queueLayer( layer );
+    // }
+
+    return layer;
+  };
+
+  if (self.skipping && !firstGet) {
+    // log('skip layers');
+    return null;
+  }
+
+  // log('do layers');
+
+  var layer = null;
+  var maxElesPerLayer = eles.length / defNumLayers;
+  var allowLazyQueueing = alwaysQueue && !firstGet;
+
+  for (var i = 0; i < eles.length; i++) {
+    var ele = eles[i];
+    var rs = ele._private.rscratch;
+    var caches = (rs.imgLayerCaches = rs.imgLayerCaches || {});
+
+    // log('look at ele', ele.id());
+
+    var existingLayer = caches[lvl];
+
+    if (existingLayer) {
+      // reuse layer for later eles
+      // log('reuse layer for', ele.id());
+      layer = existingLayer;
+      continue;
+    }
+
+    if (!layer || layer.eles.length >= maxElesPerLayer || !math.boundingBoxInBoundingBox(layer.bb, ele.boundingBox())) {
+      // log('make new layer for ele %s', ele.id());
+
+      layer = makeLayer({ insert: true, after: layer });
+
+      // if now layer can be built then we can't use layers at this level
+      if (!layer) {
+        return null;
+      }
+
+      // log('new layer with id %s', layer.id);
+    }
+
+    if (tmpLayers || allowLazyQueueing) {
+      // log('queue ele %s in layer %s', ele.id(), layer.id);
+      self.queueLayer(layer, ele);
+    } else {
+      // log('draw ele %s in layer %s', ele.id(), layer.id);
+      self.drawEleInLayer(layer, ele, lvl, pxRatio);
+    }
+
+    layer.eles.push(ele);
+
+    caches[lvl] = layer;
+  }
+
+  // log('--');
+
+  if (tmpLayers) {
+    // then we only queued the current layerset and can't draw it yet
+    return tmpLayers;
+  }
+
+  if (allowLazyQueueing) {
+    // log('lazy queue level', lvl);
+    return null;
+  }
+
+  return layers;
+};
+
+// a layer may want to use an ele cache of a higher level to avoid blurriness
+// so the layer level might not equal the ele level
+LTCp.getEleLevelForLayerLevel = function (lvl, pxRatio) {
+  return lvl;
+};
+
+LTCp.drawEleInLayer = function (layer, ele, lvl, pxRatio) {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  var self = this;
+  var r = this.renderer;
+  var context = layer.context;
+  var bb = ele.boundingBox();
+
+  if (bb.w === 0 || bb.h === 0 || !ele.visible()) {
+    return;
+  }
+
+  lvl = self.getEleLevelForLayerLevel(lvl, pxRatio);
+
+  if (disableEleImgSmoothing) {
+    r.setImgSmoothing(context, false);
+  }
+
+  if (useEleTxrCaching) {
+    r.drawCachedElement(context, ele, null, null, lvl, useHighQualityEleTxrReqs);
+  } else {
+    // if the element is not cacheable, then draw directly
+    r.drawElement(context, ele);
+  }
+
+  if (disableEleImgSmoothing) {
+    r.setImgSmoothing(context, true);
+  }
+};
+
+LTCp.levelIsComplete = function (lvl, eles) {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  var self = this;
+  var layers = self.layersByLevel[lvl];
+
+  if (!layers || layers.length === 0) {
+    return false;
+  }
+
+  var numElesInLayers = 0;
+
+  for (var i = 0; i < layers.length; i++) {
+    var layer = layers[i];
+
+    // if there are any eles needed to be drawn yet, the level is not complete
+    if (layer.reqs > 0) {
+      return false;
+    }
+
+    // if the layer is invalid, the level is not complete
+    if (layer.invalid) {
+      return false;
+    }
+
+    numElesInLayers += layer.eles.length;
+  }
+
+  // we should have exactly the number of eles passed in to be complete
+  if (numElesInLayers !== eles.length) {
+    return false;
+  }
+
+  return true;
+};
+
+LTCp.validateLayersElesOrdering = function (lvl, eles) {
+  var layers = this.layersByLevel[lvl];
+
+  if (!layers) {
+    return;
+  }
+
+  // if in a layer the eles are not in the same order, then the layer is invalid
+  // (i.e. there is an ele in between the eles in the layer)
+
+  for (var i = 0; i < layers.length; i++) {
+    var layer = layers[i];
+    var offset = -1;
+
+    // find the offset
+    for (var j = 0; j < eles.length; j++) {
+      if (layer.eles[0] === eles[j]) {
+        offset = j;
+        break;
+      }
+    }
+
+    if (offset < 0) {
+      // then the layer has nonexistant elements and is invalid
+      this.invalidateLayer(layer);
+      continue;
+    }
+
+    // the eles in the layer must be in the same continuous order, else the layer is invalid
+
+    var o = offset;
+
+    for (var j = 0; j < layer.eles.length; j++) {
+      if (layer.eles[j] !== eles[o + j]) {
+        // log('invalidate based on ordering', layer.id);
+
+        this.invalidateLayer(layer);
+        break;
+      }
+    }
+  }
+};
+
+LTCp.updateElementsInLayers = function (eles, update) {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  var self = this;
+  var isEles = is.element(eles[0]);
+
+  // collect udpated elements (cascaded from the layers) and update each
+  // layer itself along the way
+  for (var i = 0; i < eles.length; i++) {
+    var req = isEles ? null : eles[i];
+    var ele = isEles ? eles[i] : eles[i].ele;
+    var rs = ele._private.rscratch;
+    var caches = (rs.imgLayerCaches = rs.imgLayerCaches || {});
+
+    for (var l = minLvl; l <= maxLvl; l++) {
+      var layer = caches[l];
+
+      if (!layer) {
+        continue;
+      }
+
+      // if update is a request from the ele cache, then it affects only
+      // the matching level
+      if (req && self.getEleLevelForLayerLevel(layer.level) !== req.level) {
+        continue;
+      }
+
+      update(layer, ele, req);
+    }
+  }
+};
+
+LTCp.haveLayers = function () {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  var self = this;
+  var haveLayers = false;
+
+  for (var l = minLvl; l <= maxLvl; l++) {
+    var layers = self.layersByLevel[l];
+
+    if (layers && layers.length > 0) {
+      haveLayers = true;
+      break;
+    }
+  }
+
+  return haveLayers;
+};
+
+LTCp.invalidateElements = function (eles) {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  var self = this;
+
+  if (eles.length === 0) {
+    return;
+  }
+
+  self.lastInvalidationTime = util.performanceNow();
+
+  // log('update invalidate layer time from eles');
+
+  if (eles.length === 0 || !self.haveLayers()) {
+    return;
+  }
+
+  self.updateElementsInLayers(eles, function invalAssocLayers(layer, ele, req) {
+    self.invalidateLayer(layer);
+  });
+};
+
+LTCp.invalidateLayer = function (layer) {
+  // log('update invalidate layer time');
+
+  this.lastInvalidationTime = util.performanceNow();
+
+  if (layer.invalid) {
+    return;
+  } // save cycles
+
+  var lvl = layer.level;
+  var eles = layer.eles;
+  var layers = this.layersByLevel[lvl];
+
+  // log('invalidate layer', layer.id );
+
+  util.removeFromArray(layers, layer);
+  // layer.eles = [];
+
+  layer.elesQueue = [];
+
+  layer.invalid = true;
+
+  if (layer.replacement) {
+    layer.replacement.invalid = true;
+  }
+
+  for (var i = 0; i < eles.length; i++) {
+    var caches = eles[i]._private.rscratch.imgLayerCaches;
+
+    if (caches) {
+      caches[lvl] = null;
+    }
+  }
+};
+
+LTCp.refineElementTextures = function (eles) {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  var self = this;
+
+  // log('refine', eles.length);
+
+  self.updateElementsInLayers(eles, function refineEachEle(layer, ele, req) {
+    var rLyr = layer.replacement;
+
+    if (!rLyr) {
+      rLyr = layer.replacement = self.makeLayer(layer.bb, layer.level);
+      rLyr.replaces = layer;
+      rLyr.eles = layer.eles;
+
+      // log('make replacement layer %s for %s with level %s', rLyr.id, layer.id, rLyr.level);
+    }
+
+    if (!rLyr.reqs) {
+      for (var i = 0; i < rLyr.eles.length; i++) {
+        self.queueLayer(rLyr, rLyr.eles[i]);
+      }
+
+      // log('queue replacement layer refinement', rLyr.id);
+    }
+  });
+};
+
+LTCp.enqueueElementRefinement = function (ele) {
+  if (!useEleTxrCaching) {
+    return;
+  }
+
+  this.eleTxrDeqs.merge(ele);
+  this.scheduleElementRefinement();
+};
+
+LTCp.queueLayer = function (layer, ele) {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  var self = this;
+  var q = self.layersQueue;
+  var elesQ = layer.elesQueue;
+  var hasId = (elesQ.hasId = elesQ.hasId || {});
+
+  // if a layer is going to be replaced, queuing is a waste of time
+  if (layer.replacement) {
+    return;
+  }
+
+  if (ele) {
+    if (hasId[ele.id()]) {
+      return;
+    }
+
+    elesQ.push(ele);
+    hasId[ele.id()] = true;
+  }
+
+  if (layer.reqs) {
+    layer.reqs++;
+
+    q.updateItem(layer);
+  } else {
+    layer.reqs = 1;
+
+    q.push(layer);
+  }
+};
+
+LTCp.dequeue = function (pxRatio) {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  var self = this;
+  var q = self.layersQueue;
+  var deqd = [];
+  var eleDeqs = 0;
+
+  while (eleDeqs < maxDeqSize) {
+    if (q.size() === 0) {
+      break;
+    }
+
+    var layer = q.peek();
+
+    // if a layer has been or will be replaced, then don't waste time with it
+    if (layer.replacement) {
+      // log('layer %s in queue skipped b/c it already has a replacement', layer.id);
+      q.pop();
+      continue;
+    }
+
+    // if this is a replacement layer that has been superceded, then forget it
+    if (layer.replaces && layer !== layer.replaces.replacement) {
+      // log('layer is no longer the most uptodate replacement; dequeued', layer.id)
+      q.pop();
+      continue;
+    }
+
+    if (layer.invalid) {
+      // log('replacement layer %s is invalid; dequeued', layer.id);
+      q.pop();
+      continue;
+    }
+
+    var ele = layer.elesQueue.shift();
+
+    if (ele) {
+      // log('dequeue layer %s', layer.id);
+
+      self.drawEleInLayer(layer, ele, layer.level, pxRatio);
+
+      eleDeqs++;
+    }
+
+    if (deqd.length === 0) {
+      // we need only one entry in deqd to queue redrawing etc
+      deqd.push(true);
+    }
+
+    // if the layer has all its eles done, then remove from the queue
+    if (layer.elesQueue.length === 0) {
+      q.pop();
+
+      layer.reqs = 0;
+
+      // log('dequeue of layer %s complete', layer.id);
+
+      // when a replacement layer is dequeued, it replaces the old layer in the level
+      if (layer.replaces) {
+        self.applyLayerReplacement(layer);
+      }
+
+      self.requestRedraw();
+    }
+  }
+
+  return deqd;
+};
+
+LTCp.applyLayerReplacement = function (layer) {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  var self = this;
+  var layersInLevel = self.layersByLevel[layer.level];
+  var replaced = layer.replaces;
+  var index = layersInLevel.indexOf(replaced);
+
+  // if the replaced layer is not in the active list for the level, then replacing
+  // refs would be a mistake (i.e. overwriting the true active layer)
+  if (index < 0 || replaced.invalid) {
+    // log('replacement layer would have no effect', layer.id);
+    return;
+  }
+
+  layersInLevel[index] = layer; // replace level ref
+
+  // replace refs in eles
+  for (var i = 0; i < layer.eles.length; i++) {
+    var _p = layer.eles[i]._private;
+    var cache = (_p.imgLayerCaches = _p.imgLayerCaches || {});
+
+    if (cache) {
+      cache[layer.level] = layer;
+    }
+  }
+
+  // log('apply replacement layer %s over %s', layer.id, replaced.id);
+
+  self.requestRedraw();
+};
+
+LTCp.requestRedraw = util.debounce(function () {
+  var r = this.renderer;
+
+  r.redrawHint('eles', true);
+  r.redrawHint('drag', true);
+  r.redraw();
+}, 100);
+
+LTCp.setupDequeueing = defs.setupDequeueing({
+  deqRedrawThreshold: deqRedrawThreshold,
+  deqCost: deqCost,
+  deqAvgCost: deqAvgCost,
+  deqNoDrawCost: deqNoDrawCost,
+  deqFastCost: deqFastCost,
+  deq: function (self, pxRatio) {
+    return self.dequeue(pxRatio);
+  },
+  onDeqd: util.noop,
+  shouldRedraw: util.trueify,
+  priority: function (self) {
+    return self.renderer.beforeRenderPriorities.lyrTxrDeq;
+  },
+});
+
+export default LayeredTextureCache;

--- a/src/component/cytoscape/renderer/core/canvas/layered-texture-cache.js
+++ b/src/component/cytoscape/renderer/core/canvas/layered-texture-cache.js
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as util from '../../../../../../node_modules/cytoscape/src/util';
-import * as math from '../../../../../../node_modules/cytoscape/src/math';
-import Heap from '../../../../../../node_modules/cytoscape/src/heap';
-import * as is from '../../../../../../node_modules/cytoscape/src/is';
+import * as util from 'cytoscape/src/util';
+import * as math from 'cytoscape/src/math';
+import Heap from 'cytoscape/src/heap';
+import * as is from 'cytoscape/src/is';
 import defs from './texture-cache-defs';
 
 var defNumLayers = 1; // default number of layers to use

--- a/src/component/cytoscape/renderer/core/canvas/node-shapes.js
+++ b/src/component/cytoscape/renderer/core/canvas/node-shapes.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+var CRp = {};
+
+CRp.nodeShapeImpl = function (name, context, centerX, centerY, width, height, points) {
+  switch (name) {
+    case 'ellipse':
+      return this.drawEllipsePath(context, centerX, centerY, width, height);
+    case 'polygon':
+      return this.drawPolygonPath(context, centerX, centerY, width, height, points);
+    case 'round-polygon':
+      return this.drawRoundPolygonPath(context, centerX, centerY, width, height, points);
+    case 'roundrectangle':
+    case 'round-rectangle':
+      return this.drawRoundRectanglePath(context, centerX, centerY, width, height);
+    case 'cutrectangle':
+    case 'cut-rectangle':
+      return this.drawCutRectanglePath(context, centerX, centerY, width, height);
+    case 'bottomroundrectangle':
+    case 'bottom-round-rectangle':
+      return this.drawBottomRoundRectanglePath(context, centerX, centerY, width, height);
+    case 'barrel':
+      return this.drawBarrelPath(context, centerX, centerY, width, height);
+    case 'new-shape':
+      return this.drawNewShapePath(context, centerX, centerY, width, height);
+  }
+};
+
+export default CRp;

--- a/src/component/cytoscape/renderer/core/canvas/texture-cache-defs.js
+++ b/src/component/cytoscape/renderer/core/canvas/texture-cache-defs.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as util from '../../../../../../node_modules/cytoscape/src/util';
+import * as util from 'cytoscape/src/util';
 
 var fullFpsTime = 1000 / 60; // assume 60 frames per second
 

--- a/src/component/cytoscape/renderer/core/canvas/texture-cache-defs.js
+++ b/src/component/cytoscape/renderer/core/canvas/texture-cache-defs.js
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as util from '../../../../../../node_modules/cytoscape/src/util';
+
+var fullFpsTime = 1000 / 60; // assume 60 frames per second
+
+export default {
+  setupDequeueing: function (opts) {
+    return function setupDequeueingImpl() {
+      // eslint-disable-next-line @typescript-eslint/no-this-alias
+      var self = this;
+      var r = this.renderer;
+
+      if (self.dequeueingSetup) {
+        return;
+      } else {
+        self.dequeueingSetup = true;
+      }
+
+      var queueRedraw = util.debounce(function () {
+        r.redrawHint('eles', true);
+        r.redrawHint('drag', true);
+
+        r.redraw();
+      }, opts.deqRedrawThreshold);
+
+      var dequeue = function (willDraw, frameStartTime) {
+        var startTime = util.performanceNow();
+        var avgRenderTime = r.averageRedrawTime;
+        var renderTime = r.lastRedrawTime;
+        var deqd = [];
+        var extent = r.cy.extent();
+        var pixelRatio = r.getPixelRatio();
+
+        // if we aren't in a tick that causes a draw, then the rendered style
+        // queue won't automatically be flushed before dequeueing starts
+        if (!willDraw) {
+          r.flushRenderedStyleQueue();
+        }
+
+        while (true) {
+          // eslint-disable-line no-constant-condition
+          var now = util.performanceNow();
+          var duration = now - startTime;
+          var frameDuration = now - frameStartTime;
+
+          if (renderTime < fullFpsTime) {
+            // if we're rendering faster than the ideal fps, then do dequeueing
+            // during all of the remaining frame time
+
+            var timeAvailable = fullFpsTime - (willDraw ? avgRenderTime : 0);
+
+            if (frameDuration >= opts.deqFastCost * timeAvailable) {
+              break;
+            }
+          } else {
+            if (willDraw) {
+              if (duration >= opts.deqCost * renderTime || duration >= opts.deqAvgCost * avgRenderTime) {
+                break;
+              }
+            } else if (frameDuration >= opts.deqNoDrawCost * fullFpsTime) {
+              break;
+            }
+          }
+
+          var thisDeqd = opts.deq(self, pixelRatio, extent);
+
+          if (thisDeqd.length > 0) {
+            for (var i = 0; i < thisDeqd.length; i++) {
+              deqd.push(thisDeqd[i]);
+            }
+          } else {
+            break;
+          }
+        }
+
+        // callbacks on dequeue
+        if (deqd.length > 0) {
+          opts.onDeqd(self, deqd);
+
+          if (!willDraw && opts.shouldRedraw(self, deqd, pixelRatio, extent)) {
+            queueRedraw();
+          }
+        }
+      };
+
+      var priority = opts.priority || util.noop;
+
+      r.beforeRender(dequeue, priority(self));
+    };
+  },
+};

--- a/src/component/cytoscape/renderer/core/index.ts
+++ b/src/component/cytoscape/renderer/core/index.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+// import CanvasRenderer from '../../../../../node_modules/cytoscape/src/extensions/renderer/canvas/index.js';
+import CanvasRenderer from './canvas/index.js';
+
+// export default function extension(): any {
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+// const CanvasRenderer = cytoscape().extension('renderer', 'canvas');
+
+// CanvasRenderer.prototype.nodeShapeImpl = function (name: any, context: any, centerX: any, centerY: any, width: any, height: any, points: any) {
+//   // eslint-disable-next-line no-console
+//   console.log('____________________________________EXTENDED___________________________________');
+//   switch (name) {
+//     case 'ellipse':
+//       return this.drawEllipsePath(context, centerX, centerY, width, height);
+//     case 'polygon':
+//       return this.drawPolygonPath(context, centerX, centerY, width, height, points);
+//     case 'round-polygon':
+//       return this.drawRoundPolygonPath(context, centerX, centerY, width, height, points);
+//     case 'roundrectangle':
+//     case 'round-rectangle':
+//       return this.drawRoundRectanglePath(context, centerX, centerY, width, height);
+//     case 'cutrectangle':
+//     case 'cut-rectangle':
+//       return this.drawCutRectanglePath(context, centerX, centerY, width, height);
+//     case 'bottomroundrectangle':
+//     case 'bottom-round-rectangle':
+//       return this.drawBottomRoundRectanglePath(context, centerX, centerY, width, height);
+//     case 'barrel':
+//       return this.drawBarrelPath(context, centerX, centerY, width, height);
+//     case 'newShape':
+//       return this.drawBarrelPath(context, centerX, centerY, width, height);
+//   }
+// };
+
+// return CanvasRenderer;
+// }
+export default CanvasRenderer;

--- a/src/component/cytoscape/renderer/index.ts
+++ b/src/component/cytoscape/renderer/index.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import CanvasRenderer from './core';
+
+export default function register(cy?: any): void {
+  if (!cy) {
+    return;
+  }
+  // Initialize extension
+
+  // Register extension
+  const extensionName = 'custom';
+  cy('renderer', extensionName, CanvasRenderer);
+}
+
+// Automatically register the extension for browser
+declare global {
+  interface Window {
+    cytoscape?: any;
+  }
+}
+if (typeof window.cytoscape !== 'undefined') {
+  register(window.cytoscape);
+}

--- a/src/demo/index.ts
+++ b/src/demo/index.ts
@@ -18,11 +18,13 @@ import { GlobalOptions, FitOptions, FitType, LoadOptions } from '../component/op
 import { log, logStartup } from './helper';
 import { DropFileUserInterface } from './component/DropFileUserInterface';
 import { BpmnElement, BpmnElementKind } from '../component/registry/bpmn-elements-registry';
+import CytoBpmnVisualization from '../component/CytoBpmnVisualization';
 
 export * from './helper';
 
 let bpmnVisualization: BpmnVisualization;
 let loadOptions: LoadOptions = {};
+let cytoBpmnVisualization: CytoBpmnVisualization;
 
 export function updateLoadOptions(fitOptions: FitOptions): void {
   log('Updating load options', fitOptions);
@@ -65,11 +67,24 @@ export function removeCssClasses(bpmnElementId: string | string[], classNames: s
   return bpmnVisualization.bpmnElementsRegistry.removeCssClasses(bpmnElementId, classNames);
 }
 
+function loadBpmnCyto(bpmn: string): void {
+  log('Loading bpmn....');
+  cytoBpmnVisualization.load(bpmn);
+  log('BPMN loaded');
+}
+
 // callback function for opening | dropping the file to be loaded
 function readAndLoadFile(f: File): void {
   const reader = new FileReader();
   reader.onload = () => {
     loadBpmn(reader.result as string);
+  };
+  reader.readAsText(f);
+}
+function readAndLoadFileCyto(f: File): void {
+  const reader = new FileReader();
+  reader.onload = () => {
+    loadBpmnCyto(reader.result as string);
   };
   reader.readAsText(f);
 }
@@ -82,6 +97,10 @@ function readAndLoadFile(f: File): void {
 export function handleFileSelect(evt: any): void {
   const f = evt.target.files[0];
   readAndLoadFile(f);
+}
+export function handleFileSelectCyto(evt: any): void {
+  const f = evt.target.files[0];
+  readAndLoadFileCyto(f);
 }
 
 function fetchBpmnContent(url: string): Promise<string> {
@@ -173,4 +192,11 @@ export function startBpmnVisualization(config: BpmnVisualizationDemoConfiguratio
     return;
   }
   log("No 'url to fetch BPMN content' provided");
+}
+
+export function initCytoBpmnVisualization(containerId: string): void {
+  const log = logStartup;
+
+  log(`Initializing BpmnVisualization with container '${containerId}'...`);
+  cytoBpmnVisualization = new CytoBpmnVisualization(containerId);
 }

--- a/src/index-cytoscape.html
+++ b/src/index-cytoscape.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>BPMN Visualization Demo</title>
+    <link href="./static/css/main.css" rel="stylesheet">
+    <link rel="shortcut icon" href="./static/img/favicon.ico">
+</head>
+<body>
+    <div id="controls" class="controls">
+      <div id="file-panel">
+        <div id="file-selector">
+          <input type="file" id="bpmn-file" name="file"/>
+          <label for="bpmn-file" class="btn"><span>open BPMN file</span></label>
+        </div>
+        <p class="info">(either drop a file here)</p>
+      </div>
+    </div>
+
+    <div>
+      <div style="width: 100%; height: 100%; min-height: 800px; display: block;" id="graph-cyto"></div>
+    </div>
+
+    <!-- load global settings -->
+    <script src="./static/js/configureMxGraphGlobals.js"></script>
+    <!-- load mxGraph client library -->
+    <script src="./static/js/mxClient.min.js"></script>
+    <!-- load demo -->
+    <script src="./static/js/demo-cytoscape.js" type="module"></script>
+</body>
+</html>

--- a/src/static/js/demo-cytoscape.js
+++ b/src/static/js/demo-cytoscape.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { documentReady, handleFileSelectCyto, initCytoBpmnVisualization } from '../../index.es.js';
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+function startDemo() {
+  initCytoBpmnVisualization('graph');
+
+  // Configure custom html elements
+  document.getElementById('bpmn-file').addEventListener('change', handleFileSelectCyto, false);
+}
+
+// Start
+documentReady(startDemo);


### PR DESCRIPTION
This is complete Renderer based on original one
- not yet in TS
- it is raw just to test possibility

The good thing - it works!
This way it is possible to introduce custom shapes.


/!\ Personal feeling: comparing to mxGraph - it is not that well documented, neither intuitive and the initial learning curve seems to be steep.




previously I have tried different approaches which did not work:
cytoscape.use, cytoscape.extension:
CanvasRenderer.prototype changes inspired by css renderer (https://github.com/wehriam/cytoscape-css-renderer)
BpmnVisuRenderer.prototype = Object.create(CanvasRenderer.prototype);
available in branch: poc-cytoscape-integration-extend-css-canvas-approach-not-working

cytoscape.extension (cy.extension('renderer', 'canvas', 'nodeShape', 'newShape', {...}); ):
adding new shapes for renderer
available in branch: poc-cytoscape-integration-extend-trial-not-working