### PR TITLE
[FEAT] Do not trigger panning on right click

### DIFF
--- a/src/component/mxgraph/MxGraphConfigurator.ts
+++ b/src/component/mxgraph/MxGraphConfigurator.ts
@@ -63,18 +63,26 @@ export default class MxGraphConfigurator {
   private configureMouseNavigationSupport(options?: GlobalOptions): void {
     const mouseNavigationSupport = options?.mouseNavigationSupport;
     // Pan configuration
+    const panningHandler = this.graph.panningHandler;
     if (mouseNavigationSupport) {
-      this.graph.panningHandler.useLeftButtonForPanning = true;
-      this.graph.panningHandler.ignoreCell = true; // ok here as we cannot select cells
-      this.graph.panningHandler.addListener(mxEvent.PAN_START, this.getPanningHandler('grab'));
-      this.graph.panningHandler.addListener(mxEvent.PAN_END, this.getPanningHandler('default'));
+      panningHandler.addListener(mxEvent.PAN_START, this.getPanningHandler('grab'));
+      panningHandler.addListener(mxEvent.PAN_END, this.getPanningHandler('default'));
+
+      this.graph.panningHandler.usePopupTrigger = false; // only use the left button to trigger panning
+      // Reimplement the function as we also want to trigger 'panning on cells' (ignoreCell to true) and only on left click
+      // The mxGraph standard implementation doesn't ignore right click in this case, so do it by ourself
+      panningHandler.isForcePanningEvent = (me): boolean => mxEvent.isLeftMouseButton(me.getEvent()) || mxEvent.isMultiTouchEvent(me.getEvent());
       this.graph.setPanning(true);
 
       // Zoom configuration
       this.graph.createMouseWheelZoomExperience(options.zoomConfiguration);
     } else {
       this.graph.setPanning(false);
-      this.graph.panningHandler.setPinchEnabled(false); // ensure gesture support is disabled (zoom only for now!)
+      // Disable gesture support for zoom
+      panningHandler.setPinchEnabled(false);
+      // Disable panning on touch device
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      panningHandler.isForcePanningEvent = (me: mxMouseEvent): boolean => false;
     }
   }
 


### PR DESCRIPTION
As mxgraph enable it by default on right click, some extra configuration is
needed.
We also want to trigger panning over cells, but in that case, mxgraph ignores by
default the mouse button which has been clicked. So custom mxgraph code is
needed here.

In addition, improve the panning support on touch device: disable panning when
no navigation support.

closes #768
covers #847