### PR TITLE
[REFACTOR] Remove mxgraph code related to error management

### DIFF
--- a/src/component/BpmnVisualization.ts
+++ b/src/component/BpmnVisualization.ts
@@ -14,16 +14,12 @@
  * limitations under the License.
  */
 import MxGraphConfigurator from './mxgraph/MxGraphConfigurator';
-import { mxgraph } from 'ts-mxgraph';
 import { defaultMxGraphRenderer } from './mxgraph/MxGraphRenderer';
 import { newBpmnParser } from './parser/BpmnParser';
 import { BpmnMxGraph } from './mxgraph/BpmnMxGraph';
 import { FitOptions, GlobalOptions, LoadOptions } from './options';
 import { BpmnElementsRegistry } from './registry';
 import { newBpmnElementsRegistry } from './registry/bpmn-elements-registry';
-
-// TODO unable to load mxClient from mxgraph-type-definitions@1.0.2
-declare const mxClient: typeof mxgraph.mxClient;
 
 export default class BpmnVisualization {
   public readonly graph: BpmnMxGraph;
@@ -33,20 +29,11 @@ export default class BpmnVisualization {
   readonly bpmnElementsRegistry: BpmnElementsRegistry;
 
   constructor(protected container: HTMLElement, options?: GlobalOptions) {
-    try {
-      if (!mxClient.isBrowserSupported()) {
-        mxUtils.error('Browser is not supported!', 200, false);
-      }
-      // Instantiate and configure mxgraph
-      const configurator = new MxGraphConfigurator(this.container);
-      this.graph = configurator.configure(options);
-
-      this.bpmnElementsRegistry = newBpmnElementsRegistry(this.graph);
-    } catch (e) {
-      // TODO error handling
-      mxUtils.alert('Cannot start application: ' + e.message);
-      throw e;
-    }
+    // mxgraph configuration
+    const configurator = new MxGraphConfigurator(this.container);
+    this.graph = configurator.configure(options);
+    // other configurations
+    this.bpmnElementsRegistry = newBpmnElementsRegistry(this.graph);
   }
 
   public load(xml: string, options?: LoadOptions): void {
@@ -55,7 +42,7 @@ export default class BpmnVisualization {
       defaultMxGraphRenderer(this.graph).render(bpmnModel, options);
     } catch (e) {
       // TODO error handling
-      mxUtils.alert('Cannot load bpmn diagram: ' + e.message);
+      window.alert(`Cannot load bpmn diagram: ${e.message}`);
       throw e;
     }
   }


### PR DESCRIPTION
Remove mxgraph browser support check
The implementation of `mxClient.isBrowserSupported())` always returns true as it
checks if the browser support svg or vml and all browser supported by the lib
support them.

No catch exception in the constructor
We previously already throw an Error, the alert was redundant. The calling code
must handle it anyway because no subsequent calls to bpmn-visualization function
will work

Don't use mxgraph code to create alert popup, which only calls `window.alert`

covers #54 