### PR TITLE
[INFRA] Remove extra node installation check step in GitHub workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,10 +50,6 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 12.x
-      - name: Verify node, npm version
-        run: |
-          node --version
-          npm --version
       - name: Install dependencies
         run: npm ci
       - name: Lint check

--- a/.github/workflows/upload-demo-archive.yml
+++ b/.github/workflows/upload-demo-archive.yml
@@ -35,10 +35,6 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 12.x
-      - name: Verify node, npm version
-        run: |
-          node --version
-          npm --version
       - name: Install dependencies
         run: npm ci
       - name: Build Demo


### PR DESCRIPTION
The setup-node action already displays the node and npm version in the logs, so
there is no need to have a dedicated step calling the version options of these
tools.