### PR TITLE
[INFRA] Fix release-drafter template

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -45,8 +45,8 @@ exclude-labels:
   - reverted
   - wontfix
 template: |
-  **TODO: add a short description about the release content - important for url preview **
-  This new release focuses on .... ** or something similar **
+  **TODO: add a short description about the release content - important for url preview**
+  This new release focuses on .... **or something similar**
 
 
   **TODO: review the contributors list (remove ALL bots and avoid duplicates)**


### PR DESCRIPTION
Remove the extra spaces that prevented from applying bold to certain phrases in the template.