### PR TITLE
[INFRA] Generate documentation on demand with GH workflows

### DIFF
--- a/.github/workflows/generate-documentation-api.yml
+++ b/.github/workflows/generate-documentation-api.yml
@@ -1,6 +1,7 @@
 name: Generate Documentation API
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master

--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -1,6 +1,7 @@
 name: Generate Documentation
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master


### PR DESCRIPTION
Let collaborators trigger generation with `workflow_dispatch`. This is useful
when the generated documentation is not in sync with the master branch.