### PR TITLE
[TEST] Generate visual test diff images close to test reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@
 /build/
 /dist/
 /node_modules/
-/test/e2e/__image_snapshots__/__diff_output__/
 /scripts/utils/dist/
 
 # npm build

--- a/src/component/mxgraph/MxGraphRenderer.ts
+++ b/src/component/mxgraph/MxGraphRenderer.ts
@@ -152,7 +152,8 @@ export default class MxGraphRenderer {
 
     if (labelBounds) {
       // label coordinates are relative in the cell referential coordinates
-      const relativeLabelX = labelBounds.x - bounds.x;
+      // TMP generate visualization errors
+      const relativeLabelX = labelBounds.x - bounds.x - 4;
       const relativeLabelY = labelBounds.y - bounds.y;
       cell.geometry.offset = new mxgraph.mxPoint(relativeLabelX, relativeLabelY);
     }

--- a/src/component/mxgraph/MxGraphRenderer.ts
+++ b/src/component/mxgraph/MxGraphRenderer.ts
@@ -152,8 +152,7 @@ export default class MxGraphRenderer {
 
     if (labelBounds) {
       // label coordinates are relative in the cell referential coordinates
-      // TMP generate visualization errors
-      const relativeLabelX = labelBounds.x - bounds.x - 4;
+      const relativeLabelX = labelBounds.x - bounds.x;
       const relativeLabelY = labelBounds.y - bounds.y;
       cell.geometry.offset = new mxgraph.mxPoint(relativeLabelX, relativeLabelY);
     }

--- a/src/component/mxgraph/MxGraphRenderer.ts
+++ b/src/component/mxgraph/MxGraphRenderer.ts
@@ -148,8 +148,7 @@ export default class MxGraphRenderer {
 
   private insertVertex(parent: mxCell, id: string | null, value: string, bounds: Bounds, labelBounds: Bounds, style?: string): mxCell {
     const vertexCoordinates = this.coordinatesTranslator.computeRelativeCoordinates(parent, new mxgraph.mxPoint(bounds.x, bounds.y));
-    // TMP generate visualization errors
-    const cell = this.graph.insertVertex(parent, id, value, vertexCoordinates.x + 2, vertexCoordinates.y, bounds.width, bounds.height, style);
+    const cell = this.graph.insertVertex(parent, id, value, vertexCoordinates.x, vertexCoordinates.y, bounds.width, bounds.height, style);
 
     if (labelBounds) {
       // label coordinates are relative in the cell referential coordinates

--- a/src/component/mxgraph/MxGraphRenderer.ts
+++ b/src/component/mxgraph/MxGraphRenderer.ts
@@ -148,7 +148,8 @@ export default class MxGraphRenderer {
 
   private insertVertex(parent: mxCell, id: string | null, value: string, bounds: Bounds, labelBounds: Bounds, style?: string): mxCell {
     const vertexCoordinates = this.coordinatesTranslator.computeRelativeCoordinates(parent, new mxgraph.mxPoint(bounds.x, bounds.y));
-    const cell = this.graph.insertVertex(parent, id, value, vertexCoordinates.x, vertexCoordinates.y, bounds.width, bounds.height, style);
+    // TMP generate visualization errors
+    const cell = this.graph.insertVertex(parent, id, value, vertexCoordinates.x + 2, vertexCoordinates.y, bounds.width, bounds.height, style);
 
     if (labelBounds) {
       // label coordinates are relative in the cell referential coordinates

--- a/test/e2e/helpers/visu/ImageSnapshotConfigurator.ts
+++ b/test/e2e/helpers/visu/ImageSnapshotConfigurator.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { dirname, join } from 'path';
+import { join } from 'path';
 import { MatchImageSnapshotOptions } from 'jest-image-snapshot';
 import { getSimplePlatformName, log } from '../test-utils';
 

--- a/test/e2e/helpers/visu/ImageSnapshotConfigurator.ts
+++ b/test/e2e/helpers/visu/ImageSnapshotConfigurator.ts
@@ -41,7 +41,6 @@ function getSnapshotsDir(): string {
 function getDiffDir(): string {
   const testDirName = dirname(expect.getState().testPath);
   // directory is relative to $ROOT/test/e2e
-  // TODO can we get the path from the jest configuration?
   return join(testDirName, '../../build/test-report/e2e/__diff_output__');
 }
 

--- a/test/e2e/helpers/visu/ImageSnapshotConfigurator.ts
+++ b/test/e2e/helpers/visu/ImageSnapshotConfigurator.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { MatchImageSnapshotOptions } from 'jest-image-snapshot';
 import { getSimplePlatformName, log } from '../test-utils';
 
@@ -34,6 +34,17 @@ const defaultImageSnapshotConfig: MatchImageSnapshotOptions = {
   failureThresholdType: 'percent',
 };
 
+function getSnapshotsDir(): string {
+  return join(dirname(expect.getState().testPath), '__image_snapshots__');
+}
+
+function getDiffDir(): string {
+  const testDirName = dirname(expect.getState().testPath);
+  // directory is relative to $ROOT/test/e2e
+  // TODO can we get the path from the jest configuration?
+  return join(testDirName, '../../build/test-report/e2e/__diff_output__');
+}
+
 export class ImageSnapshotConfigurator {
   protected readonly defaultCustomDiffDir: string;
   protected readonly defaultCustomSnapshotsDir: string;
@@ -48,10 +59,8 @@ export class ImageSnapshotConfigurator {
   // minimal threshold to make tests for diagram renders pass on local
   // macOS: Expected image to match or be a close match to snapshot but was 0.00031509446166699817% different from snapshot
   constructor(readonly thresholdConfig: Map<string, ImageSnapshotThresholdConfig>, snapshotsSubDirName: string, readonly defaultFailureThreshold = 0.000004) {
-    // directories are relative to $ROOT/test/e2e
-    this.defaultCustomSnapshotsDir = join('__image_snapshots__', snapshotsSubDirName);
-    // TODO can we get the path from the jest configuration?
-    this.defaultCustomDiffDir = join('../../build/test-report/e2e/__diff_output__', snapshotsSubDirName);
+    this.defaultCustomDiffDir = join(getDiffDir(), snapshotsSubDirName);
+    this.defaultCustomSnapshotsDir = join(getSnapshotsDir(), snapshotsSubDirName);
   }
 
   getConfig(param: string | { fileName: string }): MatchImageSnapshotOptions {

--- a/test/e2e/helpers/visu/ImageSnapshotConfigurator.ts
+++ b/test/e2e/helpers/visu/ImageSnapshotConfigurator.ts
@@ -34,16 +34,6 @@ const defaultImageSnapshotConfig: MatchImageSnapshotOptions = {
   failureThresholdType: 'percent',
 };
 
-function getSnapshotsDir(): string {
-  return join(dirname(expect.getState().testPath), '__image_snapshots__');
-}
-
-function getDiffDir(): string {
-  const testDirName = dirname(expect.getState().testPath);
-  // directory is relative to $ROOT/test/e2e
-  return join(testDirName, '../../build/test-report/e2e/__diff_output__');
-}
-
 export class ImageSnapshotConfigurator {
   protected readonly defaultCustomDiffDir: string;
   protected readonly defaultCustomSnapshotsDir: string;
@@ -58,8 +48,8 @@ export class ImageSnapshotConfigurator {
   // minimal threshold to make tests for diagram renders pass on local
   // macOS: Expected image to match or be a close match to snapshot but was 0.00031509446166699817% different from snapshot
   constructor(readonly thresholdConfig: Map<string, ImageSnapshotThresholdConfig>, snapshotsSubDirName: string, readonly defaultFailureThreshold = 0.000004) {
-    this.defaultCustomDiffDir = join(getDiffDir(), snapshotsSubDirName);
-    this.defaultCustomSnapshotsDir = join(getSnapshotsDir(), snapshotsSubDirName);
+    this.defaultCustomDiffDir = join(ImageSnapshotConfigurator.getDiffDir(), snapshotsSubDirName);
+    this.defaultCustomSnapshotsDir = join(ImageSnapshotConfigurator.getSnapshotsDir(), snapshotsSubDirName);
   }
 
   getConfig(param: string | { fileName: string }): MatchImageSnapshotOptions {
@@ -88,5 +78,15 @@ export class ImageSnapshotConfigurator {
     log(`ImageSnapshot - using failureThreshold: ${failureThreshold}`);
 
     return failureThreshold;
+  }
+
+  static getSnapshotsDir(): string {
+    return join(dirname(expect.getState().testPath), '__image_snapshots__');
+  }
+
+  static getDiffDir(): string {
+    const testDirName = dirname(expect.getState().testPath);
+    // directory is relative to $ROOT/test/e2e
+    return join(testDirName, '../../build/test-report/e2e/__diff_output__');
   }
 }

--- a/test/e2e/helpers/visu/ImageSnapshotConfigurator.ts
+++ b/test/e2e/helpers/visu/ImageSnapshotConfigurator.ts
@@ -26,8 +26,8 @@ export interface ImageSnapshotThresholdConfig {
 
 const defaultImageSnapshotConfig: MatchImageSnapshotOptions = {
   diffDirection: 'vertical',
-  // useful on CI (no need to retrieve the diff image, copy/paste image content from logs)
-  dumpDiffToConsole: true,
+  // locally and on CI, see diff images folder directly
+  dumpDiffToConsole: false,
   // use SSIM to limit false positive
   // https://github.com/americanexpress/jest-image-snapshot#recommendations-when-using-ssim-comparison
   comparisonMethod: 'ssim',
@@ -47,9 +47,11 @@ export class ImageSnapshotConfigurator {
    */
   // minimal threshold to make tests for diagram renders pass on local
   // macOS: Expected image to match or be a close match to snapshot but was 0.00031509446166699817% different from snapshot
-  constructor(readonly thresholdConfig: Map<string, ImageSnapshotThresholdConfig>, private customDirName: string, readonly defaultFailureThreshold = 0.000004) {
-    this.defaultCustomDiffDir = join(ImageSnapshotConfigurator.getDiffDir(), customDirName);
-    this.defaultCustomSnapshotsDir = join(ImageSnapshotConfigurator.getSnapshotsDir(), customDirName);
+  constructor(readonly thresholdConfig: Map<string, ImageSnapshotThresholdConfig>, snapshotsSubDirName: string, readonly defaultFailureThreshold = 0.000004) {
+    // directories are relative to $ROOT/test/e2e
+    this.defaultCustomSnapshotsDir = join('__image_snapshots__', snapshotsSubDirName);
+    // TODO can we get the path from the jest configuration?
+    this.defaultCustomDiffDir = join('../../build/test-report/e2e/__diff_output__', snapshotsSubDirName);
   }
 
   getConfig(param: string | { fileName: string }): MatchImageSnapshotOptions {
@@ -78,13 +80,5 @@ export class ImageSnapshotConfigurator {
     log(`ImageSnapshot - using failureThreshold: ${failureThreshold}`);
 
     return failureThreshold;
-  }
-
-  static getSnapshotsDir(): string {
-    return join(dirname(expect.getState().testPath), '__image_snapshots__');
-  }
-
-  static getDiffDir(): string {
-    return join(ImageSnapshotConfigurator.getSnapshotsDir(), '__diff_output__');
   }
 }


### PR DESCRIPTION
This simplifies test failures review, especially when checking GitHub workflows.
The html test report and the diff images are in the same directory.

The GitHub workflow also upload diff images in the test failures artifact without
extra configuration and there is no more need to dump the diff to the console. So we
also produce smaller and more manageable logs.