### PR TITLE
[INFRA] Add missing dependency for jest-puppeteer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3655,6 +3655,16 @@
       "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
       "dev": true
     },
+    "@types/expect-puppeteer": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/@types/expect-puppeteer/-/expect-puppeteer-4.4.5.tgz",
+      "integrity": "sha512-vxPaumA8Fj6xlm3llKCR9V8L936HX4PyipaNMxDbWQIOWZoCl99jabD/6xuxXnCptOWUdUhXwDuX5cAJgCHsLg==",
+      "dev": true,
+      "requires": {
+        "@types/jest": "*",
+        "@types/puppeteer": "*"
+      }
+    },
     "@types/fs-extra": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "@rollup/plugin-node-resolve": "^11.1.1",
     "@typed-mxgraph/typed-mxgraph": "^1.0.0-2",
     "@types/debug": "^4.1.5",
+    "@types/expect-puppeteer": "^4.4.5",
     "@types/jest": "^26.0.20",
     "@types/jest-environment-puppeteer": "^4.3.2",
     "@types/jest-image-snapshot": "^4.1.3",


### PR DESCRIPTION
Following [Jest-puppeteer](https://github.com/smooth-code/jest-puppeteer) readme, `@types/expect-puppeteer` is missing. 