### PR TITLE
[REFACTOR] Don't catch and only log warnings in the Json Parser

### DIFF
--- a/src/component/parser/BpmnParser.ts
+++ b/src/component/parser/BpmnParser.ts
@@ -21,6 +21,7 @@ class BpmnParser {
   constructor(readonly jsonParser: BpmnJsonParser, readonly xmlParser: BpmnXmlParser) {}
 
   parse(bpmnAsXml: string): BpmnModel {
+    // TODO decide how to manage parsing errors as part of #35
     const json = this.xmlParser.parse(bpmnAsXml);
     return this.jsonParser.parse(json);
   }

--- a/src/component/parser/json/converter/CollaborationConverter.ts
+++ b/src/component/parser/json/converter/CollaborationConverter.ts
@@ -25,12 +25,7 @@ export default class CollaborationConverter {
   constructor(readonly convertedElements: ConvertedElements) {}
 
   deserialize(collaborations: string | TCollaboration | (string | TCollaboration)[]): void {
-    try {
-      ensureIsArray(collaborations).forEach(collaboration => this.parseCollaboration(collaboration));
-    } catch (e) {
-      // TODO error management
-      console.error(e as Error);
-    }
+    ensureIsArray(collaborations).forEach(collaboration => this.parseCollaboration(collaboration));
   }
 
   private parseCollaboration(collaboration: TCollaboration): void {

--- a/src/component/parser/json/converter/DiagramConverter.ts
+++ b/src/component/parser/json/converter/DiagramConverter.ts
@@ -41,22 +41,17 @@ export default class DiagramConverter {
 
     const bpmnDiagram = ensureIsArray(bpmnDiagrams)[0];
     if (bpmnDiagram) {
-      try {
-        // Need to be done before deserialization of Shape and Edge, to link the converted fonts to them
-        this.deserializeFonts(bpmnDiagram.BPMNLabelStyle);
+      // Need to be done before deserialization of Shape and Edge, to link the converted fonts to them
+      this.deserializeFonts(bpmnDiagram.BPMNLabelStyle);
 
-        const plane = bpmnDiagram.BPMNPlane;
-        const convertedEdges = this.deserializeEdges(plane.BPMNEdge);
-        const convertedShapes = this.deserializeShapes(plane.BPMNShape);
+      const plane = bpmnDiagram.BPMNPlane;
+      const convertedEdges = this.deserializeEdges(plane.BPMNEdge);
+      const convertedShapes = this.deserializeShapes(plane.BPMNShape);
 
-        flowNodes.push(...convertedShapes.flowNodes);
-        lanes.push(...convertedShapes.lanes);
-        pools.push(...convertedShapes.pools);
-        edges.push(...convertedEdges);
-      } catch (e) {
-        // TODO error management
-        console.error(e as Error);
-      }
+      flowNodes.push(...convertedShapes.flowNodes);
+      lanes.push(...convertedShapes.lanes);
+      pools.push(...convertedShapes.pools);
+      edges.push(...convertedEdges);
     }
     return { flowNodes, lanes, pools, edges };
   }
@@ -100,7 +95,7 @@ export default class DiagramConverter {
         continue;
       }
 
-      // TODO error management
+      // TODO decide how to manage elements not found during parsing as part of #35
       console.warn('Shape json deserialization: unable to find bpmn element with id %s', shape.bpmnElement);
     }
 
@@ -149,7 +144,7 @@ export default class DiagramConverter {
           this.convertedElements.findAssociationFlow(edge.bpmnElement);
 
         if (!flow) {
-          // TODO error management
+          // TODO decide how to manage elements not found during parsing as part of #35
           console.warn('Edge json deserialization: unable to find bpmn element with id %s', edge.bpmnElement);
           return;
         }
@@ -186,7 +181,7 @@ export default class DiagramConverter {
       font = this.convertedFonts.get(labelStyle);
 
       if (!font) {
-        // TODO error management
+        // TODO decide how to manage elements not found during parsing as part of #35
         console.warn('Unable to assign font from style %s to shape/edge %s', labelStyle, id);
       }
     }

--- a/src/component/parser/json/converter/EventDefinitionConverter.ts
+++ b/src/component/parser/json/converter/EventDefinitionConverter.ts
@@ -23,17 +23,12 @@ export default class EventDefinitionConverter {
   constructor(readonly convertedElements: ConvertedElements) {}
 
   deserialize(definitions: TDefinitions): void {
-    try {
-      bpmnEventKinds.forEach(eventKind => {
-        // sometimes eventDefinition is simple and therefore it is parsed as empty string "", in that case eventDefinition will be converted to an empty object
-        const eventDefinitions: string | TEventDefinition | (string | TEventDefinition)[] = definitions[eventKind + 'EventDefinition'];
-        ensureIsArray<TEventDefinition>(eventDefinitions, true).forEach(eventDefinition => {
-          this.convertedElements.registerEventDefinitionsOfDefinitions(eventDefinition.id, eventKind);
-        });
+    bpmnEventKinds.forEach(eventKind => {
+      // sometimes eventDefinition is simple and therefore it is parsed as empty string "", in that case eventDefinition will be converted to an empty object
+      const eventDefinitions: string | TEventDefinition | (string | TEventDefinition)[] = definitions[eventKind + 'EventDefinition'];
+      ensureIsArray<TEventDefinition>(eventDefinitions, true).forEach(eventDefinition => {
+        this.convertedElements.registerEventDefinitionsOfDefinitions(eventDefinition.id, eventKind);
       });
-    } catch (e) {
-      // TODO error management
-      console.error(e as Error);
-    }
+    });
   }
 }

--- a/src/component/parser/json/converter/GlobalTaskConverter.ts
+++ b/src/component/parser/json/converter/GlobalTaskConverter.ts
@@ -22,16 +22,11 @@ export default class GlobalTaskConverter {
   constructor(readonly convertedElements: ConvertedElements) {}
 
   deserialize(definitions: TDefinitions): void {
-    try {
-      this.parseGlobalTasks(definitions.globalTask);
-      this.parseGlobalTasks(definitions.globalBusinessRuleTask);
-      this.parseGlobalTasks(definitions.globalManualTask);
-      this.parseGlobalTasks(definitions.globalScriptTask);
-      this.parseGlobalTasks(definitions.globalUserTask);
-    } catch (e) {
-      // TODO error management
-      console.error(e as Error);
-    }
+    this.parseGlobalTasks(definitions.globalTask);
+    this.parseGlobalTasks(definitions.globalBusinessRuleTask);
+    this.parseGlobalTasks(definitions.globalManualTask);
+    this.parseGlobalTasks(definitions.globalScriptTask);
+    this.parseGlobalTasks(definitions.globalUserTask);
   }
 
   private parseGlobalTasks<T extends TGlobalTask>(globalTasks: T | T[]): void {

--- a/src/component/parser/json/converter/ProcessConverter.ts
+++ b/src/component/parser/json/converter/ProcessConverter.ts
@@ -62,12 +62,7 @@ export default class ProcessConverter {
   constructor(readonly convertedElements: ConvertedElements) {}
 
   deserialize(processes: string | TProcess | (string | TProcess)[]): void {
-    try {
-      ensureIsArray(processes).forEach(process => this.parseProcess(process));
-    } catch (e) {
-      // TODO error management
-      console.error(e as Error);
-    }
+    ensureIsArray(processes).forEach(process => this.parseProcess(process));
   }
 
   private parseProcess(process: TProcess): void {
@@ -192,7 +187,7 @@ export default class ProcessConverter {
     if (ShapeUtil.isActivity(parent?.kind)) {
       return new ShapeBpmnBoundaryEvent(bpmnElement.id, bpmnElement.name, eventKind, bpmnElement.attachedToRef, bpmnElement.cancelActivity);
     } else {
-      // TODO error management
+      // TODO decide how to manage elements not found during parsing as part of #35
       console.warn('The boundary event %s must be attach to an activity, and not to %s', bpmnElement.id, parent?.kind);
     }
   }
@@ -263,7 +258,7 @@ export default class ProcessConverter {
           shapeBpmnElement.parentId = laneId;
         }
       } else {
-        // TODO error management
+        // TODO decide how to manage elements not found during parsing as part of #35
         console.warn('Unable to assign lane %s as parent: flow node %s is not found', laneId, flowNodeRef);
       }
     });


### PR DESCRIPTION
Catching errors and only log them hide parsing problems and generate new ones.
The parsing flow continues after an error is triggered which create side
effects: some valid data are missing and then are not available for the
subsequent parsing process. In that case, the model would be partially filled.
It is so better to propagate the error as it is not managed for now.

In addition, we don't have tests that show we can have such errors so we are not
even sure that such errors could occur.

