### PR TITLE
[TEST] Add more DOM integration tests

### DIFF
--- a/test/integration/dom.interactions.test.ts
+++ b/test/integration/dom.interactions.test.ts
@@ -40,6 +40,17 @@ describe('DOM only checks', () => {
     htmlElementLookup.expectTask('Activity_1');
     htmlElementLookup.expectEndEvent('EndEvent_1');
   });
+
+  it('DOM should contains BPMN elements when loading model-complete-semantic.bpmn', async () => {
+    bpmnVisualization.load(readFileSync('../fixtures/bpmn/model-complete-semantic.bpmn'));
+
+    const htmlElementLookup = new HtmlElementLookup(bpmnVisualization);
+    htmlElementLookup.expectPool('participant_1_id');
+    htmlElementLookup.expectLane('lane_4_1_id');
+
+    htmlElementLookup.expectStartEvent('start_event_signal_id');
+    htmlElementLookup.expectIntermediateThrowEvent('intermediate_throw_event_message_id');
+  });
 });
 
 function expectStartEventBpmnElement(bpmnElement: BpmnElement, expected: ExpectedBaseBpmnElement): void {

--- a/test/integration/helpers/html-utils.ts
+++ b/test/integration/helpers/html-utils.ts
@@ -34,6 +34,12 @@ export class HtmlElementLookup {
     expectSvgElementClassAttribute(svgGroupElement, 'bpmn-start-event');
   }
 
+  expectIntermediateThrowEvent(bpmnId: string): void {
+    const svgGroupElement = this.findSvgElement(bpmnId);
+    expectSvgEvent(svgGroupElement);
+    expectSvgElementClassAttribute(svgGroupElement, 'bpmn-intermediate-throw-event');
+  }
+
   expectEndEvent(bpmnId: string, additionalClasses?: string[]): void {
     const svgGroupElement = this.findSvgElement(bpmnId);
     expectSvgEvent(svgGroupElement);
@@ -62,6 +68,12 @@ export class HtmlElementLookup {
     const svgGroupElement = this.findSvgElement(bpmnId);
     expectSvgLane(svgGroupElement);
     expectSvgElementClassAttribute(svgGroupElement, HtmlElementLookup.computeClassValue('bpmn-lane', additionalClasses));
+  }
+
+  expectPool(bpmnId: string): void {
+    const svgGroupElement = this.findSvgElement(bpmnId);
+    expectSvgPool(svgGroupElement);
+    expectSvgElementClassAttribute(svgGroupElement, 'bpmn-pool');
   }
 
   expectExclusiveGateway(bpmnId: string, additionalClasses?: string[]): void {


### PR DESCRIPTION
We load a file with all supported BPMN elements to ensure we don't have any
issue when producing the SVG.
The code coverage increases significantly as we now pass in all custom `mxGraph`
shapes when running the new tests. For instance, the integration tests coverage
for statements increases from `68.45%` to `93.04%`.