### PR TITLE
[POC]  overlays - use mxCell + listeners 

### DIFF
--- a/src/component/BpmnVisualization.ts
+++ b/src/component/BpmnVisualization.ts
@@ -23,6 +23,7 @@ import { BpmnElementsRegistry } from './registry';
 import { newBpmnElementsRegistry } from './registry/bpmn-elements-registry';
 import { BpmnModelRegistry } from './registry/bpmn-model-registry';
 import { htmlElement } from './helpers/dom-utils';
+import { mxgraph } from './mxgraph/initializer';
 
 /**
  * @category Initialization
@@ -43,6 +44,19 @@ export default class BpmnVisualization {
     // other configurations
     this.bpmnModelRegistry = new BpmnModelRegistry();
     this.bpmnElementsRegistry = newBpmnElementsRegistry(this.bpmnModelRegistry, this.graph);
+    // TODO: this will handle event on the graph level - further filtering will be needed
+    // this.addEvents();
+  }
+
+  addEvents() {
+    this.graph.addListener(mxgraph.mxEvent.CLICK, function (sender, evt) {
+      const cell = evt.getProperty('cell'); // cell may be null
+      // eslint-disable-next-line no-console
+      console.log('EVENT FROM MODEL', sender, evt, cell);
+      // if (cell != null) {
+      // }
+      //evt.consume();
+    });
   }
 
   public load(xml: string, options?: LoadOptions): void {

--- a/src/component/mxgraph/MxGraphCellUpdater.ts
+++ b/src/component/mxgraph/MxGraphCellUpdater.ts
@@ -20,6 +20,8 @@ import { Overlay } from '../registry';
 import { MxGraphCustomOverlay } from './overlay/custom-overlay';
 import { ensureIsArray } from '../helpers/array-utils';
 import { OverlayConverter } from './overlay/OverlayConverter';
+import { mxCell, mxGeometry } from 'mxgraph';
+import { mxgraph } from './initializer'; // for types
 
 export function newMxGraphCellUpdater(graph: BpmnMxGraph): MxGraphCellUpdater {
   return new MxGraphCellUpdater(graph, new OverlayConverter());
@@ -49,8 +51,54 @@ export default class MxGraphCellUpdater {
       return;
     }
     ensureIsArray(overlays).forEach(overlay => {
-      const bpmnOverlay = new MxGraphCustomOverlay(overlay.label, this.overlayConverter.convert(overlay));
-      this.graph.addCellOverlay(mxCell, bpmnOverlay);
+      // const bpmnOverlay = new MxGraphCustomOverlay(overlay.label, this.overlayConverter.convert(overlay));
+      // this.graph.addCellOverlay(mxCell, bpmnOverlay);
+      this.addVertexOverlay(mxCell, overlay);
+    });
+  }
+
+  private addVertexOverlay(mxCell: mxCell, overlay: Overlay): void {
+    if (mxCell['vertexOverlays'] && mxCell['vertexOverlays'].length) {
+      mxCell['vertexOverlays'].push(overlay);
+    } else {
+      mxCell['vertexOverlays'] = [overlay];
+    }
+
+    let vertex: mxCell;
+    const model = this.graph.getModel();
+    model.beginUpdate();
+    try {
+      // Creates the geometry for the vertex
+      const geometry = new mxgraph.mxGeometry(1, 1, 20, 14);
+      geometry.relative = true;
+      geometry.offset = new mxgraph.mxPoint(-10, -7);
+
+      // Creates the vertex
+      // const vertex = new mxgraph.mxCell(overlay.label, geometry, 'cursor-pointer');
+      vertex = new CellWithListeners(overlay.label, geometry, 'cursor-pointer');
+      vertex.setId(`vertexOverlay_${mxCell.id}_${overlay.label}`);
+      vertex.setVertex(true);
+      vertex.setConnectable(true);
+      this.graph.addCell(vertex, mxCell);
+    } finally {
+      model.endUpdate();
+    }
+    const graphInstance = this.graph;
+    const view = this.graph.getView();
+    const state = view.getState(vertex);
+
+    // TODO: finally not needed if we do not plan to interfere with the internal mxGraph events
+    // vertex.addListener(mxgraph.mxEvent.CLICK, () => {
+    //   do something eventually
+    // });
+    mxgraph.mxEvent.addListener(state.shape.node, 'click', function (evt: Event) {
+      // eslint-disable-next-line no-console
+      console.log('EVENT FIRED FROM vertex - mxgraph.mxEvent.addListener');
+      // if (graphInstance.isEditing()) {
+      //   graphInstance.stopEditing(!graphInstance.isInvokesStopCellEditing());
+      // }
+      // TODO: finally not needed if we do not plan to interfere with the internal mxGraph events
+      //vertex.fireEvent(new mxgraph.mxEventObject(mxgraph.mxEvent.CLICK, 'event', evt, 'cell', vertex));
     });
   }
 
@@ -60,5 +108,20 @@ export default class MxGraphCellUpdater {
       return;
     }
     this.graph.removeCellOverlays(mxCell);
+  }
+}
+
+class CellWithListeners extends mxgraph.mxCell {
+  constructor(value?: any, geometry?: mxGeometry, style?: string) {
+    super(value, geometry, style);
+    // TODO: finally not needed if we do not plan to interfere with the internal mxGraph events
+    //
+    // // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // // @ts-ignore
+    // for (const prop: any in mxgraph.mxEventSource.prototype) {
+    //   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    //   // @ts-ignore
+    //   this[prop] = mxgraph.mxEventSource.prototype[prop];
+    // }
   }
 }


### PR DESCRIPTION
- [x] the creation of overlay is rather straight forward

the complexity comes out with listeners:
- [x] add a listener to a node of the shape associated to created mxCell (the overlay)
⚠️ the problem with that is that label is overlapping the area where the listener is attached (a very small space actually can react with events)
⚠️ changing the dialect of label to svg does NOT change anything
