### PR TITLE
[POC] Manage both overlays shape and text

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -121,7 +121,8 @@ export default rollupConfigs;
 
 function typescriptPlugin() {
   const tsDeclarationFiles = !demoMode || buildBundles;
-  const tsconfigOverride = { compilerOptions: { declaration: tsDeclarationFiles } };
+  const tsSourceMap = !demoMode && !buildBundles; // TODO logic duplicated with build selection
+  const tsconfigOverride = { compilerOptions: { sourceMap: tsSourceMap, declaration: tsDeclarationFiles } };
   return typescript({
     typescript: require('typescript'),
     tsconfigOverride: tsconfigOverride,

--- a/src/component/mxgraph/config/ShapeConfigurator.ts
+++ b/src/component/mxgraph/config/ShapeConfigurator.ts
@@ -46,6 +46,7 @@ export default class ShapeConfigurator {
     this.initMxShapePrototype();
     this.registerShapes();
     this.initMxCellRendererCreateCellOverlays();
+    this.mxSvgCanvas2DForOverlays();
   }
 
   private registerShapes(): void {
@@ -184,5 +185,299 @@ export default class ShapeConfigurator {
 
       state.overlays = dict;
     };
+  }
+
+
+  /**
+   * The adjustment here is done to have equal paddings in overlays (badges)
+   * without this adjustment the right and bottom spacing appears not equal to left and top spacing
+   */
+  private mxSvgCanvas2DForOverlays() {
+    console.info('#### Custom configuration mxSvgCanvas2DForOverlays');
+
+    // TODO here we could have a smaller dedicated implementation for overlays
+    // delegate to original function otherwise
+    mxgraph.mxSvgCanvas2D.prototype.plainText = function(x, y, w, h, str, align, valign, wrap, overflow, clip, rotation, dir): void
+    {
+      // @ts-ignore
+      this.rotation = (rotation != null) ? rotation : 0;
+      var s = this.state;
+      var size = s.fontSize;
+      var node = this.createElement('g');
+      // @ts-ignore
+      var tr = s.transform || '';
+      this.updateFont(node);
+
+      // Ignores pointer events
+      // @ts-ignore
+      if (!this.pointerEvents && this.originalRoot == null)
+      {
+        node.setAttribute('pointer-events', 'none');
+      }
+
+      // Non-rotated text
+      if (rotation != 0)
+      {
+        // @ts-ignore
+        tr += 'rotate(' + rotation  + ',' + this.format(x * s.scale) + ',' + this.format(y * s.scale) + ')';
+      }
+
+      if (dir != null)
+      {
+        node.setAttribute('direction', dir);
+      }
+
+      // no clip support in bpmn-visualization
+      // if (clip && w > 0 && h > 0)
+      // {
+      //   var cx = x;
+      //   var cy = y;
+      //
+      //   if (align == mxConstants.ALIGN_CENTER)
+      //   {
+      //     cx -= w / 2;
+      //   }
+      //   else if (align == mxConstants.ALIGN_RIGHT)
+      //   {
+      //     cx -= w;
+      //   }
+      //
+      //   if (overflow != 'fill')
+      //   {
+      //     if (valign == mxConstants.ALIGN_MIDDLE)
+      //     {
+      //       cy -= h / 2;
+      //     }
+      //     else if (valign == mxConstants.ALIGN_BOTTOM)
+      //     {
+      //       cy -= h;
+      //     }
+      //   }
+      //
+      //   // LATER: Remove spacing from clip rectangle
+      //   var c = this.createClip(cx * s.scale - 2, cy * s.scale - 2, w * s.scale + 4, h * s.scale + 4);
+      //
+      //   if (this.defs != null)
+      //   {
+      //     this.defs.appendChild(c);
+      //   }
+      //   else
+      //   {
+      //     // Makes sure clip is removed with referencing node
+      //     this.root.appendChild(c);
+      //   }
+      //
+      //   if (!mxClient.IS_CHROMEAPP && !mxClient.IS_IE && !mxClient.IS_IE11 &&
+      //     !mxClient.IS_EDGE && this.root.ownerDocument == document)
+      //   {
+      //     // Workaround for potential base tag
+      //     var base = this.getBaseUrl().replace(/([\(\)])/g, '\\$1');
+      //     node.setAttribute('clip-path', 'url(' + base + '#' + c.getAttribute('id') + ')');
+      //   }
+      //   else
+      //   {
+      //     node.setAttribute('clip-path', 'url(#' + c.getAttribute('id') + ')');
+      //   }
+      // }
+
+      // Default is left
+      var anchor = (align == mxgraph.mxConstants.ALIGN_RIGHT) ? 'end' :
+        (align == mxgraph.mxConstants.ALIGN_CENTER) ? 'middle' :
+          'start';
+
+      // Text-anchor start is default in SVG
+      if (anchor != 'start')
+      {
+        node.setAttribute('text-anchor', anchor);
+      }
+
+      if (!this.styleEnabled || size != mxgraph.mxConstants.DEFAULT_FONTSIZE)
+      {
+        node.setAttribute('font-size', (size * s.scale) + 'px');
+      }
+
+      if (tr.length > 0)
+      {
+        node.setAttribute('transform', tr);
+      }
+
+      if (s.alpha < 1)
+      {
+        node.setAttribute('opacity', `${s.alpha}`);
+      }
+
+      var lines = str.split('\n');
+      var lh = Math.round(size * mxgraph.mxConstants.LINE_HEIGHT);
+      // START bpmn-visualization CUSTOMIZATION
+      // const isOverlayBadge = (<SVGGElement>node.parentNode).classList.contains('overlay-badge');
+      const isOverlayBadge = (this.root).classList.contains('overlay-badge');
+      console.info('@@@@custom canvas plainText - isOverlayBadge', isOverlayBadge);
+      const textHeight = isOverlayBadge ? lines.length * lh: size + (lines.length - 1) * lh;
+      // var textHeight = size + (lines.length - 1) * lh;
+      // END bpmn-visualization CUSTOMIZATION
+
+      var cy = y + size - 1;
+
+      if (valign == mxgraph.mxConstants.ALIGN_MIDDLE)
+      {
+        if (overflow == 'fill')
+        {
+          cy -= h / 2;
+        }
+        else
+        {
+          var dy = ((this.matchHtmlAlignment && clip && h > 0) ? Math.min(textHeight, h) : textHeight) / 2;
+          cy -= dy;
+        }
+      }
+      else if (valign == mxgraph.mxConstants.ALIGN_BOTTOM)
+      {
+        if (overflow == 'fill')
+        {
+          cy -= h;
+        }
+        else
+        {
+          var dy = (this.matchHtmlAlignment && clip && h > 0) ? Math.min(textHeight, h) : textHeight;
+          cy -= dy + 1;
+        }
+      }
+
+      for (var i = 0; i < lines.length; i++)
+      {
+        // Workaround for bounding box of empty lines and spaces
+        if (lines[i].length > 0 && mxgraph.mxUtils.trim(lines[i], '\\s').length > 0)
+        {
+          var text = this.createElement('text');
+          // LATER: Match horizontal HTML alignment
+          // TODO wrong signature in typed-mxgraph for canvas format method
+          // @ts-ignore
+          text.setAttribute('x', this.format(x * s.scale) + this.textOffset);
+          // @ts-ignore
+          text.setAttribute('y', this.format(cy * s.scale) + this.textOffset);
+
+          mxgraph.mxUtils.write(text, lines[i]);
+          node.appendChild(text);
+        }
+
+        cy += lh;
+      }
+
+      this.root.appendChild(node);
+      this.addTextBackground(node, str, x, y, w, (overflow == 'fill') ? h : textHeight, align, valign, overflow);
+    };
+
+
+
+
+
+    // mxgraph.mxSvgCanvas2D.prototype.addTextBackground = function(node, str, x, y, w, h, align, valign, overflow) {
+    //   console.log(arguments);
+    //   const s = this.state;
+    //
+    //   if (s.fontBackgroundColor != null || s.fontBorderColor != null) {
+    //     var bbox = null;
+    //
+    //     if (overflow == 'fill' || overflow == 'width') {
+    //       if (align == mxgraph.mxConstants.ALIGN_CENTER) {
+    //         x -= w / 2;
+    //       } else if (align == mxgraph.mxConstants.ALIGN_RIGHT) {
+    //         x -= w;
+    //       }
+    //
+    //       if (valign == mxgraph.mxConstants.ALIGN_MIDDLE) {
+    //         y -= h / 2;
+    //       } else if (valign == mxgraph.mxConstants.ALIGN_BOTTOM) {
+    //         y -= h;
+    //       }
+    //
+    //       bbox = new mxgraph.mxRectangle((x + 1) * s.scale, y * s.scale, (w - 2) * s.scale, (h + 2) * s.scale);
+    //       // @ts-ignore
+    //     } else if (node.getBBox != null && this.root.ownerDocument == document) {
+    //       // Uses getBBox only if inside document for correct size
+    //       try {
+    //         // @ts-ignore
+    //         bbox = node.getBBox();
+    //         const ie = mxgraph.mxClient.IS_IE && mxgraph.mxClient.IS_SVG;
+    //         bbox = new mxgraph.mxRectangle(bbox.x, bbox.y + ((ie) ? 0 : 1), bbox.width, bbox.height + ((ie) ? 1 : 0));
+    //       } catch (e) {
+    //         // Ignores NS_ERROR_FAILURE in FF if container display is none.
+    //       }
+    //     } else {
+    //       // Computes size if not in document or no getBBox available
+    //       const div = document.createElement('div');
+    //
+    //       // Wrapping and clipping can be ignored here
+    //       div.style.lineHeight = (mxgraph.mxConstants.ABSOLUTE_LINE_HEIGHT) ? (s.fontSize * mxgraph.mxConstants.LINE_HEIGHT) + 'px' : mxgraph.mxConstants.LINE_HEIGHT + 'px';
+    //       div.style.fontSize = s.fontSize + 'px';
+    //       div.style.fontFamily = s.fontFamily;
+    //       div.style.whiteSpace = 'nowrap';
+    //       div.style.position = 'absolute';
+    //       div.style.visibility = 'hidden';
+    //       div.style.display = (mxgraph.mxClient.IS_QUIRKS) ? 'inline' : 'inline-block';
+    //       div.style.zoom = '1';
+    //
+    //       if ((s.fontStyle & mxgraph.mxConstants.FONT_BOLD) == mxgraph.mxConstants.FONT_BOLD) {
+    //         div.style.fontWeight = 'bold';
+    //       }
+    //
+    //       if ((s.fontStyle & mxgraph.mxConstants.FONT_ITALIC) == mxgraph.mxConstants.FONT_ITALIC) {
+    //         div.style.fontStyle = 'italic';
+    //       }
+    //
+    //       // @ts-ignore
+    //       str = mxgraph.mxUtils.htmlEntities(str, false);
+    //       div.innerHTML = str.replace(/\n/g, '<br/>');
+    //
+    //       document.body.appendChild(div);
+    //       const w = div.offsetWidth;
+    //       const h = div.offsetHeight;
+    //       div.parentNode.removeChild(div);
+    //
+    //       if (align == mxgraph.mxConstants.ALIGN_CENTER) {
+    //         x -= w / 2;
+    //       } else if (align == mxgraph.mxConstants.ALIGN_RIGHT) {
+    //         x -= w;
+    //       }
+    //
+    //       if (valign == mxgraph.mxConstants.ALIGN_MIDDLE) {
+    //         y -= h / 2;
+    //       } else if (valign == mxgraph.mxConstants.ALIGN_BOTTOM) {
+    //         y -= h;
+    //       }
+    //
+    //       bbox = new mxgraph.mxRectangle((x + 1) * s.scale, (y + 2) * s.scale, w * s.scale, (h + 1) * s.scale);
+    //     }
+    //
+    //     if (bbox != null) {
+    //       const n = this.createElement('rect');
+    //       n.setAttribute('fill', s.fontBackgroundColor || 'none');
+    //       n.setAttribute('stroke', s.fontBorderColor || 'none');
+    //       n.setAttribute('x', String(Math.floor(bbox.x - 1)));
+    //       n.setAttribute('y', String(Math.floor(bbox.y - 1)));
+    //
+    //       // START bpmn-visualization CUSTOMIZATION
+    //       // Adjust the padding for badges only
+    //       if((<SVGGElement>node.parentNode).classList.contains('overlay-badge')) {
+    //         n.setAttribute('width', String(Math.ceil(bbox.width + 2 + s.scale)));
+    //         n.setAttribute('height', String(Math.ceil(bbox.height + 1)));
+    //       } else {
+    //         n.setAttribute('width', String(Math.ceil(bbox.width + 2)));
+    //         n.setAttribute('height', String(Math.ceil(bbox.height)));
+    //       }
+    //       // END bpmn-visualization CUSTOMIZATION
+    //
+    //       const sw = (s.fontBorderColor != null) ? Math.max(1, this.format(String(s.scale))) : 0;
+    //       n.setAttribute('stroke-width', String(sw));
+    //
+    //       // Workaround for crisp rendering - only required if not exporting
+    //       if (this.root.ownerDocument == document && mxgraph.mxUtils.mod(sw, 2) == 1) {
+    //         n.setAttribute('transform', 'translate(0.5, 0.5)');
+    //       }
+    //
+    //       node.insertBefore(n, node.firstChild);
+    //     }
+    //   }
+    // };
   }
 }

--- a/src/component/mxgraph/config/ShapeConfigurator.ts
+++ b/src/component/mxgraph/config/ShapeConfigurator.ts
@@ -350,7 +350,7 @@ export default class ShapeConfigurator {
         {
           var text = this.createElement('text');
           // LATER: Match horizontal HTML alignment
-          // TODO wrong signature in typed-mxgraph for canvas format method
+          // TODO wrong signature in typed-mxgraph for canvas format method (should be a number parameter)
           // @ts-ignore
           text.setAttribute('x', this.format(x * s.scale) + this.textOffset);
           // @ts-ignore

--- a/src/component/mxgraph/overlay/shapes.ts
+++ b/src/component/mxgraph/overlay/shapes.ts
@@ -132,12 +132,12 @@ export class OverlayBadgeShape extends mxgraph.mxText {
 
     // c.rect(Math.floor(textBbox.x - 1), Math.floor(textBbox.y - 1), Math.ceil(textBbox.width + 2), Math.ceil(textBbox.height));
     // c.rect(textBbox.x - 1, textBbox.y - 1, textBbox.width, textBbox.height - 4);
-    // c.rect(textBbox.x, textBbox.y, textBbox.width, textBbox.height);
-    // c.fillAndStroke();
+    c.rect(textBbox.x, textBbox.y, textBbox.width, textBbox.height);
+    c.fillAndStroke();
 
     // ellipse
-    c.ellipse(textBbox.x, textBbox.y, textBbox.width, textBbox.height);
-    c.fillAndStroke();
+    // c.ellipse(textBbox.x, textBbox.y, textBbox.width, textBbox.height);
+    // c.fillAndStroke();
 
     // circle
     // const circleWidth = Math.max(textBbox.width, textBbox.height);

--- a/src/component/mxgraph/overlay/shapes.ts
+++ b/src/component/mxgraph/overlay/shapes.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { mxgraph } from '../initializer';
-import { mxRectangle } from 'mxgraph';
+import { mxCellState, mxRectangle } from 'mxgraph';
 import { MxGraphCustomOverlayStyle } from './custom-overlay';
 
 export class OverlayBadgeShape extends mxgraph.mxText {
@@ -44,5 +44,20 @@ export class OverlayBadgeShape extends mxgraph.mxText {
     );
     this.fillOpacity = style.fill.opacity;
     this.strokewidth = style.stroke.width;
+
+    this.opacity = 40;
+
+    // const old = this.spacing;
+    //this.spacing = parseInt(mxUtils.getValue(this.style, mxConstants.STYLE_SPACING, this.spacing));
+    this.spacingTop = 12; //(this.spacingTop - old)) + this.spacing;
+    // this.spacingRight = parseInt(mxUtils.getValue(this.style, mxConstants.STYLE_SPACING_RIGHT, this.spacingRight - old)) + this.spacing;
+    // this.spacingBottom = parseInt(mxUtils.getValue(this.style, mxConstants.STYLE_SPACING_BOTTOM, this.spacingBottom - old)) + this.spacing;
+    // this.spacingLeft = parseInt(mxUtils.getValue(this.style, mxConstants.STYLE_SPACING_LEFT, this.spacingLeft - old)) + this.spacing;
+  }
+
+  apply(state: mxCellState): void {
+    super.apply(state);
+
+    this.opacity = 30;
   }
 }

--- a/src/component/mxgraph/overlay/shapes.ts
+++ b/src/component/mxgraph/overlay/shapes.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 import { mxgraph } from '../initializer';
-import { mxRectangle } from 'mxgraph';
+import { mxAbstractCanvas2D, mxRectangle } from 'mxgraph';
 import { MxGraphCustomOverlayStyle } from './custom-overlay';
 
+/* eslint-disable no-console */
 export class OverlayBadgeShape extends mxgraph.mxText {
   // TODO to remove when typed-mxgraph@1.0.1 mxText definitions won't declare these fields as protected (prevent assign OverlayBadgeShape instances as mxShape)
   spacing: number;
@@ -29,8 +30,8 @@ export class OverlayBadgeShape extends mxgraph.mxText {
     super(
       value,
       bounds,
-      undefined,
-      undefined,
+      mxgraph.mxConstants.ALIGN_CENTER,
+      mxgraph.mxConstants.ALIGN_MIDDLE,
       style.font.color,
       undefined,
       style.font.size,
@@ -41,17 +42,20 @@ export class OverlayBadgeShape extends mxgraph.mxText {
       undefined,
       undefined,
       undefined,
-      style.fill.color,
+      undefined, //style.fill.color,
       style.stroke.color,
+      // undefined, //style.stroke.color,
     );
     this.fillOpacity = style.fill.opacity;
     this.strokewidth = style.stroke.width;
 
-    this.opacity = 40;
+    this.opacity = 50;
+
+    // this.labelPadding = 4;
 
     // const old = this.spacing;
     //this.spacing = parseInt(mxUtils.getValue(this.style, mxConstants.STYLE_SPACING, this.spacing));
-    this.spacingTop = 12; //(this.spacingTop - old)) + this.spacing;
+    // this.spacingTop = 12; //(this.spacingTop - old)) + this.spacing;
     // this.spacingRight = parseInt(mxUtils.getValue(this.style, mxConstants.STYLE_SPACING_RIGHT, this.spacingRight - old)) + this.spacing;
     // this.spacingBottom = parseInt(mxUtils.getValue(this.style, mxConstants.STYLE_SPACING_BOTTOM, this.spacingBottom - old)) + this.spacing;
     // this.spacingLeft = parseInt(mxUtils.getValue(this.style, mxConstants.STYLE_SPACING_LEFT, this.spacingLeft - old)) + this.spacing;
@@ -63,81 +67,107 @@ export class OverlayBadgeShape extends mxgraph.mxText {
   //   this.opacity = 30;
   // }
 
-  // paint(c: mxAbstractCanvas2D): void {
-  //   // // Scale is passed-through to canvas
-  //   // var s = this.scale;
-  //   // var x = this.bounds.x / s;
-  //   // var y = this.bounds.y / s;
-  //   // var w = this.bounds.width / s;
-  //   // var h = this.bounds.height / s;
-  //   //
-  //   // this.updateTransform(c, x, y, w, h);
-  //   // this.configureCanvas(c, x, y, w, h);
-  //   //
-  //   // if (update)
-  //   // {
-  //   //   c.updateText(x, y, w, h, this.align, this.valign, this.wrap, this.overflow,
-  //   //     this.clipped, this.getTextRotation(), this.node);
-  //   // }
-  //   // else
-  //   // {
-  //   //   // Checks if text contains HTML markup
-  //   //   var realHtml = mxUtils.isNode(this.value) || this.dialect == mxConstants.DIALECT_STRICTHTML;
-  //   //
-  //   //   // Always renders labels as HTML in VML
-  //   //   var fmt = (realHtml || c instanceof mxVmlCanvas2D) ? 'html' : '';
-  //   //   var val = this.value;
-  //   //
-  //   //   if (!realHtml && fmt == 'html')
-  //   //   {
-  //   //     val = mxUtils.htmlEntities(val, false);
-  //   //   }
-  //   //
-  //   //   if (fmt == 'html' && !mxUtils.isNode(this.value))
-  //   //   {
-  //   //     val = mxUtils.replaceTrailingNewlines(val, '<div><br></div>');
-  //   //   }
-  //   //
-  //   //   // Handles trailing newlines to make sure they are visible in rendering output
-  //   //   val = (!mxUtils.isNode(this.value) && this.replaceLinefeeds && fmt == 'html') ?
-  //   //     val.replace(/\n/g, '<br/>') : val;
-  //   //
-  //   //   var dir = this.textDirection;
-  //   //
-  //   //   if (dir == mxConstants.TEXT_DIRECTION_AUTO && !realHtml)
-  //   //   {
-  //   //     dir = this.getAutoDirection();
-  //   //   }
-  //   //
-  //   //   if (dir != mxConstants.TEXT_DIRECTION_LTR && dir != mxConstants.TEXT_DIRECTION_RTL)
-  //   //   {
-  //   //     dir = null;
-  //   //   }
-  //   //
-  //   //   c.text(x, y, w, h, val, this.align, this.valign, this.wrap, fmt,
-  //   //     this.overflow, this.clipped, this.getTextRotation(), dir);
-  //   // }
-  //
-  //   // TODO disable stroke, fill (set to transparent) after having paint the background
-  //   super.paint(c, false);
-  //   console.info('@@@this.boundingBox after super paint', this.boundingBox);
-  //
-  //   // Scale is passed-through to canvas
-  //   const s = this.scale;
-  //   const x = this.bounds.x / s;
-  //   const y = this.bounds.y / s;
-  //   const w = this.bounds.width / s;
-  //   const h = this.bounds.height / s;
-  //
-  //   console.info('this.value', this.value);
-  //   const textBbox = this.computeTextBbox(this.value, x, y);
-  //   console.info('@@@computeTextBbox', textBbox);
-  //
-  //   c.ellipse(x + 10, y + 10, 30, 30);
-  //   c.fillAndStroke();
-  //   // c.stroke();
-  //   console.info('@@@@after ellipse');
-  // }
+  paint(c: mxAbstractCanvas2D): void {
+    // // Scale is passed-through to canvas
+    // var s = this.scale;
+    // var x = this.bounds.x / s;
+    // var y = this.bounds.y / s;
+    // var w = this.bounds.width / s;
+    // var h = this.bounds.height / s;
+    //
+    // this.updateTransform(c, x, y, w, h);
+    // this.configureCanvas(c, x, y, w, h);
+    //
+    // if (update)
+    // {
+    //   c.updateText(x, y, w, h, this.align, this.valign, this.wrap, this.overflow,
+    //     this.clipped, this.getTextRotation(), this.node);
+    // }
+    // else
+    // {
+    //   // Checks if text contains HTML markup
+    //   var realHtml = mxUtils.isNode(this.value) || this.dialect == mxConstants.DIALECT_STRICTHTML;
+    //
+    //   // Always renders labels as HTML in VML
+    //   var fmt = (realHtml || c instanceof mxVmlCanvas2D) ? 'html' : '';
+    //   var val = this.value;
+    //
+    //   if (!realHtml && fmt == 'html')
+    //   {
+    //     val = mxUtils.htmlEntities(val, false);
+    //   }
+    //
+    //   if (fmt == 'html' && !mxUtils.isNode(this.value))
+    //   {
+    //     val = mxUtils.replaceTrailingNewlines(val, '<div><br></div>');
+    //   }
+    //
+    //   // Handles trailing newlines to make sure they are visible in rendering output
+    //   val = (!mxUtils.isNode(this.value) && this.replaceLinefeeds && fmt == 'html') ?
+    //     val.replace(/\n/g, '<br/>') : val;
+    //
+    //   var dir = this.textDirection;
+    //
+    //   if (dir == mxConstants.TEXT_DIRECTION_AUTO && !realHtml)
+    //   {
+    //     dir = this.getAutoDirection();
+    //   }
+    //
+    //   if (dir != mxConstants.TEXT_DIRECTION_LTR && dir != mxConstants.TEXT_DIRECTION_RTL)
+    //   {
+    //     dir = null;
+    //   }
+    //
+    //   c.text(x, y, w, h, val, this.align, this.valign, this.wrap, fmt,
+    //     this.overflow, this.clipped, this.getTextRotation(), dir);
+    // }
+
+    console.info('@@@bounds before paint', this.bounds);
+    console.info('@@scale before paint', this.scale);
+
+    const firstComputedTextBbox = this.computeTextBbox(this.value, this.bounds.x / this.scale, this.bounds.y / this.scale);
+
+    console.info('@@@firstComputedTextBbox prior paint', firstComputedTextBbox);
+
+    // TODO disable stroke, fill (set to transparent) after having paint the background
+    super.paint(c);
+    console.info('@@@bounds after paint', this.bounds);
+
+    console.info('@@@this.boundingBox after super paint', this.boundingBox);
+
+    // Scale is passed-through to canvas
+    const s = this.scale;
+    const x = this.bounds.x / s;
+    const y = this.bounds.y / s;
+    // const w = this.bounds.width / s;
+    // const h = this.bounds.height / s;
+
+    console.info('this.value', this.value);
+    const textBbox = this.computeTextBbox(this.value, x, y);
+
+    console.info('@@@computeTextBbox', textBbox);
+
+    c.setFillColor('green');
+    c.setFillAlpha(0.2);
+    c.setStrokeColor('red');
+    c.setStrokeWidth(1);
+    // c.ellipse(x + 10, y + 10, 30, 30);
+    // c.ellipse(textBbox.x, textBbox.y, textBbox.width, textBbox.height);
+
+    // rect build by addTextBackground
+    // n.setAttribute('x', String(Math.floor(bbox.x - 1)));
+    // n.setAttribute('y', String(Math.floor(bbox.y - 1)));
+    // n.setAttribute('width', String(Math.ceil(bbox.width + 2)));
+    // n.setAttribute('height', String(Math.ceil(bbox.height)));
+
+    // c.rect(Math.floor(textBbox.x - 1), Math.floor(textBbox.y - 1), Math.ceil(textBbox.width + 2), Math.ceil(textBbox.height));
+    // c.rect(textBbox.x, textBbox.y, textBbox.width, textBbox.height);
+    c.rect(textBbox.x - 1, textBbox.y - 1, textBbox.width, textBbox.height - 4);
+    c.fillAndStroke();
+    // c.stroke();
+
+    console.info('@@@@after extra shape');
+  }
 
   // TODO can we computeTextBbox()?
   // from mxSvgCanvas2D.prototype.addTextBackground
@@ -190,7 +220,7 @@ export class OverlayBadgeShape extends mxgraph.mxText {
     // Computes size if not in document or no getBBox available
     const div = document.createElement('div');
 
-    const s = this.state;
+    // const s = this.state;
     // console.info('@@@state during paint', s);
 
     // Wrapping and clipping can be ignored here
@@ -226,21 +256,32 @@ export class OverlayBadgeShape extends mxgraph.mxText {
     document.body.appendChild(div);
     const w = div.offsetWidth;
     const h = div.offsetHeight;
+
+    console.info('@@computed w/h', w, h);
+    console.info('@@div getBoundingClientRect', div.getBoundingClientRect());
+
     div.parentNode.removeChild(div);
 
-    if (this.align == mxgraph.mxConstants.ALIGN_CENTER) {
-      x -= w / 2;
-    } else if (this.align == mxgraph.mxConstants.ALIGN_RIGHT) {
-      x -= w;
-    }
+    //add padding
+    //w += 2 * 3; // 3 points on each side
 
-    if (this.valign == mxgraph.mxConstants.ALIGN_MIDDLE) {
-      y -= h / 2;
-    } else if (this.valign == mxgraph.mxConstants.ALIGN_BOTTOM) {
-      y -= h;
-    }
+    // if (this.align == mxgraph.mxConstants.ALIGN_CENTER) {
+    x -= w / 2;
+    // } else if (this.align == mxgraph.mxConstants.ALIGN_RIGHT) {
+    //   x -= w;
+    // }
+    //
+    // if (this.valign == mxgraph.mxConstants.ALIGN_MIDDLE) {
+    y -= h / 2;
+    // y -= h / 2 + h / 8;
+    // } else if (this.valign == mxgraph.mxConstants.ALIGN_BOTTOM) {
+    //   y -= h;
+    // }
 
-    return new mxgraph.mxRectangle((x + 1) * this.scale, (y + 2) * this.scale, w * this.scale, (h + 1) * this.scale);
+    // return new mxgraph.mxRectangle(x, y + 2, w, h + 1);
+    return new mxgraph.mxRectangle(x, y, w, h);
+    // return new mxgraph.mxRectangle(x + 1, y + 2, w, h + 1);
+    //return new mxgraph.mxRectangle((x + 1) * this.scale, (y + 2) * this.scale, w * this.scale, (h + 1) * this.scale);
     // const bbox = new mxRectangle((x + 1) * s.scale, (y + 2) * s.scale, w * s.scale, (h + 1) * s.scale);
     // }
 

--- a/src/component/mxgraph/overlay/shapes.ts
+++ b/src/component/mxgraph/overlay/shapes.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { mxgraph } from '../initializer';
-import { mxCellState, mxRectangle } from 'mxgraph';
+import { mxRectangle } from 'mxgraph';
 import { MxGraphCustomOverlayStyle } from './custom-overlay';
 
 export class OverlayBadgeShape extends mxgraph.mxText {
@@ -23,6 +23,8 @@ export class OverlayBadgeShape extends mxgraph.mxText {
   bounds: mxRectangle;
   // end of typed-mxgraph issue
 
+  // TODO remove the bounds parameter
+  // should always be set in the constructor
   constructor(value: string, bounds: mxRectangle, style: MxGraphCustomOverlayStyle) {
     super(
       value,
@@ -55,9 +57,215 @@ export class OverlayBadgeShape extends mxgraph.mxText {
     // this.spacingLeft = parseInt(mxUtils.getValue(this.style, mxConstants.STYLE_SPACING_LEFT, this.spacingLeft - old)) + this.spacing;
   }
 
-  apply(state: mxCellState): void {
-    super.apply(state);
+  // apply(state: mxCellState): void {
+  //   super.apply(state);
+  //
+  //   this.opacity = 30;
+  // }
 
-    this.opacity = 30;
+  // paint(c: mxAbstractCanvas2D): void {
+  //   // // Scale is passed-through to canvas
+  //   // var s = this.scale;
+  //   // var x = this.bounds.x / s;
+  //   // var y = this.bounds.y / s;
+  //   // var w = this.bounds.width / s;
+  //   // var h = this.bounds.height / s;
+  //   //
+  //   // this.updateTransform(c, x, y, w, h);
+  //   // this.configureCanvas(c, x, y, w, h);
+  //   //
+  //   // if (update)
+  //   // {
+  //   //   c.updateText(x, y, w, h, this.align, this.valign, this.wrap, this.overflow,
+  //   //     this.clipped, this.getTextRotation(), this.node);
+  //   // }
+  //   // else
+  //   // {
+  //   //   // Checks if text contains HTML markup
+  //   //   var realHtml = mxUtils.isNode(this.value) || this.dialect == mxConstants.DIALECT_STRICTHTML;
+  //   //
+  //   //   // Always renders labels as HTML in VML
+  //   //   var fmt = (realHtml || c instanceof mxVmlCanvas2D) ? 'html' : '';
+  //   //   var val = this.value;
+  //   //
+  //   //   if (!realHtml && fmt == 'html')
+  //   //   {
+  //   //     val = mxUtils.htmlEntities(val, false);
+  //   //   }
+  //   //
+  //   //   if (fmt == 'html' && !mxUtils.isNode(this.value))
+  //   //   {
+  //   //     val = mxUtils.replaceTrailingNewlines(val, '<div><br></div>');
+  //   //   }
+  //   //
+  //   //   // Handles trailing newlines to make sure they are visible in rendering output
+  //   //   val = (!mxUtils.isNode(this.value) && this.replaceLinefeeds && fmt == 'html') ?
+  //   //     val.replace(/\n/g, '<br/>') : val;
+  //   //
+  //   //   var dir = this.textDirection;
+  //   //
+  //   //   if (dir == mxConstants.TEXT_DIRECTION_AUTO && !realHtml)
+  //   //   {
+  //   //     dir = this.getAutoDirection();
+  //   //   }
+  //   //
+  //   //   if (dir != mxConstants.TEXT_DIRECTION_LTR && dir != mxConstants.TEXT_DIRECTION_RTL)
+  //   //   {
+  //   //     dir = null;
+  //   //   }
+  //   //
+  //   //   c.text(x, y, w, h, val, this.align, this.valign, this.wrap, fmt,
+  //   //     this.overflow, this.clipped, this.getTextRotation(), dir);
+  //   // }
+  //
+  //   // TODO disable stroke, fill (set to transparent) after having paint the background
+  //   super.paint(c, false);
+  //   console.info('@@@this.boundingBox after super paint', this.boundingBox);
+  //
+  //   // Scale is passed-through to canvas
+  //   const s = this.scale;
+  //   const x = this.bounds.x / s;
+  //   const y = this.bounds.y / s;
+  //   const w = this.bounds.width / s;
+  //   const h = this.bounds.height / s;
+  //
+  //   console.info('this.value', this.value);
+  //   const textBbox = this.computeTextBbox(this.value, x, y);
+  //   console.info('@@@computeTextBbox', textBbox);
+  //
+  //   c.ellipse(x + 10, y + 10, 30, 30);
+  //   c.fillAndStroke();
+  //   // c.stroke();
+  //   console.info('@@@@after ellipse');
+  // }
+
+  // TODO can we computeTextBbox()?
+  // from mxSvgCanvas2D.prototype.addTextBackground
+  private computeTextBbox(str: string, x: number, y: number): mxRectangle {
+    // var s = this.state;
+    //
+    // if (s.fontBackgroundColor != null || s.fontBorderColor != null)
+    // {
+    //   var bbox = null;
+    //
+    //   if (overflow == 'fill' || overflow == 'width')
+    //   {
+    //     if (align == mxConstants.ALIGN_CENTER)
+    //     {
+    //       x -= w / 2;
+    //     }
+    //     else if (align == mxConstants.ALIGN_RIGHT)
+    //     {
+    //       x -= w;
+    //     }
+    //
+    //     if (valign == mxConstants.ALIGN_MIDDLE)
+    //     {
+    //       y -= h / 2;
+    //     }
+    //     else if (valign == mxConstants.ALIGN_BOTTOM)
+    //     {
+    //       y -= h;
+    //     }
+    //
+    //     bbox = new mxRectangle((x + 1) * s.scale, y * s.scale, (w - 2) * s.scale, (h + 2) * s.scale);
+    //   }
+    //   else if (node.getBBox != null && this.root.ownerDocument == document)
+    //   {
+    //     // Uses getBBox only if inside document for correct size
+    //     try
+    //     {
+    //       bbox = node.getBBox();
+    //       var ie = mxClient.IS_IE && mxClient.IS_SVG;
+    //       bbox = new mxRectangle(bbox.x, bbox.y + ((ie) ? 0 : 1), bbox.width, bbox.height + ((ie) ? 1 : 0));
+    //     }
+    //     catch (e)
+    //     {
+    //       // Ignores NS_ERROR_FAILURE in FF if container display is none.
+    //     }
+    //   }
+
+    // if (bbox == null || bbox.width == 0 || bbox.height == 0)
+    // {
+    // Computes size if not in document or no getBBox available
+    const div = document.createElement('div');
+
+    const s = this.state;
+    // console.info('@@@state during paint', s);
+
+    // Wrapping and clipping can be ignored here
+    div.style.lineHeight = mxgraph.mxConstants.ABSOLUTE_LINE_HEIGHT ? this.size * mxgraph.mxConstants.LINE_HEIGHT + 'px' : `${mxgraph.mxConstants.LINE_HEIGHT}`;
+    div.style.fontSize = this.size + 'px';
+    div.style.fontFamily = this.family;
+    // div.style.lineHeight = (mxgraph.mxConstants.ABSOLUTE_LINE_HEIGHT) ? (s.fontSize * mxgraph.mxConstants.LINE_HEIGHT) + 'px' : mxgraph.mxConstants.LINE_HEIGHT;
+    // div.style.fontSize = s.fontSize + 'px';
+    // div.style.fontFamily = s.fontFamily;
+    div.style.whiteSpace = 'nowrap';
+    div.style.position = 'absolute';
+    div.style.visibility = 'hidden';
+    div.style.display = 'inline-block';
+    // div.style.display = (mxClient.IS_QUIRKS) ? 'inline' : 'inline-block';
+    // div.style.zoom = '1';
+
+    if ((this.fontStyle & mxgraph.mxConstants.FONT_BOLD) == mxgraph.mxConstants.FONT_BOLD) {
+      // if ((s.fontStyle & mxConstants.FONT_BOLD) == mxConstants.FONT_BOLD)
+      div.style.fontWeight = 'bold';
+    }
+
+    if ((this.fontStyle & mxgraph.mxConstants.FONT_ITALIC) == mxgraph.mxConstants.FONT_ITALIC) {
+      // if ((s.fontStyle & mxConstants.FONT_ITALIC) == mxConstants.FONT_ITALIC)
+      div.style.fontStyle = 'italic';
+    }
+
+    // TODO error in typed-mxgraph@1.0.1
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    str = mxgraph.mxUtils.htmlEntities(str, false);
+    div.innerHTML = str.replace(/\n/g, '<br/>');
+
+    document.body.appendChild(div);
+    const w = div.offsetWidth;
+    const h = div.offsetHeight;
+    div.parentNode.removeChild(div);
+
+    if (this.align == mxgraph.mxConstants.ALIGN_CENTER) {
+      x -= w / 2;
+    } else if (this.align == mxgraph.mxConstants.ALIGN_RIGHT) {
+      x -= w;
+    }
+
+    if (this.valign == mxgraph.mxConstants.ALIGN_MIDDLE) {
+      y -= h / 2;
+    } else if (this.valign == mxgraph.mxConstants.ALIGN_BOTTOM) {
+      y -= h;
+    }
+
+    return new mxgraph.mxRectangle((x + 1) * this.scale, (y + 2) * this.scale, w * this.scale, (h + 1) * this.scale);
+    // const bbox = new mxRectangle((x + 1) * s.scale, (y + 2) * s.scale, w * s.scale, (h + 1) * s.scale);
+    // }
+
+    // if (bbox != null)
+    // {
+    //   var n = this.createElement('rect');
+    //   n.setAttribute('fill', s.fontBackgroundColor || 'none');
+    //   n.setAttribute('stroke', s.fontBorderColor || 'none');
+    //   n.setAttribute('x', Math.floor(bbox.x - 1));
+    //   n.setAttribute('y', Math.floor(bbox.y - 1));
+    //   n.setAttribute('width', Math.ceil(bbox.width + 2));
+    //   n.setAttribute('height', Math.ceil(bbox.height));
+    //
+    //   var sw = (s.fontBorderColor != null) ? Math.max(1, this.format(s.scale)) : 0;
+    //   n.setAttribute('stroke-width', sw);
+    //
+    //   // Workaround for crisp rendering - only required if not exporting
+    //   if (this.root.ownerDocument == document && mxUtils.mod(sw, 2) == 1)
+    //   {
+    //     n.setAttribute('transform', 'translate(0.5, 0.5)');
+    //   }
+    //
+    //   node.insertBefore(n, node.firstChild);
+    // }
+    //   }
+    // }
   }
 }

--- a/src/component/mxgraph/overlay/shapes.ts
+++ b/src/component/mxgraph/overlay/shapes.ts
@@ -42,13 +42,14 @@ export class OverlayBadgeShape extends mxgraph.mxText {
       undefined,
       undefined,
       undefined,
-      undefined, //style.fill.color,
-      style.stroke.color,
+      undefined, // fill color: delegated to the background shape
+      style.stroke.color, // TODO stroke color: delegated to the background shape
       // undefined, //style.stroke.color,
     );
     this.fillOpacity = style.fill.opacity;
     this.strokewidth = style.stroke.width;
 
+    // This for both stroke, fill and font for the mxText part
     this.opacity = 50;
 
     // this.labelPadding = 4;
@@ -68,72 +69,41 @@ export class OverlayBadgeShape extends mxgraph.mxText {
   // }
 
   paint(c: mxAbstractCanvas2D): void {
-    // // Scale is passed-through to canvas
-    // var s = this.scale;
-    // var x = this.bounds.x / s;
-    // var y = this.bounds.y / s;
-    // var w = this.bounds.width / s;
-    // var h = this.bounds.height / s;
-    //
+    // const s = this.scale;
+    // const x = this.bounds.x / s;
+    // const y = this.bounds.y / s;
+    // const w = this.bounds.width / s;
+    // const h = this.bounds.height / s;
     // this.updateTransform(c, x, y, w, h);
-    // this.configureCanvas(c, x, y, w, h);
-    //
-    // if (update)
-    // {
-    //   c.updateText(x, y, w, h, this.align, this.valign, this.wrap, this.overflow,
-    //     this.clipped, this.getTextRotation(), this.node);
-    // }
-    // else
-    // {
-    //   // Checks if text contains HTML markup
-    //   var realHtml = mxUtils.isNode(this.value) || this.dialect == mxConstants.DIALECT_STRICTHTML;
-    //
-    //   // Always renders labels as HTML in VML
-    //   var fmt = (realHtml || c instanceof mxVmlCanvas2D) ? 'html' : '';
-    //   var val = this.value;
-    //
-    //   if (!realHtml && fmt == 'html')
-    //   {
-    //     val = mxUtils.htmlEntities(val, false);
-    //   }
-    //
-    //   if (fmt == 'html' && !mxUtils.isNode(this.value))
-    //   {
-    //     val = mxUtils.replaceTrailingNewlines(val, '<div><br></div>');
-    //   }
-    //
-    //   // Handles trailing newlines to make sure they are visible in rendering output
-    //   val = (!mxUtils.isNode(this.value) && this.replaceLinefeeds && fmt == 'html') ?
-    //     val.replace(/\n/g, '<br/>') : val;
-    //
-    //   var dir = this.textDirection;
-    //
-    //   if (dir == mxConstants.TEXT_DIRECTION_AUTO && !realHtml)
-    //   {
-    //     dir = this.getAutoDirection();
-    //   }
-    //
-    //   if (dir != mxConstants.TEXT_DIRECTION_LTR && dir != mxConstants.TEXT_DIRECTION_RTL)
-    //   {
-    //     dir = null;
-    //   }
-    //
-    //   c.text(x, y, w, h, val, this.align, this.valign, this.wrap, fmt,
-    //     this.overflow, this.clipped, this.getTextRotation(), dir);
-    // }
+
+    // update side effect of super.paint that calls mxShape.updateTransform
+    c.scale(this.scale);
+    this.paintBackgroundShape(c);
+    c.scale(1 / this.scale); // restore initial value
 
     console.info('@@@bounds before paint', this.bounds);
     console.info('@@scale before paint', this.scale);
 
+    // see also mxShape.augmentBoundingBox
     const firstComputedTextBbox = this.computeTextBbox(this.value, this.bounds.x / this.scale, this.bounds.y / this.scale);
 
     console.info('@@@firstComputedTextBbox prior paint', firstComputedTextBbox);
 
     // TODO disable stroke, fill (set to transparent) after having paint the background
+    // probably by overriding the super.configureCanvas method
+    // c.setFillColor(undefined);
     super.paint(c);
-    console.info('@@@bounds after paint', this.bounds);
+    // console.info('@@@bounds after paint', this.bounds);
+    //
+    // console.info('@@@this.boundingBox after super paint', this.boundingBox);
+    //
+    // this.paintBackgroundShape(c);
+  }
 
-    console.info('@@@this.boundingBox after super paint', this.boundingBox);
+  private paintBackgroundShape(c: mxAbstractCanvas2D): void {
+    console.info('@@@@START paintBackgroundShape');
+    console.info('@@@bounds', this.bounds);
+    console.info('@@scale', this.scale);
 
     // Scale is passed-through to canvas
     const s = this.scale;
@@ -147,10 +117,12 @@ export class OverlayBadgeShape extends mxgraph.mxText {
 
     console.info('@@@computeTextBbox', textBbox);
 
+    // TODO set canvas configuration in a dedicated method
     c.setFillColor('green');
     c.setFillAlpha(0.2);
     c.setStrokeColor('red');
     c.setStrokeWidth(1);
+
     // c.ellipse(x + 10, y + 10, 30, 30);
     // c.ellipse(textBbox.x, textBbox.y, textBbox.width, textBbox.height);
 
@@ -166,7 +138,7 @@ export class OverlayBadgeShape extends mxgraph.mxText {
     c.fillAndStroke();
     // c.stroke();
 
-    console.info('@@@@after extra shape');
+    console.info('@@@@done paintBackgroundShape');
   }
 
   // TODO can we computeTextBbox()?

--- a/src/component/mxgraph/overlay/shapes.ts
+++ b/src/component/mxgraph/overlay/shapes.ts
@@ -42,11 +42,15 @@ export class OverlayBadgeShape extends mxgraph.mxText {
       undefined,
       undefined,
       undefined,
-      style.fill.color,
-      style.stroke.color,
+      undefined, // fill color delegated to background shape
+      undefined, // stroke color delegated to background shape
     );
     this.fillOpacity = style.fill.opacity;
+    this.fill = style.fill.color;
+
+    this.stroke = style.stroke.color;
     this.strokewidth = style.stroke.width;
+    console.info('@@@@constructor - strokewidth', this.strokewidth);
 
     // This for both stroke, fill and font for the mxText part
     // this.opacity = 50;
@@ -98,15 +102,15 @@ export class OverlayBadgeShape extends mxgraph.mxText {
   private configureBackgroundShapeCanvas(c: mxAbstractCanvas2D): void {
     console.info('@@@configureBackgroundShapeCanvas');
     super.configureCanvas(c, 0, 0, 0, 0);
+    c.setStrokeWidth(this.strokewidth);
 
     // c.setFillColor(this.fill);
     // c.setStrokeColor(this.stroke);
 
     // TODO remove hard coded canvas style
-    c.setFillColor('green');
-    c.setFillAlpha(0.2);
-    c.setStrokeColor('red');
-    c.setStrokeWidth(1);
+    // c.setFillColor('green');
+    // c.setFillAlpha(0.2);
+    // // c.setStrokeColor('red');
   }
 
   configureCanvas(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): void {
@@ -119,7 +123,7 @@ export class OverlayBadgeShape extends mxgraph.mxText {
 
     // delegate border and background colors to the background shape
     c.setFontBackgroundColor(null);
-    // c.setFontBorderColor(null);
+    c.setFontBorderColor(null); // unset this to display the text border
   }
 
   private paintBackgroundShape(c: mxAbstractCanvas2D): void {
@@ -157,12 +161,12 @@ export class OverlayBadgeShape extends mxgraph.mxText {
 
     // c.rect(Math.floor(textBbox.x - 1), Math.floor(textBbox.y - 1), Math.ceil(textBbox.width + 2), Math.ceil(textBbox.height));
     // c.rect(textBbox.x - 1, textBbox.y - 1, textBbox.width, textBbox.height - 4);
-    c.rect(textBbox.x, textBbox.y, textBbox.width, textBbox.height);
-    c.fillAndStroke();
+    // c.rect(textBbox.x, textBbox.y, textBbox.width, textBbox.height);
+    // c.fillAndStroke();
 
     // ellipse
-    // c.ellipse(textBbox.x, textBbox.y, textBbox.width, textBbox.height);
-    // c.fillAndStroke();
+    c.ellipse(textBbox.x, textBbox.y, textBbox.width, textBbox.height);
+    c.fillAndStroke();
 
     // circle
     // const circleWidth = Math.max(textBbox.width, textBbox.height);

--- a/src/component/mxgraph/overlay/shapes.ts
+++ b/src/component/mxgraph/overlay/shapes.ts
@@ -272,7 +272,7 @@ export class OverlayBadgeShape extends mxgraph.mxText {
     div.innerHTML = str.replace(/\n/g, '<br/>');
 
     document.body.appendChild(div);
-    const w = div.offsetWidth;
+    let w = div.offsetWidth;
     const h = div.offsetHeight;
 
     console.info('@@computed w/h', w, h);
@@ -280,8 +280,9 @@ export class OverlayBadgeShape extends mxgraph.mxText {
 
     div.parentNode.removeChild(div);
 
+    // TODO manage spacing based on configuration
     //add padding
-    //w += 2 * 3; // 3 points on each side
+    w += 2 * 3; // 3 points on each side
 
     // if (this.align == mxgraph.mxConstants.ALIGN_CENTER) {
     x -= w / 2;

--- a/src/component/mxgraph/overlay/shapes.ts
+++ b/src/component/mxgraph/overlay/shapes.ts
@@ -45,6 +45,7 @@ export class OverlayBadgeShape extends mxgraph.mxText {
       undefined, // fill color delegated to background shape
       undefined, // stroke color delegated to background shape
     );
+    console.info(`@@@@constructor - value ##${this.value}##`);
     this.fillOpacity = style.fill.opacity;
     this.fill = style.fill.color;
 
@@ -150,8 +151,11 @@ export class OverlayBadgeShape extends mxgraph.mxText {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     text = mxgraph.mxUtils.htmlEntities(text, false);
-    console.info('@computeTextBbox label after htmlEntities', text);
-    div.innerHTML = text.replace(/\n/g, '<br/>');
+    console.info(`@@@@computeTextBbox label after htmlEntities ##${text}##`);
+    text = text.replace(/\n/g, '<br/>').trim();
+
+    text = text.length > 0 ? text : '&nbsp;&nbsp;';
+    div.innerHTML = text;
 
     document.body.appendChild(div);
     let w = div.offsetWidth;

--- a/src/component/mxgraph/overlay/shapes.ts
+++ b/src/component/mxgraph/overlay/shapes.ts
@@ -55,48 +55,27 @@ export class OverlayBadgeShape extends mxgraph.mxText {
     // This for both stroke, fill and font for the mxText part
     // this.opacity = 50;
 
+    // TODO manage padding/spacing with configuration
+    // the following is taken from mxText but not use in svg generation (canvas and renderer)
     // this.labelPadding = 4;
 
     // const old = this.spacing;
-    //this.spacing = parseInt(mxUtils.getValue(this.style, mxConstants.STYLE_SPACING, this.spacing));
+    // this.spacing = parseInt(mxUtils.getValue(this.style, mxConstants.STYLE_SPACING, this.spacing));
     // this.spacingTop = 12; //(this.spacingTop - old)) + this.spacing;
     // this.spacingRight = parseInt(mxUtils.getValue(this.style, mxConstants.STYLE_SPACING_RIGHT, this.spacingRight - old)) + this.spacing;
     // this.spacingBottom = parseInt(mxUtils.getValue(this.style, mxConstants.STYLE_SPACING_BOTTOM, this.spacingBottom - old)) + this.spacing;
     // this.spacingLeft = parseInt(mxUtils.getValue(this.style, mxConstants.STYLE_SPACING_LEFT, this.spacingLeft - old)) + this.spacing;
   }
 
-  // apply(state: mxCellState): void {
-  //   super.apply(state);
-  //
-  //   this.opacity = 30;
-  // }
-
   paint(c: mxAbstractCanvas2D): void {
-    // const s = this.scale;
-    // const x = this.bounds.x / s;
-    // const y = this.bounds.y / s;
-    // const w = this.bounds.width / s;
-    // const h = this.bounds.height / s;
-    // this.updateTransform(c, x, y, w, h);
-
-    // update side effect of super.paint that calls mxShape.updateTransform
+    // mimic super.paint that calls mxShape.updateTransform
     c.scale(this.scale);
     this.configureBackgroundShapeCanvas(c);
     this.paintBackgroundShape(c);
     c.scale(1 / this.scale); // restore initial value
 
-    console.info('@@@bounds before paint', this.bounds);
-    console.info('@@scale before paint', this.scale);
-
-    // const firstComputedTextBbox = this.computeTextBbox(this.value, this.bounds.x / this.scale, this.bounds.y / this.scale);
-    // console.info('@@@firstComputedTextBbox prior paint', firstComputedTextBbox);
-
+    // paint text
     super.paint(c);
-    // console.info('@@@bounds after paint', this.bounds);
-    //
-    // console.info('@@@this.boundingBox after super paint', this.boundingBox);
-    //
-    // this.paintBackgroundShape(c);
   }
 
   private configureBackgroundShapeCanvas(c: mxAbstractCanvas2D): void {
@@ -115,23 +94,12 @@ export class OverlayBadgeShape extends mxgraph.mxText {
     c.setFontBorderColor(null); // unset this to display the text border
   }
 
+  // this is the method that will be implemented by each overlay shape implementation
   private paintBackgroundShape(c: mxAbstractCanvas2D): void {
-    console.info('@@@@START paintBackgroundShape');
+    // this should be passed to the method to avoid calling it in all implementations
     const textBbox = this.computeTextBbox();
 
-    console.info('@@@computeTextBbox', textBbox);
-
-    // c.ellipse(x + 10, y + 10, 30, 30);
-    // c.ellipse(textBbox.x, textBbox.y, textBbox.width, textBbox.height);
-
-    // rect build by addTextBackground
-    // n.setAttribute('x', String(Math.floor(bbox.x - 1)));
-    // n.setAttribute('y', String(Math.floor(bbox.y - 1)));
-    // n.setAttribute('width', String(Math.ceil(bbox.width + 2)));
-    // n.setAttribute('height', String(Math.ceil(bbox.height)));
-
-    // c.rect(Math.floor(textBbox.x - 1), Math.floor(textBbox.y - 1), Math.ceil(textBbox.width + 2), Math.ceil(textBbox.height));
-    // c.rect(textBbox.x - 1, textBbox.y - 1, textBbox.width, textBbox.height - 4);
+    // rectangle
     c.rect(textBbox.x, textBbox.y, textBbox.width, textBbox.height);
     c.fillAndStroke();
 
@@ -144,163 +112,61 @@ export class OverlayBadgeShape extends mxgraph.mxText {
     // // TODO for circle, the x and y position need to be updated accordingly
     // c.ellipse(textBbox.x, textBbox.y, circleWidth, circleWidth);
     // c.fillAndStroke();
-
-    console.info('@@@@done paintBackgroundShape');
   }
 
-  // TODO can we computeTextBbox()?
-  // from mxSvgCanvas2D.prototype.addTextBackground
+  // implementation inspired of mxSvgCanvas2D.prototype.addTextBackground
   // TODO do we need to use mxShape.augmentBoundingBox
   private computeTextBbox(): mxRectangle {
     // Scale is passed-through to canvas
     const s = this.scale;
-    console.info('@@@computeTextBbox bounds', this.bounds);
-    console.info('@@@computeTextBbox scale', s);
-
     let x = this.bounds.x / s;
     let y = this.bounds.y / s;
 
-    let str = this.value;
-    console.info('@computeTextBbox label', str);
+    let text = this.value;
 
-    // var s = this.state;
-    //
-    // if (s.fontBackgroundColor != null || s.fontBorderColor != null)
-    // {
-    //   var bbox = null;
-    //
-    //   if (overflow == 'fill' || overflow == 'width')
-    //   {
-    //     if (align == mxConstants.ALIGN_CENTER)
-    //     {
-    //       x -= w / 2;
-    //     }
-    //     else if (align == mxConstants.ALIGN_RIGHT)
-    //     {
-    //       x -= w;
-    //     }
-    //
-    //     if (valign == mxConstants.ALIGN_MIDDLE)
-    //     {
-    //       y -= h / 2;
-    //     }
-    //     else if (valign == mxConstants.ALIGN_BOTTOM)
-    //     {
-    //       y -= h;
-    //     }
-    //
-    //     bbox = new mxRectangle((x + 1) * s.scale, y * s.scale, (w - 2) * s.scale, (h + 2) * s.scale);
-    //   }
-    //   else if (node.getBBox != null && this.root.ownerDocument == document)
-    //   {
-    //     // Uses getBBox only if inside document for correct size
-    //     try
-    //     {
-    //       bbox = node.getBBox();
-    //       var ie = mxClient.IS_IE && mxClient.IS_SVG;
-    //       bbox = new mxRectangle(bbox.x, bbox.y + ((ie) ? 0 : 1), bbox.width, bbox.height + ((ie) ? 1 : 0));
-    //     }
-    //     catch (e)
-    //     {
-    //       // Ignores NS_ERROR_FAILURE in FF if container display is none.
-    //     }
-    //   }
-
-    // if (bbox == null || bbox.width == 0 || bbox.height == 0)
-    // {
-    // Computes size if not in document or no getBBox available
+    // Computes size by adding the text in a hidden div that lives only temporary
     const div = document.createElement('div');
 
-    // const s = this.state;
-    // console.info('@@@state during paint', s);
-
     // Wrapping and clipping can be ignored here
-    // div.style.lineHeight = '1';
     div.style.lineHeight = mxgraph.mxConstants.ABSOLUTE_LINE_HEIGHT ? this.size * mxgraph.mxConstants.LINE_HEIGHT + 'px' : `${mxgraph.mxConstants.LINE_HEIGHT}`;
     div.style.fontSize = this.size + 'px';
     div.style.fontFamily = this.family;
-    // div.style.lineHeight = (mxgraph.mxConstants.ABSOLUTE_LINE_HEIGHT) ? (s.fontSize * mxgraph.mxConstants.LINE_HEIGHT) + 'px' : mxgraph.mxConstants.LINE_HEIGHT;
-    // div.style.fontSize = s.fontSize + 'px';
-    // div.style.fontFamily = s.fontFamily;
     div.style.whiteSpace = 'nowrap';
     div.style.position = 'absolute';
     div.style.visibility = 'hidden';
     div.style.display = 'inline-block';
-    // div.style.display = (mxClient.IS_QUIRKS) ? 'inline' : 'inline-block';
+    // non standard
     // div.style.zoom = '1';
 
     if ((this.fontStyle & mxgraph.mxConstants.FONT_BOLD) == mxgraph.mxConstants.FONT_BOLD) {
-      // if ((s.fontStyle & mxConstants.FONT_BOLD) == mxConstants.FONT_BOLD)
       div.style.fontWeight = 'bold';
     }
 
     if ((this.fontStyle & mxgraph.mxConstants.FONT_ITALIC) == mxgraph.mxConstants.FONT_ITALIC) {
-      // if ((s.fontStyle & mxConstants.FONT_ITALIC) == mxConstants.FONT_ITALIC)
       div.style.fontStyle = 'italic';
     }
 
     // TODO error in typed-mxgraph@1.0.1
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    str = mxgraph.mxUtils.htmlEntities(str, false);
-    console.info('@computeTextBbox label after htmlEntities', str);
-    div.innerHTML = str.replace(/\n/g, '<br/>');
+    text = mxgraph.mxUtils.htmlEntities(text, false);
+    console.info('@computeTextBbox label after htmlEntities', text);
+    div.innerHTML = text.replace(/\n/g, '<br/>');
 
     document.body.appendChild(div);
     let w = div.offsetWidth;
     const h = div.offsetHeight;
-
-    console.info('@@computed w/h', w, h);
-    console.info('@@div getBoundingClientRect', div.getBoundingClientRect());
-
     div.parentNode.removeChild(div);
 
-    // TODO manage spacing based on configuration
-    //add padding
+    // TODO manage spacing based on configuration and open it to vertical spacing on height
+    // padding/spacing (same for left and right)
     w += 2 * 3; // 3 points on each side
 
-    // if (this.align == mxgraph.mxConstants.ALIGN_CENTER) {
+    // we are always using ALIGN_CENTER
     x -= w / 2;
-    // } else if (this.align == mxgraph.mxConstants.ALIGN_RIGHT) {
-    //   x -= w;
-    // }
-    //
-    // if (this.valign == mxgraph.mxConstants.ALIGN_MIDDLE) {
+    // we are always using ALIGN_MIDDLE
     y -= h / 2;
-    // y -= h / 2 + h / 8;
-    // } else if (this.valign == mxgraph.mxConstants.ALIGN_BOTTOM) {
-    //   y -= h;
-    // }
 
-    // return new mxgraph.mxRectangle(x, y + 2, w, h + 1);
     return new mxgraph.mxRectangle(x, y, w, h);
-    // return new mxgraph.mxRectangle(x + 1, y + 2, w, h + 1);
-    //return new mxgraph.mxRectangle((x + 1) * this.scale, (y + 2) * this.scale, w * this.scale, (h + 1) * this.scale);
-    // const bbox = new mxRectangle((x + 1) * s.scale, (y + 2) * s.scale, w * s.scale, (h + 1) * s.scale);
-    // }
-
-    // if (bbox != null)
-    // {
-    //   var n = this.createElement('rect');
-    //   n.setAttribute('fill', s.fontBackgroundColor || 'none');
-    //   n.setAttribute('stroke', s.fontBorderColor || 'none');
-    //   n.setAttribute('x', Math.floor(bbox.x - 1));
-    //   n.setAttribute('y', Math.floor(bbox.y - 1));
-    //   n.setAttribute('width', Math.ceil(bbox.width + 2));
-    //   n.setAttribute('height', Math.ceil(bbox.height));
-    //
-    //   var sw = (s.fontBorderColor != null) ? Math.max(1, this.format(s.scale)) : 0;
-    //   n.setAttribute('stroke-width', sw);
-    //
-    //   // Workaround for crisp rendering - only required if not exporting
-    //   if (this.root.ownerDocument == document && mxUtils.mod(sw, 2) == 1)
-    //   {
-    //     n.setAttribute('transform', 'translate(0.5, 0.5)');
-    //   }
-    //
-    //   node.insertBefore(n, node.firstChild);
-    // }
-    //   }
-    // }
   }
 }

--- a/src/component/mxgraph/overlay/shapes.ts
+++ b/src/component/mxgraph/overlay/shapes.ts
@@ -116,7 +116,7 @@ export class OverlayBadgeShape extends mxgraph.mxText {
   }
 
   // implementation inspired of mxSvgCanvas2D.prototype.addTextBackground
-  // TODO do we need to use mxShape.augmentBoundingBox
+  // TODO do we need to use mxShape.augmentBoundingBox?
   private computeTextBbox(): mxRectangle {
     // Scale is passed-through to canvas
     const s = this.scale;
@@ -154,10 +154,13 @@ export class OverlayBadgeShape extends mxgraph.mxText {
     console.info(`@@@@computeTextBbox label after htmlEntities ##${text}##`);
     text = text.replace(/\n/g, '<br/>').trim();
 
-    text = text.length > 0 ? text : '&nbsp;&nbsp;';
+    const isBoxForEmptyText = text.length > 0;
+    text = isBoxForEmptyText ? text : '&nbsp;&nbsp;';
     div.innerHTML = text;
 
     document.body.appendChild(div);
+    // TODO find a better way to ensure we have square dimension for empty text
+    // in this case, we also don't need padding/spacing
     let w = div.offsetWidth;
     const h = div.offsetHeight;
     div.parentNode.removeChild(div);

--- a/src/component/mxgraph/overlay/shapes.ts
+++ b/src/component/mxgraph/overlay/shapes.ts
@@ -102,25 +102,14 @@ export class OverlayBadgeShape extends mxgraph.mxText {
   private configureBackgroundShapeCanvas(c: mxAbstractCanvas2D): void {
     console.info('@@@configureBackgroundShapeCanvas');
     super.configureCanvas(c, 0, 0, 0, 0);
+    // TODO strange this should have been configure in super.configureCanvas
+    // otherwise, the value is default (1) * scale
     c.setStrokeWidth(this.strokewidth);
-
-    // c.setFillColor(this.fill);
-    // c.setStrokeColor(this.stroke);
-
-    // TODO remove hard coded canvas style
-    // c.setFillColor('green');
-    // c.setFillAlpha(0.2);
-    // // c.setStrokeColor('red');
   }
 
   configureCanvas(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): void {
     console.info('@@@configureCanvas');
     super.configureCanvas(c, x, y, w, h);
-
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    // c.matchHtmlAlignment = false;
-
     // delegate border and background colors to the background shape
     c.setFontBackgroundColor(null);
     c.setFontBorderColor(null); // unset this to display the text border
@@ -128,27 +117,9 @@ export class OverlayBadgeShape extends mxgraph.mxText {
 
   private paintBackgroundShape(c: mxAbstractCanvas2D): void {
     console.info('@@@@START paintBackgroundShape');
-    // console.info('@@@bounds', this.bounds);
-    // console.info('@@scale', this.scale);
-
-    // Scale is passed-through to canvas
-    // const s = this.scale;
-    // const x = this.bounds.x / s;
-    // const y = this.bounds.y / s;
-    // const w = this.bounds.width / s;
-    // const h = this.bounds.height / s;
-
-    // console.info('this.value', this.value);
-    // const textBbox = this.computeTextBbox(this.value, x, y);
     const textBbox = this.computeTextBbox();
 
     console.info('@@@computeTextBbox', textBbox);
-
-    // TODO set canvas configuration in a dedicated method
-    // c.setFillColor('green');
-    // c.setFillAlpha(0.2);
-    // c.setStrokeColor('red');
-    // c.setStrokeWidth(1);
 
     // c.ellipse(x + 10, y + 10, 30, 30);
     // c.ellipse(textBbox.x, textBbox.y, textBbox.width, textBbox.height);

--- a/src/demo/index.ts
+++ b/src/demo/index.ts
@@ -93,8 +93,8 @@ export function removeCssClasses(bpmnElementId: string | string[], classNames: s
 /**
  * @internal
  */
-export function addOverlays(bpmnElementId: string, overlay: Overlay): void {
-  return bpmnVisualization.bpmnElementsRegistry.addOverlays(bpmnElementId, [overlay]);
+export function addOverlays(bpmnElementId: string, overlays: Overlay | Overlay[]): void {
+  return bpmnVisualization.bpmnElementsRegistry.addOverlays(bpmnElementId, overlays);
 }
 
 /**

--- a/src/static/js/elements-identification.js
+++ b/src/static/js/elements-identification.js
@@ -102,7 +102,7 @@ function getOverlay(bpmnKind) {
       position: 'top-left',
       label: '30 💯',
       // label: '30 👌',
-      // label: '30 🎈',
+      // label: '30 🎈'
       // label: '30\nnext line',
       style: {
         font: {

--- a/src/static/js/elements-identification.js
+++ b/src/static/js/elements-identification.js
@@ -100,7 +100,7 @@ function getOverlay(bpmnKind) {
   if (ShapeUtil.isActivity(bpmnKind)) {
     return {
       position: 'top-left',
-      label: '30 💯',
+      label: '    ',
       // label: '30 👌',
       // label: '30 🎈'
       // label: '30\nnext line',

--- a/src/static/js/elements-identification.js
+++ b/src/static/js/elements-identification.js
@@ -98,12 +98,7 @@ function getCustomCssClassName(bpmnKind) {
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 function getOverlay(bpmnKind) {
   if (ShapeUtil.isActivity(bpmnKind)) {
-    return {
-      position: 'top-left',
-      label: '    ',
-      // label: '30 👌',
-      // label: '30 🎈'
-      // label: '30\nnext line',
+    const overlayTemplate = {
       style: {
         font: {
           color: 'Chartreuse',
@@ -115,6 +110,26 @@ function getOverlay(bpmnKind) {
         },
       },
     };
+
+    return [
+      { ...overlayTemplate, position: 'top-left', label: '30 👌' },
+      // TODO remove duplication in overlay definition
+      {
+        position: 'bottom-left',
+        style: {
+          font: {
+            color: 'Chartreuse',
+            size: 25,
+          },
+          fill: {
+            color: 'DimGray',
+            opacity: 80,
+          },
+        },
+      },
+      { ...overlayTemplate, position: 'top-right', label: '    ' },
+      { ...overlayTemplate, position: 'bottom-right', label: '30\nnext line 🎈' },
+    ];
   } else if (bpmnKind.includes('Gateway')) {
     return {
       position: 'top-right',

--- a/src/static/js/elements-identification.js
+++ b/src/static/js/elements-identification.js
@@ -108,6 +108,7 @@ function getOverlay(bpmnKind) {
         },
         fill: {
           color: 'DimGray',
+          opacity: 80,
         },
       },
     };
@@ -131,7 +132,13 @@ function getOverlay(bpmnKind) {
       label: '15',
       style: {
         font: {
-          size: 30,
+          size: 25,
+        },
+        fill: {
+          color: 'orange',
+        },
+        stroke: {
+          color: 'orange',
         },
       },
     };

--- a/src/static/js/elements-identification.js
+++ b/src/static/js/elements-identification.js
@@ -100,11 +100,11 @@ function getOverlay(bpmnKind) {
   if (ShapeUtil.isActivity(bpmnKind)) {
     return {
       position: 'top-left',
-      label: '30',
+      label: '30\nnext line',
       style: {
         font: {
           color: 'Chartreuse',
-          size: 30,
+          size: 15,
         },
         fill: {
           color: 'DimGray',
@@ -120,10 +120,21 @@ function getOverlay(bpmnKind) {
           color: 'HotPink',
           width: 4,
         },
+        font: {
+          size: 30,
+        },
       },
     };
   } else if (bpmnKind.includes('Event')) {
-    return { position: 'bottom-left', label: '15' };
+    return {
+      position: 'bottom-left',
+      label: '15',
+      style: {
+        font: {
+          size: 30,
+        },
+      },
+    };
   } else if (bpmnKind.includes('lane')) {
     return { position: 'bottom-right', label: '100' };
   } else if (bpmnKind.includes('Flow')) {

--- a/src/static/js/elements-identification.js
+++ b/src/static/js/elements-identification.js
@@ -100,7 +100,10 @@ function getOverlay(bpmnKind) {
   if (ShapeUtil.isActivity(bpmnKind)) {
     return {
       position: 'top-left',
-      label: '30\nnext line',
+      label: '30 💯',
+      // label: '30 👌',
+      // label: '30 🎈',
+      // label: '30\nnext line',
       style: {
         font: {
           color: 'Chartreuse',


### PR DESCRIPTION
This poc provides a new way of managing the overlay shape and covers
- various shape #1171
- implement fill opacity and stroke width #1234
- margin/spacing/padding #1212
- better center the text vertically

The shape extends mxText but the background shape is managed manually. The mxText part is only used to displays the text, no more for the fill and border.


**Note**: I have manually tested the changes with various pages like
- http://localhost:10001/elements-identification.html?url=./static/diagrams/overlays.start.flow.task.gateway.bpmn
- http://localhost:10001/overlays.html?showControlsPanel=true&url=./static/diagrams/overlays.start.flow.task.bpmn

### Rectangle overlays

![GH_PR_1293_POC_rectangle_2_lines_text](https://user-images.githubusercontent.com/27200110/117796688-99f40a00-b24f-11eb-8435-cb3f7d40436a.png)

![GH_PR_1293_POC_rectangle_overlays](https://user-images.githubusercontent.com/27200110/117796699-9b253700-b24f-11eb-9708-faa395db66ce.gif)

### Ellipse overlays

We probably would also want circle that could be adapted from ellipse.

![GH_PR_1293_POC_ellipse_2_lines_text](https://user-images.githubusercontent.com/27200110/117796697-9b253700-b24f-11eb-824a-076dc558408b.png)

![GH_PR_1293_POC_ellipse_overlays](https://user-images.githubusercontent.com/27200110/117796694-9a8ca080-b24f-11eb-8748-eaf86b538a87.gif)
