### PR TITLE
[REFACTOR] Remove the demo code from the packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ bpmnVisualization.load(bpmnContent);
 You can set the BPMN content using one of the following ways:
   * Copy/Paste directly the XML content in a variable
   * Load it from an url, like this [example](https://github.com/process-analytics/bpmn-visualization-examples/blob/master/examples/display-bpmn-diagram/load-remote-bpmn-diagrams/index.html)
-  * Load from your computer, like the [demo example](https://github.com/process-analytics/bpmn-visualization-js/blob/master/src/demo/index.ts)
+  * Load from your computer, like the [demo example](https://github.com/process-analytics/bpmn-visualization-examples/tree/master/examples/display-bpmn-diagram/load-local-bpmn-diagrams/index.html)
 
 
 ### 💠 Browser usage

--- a/dev/ts/component/DropFileUserInterface.ts
+++ b/dev/ts/component/DropFileUserInterface.ts
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-/**
- * @internal
- */
 export class DropFileUserInterface {
   private document: Document;
   private head: Element;

--- a/dev/ts/demo.ts
+++ b/dev/ts/demo.ts
@@ -14,30 +14,24 @@
  * limitations under the License.
  */
 
-import BpmnVisualization from '../component/BpmnVisualization';
-import { GlobalOptions, FitOptions, FitType, LoadOptions } from '../component/options';
+import BpmnVisualization from '../../src/component/BpmnVisualization';
+import { GlobalOptions, FitOptions, FitType, LoadOptions } from '../../src/component/options';
 import { log, logStartup } from './helper';
 import { DropFileUserInterface } from './component/DropFileUserInterface';
-import { BpmnElement, Overlay } from '../component/registry';
-import { BpmnElementKind } from '../model/bpmn/internal/api';
+import { BpmnElement, Overlay } from '../../src/component/registry';
+import { BpmnElementKind } from '../../src/model/bpmn/internal/api';
 
 export * from './helper';
 
 let bpmnVisualization: BpmnVisualization;
 let loadOptions: LoadOptions = {};
 
-/**
- * @internal
- */
 export function updateLoadOptions(fitOptions: FitOptions): void {
   log('Updating load options', fitOptions);
   loadOptions.fit = fitOptions;
   log('Load options updated!', stringify(loadOptions));
 }
 
-/**
- * @internal
- */
 export function getCurrentLoadOptions(): LoadOptions {
   return { ...loadOptions };
 }
@@ -53,53 +47,32 @@ function loadBpmn(bpmn: string): void {
   document.dispatchEvent(new CustomEvent('diagramLoaded'));
 }
 
-/**
- * @internal
- */
 export function fit(fitOptions: FitOptions): void {
   log('Fitting....');
   bpmnVisualization.fit(fitOptions);
   log('Fit done with configuration', stringify(fitOptions));
 }
 
-/**
- * @internal
- */
 export function getElementsByKinds(bpmnKinds: BpmnElementKind | BpmnElementKind[]): BpmnElement[] {
   return bpmnVisualization.bpmnElementsRegistry.getElementsByKinds(bpmnKinds);
 }
 
-/**
- * @internal
- */
 export function getElementsByIds(bpmnId: string | string[]): BpmnElement[] {
   return bpmnVisualization.bpmnElementsRegistry.getElementsByIds(bpmnId);
 }
 
-/**
- * @internal
- */
 export function addCssClasses(bpmnElementId: string | string[], classNames: string | string[]): void {
   return bpmnVisualization.bpmnElementsRegistry.addCssClasses(bpmnElementId, classNames);
 }
 
-/**
- * @internal
- */
 export function removeCssClasses(bpmnElementId: string | string[], classNames: string | string[]): void {
   return bpmnVisualization.bpmnElementsRegistry.removeCssClasses(bpmnElementId, classNames);
 }
 
-/**
- * @internal
- */
 export function addOverlays(bpmnElementId: string, overlay: Overlay): void {
   return bpmnVisualization.bpmnElementsRegistry.addOverlays(bpmnElementId, [overlay]);
 }
 
-/**
- * @internal
- */
 export function removeAllOverlays(bpmnElementId: string): void {
   return bpmnVisualization.bpmnElementsRegistry.removeAllOverlays(bpmnElementId);
 }
@@ -116,7 +89,6 @@ function readAndLoadFile(f: File): void {
 // TODO: make File Open Button a self contained component
 /**
  * <b>IMPORTANT</b>: be sure to have call the `startBpmnVisualization` function prior calling this function as it relies on resources that must be initialized first.
- * @internal
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any,@typescript-eslint/explicit-module-boundary-types
 export function handleFileSelect(evt: any): void {
@@ -151,9 +123,6 @@ function loadBpmnFromUrl(url: string, statusFetchKoNotifier: (errorMsg: string) 
     });
 }
 
-/**
- * @internal
- */
 export interface BpmnVisualizationDemoConfiguration {
   statusFetchKoNotifier?: (errorMsg: string) => void;
   globalOptions: GlobalOptions;
@@ -178,9 +147,6 @@ function getFitOptionsFromParameters(config: BpmnVisualizationDemoConfiguration,
   return fitOptions;
 }
 
-/**
- * @internal
- */
 export function startBpmnVisualization(config: BpmnVisualizationDemoConfiguration): void {
   const log = logStartup;
   const container = config.globalOptions.container;

--- a/dev/ts/helper.ts
+++ b/dev/ts/helper.ts
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-/**
- * @internal
- */
 export function documentReady(callbackFunction: () => void): void {
   // see if DOM is already available
   if (document.readyState === 'complete' || document.readyState === 'interactive') {
@@ -32,16 +29,10 @@ function _log(header: string, message: unknown, ...optionalParams: unknown[]): v
   console.info(header + ' ' + message, ...optionalParams);
 }
 
-/**
- * @internal
- */
 export function logStartup(message?: string, ...optionalParams: unknown[]): void {
   _log('[DEMO STARTUP]', message, ...optionalParams);
 }
 
-/**
- * @internal
- */
 export function log(message?: string, ...optionalParams: unknown[]): void {
   _log('[DEMO]', message, ...optionalParams);
 }

--- a/dev/ts/internal-dev-bundle-index.ts
+++ b/dev/ts/internal-dev-bundle-index.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2021 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export * from './demo';
+export * from '../../src/bpmn-visualization';

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -41,7 +41,6 @@ const serverPort = process.env.SERVER_PORT || argv['config-server-port'] || 1000
 const buildBundles = argv['config-build-bundles'] || false;
 
 const outputDir = demoMode ? 'build/demo' : 'build/public';
-const libInput = 'src/bpmn-visualization.ts';
 let rollupConfigs;
 
 // internal lib development
@@ -49,7 +48,7 @@ if (!buildBundles) {
   const sourceMap = !demoMode;
   rollupConfigs = [
     {
-      input: libInput,
+      input: 'dev/ts/internal-dev-bundle-index.ts',
       output: [
         {
           file: `${outputDir}/index.es.js`,
@@ -62,6 +61,7 @@ if (!buildBundles) {
     },
   ];
 } else {
+  const libInput = 'src/bpmn-visualization.ts';
   const pluginsBundleIIFE = [typescriptPlugin(), resolve(), commonjs(), json()];
   const outputIIFE = {
     file: pkg.browser.replace('.min.js', '.js'),

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,7 +9,7 @@ sonar.projectVersion=0.15.0-post
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=src
 # The HTML page are only use internally for tests or demo. No need to analyze them.
-sonar.exclusions=src/model/**/*,src/demo/**/*
+sonar.exclusions=src/model/**/*
 #sonar.inclusions=
 # Encoding of the source code. Default is default system encoding
 sonar.sourceEncoding=UTF-8

--- a/src/bpmn-visualization.ts
+++ b/src/bpmn-visualization.ts
@@ -33,11 +33,6 @@ export * from './component/mxgraph/StyleUtils';
 export * from './component/mxgraph/shape/render';
 export * from './component/registry';
 
-// TODO restore 'alias export' to avoid any name clash with the demo code, when esLint parsing error is fixed: "Parsing error: Cannot read property 'map' of undefined"
-// bug: https://github.com/typescript-eslint/typescript-eslint/issues/1653
-// enhancement: https://github.com/typescript-eslint/typescript-eslint/issues/1436
-// export * as bpmnVisualizationDemo from './demo';
-export * from './demo';
 export * from './model/bpmn/internal/shape';
 
 export const mxConstants = mxgraph.mxConstants;

--- a/test/e2e/jest.config.js
+++ b/test/e2e/jest.config.js
@@ -32,7 +32,7 @@ module.exports = {
     },
   },
   collectCoverageFrom: ['**/*.{ts,js}'],
-  coveragePathIgnorePatterns: ['/node_modules/', 'dev', 'dist', 'src/demo', 'src/model', 'test'],
+  coveragePathIgnorePatterns: ['/node_modules/', 'dev', 'dist', 'src/model', 'test'],
   coverageReporters: ['lcov', 'text-summary'],
   coverageDirectory: 'build/test-report/e2e',
   setupFiles: ['./test/e2e/config/copy.bpmn.diagram.ts'],

--- a/test/integration/jest.config.js
+++ b/test/integration/jest.config.js
@@ -29,7 +29,7 @@ module.exports = {
     },
   },
   collectCoverageFrom: ['**/*.{ts,js}'],
-  coveragePathIgnorePatterns: ['/node_modules/', 'dev', 'dist', 'src/demo', 'src/model', 'test'],
+  coveragePathIgnorePatterns: ['/node_modules/', 'dev', 'dist', 'src/model', 'test'],
   coverageReporters: ['lcov', 'text-summary'],
   coverageDirectory: 'build/test-report/integration',
   reporters: [

--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -29,7 +29,7 @@ module.exports = {
     },
   },
   collectCoverageFrom: ['**/*.{ts,js}'],
-  coveragePathIgnorePatterns: ['/node_modules/', 'dev', 'dist', 'src/demo', 'src/model', 'test'],
+  coveragePathIgnorePatterns: ['/node_modules/', 'dev', 'dist', 'src/model', 'test'],
   coverageReporters: ['lcov', 'text-summary'],
   coverageDirectory: 'build/test-report/unit',
   reporters: [


### PR DESCRIPTION
Move the demo and test-only code out of the main codebase. This clarifies that
is it is not part of the library and make it easier to not package it into the
bundles.

closes #717