### PR TITLE
[INFRA] Skip GitHub workflow elements when secrets are not available

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,7 +116,7 @@ jobs:
 
       # No need to run the analysis from all environments
       - name: SonarCloud Scan
-        if: ${{ success() && contains(matrix.os.coverage, 'coverage') }}
+        if: ${{ success() && contains(matrix.os.coverage, 'coverage') && env.SONAR_TOKEN != '' }}
         uses: SonarSource/sonarcloud-github-action@v1.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any

--- a/.github/workflows/generate-demo-preview.yml
+++ b/.github/workflows/generate-demo-preview.yml
@@ -17,7 +17,23 @@ on:
       - 'tsconfig.json'
 
 jobs:
+  # inspired from https://github.com/process-analytics/github-actions-playground/pull/23
+  check_secrets:
+    runs-on: ubuntu-20.04
+    outputs:
+      is_SURGE_TOKEN_set: ${{ steps.secret_availability.outputs.is_SURGE_TOKEN_set }}
+    steps:
+      - name: Compute secrets availability
+        id: secret_availability
+        env:
+          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
+        run: |
+          echo "is_SURGE_TOKEN_set: ${{ env.SURGE_TOKEN != '' }}"
+          echo "::set-output name=is_SURGE_TOKEN_set::${{ env.SURGE_TOKEN != '' }}"
+
   demo_preview:
+    needs: [check_secrets]
+    if: needs.check_secrets.outputs.is_SURGE_TOKEN_set == 'true'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -28,8 +28,24 @@ on:
       - 'typedoc.json'
 
 jobs:
-  doc_preview:
+  # inspired from https://github.com/process-analytics/github-actions-playground/pull/23
+  check_secrets:
     if: github.event_name == 'pull_request'
+    runs-on: ubuntu-20.04
+    outputs:
+      is_SURGE_TOKEN_set: ${{ steps.secret_availability.outputs.is_SURGE_TOKEN_set }}
+    steps:
+      - name: Compute secrets availability
+        id: secret_availability
+        env:
+          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
+        run: |
+          echo "is_SURGE_TOKEN_set: ${{ env.SURGE_TOKEN != '' }}"
+          echo "::set-output name=is_SURGE_TOKEN_set::${{ env.SURGE_TOKEN != '' }}"
+
+  doc_preview:
+    needs: [check_secrets]
+    if: github.event_name == 'pull_request' && needs.check_secrets.outputs.is_SURGE_TOKEN_set == 'true'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This will prevent errors when Pull Request are created from forked repositories
and by Dependabot.

closes #1279