### PR TITLE
[FIX] Don't use a select text cursor on label hover

### DIFF
--- a/src/component/mxgraph/BpmnMxGraph.ts
+++ b/src/component/mxgraph/BpmnMxGraph.ts
@@ -29,6 +29,8 @@ export class BpmnMxGraph extends mxgraph.mxGraph {
    */
   constructor(readonly container: HTMLElement) {
     super(container);
+    // ensure we don't have a select text cursor on label hover, see #294
+    this.container.style.cursor = 'default';
   }
 
   /**

--- a/src/component/mxgraph/BpmnMxGraph.ts
+++ b/src/component/mxgraph/BpmnMxGraph.ts
@@ -29,8 +29,10 @@ export class BpmnMxGraph extends mxgraph.mxGraph {
    */
   constructor(readonly container: HTMLElement) {
     super(container);
-    // ensure we don't have a select text cursor on label hover, see #294
-    this.container.style.cursor = 'default';
+    if (this.container) {
+      // ensure we don't have a select text cursor on label hover, see #294
+      this.container.style.cursor = 'default';
+    }
   }
 
   /**

--- a/test/e2e/helpers/visu/bpmn-page-utils.ts
+++ b/test/e2e/helpers/visu/bpmn-page-utils.ts
@@ -29,7 +29,10 @@ export class BpmnPage {
   }
 
   async expectAvailableBpmnContainer(options?: PageWaitForSelectorOptions): Promise<ElementHandle<SVGElement | HTMLElement>> {
-    return await this.currentPage.waitForSelector(`#${this.bpmnContainerId}`, options);
+    const bpmnContainer = await this.currentPage.waitForSelector(`#${this.bpmnContainerId}`, options);
+    const style = await bpmnContainer.getAttribute('style');
+    expect(style).toContain('cursor: default');
+    return bpmnContainer;
   }
 
   async expectPageTitle(title: string): Promise<void> {


### PR DESCRIPTION
The text is not selectable, so use the default cursor. This prevents to let
users think that the label is editable.

Fix #294