### PR TITLE
[INFRA] Fix .eslintignore to consider files in `config` folders

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,8 +1,8 @@
 .github/
 .idea/
-build/
-config/
-dist/
+/build/
+/config/
+/dist/
 node_modules/
 scripts/utils/dist/
 test/performance/data/

--- a/src/component/mxgraph/config/ShapeConfigurator.ts
+++ b/src/component/mxgraph/config/ShapeConfigurator.ts
@@ -15,7 +15,7 @@
  */
 
 import { mxgraph } from '../initializer';
-import { mxCellOverlay, mxCellState, mxImageShape, mxShape } from 'mxgraph'; // for types
+import { mxCellState, mxImageShape, mxShape } from 'mxgraph'; // for types
 import { ShapeBpmnElementKind } from '../../../model/bpmn/internal/shape';
 import { BoundaryEventShape, CatchIntermediateEventShape, EndEventShape, StartEventShape, ThrowIntermediateEventShape } from '../shape/event-shapes';
 import { EventBasedGatewayShape, ExclusiveGatewayShape, InclusiveGatewayShape, ParallelGatewayShape } from '../shape/gateway-shapes';
@@ -104,7 +104,7 @@ export default class ShapeConfigurator {
         const cell = this.state.cell;
         // dialect = strictHtml is set means that current node holds an html label
         let allBpmnClassNames = computeAllBpmnClassNames(extractBpmnKindFromStyle(cell), this.dialect === mxgraph.mxConstants.DIALECT_STRICTHTML);
-        const extraCssClasses =  this.state.style[StyleIdentifier.BPMN_STYLE_EXTRA_CSS_CLASSES];
+        const extraCssClasses = this.state.style[StyleIdentifier.BPMN_STYLE_EXTRA_CSS_CLASSES];
         if (extraCssClasses) {
           allBpmnClassNames = allBpmnClassNames.concat(extraCssClasses);
         }
@@ -127,7 +127,7 @@ export default class ShapeConfigurator {
   }
 
   initMxCellRendererCreateCellOverlays(): void {
-    mxgraph.mxCellRenderer.prototype.createCellOverlays = function(state: mxCellState) {
+    mxgraph.mxCellRenderer.prototype.createCellOverlays = function (state: mxCellState) {
       const graph = state.view.graph;
       const overlays = graph.getCellOverlays(state.cell);
       let dict = null;
@@ -135,8 +135,8 @@ export default class ShapeConfigurator {
       if (overlays != null) {
         dict = new mxgraph.mxDictionary<mxShape>();
 
-        for (let currentOverlay of overlays) {
-          const shape = (state.overlays != null) ? state.overlays.remove(currentOverlay) : null;
+        for (const currentOverlay of overlays) {
+          const shape = state.overlays != null ? state.overlays.remove(currentOverlay) : null;
           if (shape != null) {
             dict.put(currentOverlay, shape);
             continue;
@@ -177,7 +177,7 @@ export default class ShapeConfigurator {
 
       // Removes unused
       if (state.overlays != null) {
-        state.overlays.visit(function(id: string, shape: mxShape) {
+        state.overlays.visit(function (id: string, shape: mxShape) {
           shape.destroy();
         });
       }

--- a/src/component/mxgraph/config/StyleConfigurator.ts
+++ b/src/component/mxgraph/config/StyleConfigurator.ts
@@ -309,7 +309,7 @@ export default class StyleConfigurator {
       .join(';');
   }
 
-  private computeShapeStyle(shape: Shape): Map<string, string | number>{
+  private computeShapeStyle(shape: Shape): Map<string, string | number> {
     const styleValues = new Map<string, string | number>();
     const bpmnElement = shape.bpmnElement;
 
@@ -342,7 +342,7 @@ export default class StyleConfigurator {
     return styleValues;
   }
 
-  private computeEdgeStyle(edge: Edge): string[]{
+  private computeEdgeStyle(edge: Edge): string[] {
     const styles: string[] = [];
 
     const bpmnElement = edge.bpmnElement;

--- a/test/e2e/config/playwright.ts
+++ b/test/e2e/config/playwright.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import debugLogger from "debug";
+import debugLogger from 'debug';
 import 'jest-playwright-preset';
 
 // Allow to get browser console logs


### PR DESCRIPTION
Update the configuration to only ignore folders at project root. To prevent new
errors in the future, also do this for the `build` and `dist` folders.
Fix lint errors in files in the `config` folders.