### PR TITLE
[TEST] Fix message flow css selector in test page

### DIFF
--- a/dev/elements-identification.html
+++ b/dev/elements-identification.html
@@ -54,17 +54,17 @@
       /* sequence flow arrow */
       .detection-flow > path:nth-child(3),
       /* message flow start */
-      .detection-flow > ellipse:nth-child(4),
+      .detection-flow > ellipse:nth-child(3),
       /* message flow arrow */
-      .detection-flow > path:nth-child(6) {
+      .detection-flow > path:nth-child(4) {
         fill: dodgerblue;
       }
       /* sequence flow arrow */
       .detection-flow > path:nth-child(3),
         /* message flow start */
-      .detection-flow > ellipse:nth-child(4),
+      .detection-flow > ellipse:nth-child(3),
         /* message flow arrow */
-      .detection-flow > path:nth-child(6),
+      .detection-flow > path:nth-child(4),
       /* edge line */
       .detection-flow > path:nth-child(2) {
         stroke: dodgerblue;


### PR DESCRIPTION
We now fill both the start and the end markers which changes the generated svg
structure.

We are subject to such changes until we implement #1035.

### Screenshots

Prior the fix
![01_before](https://user-images.githubusercontent.com/27200110/122911155-48af5e00-d357-11eb-9660-0b00cf14efd1.png)

With the fix
![02_after](https://user-images.githubusercontent.com/27200110/122911157-4947f480-d357-11eb-8660-0fafe1f305b8.png)
