### PR TITLE
[INFRA] Fix typescript missing source when using livereload

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -123,6 +123,11 @@ function typescriptPlugin() {
   const tsDeclarationFiles = !demoMode || buildBundles;
   const tsSourceMap = !demoMode && !buildBundles; // TODO logic duplicated with build selection
   const tsconfigOverride = { compilerOptions: { sourceMap: tsSourceMap, declaration: tsDeclarationFiles } };
+
+  if (devMode) {
+    tsconfigOverride.include = ['src/**/*', 'dev/ts/**/*'];
+  }
+
   return typescript({
     typescript: require('typescript'),
     tsconfigOverride: tsconfigOverride,


### PR DESCRIPTION
This has been introduced when moving the demo code to the `dev/ts` folder.

Prior the fix, when changing code in the src folder, the rollup typescript
plugin fails because it is unable to find the `dev/ts/internal-dev-bundle-index.ts`
source file.
[!] (plugin rpt2) Error: Could not find source file: 'xxxx/bpmn-visualization-js/dev/ts/internal-dev-bundle-index.ts'.