### PR TITLE
[TEST] Update position of `doctype` in test pages

### DIFF
--- a/dev/diagram-navigation.html
+++ b/dev/diagram-navigation.html
@@ -1,7 +1,7 @@
+<!DOCTYPE html>
 <!-- Available query parameters to configure the behavior of this page -->
 <!-- showControlsPanel: if true, display buttons to apply overlays to BPMN elements (on the left side of the page) -->
 <!-- showMousePointer: if true, highlight/show the mouse position -->
-<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">

--- a/dev/overlays.html
+++ b/dev/overlays.html
@@ -1,7 +1,7 @@
+<!DOCTYPE html>
 <!-- Available query parameters to configure the behavior of this page -->
 <!-- showControlsPanel: if true, display buttons to apply overlays to BPMN elements (on the left side of the page) -->
 <!-- showMousePointer: if true, highlight/show the mouse position -->
-<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">


### PR DESCRIPTION
Ensure that '<!doctype html>' is on top of the page to conform to the HTML
specification.
This also prevent build tool like 'snowpack' to consider the page as an 'HTML fragment'
(which generates build errors).


Detected during the snowpack poc #1355. Snowpack error:
> [snowpack] Error: HTML fragment found!
> HTML fragments (files not starting with "<!doctype html>") are not transformed like full HTML pages.
> Add the missing doctype, or set buildOptions.htmlFragments=true if HTML fragments are expected.
> 
