### PR TITLE
[REFACTOR] Make override methods explicit

### DIFF
--- a/dev/ts/component/SvgExporter.ts
+++ b/dev/ts/component/SvgExporter.ts
@@ -32,11 +32,11 @@ interface SvgExportOptions {
 export class SvgExporter {
   constructor(private graph: mxGraph) {}
 
-  public exportSvg(): string {
+  exportSvg(): string {
     return this.doSvgExport(true);
   }
 
-  public exportSvgForPng(): string {
+  exportSvgForPng(): string {
     // chrome and webkit: tainted canvas when svg contains foreignObject
     // also on brave --> probably fail on chromium based browsers
     // so disable foreign objects for such browsers
@@ -116,7 +116,7 @@ class CanvasForExport extends mxgraph.mxSvgCanvas2D {
     super(node);
   }
 
-  getAlternateText(
+  override getAlternateText(
     fo: Element,
     x: number,
     y: number,
@@ -141,7 +141,7 @@ class CanvasForExport extends mxgraph.mxSvgCanvas2D {
     return this.computeTruncatedText(str, w);
   }
 
-  plainText(
+  override plainText(
     x: number,
     y: number,
     w: number,

--- a/src/component/mxgraph/BpmnMxGraph.ts
+++ b/src/component/mxgraph/BpmnMxGraph.ts
@@ -27,7 +27,7 @@ export class BpmnMxGraph extends mxgraph.mxGraph {
   /**
    * @internal
    */
-  constructor(readonly container: HTMLElement) {
+  constructor(container: HTMLElement) {
     super(container);
     if (this.container) {
       // ensure we don't have a select text cursor on label hover, see #294
@@ -39,7 +39,7 @@ export class BpmnMxGraph extends mxgraph.mxGraph {
    * Overridden to set initial cumulativeZoomFactor
    * @internal
    */
-  fit(border: number, keepOrigin?: boolean, margin?: number, enabled?: boolean, ignoreWidth?: boolean, ignoreHeight?: boolean, maxHeight?: number): number {
+  override fit(border: number, keepOrigin?: boolean, margin?: number, enabled?: boolean, ignoreWidth?: boolean, ignoreHeight?: boolean, maxHeight?: number): number {
     const scale = super.fit(border, keepOrigin, margin, enabled, ignoreWidth, ignoreHeight, maxHeight);
     this.cumulativeZoomFactor = scale;
     return scale;
@@ -49,7 +49,7 @@ export class BpmnMxGraph extends mxgraph.mxGraph {
    * Overridden to set initial cumulativeZoomFactor
    * @internal
    */
-  zoomActual(): void {
+  override zoomActual(): void {
     super.zoomActual();
     this.cumulativeZoomFactor = this.view.scale;
   }
@@ -57,7 +57,7 @@ export class BpmnMxGraph extends mxgraph.mxGraph {
   /**
    * @internal
    */
-  public customFit(fitOptions: FitOptions): void {
+  customFit(fitOptions: FitOptions): void {
     // TODO avoid extra zoom/fit reset
     // see https://github.com/process-analytics/bpmn-visualization-js/issues/888
     this.zoomActual();
@@ -105,7 +105,7 @@ export class BpmnMxGraph extends mxgraph.mxGraph {
   /**
    * @internal
    */
-  zoomTo(scale: number, center?: boolean, up?: boolean, offsetX?: number, offsetY?: number, performScaling?: boolean): void {
+  override zoomTo(scale: number, center?: boolean, up?: boolean, offsetX?: number, offsetY?: number, performScaling?: boolean): void {
     if (scale === null) {
       const [newScale, dx, dy] = this.getScaleAndTranslationDeltas(up, offsetX, offsetY);
       if (performScaling) {

--- a/src/component/mxgraph/overlay/custom-overlay.ts
+++ b/src/component/mxgraph/overlay/custom-overlay.ts
@@ -33,7 +33,7 @@ export interface MxGraphCustomOverlayPosition {
 export type MxGraphCustomOverlayStyle = Required<OverlayStyle>;
 
 export class MxGraphCustomOverlay extends mxgraph.mxCellOverlay {
-  public readonly style: MxGraphCustomOverlayStyle;
+  readonly style: MxGraphCustomOverlayStyle;
 
   constructor(public label: string, options: MxGraphCustomOverlayOptions) {
     super(null, '', options.position.horizontalAlign, options.position.verticalAlign, null, 'default');
@@ -41,7 +41,7 @@ export class MxGraphCustomOverlay extends mxgraph.mxCellOverlay {
   }
 
   // Based on original method from mxCellOverlay (mxCellOverlay.prototype.getBounds)
-  getBounds(state: mxCellState): mxRectangle {
+  override getBounds(state: mxCellState): mxRectangle {
     const isEdge = state.view.graph.getModel().isEdge(state.cell);
     const s = state.view.scale;
     let pt;

--- a/src/component/mxgraph/shape/activity-shapes.ts
+++ b/src/component/mxgraph/shape/activity-shapes.ts
@@ -43,7 +43,7 @@ export abstract class BaseActivityShape extends mxgraph.mxRectangleShape {
     this.isRounded = true;
   }
 
-  public paintForeground(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): void {
+  override paintForeground(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): void {
     super.paintForeground(c, x, y, w, h);
     // 0 is used for ratioParent as if we pass undefined to builder function the default 0.25 value will be used instead
     this.paintMarkerIcons(buildPaintParameter({ canvas: c, x, y, width: w, height: h, shape: this, ratioFromParent: 0, iconStrokeWidth: 1.5 }));
@@ -101,7 +101,7 @@ abstract class BaseTaskShape extends BaseActivityShape {
     super(bounds, fill, stroke, strokewidth);
   }
 
-  public paintForeground(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): void {
+  override paintForeground(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): void {
     super.paintForeground(c, x, y, w, h);
     this.paintTaskIcon(buildPaintParameter({ canvas: c, x, y, width: w, height: h, shape: this }));
   }
@@ -113,7 +113,7 @@ abstract class BaseTaskShape extends BaseActivityShape {
  * @internal
  */
 export class TaskShape extends BaseTaskShape {
-  public constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number) {
+  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number) {
     super(bounds, fill, stroke, strokewidth);
   }
 
@@ -128,7 +128,7 @@ export class TaskShape extends BaseTaskShape {
  * @internal
  */
 export class ServiceTaskShape extends BaseTaskShape {
-  public constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number) {
+  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number) {
     super(bounds, fill, stroke, strokewidth);
   }
 
@@ -141,7 +141,7 @@ export class ServiceTaskShape extends BaseTaskShape {
  * @internal
  */
 export class UserTaskShape extends BaseTaskShape {
-  public constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number) {
+  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number) {
     super(bounds, fill, stroke, strokewidth);
   }
 
@@ -154,7 +154,7 @@ export class UserTaskShape extends BaseTaskShape {
  * @internal
  */
 export class ReceiveTaskShape extends BaseTaskShape {
-  public constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number) {
+  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number) {
     super(bounds, fill, stroke, strokewidth);
   }
 
@@ -195,7 +195,7 @@ export class ReceiveTaskShape extends BaseTaskShape {
  * @internal
  */
 export class SendTaskShape extends BaseTaskShape {
-  public constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number) {
+  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number) {
     super(bounds, fill, stroke, strokewidth);
   }
 
@@ -208,7 +208,7 @@ export class SendTaskShape extends BaseTaskShape {
  * @internal
  */
 export class ManualTaskShape extends BaseTaskShape {
-  public constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number) {
+  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number) {
     super(bounds, fill, stroke, strokewidth);
   }
 
@@ -221,7 +221,7 @@ export class ManualTaskShape extends BaseTaskShape {
  * @internal
  */
 export class ScriptTaskShape extends BaseTaskShape {
-  public constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number) {
+  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number) {
     super(bounds, fill, stroke, strokewidth);
   }
 
@@ -238,7 +238,7 @@ export class ScriptTaskShape extends BaseTaskShape {
  * @internal
  */
 export class CallActivityShape extends BaseActivityShape {
-  public constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number = StyleDefault.STROKE_WIDTH_THICK) {
+  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number = StyleDefault.STROKE_WIDTH_THICK) {
     super(bounds, fill, stroke, strokewidth);
   }
 }
@@ -247,11 +247,11 @@ export class CallActivityShape extends BaseActivityShape {
  * @internal
  */
 export class SubProcessShape extends BaseActivityShape {
-  public constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number) {
+  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number) {
     super(bounds, fill, stroke, strokewidth);
   }
 
-  public paintBackground(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): void {
+  override paintBackground(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): void {
     const subProcessKind = StyleUtils.getBpmnSubProcessKind(this.style);
     c.save(); // ensure we can later restore the configuration
     if (subProcessKind === ShapeBpmnSubProcessKind.EVENT) {
@@ -270,7 +270,7 @@ export class SubProcessShape extends BaseActivityShape {
  * @internal
  */
 export class BusinessRuleTaskShape extends BaseTaskShape {
-  public constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number) {
+  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number) {
     super(bounds, fill, stroke, strokewidth);
   }
 

--- a/src/component/mxgraph/shape/edges.ts
+++ b/src/component/mxgraph/shape/edges.ts
@@ -23,7 +23,7 @@ export class BpmnConnector extends mxgraph.mxConnector {
     super(points, stroke, strokewidth);
   }
 
-  paintEdgeShape(c: mxAbstractCanvas2D, pts: mxPoint[]): void {
+  override paintEdgeShape(c: mxAbstractCanvas2D, pts: mxPoint[]): void {
     // The indirection via functions for markers is needed in
     // order to apply the offsets before painting the line and
     // paint the markers after painting the line.

--- a/src/component/mxgraph/shape/event-shapes.ts
+++ b/src/component/mxgraph/shape/event-shapes.ts
@@ -81,7 +81,7 @@ abstract class EventShape extends mxgraph.mxEllipse {
     super(bounds, fill, stroke, strokewidth);
   }
 
-  public paintVertexShape(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): void {
+  override paintVertexShape(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): void {
     this.markNonFullyRenderedEvents(c);
     const paintParameter = buildPaintParameter({ canvas: c, x, y, width: w, height: h, shape: this, isFilled: this.withFilledIcon });
 
@@ -128,7 +128,7 @@ abstract class EventShape extends mxgraph.mxEllipse {
  * @internal
  */
 export class StartEventShape extends EventShape {
-  public constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number = StyleDefault.STROKE_WIDTH_THIN) {
+  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number = StyleDefault.STROKE_WIDTH_THIN) {
     super(bounds, fill, stroke, strokewidth);
   }
 }
@@ -137,7 +137,7 @@ export class StartEventShape extends EventShape {
  * @internal
  */
 export class EndEventShape extends EventShape {
-  public constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number = StyleDefault.STROKE_WIDTH_THICK) {
+  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number = StyleDefault.STROKE_WIDTH_THICK) {
     super(bounds, fill, stroke, strokewidth);
     this.withFilledIcon = true;
   }
@@ -150,7 +150,7 @@ abstract class IntermediateEventShape extends EventShape {
 
   // this implementation is adapted from the draw.io BPMN 'throwing' outlines
   // https://github.com/jgraph/drawio/blob/0e19be6b42755790a749af30450c78c0d83be765/src/main/webapp/shapes/bpmn/mxBpmnShape2.js#L431
-  protected paintOuterShape({ canvas, shapeConfig: { x, y, width, height, strokeWidth } }: PaintParameter): void {
+  protected override paintOuterShape({ canvas, shapeConfig: { x, y, width, height, strokeWidth } }: PaintParameter): void {
     canvas.ellipse(x, y, width, height);
     canvas.fillAndStroke();
 
@@ -164,7 +164,7 @@ abstract class IntermediateEventShape extends EventShape {
  * @internal
  */
 export class CatchIntermediateEventShape extends IntermediateEventShape {
-  public constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth?: number) {
+  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth?: number) {
     super(bounds, fill, stroke, strokewidth);
   }
 }
@@ -173,7 +173,7 @@ export class CatchIntermediateEventShape extends IntermediateEventShape {
  * @internal
  */
 export class ThrowIntermediateEventShape extends IntermediateEventShape {
-  public constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth?: number) {
+  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth?: number) {
     super(bounds, fill, stroke, strokewidth);
     this.withFilledIcon = true;
   }
@@ -183,7 +183,7 @@ export class ThrowIntermediateEventShape extends IntermediateEventShape {
  * @internal
  */
 export class BoundaryEventShape extends IntermediateEventShape {
-  public constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth?: number) {
+  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth?: number) {
     super(bounds, fill, stroke, strokewidth);
   }
 }

--- a/src/component/mxgraph/shape/flow-shapes.ts
+++ b/src/component/mxgraph/shape/flow-shapes.ts
@@ -26,11 +26,11 @@ import { mxAbstractCanvas2D, mxRectangle } from 'mxgraph'; // for types
 export class MessageFlowIconShape extends mxgraph.mxRectangleShape {
   protected iconPainter = IconPainterProvider.get();
 
-  public constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number) {
+  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number) {
     super(bounds, fill, stroke, strokewidth);
   }
 
-  public paintVertexShape(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): void {
+  override paintVertexShape(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): void {
     const withFilledIcon = StyleUtils.getBpmnIsInitiating(this.style) === MessageVisibleKind.NON_INITIATING;
     const paintParameter = buildPaintParameter({ canvas: c, x, y, width: w, height: h, shape: this, ratioFromParent: 1, isFilled: withFilledIcon });
 

--- a/src/component/mxgraph/shape/gateway-shapes.ts
+++ b/src/component/mxgraph/shape/gateway-shapes.ts
@@ -28,7 +28,7 @@ abstract class GatewayShape extends mxgraph.mxRhombus {
 
   protected abstract paintInnerShape(paintParameter: PaintParameter): void;
 
-  public paintVertexShape(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): void {
+  override paintVertexShape(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): void {
     const paintParameter = buildPaintParameter({ canvas: c, x, y, width: w, height: h, shape: this });
     this.paintOuterShape(paintParameter);
     this.paintInnerShape(paintParameter);
@@ -43,7 +43,7 @@ abstract class GatewayShape extends mxgraph.mxRhombus {
  * @internal
  */
 export class ExclusiveGatewayShape extends GatewayShape {
-  public constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number = StyleDefault.STROKE_WIDTH_THIN) {
+  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number = StyleDefault.STROKE_WIDTH_THIN) {
     super(bounds, fill, stroke, strokewidth);
   }
 
@@ -60,7 +60,7 @@ export class ExclusiveGatewayShape extends GatewayShape {
  * @internal
  */
 export class ParallelGatewayShape extends GatewayShape {
-  public constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number = StyleDefault.STROKE_WIDTH_THIN) {
+  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number = StyleDefault.STROKE_WIDTH_THIN) {
     super(bounds, fill, stroke, strokewidth);
   }
 
@@ -77,7 +77,7 @@ export class ParallelGatewayShape extends GatewayShape {
  * @internal
  */
 export class InclusiveGatewayShape extends GatewayShape {
-  public constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number = StyleDefault.STROKE_WIDTH_THIN) {
+  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number = StyleDefault.STROKE_WIDTH_THIN) {
     super(bounds, fill, stroke, strokewidth);
   }
 
@@ -94,7 +94,7 @@ export class InclusiveGatewayShape extends GatewayShape {
  * @internal
  */
 export class EventBasedGatewayShape extends GatewayShape {
-  public constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number = StyleDefault.STROKE_WIDTH_THIN) {
+  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number = StyleDefault.STROKE_WIDTH_THIN) {
     super(bounds, fill, stroke, strokewidth);
   }
 

--- a/src/component/mxgraph/shape/text-annotation-shapes.ts
+++ b/src/component/mxgraph/shape/text-annotation-shapes.ts
@@ -23,11 +23,11 @@ import { mxAbstractCanvas2D, mxRectangle } from 'mxgraph'; // for types
  */
 export class TextAnnotationShape extends mxgraph.mxRectangleShape {
   private readonly TEXT_ANNOTATION_BORDER_LENGTH = 10;
-  public constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number = StyleDefault.STROKE_WIDTH_THIN) {
+  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number = StyleDefault.STROKE_WIDTH_THIN) {
     super(bounds, fill, stroke, strokewidth);
   }
 
-  public paintBackground(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): void {
+  override paintBackground(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): void {
     // paint sort of left square bracket shape - for text annotation
     c.begin();
     c.moveTo(x + this.TEXT_ANNOTATION_BORDER_LENGTH, y);

--- a/test/bundles/bundles.test.ts
+++ b/test/bundles/bundles.test.ts
@@ -60,7 +60,7 @@ class BpmnStaticPageSvgTester extends BpmnPageSvgTester {
     super(targetedPage, currentPage);
   }
 
-  async loadBPMNDiagramInRefreshedPage(): Promise<ElementHandle<SVGElement | HTMLElement>> {
+  override async loadBPMNDiagramInRefreshedPage(): Promise<ElementHandle<SVGElement | HTMLElement>> {
     const url = `file://${resolve(__dirname, `static/${this.targetedPage.pageFileName}.html`)}`;
     return super.doLoadBPMNDiagramInRefreshedPage(url, false);
   }

--- a/test/e2e/helpers/visu/bpmn-page-utils.ts
+++ b/test/e2e/helpers/visu/bpmn-page-utils.ts
@@ -134,7 +134,7 @@ export class BpmnPageSvgTester extends PageTester {
     this.bpmnQuerySelectors = new BpmnQuerySelectorsForTests(this.bpmnContainerId);
   }
 
-  async loadBPMNDiagramInRefreshedPage(bpmnDiagramName?: string): Promise<ElementHandle<SVGElement | HTMLElement>> {
+  override async loadBPMNDiagramInRefreshedPage(bpmnDiagramName?: string): Promise<ElementHandle<SVGElement | HTMLElement>> {
     return super.loadBPMNDiagramInRefreshedPage(bpmnDiagramName ?? 'not-used-dedicated-diagram-loaded-by-the-page', {
       loadOptions: {
         fit: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
       "node_modules/@types",
       "node_modules/@typed-mxgraph"
     ],
-    "stripInternal": true
+    "stripInternal": true,
+    "noImplicitOverride": true,
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
Use the new TypeScript 4.3 override keyword: `TypeScript will always make sure
that a method with the same name exists in a the base class`.
Make override declaration mandatory: detect method removal in base class,
prevent to accidentally “trample over” a method that exists in a base class.

Also remove some public keywords on methods and constructors for simplicity
(this is the default) and consistency (we mostly avoid public keyword in this
case).

### Notes
`Override` documentation: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-3.html#override-and-the---noimplicitoverride-flag

This may force integration to use TypeScript 4.3+ if the override keyword is present in the TS definitions. For now, the definitions generated from files touched by this PR are empty (strip internal), but this may not be the case in the future.

For the public keyword on method and property, we should setup an eslint configuration to ensure we don't use it (or force using it) to ensure consistency in the codebase.