### PR TITLE
[POC] use vitejs for fastest feedback loop on development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,3 @@
 
 # npm build
 *.tgz
-# tailwind css generated for demo
-/dev/public/static/css/tailwind.css
-/dev/public/static/diagrams/

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 *.tgz
 # tailwind css generated for demo
 /dev/public/static/css/tailwind.css
+/dev/public/static/diagrams/

--- a/dev/public/diagram-navigation.html
+++ b/dev/public/diagram-navigation.html
@@ -21,7 +21,7 @@
   </style>
 
   <!-- load app -->
-  <script src="static/js/diagram-navigation.js" type="module"></script>
+  <script src="/dev/public/static/js/diagram-navigation.js" type="module"></script>
 </head>
 <body>
 <div class="flex-container">

--- a/dev/public/diagram-navigation.html
+++ b/dev/public/diagram-navigation.html
@@ -8,7 +8,6 @@
   <title>BPMN Visualization - Diagram Navigation</title>
   <link rel="icon" href="static/img/favicon.png">
   <link rel="stylesheet" href="static/css/test-page.css">
-
   <style>
     .fit {
       background-color: #f9dfe8;
@@ -19,8 +18,6 @@
       width: 35px;
     }
   </style>
-
-  <!-- load app -->
   <script src="/dev/public/static/js/diagram-navigation.js" type="module"></script>
 </head>
 <body>

--- a/dev/public/elements-identification.html
+++ b/dev/public/elements-identification.html
@@ -122,7 +122,7 @@
     </style>
 
     <!-- load app -->
-    <script src="static/js/elements-identification.js" type="module"></script>
+    <script src="/dev/public/static/js/elements-identification.js" type="module"></script>
 </head>
 <body>
     <div id="controls">

--- a/dev/public/elements-identification.html
+++ b/dev/public/elements-identification.html
@@ -120,8 +120,6 @@
         color: var(--color-flow) !important;
       }
     </style>
-
-    <!-- load app -->
     <script src="/dev/public/static/js/elements-identification.js" type="module"></script>
 </head>
 <body>

--- a/dev/public/index.html
+++ b/dev/public/index.html
@@ -5,10 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>BPMN Visualization Demo</title>
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v6.1.1/css/all.css">
-<!--  TODO vite build require the full path-->
     <link href="/dev/public/static/css/styles.css" rel="stylesheet">
     <link rel="icon" href="static/img/favicon.png">
-    <!-- load demo -->
     <script src="/dev/public/static/js/index.js" type="module"></script>
 </head>
 <body class="bg-gray-800 font-sans leading-normal tracking-normal flex flex-col h-screen">

--- a/dev/public/index.html
+++ b/dev/public/index.html
@@ -5,10 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>BPMN Visualization Demo</title>
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v6.1.1/css/all.css">
-    <link href="static/css/tailwind.css" rel="stylesheet">
+<!--  TODO vite build require the full path-->
+    <link href="/dev/public/static/css/styles.css" rel="stylesheet">
     <link rel="icon" href="static/img/favicon.png">
     <!-- load demo -->
-    <script src="static/js/index.js" type="module"></script>
+    <script src="/dev/public/static/js/index.js" type="module"></script>
 </head>
 <body class="bg-gray-800 font-sans leading-normal tracking-normal flex flex-col h-screen">
     <!--Nav-->

--- a/dev/public/lib-integration.html
+++ b/dev/public/lib-integration.html
@@ -4,7 +4,6 @@
   <meta charset="UTF-8">
   <title>BPMN Visualization Lib Integration</title>
   <link rel="icon" href="static/img/favicon.png">
-  <!-- load app -->
   <script src="/dev/public/static/js/lib-integration.js" type="module"></script>
 </head>
 <body>

--- a/dev/public/lib-integration.html
+++ b/dev/public/lib-integration.html
@@ -5,7 +5,7 @@
   <title>BPMN Visualization Lib Integration</title>
   <link rel="icon" href="static/img/favicon.png">
   <!-- load app -->
-  <script src="static/js/lib-integration.js" type="module"></script>
+  <script src="/dev/public/static/js/lib-integration.js" type="module"></script>
 </head>
 <body>
   <div id="bpmn-container-custom"></div>

--- a/dev/public/non-regression.html
+++ b/dev/public/non-regression.html
@@ -18,7 +18,6 @@
         font-weight: bold;
       }
     </style>
-    <!-- load app -->
     <script src="/dev/public/static/js/non-regression.js" type="module"></script>
 </head>
 <body>

--- a/dev/public/non-regression.html
+++ b/dev/public/non-regression.html
@@ -19,7 +19,7 @@
       }
     </style>
     <!-- load app -->
-    <script src="static/js/non-regression.js" type="module"></script>
+    <script src="/dev/public/static/js/non-regression.js" type="module"></script>
 </head>
 <body>
     <div id="fetch-status"></div>

--- a/dev/public/overlays.html
+++ b/dev/public/overlays.html
@@ -8,13 +8,11 @@
   <title>BPMN Visualization - Overlays</title>
   <link rel="icon" href="static/img/favicon.png">
   <link rel="stylesheet" href="static/css/test-page.css">
-
   <style>
     .overlay {
       background-color: MintCream;
     }
   </style>
-  <!-- load app -->
   <script src="/dev/public/static/js/overlays.js" type="module"></script>
 </head>
 <body>

--- a/dev/public/overlays.html
+++ b/dev/public/overlays.html
@@ -15,7 +15,7 @@
     }
   </style>
   <!-- load app -->
-  <script src="static/js/overlays.js" type="module"></script>
+  <script src="/dev/public/static/js/overlays.js" type="module"></script>
 </head>
 <body>
 <div class="flex-container">

--- a/dev/public/static/js/diagram-navigation.js
+++ b/dev/public/static/js/diagram-navigation.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { documentReady, startBpmnVisualization, fit, FitType } from '../../index.es.js';
+import { documentReady, startBpmnVisualization, fit, FitType } from '/dev/ts/internal-dev-bundle-index.ts';
 import { configureControlsPanel, configureMousePointer } from './helpers/controls.js';
 
 function fitOnClick(fitType) {

--- a/dev/public/static/js/elements-identification.js
+++ b/dev/public/static/js/elements-identification.js
@@ -27,7 +27,7 @@ import {
   ShapeUtil,
   addOverlays,
   removeAllOverlays,
-} from '../../index.es.js';
+} from '/dev/ts/internal-dev-bundle-index.ts';
 
 let lastIdentifiedBpmnIds = [];
 const cssClassName = 'detection';

--- a/dev/public/static/js/index.js
+++ b/dev/public/static/js/index.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { documentReady, handleFileSelect, startBpmnVisualization, fit, log, updateLoadOptions, getCurrentLoadOptions, getVersion } from '../../index.es.js';
+import { documentReady, handleFileSelect, startBpmnVisualization, fit, log, updateLoadOptions, getCurrentLoadOptions, getVersion } from '/dev/ts/internal-dev-bundle-index.ts';
 
 let fitOnLoad = true;
 let fitOptions = {};

--- a/dev/public/static/js/lib-integration.js
+++ b/dev/public/static/js/lib-integration.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { BpmnVisualization } from '../../index.es.js';
+import { BpmnVisualization } from '/src/bpmn-visualization.ts';
 
 const bpmnVisualizationIntegration = new BpmnVisualization({ container: 'bpmn-container-custom' });
 bpmnVisualizationIntegration.load(bpmnDefaultContent());

--- a/dev/public/static/js/non-regression.js
+++ b/dev/public/static/js/non-regression.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { documentReady, startBpmnVisualization } from '../../index.es.js';
+import { documentReady, startBpmnVisualization } from '/dev/ts/internal-dev-bundle-index.ts';
 
 function statusFetchKO(errorMsg) {
   const statusElt = document.getElementById('fetch-status');

--- a/dev/public/static/js/overlays.js
+++ b/dev/public/static/js/overlays.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { documentReady, startBpmnVisualization, addOverlays, removeAllOverlays, getElementsByIds } from '../../index.es.js';
+import { documentReady, startBpmnVisualization, addOverlays, removeAllOverlays, getElementsByIds } from '/dev/ts/internal-dev-bundle-index.ts';
 import { configureControlsPanel, configureMousePointer } from './helpers/controls.js';
 
 function addOverlay(overlay) {

--- a/docs/contributors/demo-page-css.md
+++ b/docs/contributors/demo-page-css.md
@@ -1,11 +1,10 @@
 ## CSS for Demo
-The project demo page uses [tailwindcss](https://tailwindcss.com/docs).
 
-To process the CSS rules and get an output `tailwind.css` file, which is used in demo page:
-run: `npm run demo`
+The project demo page (`index.html`) uses [tailwindcss](https://tailwindcss.com/docs).
 
-The `demo:css` npm script does the trick, it uses postcss. Feel free to preview config files:
+Vite automatically processes the CSS rules using `postcss`.
+
+Feel free to preview config files:
 - [postcss.config.js](postcss.config.js)
 - [tailwind.config.js](tailwind.config.js)
 
-The Rollup build handles the livereload and the html/css resources watch.

--- a/docs/contributors/development.md
+++ b/docs/contributors/development.md
@@ -13,8 +13,8 @@
 ## Build
 
 - `npm install`           *Install the dependencies in the local node_modules folder*
-- `npm run watch`         *Watch files in bundle and rebuild on changes* <br>
-                          You can now access the project on http://localhost:10001
+- `npm start`             *Start the development server and rebuild on changes* <br>
+                          You can now access the project on http://localhost:10001/dev/public/index.html
 
 ## Tests
 

--- a/docs/contributors/development.md
+++ b/docs/contributors/development.md
@@ -13,7 +13,7 @@
 ## Build
 
 - `npm install`           *Install the dependencies in the local node_modules folder*
-- `npm start`             *Start the development server and rebuild on changes* <br>
+- `npm run dev`           *Start the development server and rebuild on changes* <br>
                           You can now access the project on http://localhost:10001/dev/public/index.html
 
 ## Tests

--- a/docs/contributors/testing.md
+++ b/docs/contributors/testing.md
@@ -159,12 +159,12 @@ All configurations described here can be done in `bpmn.rendering.test.ts`.
 <a name="image-diff-threshold"></a>
 ##### Image diff threshold
 
-The ideal scenario generates SVG that does not involve font: SVG is supposed to be rendered in the same way on all OS, so
-in that case, the actual rendering exactly matches the reference image.
+The ideal scenario generates SVG that does not involve font: SVG is supposed to be rendered in the same way on all OS and
+web browsers, so in that case, the actual rendering exactly matches the reference image.
 
-As font rendering differs depending on the OS, BPMN diagram containing label won't be rendered exactly as the reference
-image on all OS. In that case, a diff threshold image must be configured: the test will fail if the diff is above the
-threshold.
+As font rendering differs depending on the OS and the web browsers, BPMN diagram containing label won't be rendered exactly
+as the reference image on all OS. In that case, a diff threshold image must be configured: the test will fail if the diff
+is above the threshold.
 
 To be able to detect most of the unwanted changes, this threshold must be set as small as possible but large enough to
 manage small variations and not produce false positive errors.
@@ -180,8 +180,13 @@ The diagrams used by tests are located in the `test/fixtures/bpmn` folder and su
 by tests are in charge of loading the BPMN diagrams.
 
 To load a diagram, just pass a relative path to the diagram as query parameter. The page is able to fetch the diagram content
-as the diagrams are served by the dev server.
-Convenient methods exist to only pass the name of the diagram without having to manage the folder tree to the file.
+as the diagrams are served by the dev server. The parameter name is `url` and the value is the path from the project root like
+`/test/fixtures/bpmn/simple-start-task-end.bpmn`. This works with all test pages of the project.
+
+Example: 
+> http://localhost:10001/dev/public/index.html?url=/test/fixtures/bpmn/non-regression/associations.and.annotations.01.general.bpmn
+
+In tests, convenient methods exist to only pass the name of the diagram without having to manage the folder tree to the file.
 
 
 ### Performance tests

--- a/index.html
+++ b/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta http-equiv="refresh" content="0; url='/dev/public/'" />
+  <title>Redirect to the actual dev page</title>
+</head>
+<body>
+<p>Please follow <a href="/dev/public/">this link</a> to see the index.html development page.</p>
+</body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,8 @@
         "tailwindcss": "~3.0.24",
         "ts-jest": "~27.1.4",
         "typedoc": "~0.22.15",
-        "typescript": "~4.6.4"
+        "typescript": "~4.6.4",
+        "vite": "2.9.9"
       }
     },
     "node_modules/@asciidoctor/cli": {
@@ -4420,6 +4421,361 @@
       "version": "4.1.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.39.tgz",
+      "integrity": "sha512-2kKujuzvRWYtwvNjYDY444LQIA3TyJhJIX3Yo4+qkFlDDtGlSicWgeHVJqMUP/2sSfH10PGwfsj+O2ro1m10xQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "esbuild-android-64": "0.14.39",
+        "esbuild-android-arm64": "0.14.39",
+        "esbuild-darwin-64": "0.14.39",
+        "esbuild-darwin-arm64": "0.14.39",
+        "esbuild-freebsd-64": "0.14.39",
+        "esbuild-freebsd-arm64": "0.14.39",
+        "esbuild-linux-32": "0.14.39",
+        "esbuild-linux-64": "0.14.39",
+        "esbuild-linux-arm": "0.14.39",
+        "esbuild-linux-arm64": "0.14.39",
+        "esbuild-linux-mips64le": "0.14.39",
+        "esbuild-linux-ppc64le": "0.14.39",
+        "esbuild-linux-riscv64": "0.14.39",
+        "esbuild-linux-s390x": "0.14.39",
+        "esbuild-netbsd-64": "0.14.39",
+        "esbuild-openbsd-64": "0.14.39",
+        "esbuild-sunos-64": "0.14.39",
+        "esbuild-windows-32": "0.14.39",
+        "esbuild-windows-64": "0.14.39",
+        "esbuild-windows-arm64": "0.14.39"
+      }
+    },
+    "node_modules/esbuild-android-64": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.39.tgz",
+      "integrity": "sha512-EJOu04p9WgZk0UoKTqLId9VnIsotmI/Z98EXrKURGb3LPNunkeffqQIkjS2cAvidh+OK5uVrXaIP229zK6GvhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-android-arm64": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.39.tgz",
+      "integrity": "sha512-+twajJqO7n3MrCz9e+2lVOnFplRsaGRwsq1KL/uOy7xK7QdRSprRQcObGDeDZUZsacD5gUkk6OiHiYp6RzU3CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-darwin-64": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.39.tgz",
+      "integrity": "sha512-ImT6eUw3kcGcHoUxEcdBpi6LfTRWaV6+qf32iYYAfwOeV+XaQ/Xp5XQIBiijLeo+LpGci9M0FVec09nUw41a5g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-darwin-arm64": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.39.tgz",
+      "integrity": "sha512-/fcQ5UhE05OiT+bW5v7/up1bDsnvaRZPJxXwzXsMRrr7rZqPa85vayrD723oWMT64dhrgWeA3FIneF8yER0XTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-freebsd-64": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.39.tgz",
+      "integrity": "sha512-oMNH8lJI4wtgN5oxuFP7BQ22vgB/e3Tl5Woehcd6i2r6F3TszpCnNl8wo2d/KvyQ4zvLvCWAlRciumhQg88+kQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-freebsd-arm64": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.39.tgz",
+      "integrity": "sha512-1GHK7kwk57ukY2yI4ILWKJXaxfr+8HcM/r/JKCGCPziIVlL+Wi7RbJ2OzMcTKZ1HpvEqCTBT/J6cO4ZEwW4Ypg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-32": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.39.tgz",
+      "integrity": "sha512-g97Sbb6g4zfRLIxHgW2pc393DjnkTRMeq3N1rmjDUABxpx8SjocK4jLen+/mq55G46eE2TA0MkJ4R3SpKMu7dg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-64": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.39.tgz",
+      "integrity": "sha512-4tcgFDYWdI+UbNMGlua9u1Zhu0N5R6u9tl5WOM8aVnNX143JZoBZLpCuUr5lCKhnD0SCO+5gUyMfupGrHtfggQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-arm": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.39.tgz",
+      "integrity": "sha512-t0Hn1kWVx5UpCzAJkKRfHeYOLyFnXwYynIkK54/h3tbMweGI7dj400D1k0Vvtj2u1P+JTRT9tx3AjtLEMmfVBQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-arm64": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.39.tgz",
+      "integrity": "sha512-23pc8MlD2D6Px1mV8GMglZlKgwgNKAO8gsgsLLcXWSs9lQsCYkIlMo/2Ycfo5JrDIbLdwgP8D2vpfH2KcBqrDQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-mips64le": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.39.tgz",
+      "integrity": "sha512-epwlYgVdbmkuRr5n4es3B+yDI0I2e/nxhKejT9H0OLxFAlMkeQZxSpxATpDc9m8NqRci6Kwyb/SfmD1koG2Zuw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-ppc64le": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.39.tgz",
+      "integrity": "sha512-W/5ezaq+rQiQBThIjLMNjsuhPHg+ApVAdTz2LvcuesZFMsJoQAW2hutoyg47XxpWi7aEjJGrkS26qCJKhRn3QQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-riscv64": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.39.tgz",
+      "integrity": "sha512-IS48xeokcCTKeQIOke2O0t9t14HPvwnZcy+5baG13Z1wxs9ZrC5ig5ypEQQh4QMKxURD5TpCLHw2W42CLuVZaA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-s390x": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.39.tgz",
+      "integrity": "sha512-zEfunpqR8sMomqXhNTFEKDs+ik7HC01m3M60MsEjZOqaywHu5e5682fMsqOlZbesEAAaO9aAtRBsU7CHnSZWyA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-netbsd-64": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.39.tgz",
+      "integrity": "sha512-Uo2suJBSIlrZCe4E0k75VDIFJWfZy+bOV6ih3T4MVMRJh1lHJ2UyGoaX4bOxomYN3t+IakHPyEoln1+qJ1qYaA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-openbsd-64": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.39.tgz",
+      "integrity": "sha512-secQU+EpgUPpYjJe3OecoeGKVvRMLeKUxSMGHnK+aK5uQM3n1FPXNJzyz1LHFOo0WOyw+uoCxBYdM4O10oaCAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-sunos-64": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.39.tgz",
+      "integrity": "sha512-qHq0t5gePEDm2nqZLb+35p/qkaXVS7oIe32R0ECh2HOdiXXkj/1uQI9IRogGqKkK+QjDG+DhwiUw7QoHur/Rwg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-32": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.39.tgz",
+      "integrity": "sha512-XPjwp2OgtEX0JnOlTgT6E5txbRp6Uw54Isorm3CwOtloJazeIWXuiwK0ONJBVb/CGbiCpS7iP2UahGgd2p1x+Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-64": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.39.tgz",
+      "integrity": "sha512-E2wm+5FwCcLpKsBHRw28bSYQw0Ikxb7zIMxw3OPAkiaQhLVr3dnVO8DofmbWhhf6b97bWzg37iSZ45ZDpLw7Ow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-arm64": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.39.tgz",
+      "integrity": "sha512-sBZQz5D+Gd0EQ09tZRnz/PpVdLwvp/ufMtJ1iDFYddDaPpZXKqPyaxfYBLs3ueiaksQ26GGa7sci0OqFzNs7KA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -11376,6 +11732,43 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "node_modules/vite": {
+      "version": "2.9.9",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.9.tgz",
+      "integrity": "sha512-ffaam+NgHfbEmfw/Vuh6BHKKlI/XIAhxE5QSS7gFLIngxg171mg1P3a4LSRME0z2ZU1ScxoKzphkipcYwSD5Ew==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.14.27",
+        "postcss": "^8.4.13",
+        "resolve": "^1.22.0",
+        "rollup": "^2.59.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": ">=12.2.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "less": "*",
+        "sass": "*",
+        "stylus": "*"
+      },
+      "peerDependenciesMeta": {
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vscode-oniguruma": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
@@ -14717,6 +15110,174 @@
     "es6-error": {
       "version": "4.1.1",
       "dev": true
+    },
+    "esbuild": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.39.tgz",
+      "integrity": "sha512-2kKujuzvRWYtwvNjYDY444LQIA3TyJhJIX3Yo4+qkFlDDtGlSicWgeHVJqMUP/2sSfH10PGwfsj+O2ro1m10xQ==",
+      "dev": true,
+      "requires": {
+        "esbuild-android-64": "0.14.39",
+        "esbuild-android-arm64": "0.14.39",
+        "esbuild-darwin-64": "0.14.39",
+        "esbuild-darwin-arm64": "0.14.39",
+        "esbuild-freebsd-64": "0.14.39",
+        "esbuild-freebsd-arm64": "0.14.39",
+        "esbuild-linux-32": "0.14.39",
+        "esbuild-linux-64": "0.14.39",
+        "esbuild-linux-arm": "0.14.39",
+        "esbuild-linux-arm64": "0.14.39",
+        "esbuild-linux-mips64le": "0.14.39",
+        "esbuild-linux-ppc64le": "0.14.39",
+        "esbuild-linux-riscv64": "0.14.39",
+        "esbuild-linux-s390x": "0.14.39",
+        "esbuild-netbsd-64": "0.14.39",
+        "esbuild-openbsd-64": "0.14.39",
+        "esbuild-sunos-64": "0.14.39",
+        "esbuild-windows-32": "0.14.39",
+        "esbuild-windows-64": "0.14.39",
+        "esbuild-windows-arm64": "0.14.39"
+      }
+    },
+    "esbuild-android-64": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.39.tgz",
+      "integrity": "sha512-EJOu04p9WgZk0UoKTqLId9VnIsotmI/Z98EXrKURGb3LPNunkeffqQIkjS2cAvidh+OK5uVrXaIP229zK6GvhQ==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-android-arm64": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.39.tgz",
+      "integrity": "sha512-+twajJqO7n3MrCz9e+2lVOnFplRsaGRwsq1KL/uOy7xK7QdRSprRQcObGDeDZUZsacD5gUkk6OiHiYp6RzU3CA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-darwin-64": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.39.tgz",
+      "integrity": "sha512-ImT6eUw3kcGcHoUxEcdBpi6LfTRWaV6+qf32iYYAfwOeV+XaQ/Xp5XQIBiijLeo+LpGci9M0FVec09nUw41a5g==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-darwin-arm64": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.39.tgz",
+      "integrity": "sha512-/fcQ5UhE05OiT+bW5v7/up1bDsnvaRZPJxXwzXsMRrr7rZqPa85vayrD723oWMT64dhrgWeA3FIneF8yER0XTw==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-freebsd-64": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.39.tgz",
+      "integrity": "sha512-oMNH8lJI4wtgN5oxuFP7BQ22vgB/e3Tl5Woehcd6i2r6F3TszpCnNl8wo2d/KvyQ4zvLvCWAlRciumhQg88+kQ==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-freebsd-arm64": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.39.tgz",
+      "integrity": "sha512-1GHK7kwk57ukY2yI4ILWKJXaxfr+8HcM/r/JKCGCPziIVlL+Wi7RbJ2OzMcTKZ1HpvEqCTBT/J6cO4ZEwW4Ypg==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-32": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.39.tgz",
+      "integrity": "sha512-g97Sbb6g4zfRLIxHgW2pc393DjnkTRMeq3N1rmjDUABxpx8SjocK4jLen+/mq55G46eE2TA0MkJ4R3SpKMu7dg==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-64": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.39.tgz",
+      "integrity": "sha512-4tcgFDYWdI+UbNMGlua9u1Zhu0N5R6u9tl5WOM8aVnNX143JZoBZLpCuUr5lCKhnD0SCO+5gUyMfupGrHtfggQ==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-arm": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.39.tgz",
+      "integrity": "sha512-t0Hn1kWVx5UpCzAJkKRfHeYOLyFnXwYynIkK54/h3tbMweGI7dj400D1k0Vvtj2u1P+JTRT9tx3AjtLEMmfVBQ==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-arm64": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.39.tgz",
+      "integrity": "sha512-23pc8MlD2D6Px1mV8GMglZlKgwgNKAO8gsgsLLcXWSs9lQsCYkIlMo/2Ycfo5JrDIbLdwgP8D2vpfH2KcBqrDQ==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-mips64le": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.39.tgz",
+      "integrity": "sha512-epwlYgVdbmkuRr5n4es3B+yDI0I2e/nxhKejT9H0OLxFAlMkeQZxSpxATpDc9m8NqRci6Kwyb/SfmD1koG2Zuw==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-ppc64le": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.39.tgz",
+      "integrity": "sha512-W/5ezaq+rQiQBThIjLMNjsuhPHg+ApVAdTz2LvcuesZFMsJoQAW2hutoyg47XxpWi7aEjJGrkS26qCJKhRn3QQ==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-riscv64": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.39.tgz",
+      "integrity": "sha512-IS48xeokcCTKeQIOke2O0t9t14HPvwnZcy+5baG13Z1wxs9ZrC5ig5ypEQQh4QMKxURD5TpCLHw2W42CLuVZaA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-s390x": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.39.tgz",
+      "integrity": "sha512-zEfunpqR8sMomqXhNTFEKDs+ik7HC01m3M60MsEjZOqaywHu5e5682fMsqOlZbesEAAaO9aAtRBsU7CHnSZWyA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-netbsd-64": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.39.tgz",
+      "integrity": "sha512-Uo2suJBSIlrZCe4E0k75VDIFJWfZy+bOV6ih3T4MVMRJh1lHJ2UyGoaX4bOxomYN3t+IakHPyEoln1+qJ1qYaA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-openbsd-64": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.39.tgz",
+      "integrity": "sha512-secQU+EpgUPpYjJe3OecoeGKVvRMLeKUxSMGHnK+aK5uQM3n1FPXNJzyz1LHFOo0WOyw+uoCxBYdM4O10oaCAA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-sunos-64": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.39.tgz",
+      "integrity": "sha512-qHq0t5gePEDm2nqZLb+35p/qkaXVS7oIe32R0ECh2HOdiXXkj/1uQI9IRogGqKkK+QjDG+DhwiUw7QoHur/Rwg==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-windows-32": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.39.tgz",
+      "integrity": "sha512-XPjwp2OgtEX0JnOlTgT6E5txbRp6Uw54Isorm3CwOtloJazeIWXuiwK0ONJBVb/CGbiCpS7iP2UahGgd2p1x+Q==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-windows-64": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.39.tgz",
+      "integrity": "sha512-E2wm+5FwCcLpKsBHRw28bSYQw0Ikxb7zIMxw3OPAkiaQhLVr3dnVO8DofmbWhhf6b97bWzg37iSZ45ZDpLw7Ow==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-windows-arm64": {
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.39.tgz",
+      "integrity": "sha512-sBZQz5D+Gd0EQ09tZRnz/PpVdLwvp/ufMtJ1iDFYddDaPpZXKqPyaxfYBLs3ueiaksQ26GGa7sci0OqFzNs7KA==",
+      "dev": true,
+      "optional": true
     },
     "escalade": {
       "version": "3.1.1",
@@ -19405,6 +19966,19 @@
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "vite": {
+      "version": "2.9.9",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.9.tgz",
+      "integrity": "sha512-ffaam+NgHfbEmfw/Vuh6BHKKlI/XIAhxE5QSS7gFLIngxg171mg1P3a4LSRME0z2ZU1ScxoKzphkipcYwSD5Ew==",
+      "dev": true,
+      "requires": {
+        "esbuild": "^0.14.27",
+        "fsevents": "~2.3.2",
+        "postcss": "^8.4.13",
+        "resolve": "^1.22.0",
+        "rollup": "^2.59.0"
       }
     },
     "vscode-oniguruma": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2425,6 +2425,13 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/bluebird": {
+      "version": "3.5.36",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.36.tgz",
+      "integrity": "sha512-HBNx4lhkxN7bx6P0++W8E289foSu8kO8GCk2unhuVggO+cE7rh9DhZUyPhUxNRG9m+5B5BTKxZQ5ZP92x/mx9Q==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/@types/debug": {
       "version": "4.1.7",
       "dev": true,
@@ -11422,6 +11429,13 @@
         }
       }
     },
+    "node_modules/ts-toolbelt": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
+      "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/ts-type": {
       "version": "2.1.2",
       "dev": true,
@@ -13769,6 +13783,13 @@
       "requires": {
         "@babel/types": "^7.3.0"
       }
+    },
+    "@types/bluebird": {
+      "version": "3.5.36",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.36.tgz",
+      "integrity": "sha512-HBNx4lhkxN7bx6P0++W8E289foSu8kO8GCk2unhuVggO+cE7rh9DhZUyPhUxNRG9m+5B5BTKxZQ5ZP92x/mx9Q==",
+      "dev": true,
+      "peer": true
     },
     "@types/debug": {
       "version": "4.1.7",
@@ -19750,6 +19771,13 @@
         "semver": "7.x",
         "yargs-parser": "20.x"
       }
+    },
+    "ts-toolbelt": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
+      "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==",
+      "dev": true,
+      "peer": true
     },
     "ts-type": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "prepack": "run-s clean build-bundles",
     "demo": "run-s demo:*",
     "demo:build": "tsc --noEmit && vite build",
+    "demo:prepare": "node scripts/prepare-demo-for-publish.mjs",
     "demo-preview": "vite preview",
     "docs": "run-s docs:*",
     "docs:user": "node scripts/docs.js",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "NOTICE"
   ],
   "scripts": {
-    "start": "vite",
+    "dev": "vite",
     "all": "run-s clean lint lint-check build test",
     "clean": "rimraf build dist",
     "build": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -47,20 +47,18 @@
     "NOTICE"
   ],
   "scripts": {
+    "start": "vite",
     "all": "run-s clean lint lint-check build test",
     "clean": "rimraf build dist",
-    "build": "rollup -c",
-    "build-bundles": "rollup -c --config-build-bundles true",
+    "build": "tsc --noEmit",
+    "build-bundles": "rollup -c",
     "prepack": "run-s clean build-bundles",
     "demo": "run-s demo:*",
-    "demo:clean": "rimraf build/demo",
-    "demo:css": "postcss dev/public/static/css/styles.css -o dev/public/static/css/tailwind.css",
-    "demo:build": "rollup -c --silent --environment demoMode:true",
+    "demo:build": "tsc --noEmit && vite build",
+    "demo-preview": "vite preview",
     "docs": "run-s docs:*",
     "docs:user": "node scripts/docs.js",
     "docs:api": "typedoc --tsconfig ./tsconfig.typedoc.json src/bpmn-visualization.ts",
-    "start": "rollup -c --silent --environment devMode:true",
-    "watch": "rollup -cw --environment devLiveReloadMode:true",
     "lint": "eslint \"*/**/*.{js,mjs,ts}\" NOTICE --max-warnings 0 --quiet --fix",
     "lint-check": "eslint \"*/**/*.{js,mjs,ts}\" NOTICE --max-warnings 0",
     "test": "run-s test:unit test:integration test:e2e",
@@ -153,7 +151,8 @@
     "tailwindcss": "~3.0.24",
     "ts-jest": "~27.1.4",
     "typedoc": "~0.22.15",
-    "typescript": "~4.6.4"
+    "typescript": "~4.6.4",
+    "vite": "2.8.6"
   },
   "lint-staged": {
     "*.{js,mjs,ts}": [

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "ts-jest": "~27.1.4",
     "typedoc": "~0.22.15",
     "typescript": "~4.6.4",
-    "vite": "2.8.6"
+    "vite": "2.9.8"
   },
   "lint-staged": {
     "*.{js,mjs,ts}": [

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "ts-jest": "~27.1.4",
     "typedoc": "~0.22.15",
     "typescript": "~4.6.4",
-    "vite": "2.9.8"
+    "vite": "2.9.9"
   },
   "lint-staged": {
     "*.{js,mjs,ts}": [

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -14,30 +14,18 @@
  * limitations under the License.
  */
 
-// const defaultPlugins = {
-//   tailwindcss: {},
-//   autoprefixer: {},
-// };
-//
-// // TODO manage development/production
-// const isDevelopment = true;
-// const plugins = isDevelopment
-//   ? defaultPlugins
-//   : {
-//       ...defaultPlugins,
-//       cssnano: {
-//         preset: 'default',
-//       },
-//     };
-// module.exports = { plugins };
-
-module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-    // TODO restore the cssnano dependency and active the following only when building the demo
-    cssnano: {
-      preset: 'default',
-    },
-  },
+const defaultPlugins = {
+  tailwindcss: {},
+  autoprefixer: {},
 };
+
+const isDevelopment = process.env.NODE_ENV === 'development';
+const plugins = isDevelopment
+  ? defaultPlugins
+  : {
+      ...defaultPlugins,
+      cssnano: {
+        preset: 'default',
+      },
+    };
+module.exports = { plugins };

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -19,13 +19,13 @@ const defaultPlugins = {
   autoprefixer: {},
 };
 
-const isDevelopment = process.env.NODE_ENV === 'development';
-const plugins = isDevelopment
-  ? defaultPlugins
-  : {
-      ...defaultPlugins,
-      cssnano: {
-        preset: 'default',
-      },
-    };
+const plugins =
+  process.env.NODE_ENV === 'development'
+    ? defaultPlugins
+    : {
+        ...defaultPlugins,
+        cssnano: {
+          preset: 'default',
+        },
+      };
 module.exports = { plugins };

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -13,17 +13,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const defaultPlugins = {
-  tailwindcss: {},
-  autoprefixer: {},
-};
 
-const plugins = process.env.devLiveReloadMode
-  ? defaultPlugins
-  : {
-      ...defaultPlugins,
-      cssnano: {
-        preset: 'default',
-      },
-    };
-module.exports = { plugins };
+// const defaultPlugins = {
+//   tailwindcss: {},
+//   autoprefixer: {},
+// };
+//
+// // TODO manage development/production
+// const isDevelopment = true;
+// const plugins = isDevelopment
+//   ? defaultPlugins
+//   : {
+//       ...defaultPlugins,
+//       cssnano: {
+//         preset: 'default',
+//       },
+//     };
+// module.exports = { plugins };
+
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+    // TODO restore the cssnano dependency and active the following only when building the demo
+    cssnano: {
+      preset: 'default',
+    },
+  },
+};

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,125 +13,85 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import serve from 'rollup-plugin-serve';
-import livereload from 'rollup-plugin-livereload';
-import copy from 'rollup-plugin-copy';
-import copyWatch from 'rollup-plugin-copy-watch';
+
+import autoExternal from 'rollup-plugin-auto-external';
 import { terser } from 'rollup-plugin-terser';
 import sizes from 'rollup-plugin-sizes';
-import autoExternal from 'rollup-plugin-auto-external';
-import execute from 'rollup-plugin-execute';
 
 import typescript from 'rollup-plugin-typescript2';
 import commonjs from '@rollup/plugin-commonjs'; // at least, needed to bundle mxGraph which is only available as a CommonJS module
 import resolve from '@rollup/plugin-node-resolve';
 import pkg from './package.json';
 
-import parseArgs from 'minimist';
+const libInput = 'src/bpmn-visualization.ts';
+const pluginsBundleIIFE = [
+  typescriptPlugin(),
+  // the 'resolve' and 'commonjs' plugins ensure we can bundle commonjs dependencies
+  resolve(),
+  commonjs(),
+  // to have sizes of dependencies listed at the end of build log
+  sizes(),
+];
+const outputIIFE = {
+  file: pkg.browser.replace('.min.js', '.js'),
+  name: 'bpmnvisu',
+  format: 'iife',
+};
 
-const devLiveReloadMode = process.env.devLiveReloadMode;
-const devMode = devLiveReloadMode ? true : process.env.devMode;
-const demoMode = process.env.demoMode;
+const configIIFE = {
+  input: libInput,
+  output: outputIIFE,
+  plugins: pluginsBundleIIFE,
+};
+const configIIFEMinified = {
+  input: libInput,
+  output: {
+    ...outputIIFE,
+    file: pkg.browser,
+  },
+  plugins: withMinification(pluginsBundleIIFE),
+};
 
-// parse command line arguments
-const argv = parseArgs(process.argv.slice(2)); // start with 'node rollup' so drop them
-// for the 'config-xxx' syntax, see https://github.com/rollup/rollup/issues/1662#issuecomment-395382741
-const serverPort = process.env.SERVER_PORT || argv['config-server-port'] || 10001;
-const buildBundles = argv['config-build-bundles'] || false;
+const pluginsBundles = [
+  typescriptPlugin(),
+  // ensure we do not bundle dependencies
+  autoExternal(),
+  // to have sizes of dependencies listed at the end of build log
+  sizes(),
+];
 
-const outputDir = demoMode ? 'build/demo' : 'build/public';
-let rollupConfigs;
-
-// internal lib development
-if (!buildBundles) {
-  const sourceMap = !demoMode;
-  rollupConfigs = [
+const configBundlesMinified = {
+  input: libInput,
+  output: [
     {
-      input: 'dev/ts/internal-dev-bundle-index.ts',
-      output: [
-        {
-          file: `${outputDir}/index.es.js`,
-          format: 'es',
-          sourcemap: sourceMap,
-        },
-      ],
-      external: [...Object.keys(pkg.peerDependencies || {})],
-      plugins: pluginsForDevelopment(),
+      file: pkg.module.replace('.js', '.min.js'),
+      format: 'es',
     },
-  ];
-} else {
-  const libInput = 'src/bpmn-visualization.ts';
-  const pluginsBundleIIFE = [
-    typescriptPlugin(),
-    // the 'resolve' and 'commonjs' plugins ensure we can bundle commonjs dependencies
-    resolve(),
-    commonjs(),
-    // to have sizes of dependencies listed at the end of build log
-    sizes(),
-  ];
-  const outputIIFE = {
-    file: pkg.browser.replace('.min.js', '.js'),
-    name: 'bpmnvisu',
-    format: 'iife',
-  };
-
-  const configIIFE = {
-    input: libInput,
-    output: outputIIFE,
-    plugins: pluginsBundleIIFE,
-  };
-  const configIIFEMinified = {
-    input: libInput,
-    output: {
-      ...outputIIFE,
-      file: pkg.browser,
+    {
+      file: pkg.main.replace('.js', '.min.js'),
+      format: 'cjs',
     },
-    plugins: withMinification(pluginsBundleIIFE),
-  };
+  ],
 
-  const pluginsBundles = [
-    typescriptPlugin(),
-    // ensure we do not bundle dependencies
-    autoExternal(),
-    // to have sizes of dependencies listed at the end of build log
-    sizes(),
-  ];
+  plugins: withMinification(pluginsBundles),
+};
+const configBundles = {
+  ...configBundlesMinified,
+  plugins: pluginsBundles,
+  output: [
+    { file: pkg.module, format: 'es' },
+    { file: pkg.main, format: 'cjs' },
+  ],
+};
 
-  const configBundlesMinified = {
-    input: libInput,
-    output: [
-      {
-        file: pkg.module.replace('.js', '.min.js'),
-        format: 'es',
-      },
-      {
-        file: pkg.main.replace('.js', '.min.js'),
-        format: 'cjs',
-      },
-    ],
-    plugins: withMinification(pluginsBundles),
-  };
-  const configBundles = {
-    ...configBundlesMinified,
-    plugins: pluginsBundles,
-    output: [
-      { file: pkg.module, format: 'es' },
-      { file: pkg.main, format: 'cjs' },
-    ],
-  };
-  rollupConfigs = [configIIFE, configIIFEMinified, configBundles, configBundlesMinified];
-}
-
-export default rollupConfigs;
+export default [configIIFE, configIIFEMinified, configBundles, configBundlesMinified];
 
 // =====================================================================================================================
 // helpers
 // =====================================================================================================================
 
 function typescriptPlugin() {
-  const tsDeclarationFiles = !demoMode || buildBundles;
-  const tsSourceMap = !demoMode && !buildBundles; // TODO logic duplicated with build selection
-  const tsconfigOverride = { compilerOptions: { sourceMap: tsSourceMap, declaration: tsDeclarationFiles } };
+  const tsconfigOverride = { compilerOptions: { sourceMap: false, declaration: true } };
 
   const options = {
     typescript: require('typescript'),
@@ -139,9 +99,7 @@ function typescriptPlugin() {
   };
 
   // Ensure we only bundle production sources
-  if (!devMode) {
-    options.tsconfig = './tsconfig.bundle.json';
-  }
+  options.tsconfig = './tsconfig.bundle.json';
 
   return typescript(options);
 }
@@ -153,51 +111,4 @@ function withMinification(plugins) {
       ecma: 6,
     }),
   ];
-}
-
-function pluginsForDevelopment() {
-  const plugins = [typescriptPlugin(), resolve(), commonjs()];
-
-  // Copy static resources
-  if (devMode || demoMode) {
-    plugins.push(execute('npm run demo:css', true)); // sync to ensure the execution is linked to the main rollup process
-    if (devLiveReloadMode) {
-      plugins.push(execute('npm run demo:css -- --watch --verbose'));
-    }
-
-    const copyTargets = [];
-    copyTargets.push({ src: 'dev/public/*.html', dest: `${outputDir}/` });
-    copyTargets.push({ src: 'dev/public/static', dest: outputDir });
-    let copyPlugin;
-    if (devLiveReloadMode) {
-      copyPlugin = copyWatch({
-        watch: ['dev/public/static/**', 'dev/public/*.html'],
-        targets: copyTargets,
-      });
-    } else {
-      copyPlugin = copy({
-        targets: copyTargets,
-      });
-    }
-    plugins.push(copyPlugin);
-
-    // to have sizes of dependencies listed at the end of build log
-    plugins.push(sizes());
-  }
-
-  if (devMode) {
-    // Create a server for dev mode
-    plugins.push(serve({ contentBase: outputDir, port: serverPort }));
-
-    if (devLiveReloadMode) {
-      // Allow to livereload on any update
-      plugins.push(livereload({ watch: outputDir, verbose: true }));
-    }
-  }
-
-  if (demoMode) {
-    return withMinification(plugins);
-  }
-
-  return plugins;
 }

--- a/scripts/prepare-demo-for-publish.mjs
+++ b/scripts/prepare-demo-for-publish.mjs
@@ -19,14 +19,13 @@ import { join } from 'path';
 
 const demoRootDirectory = './build/demo';
 
-// TODO for seamless maintenance, find the html files in the directory
-const pages = ['index.html', 'elements-identification.html'];
+const relPathToHtmlPages = 'dev/public';
+const pages = fs.readdirSync(join(demoRootDirectory, relPathToHtmlPages));
 pages.forEach(page => {
   // eslint-disable-next-line no-console
   console.info('Managing', page);
   // move page out of the public/dev directory
-  fs.renameSync(join(demoRootDirectory, 'dev/public', page), join(demoRootDirectory, page));
+  fs.renameSync(join(demoRootDirectory, relPathToHtmlPages, page), join(demoRootDirectory, page));
 });
 
-// TODO remove the whole dev folder
-fs.rmdirSync(join(demoRootDirectory, 'dev/public'));
+fs.rmSync(join(demoRootDirectory, 'dev'), { recursive: true });

--- a/scripts/prepare-demo-for-publish.mjs
+++ b/scripts/prepare-demo-for-publish.mjs
@@ -19,14 +19,6 @@ import { join } from 'path';
 
 const demoRootDirectory = './build/demo';
 
-const updateAssetsLoadingFile = path => {
-  let content = fs.readFileSync(path, 'utf8').toString();
-  content = content.replaceAll('"/assets/', '"assets/');
-  fs.writeFileSync(path, content);
-  // eslint-disable-next-line no-console
-  console.info('Content of page updated', path);
-};
-
 // TODO for seamless maintenance, find the html files in the directory
 const pages = ['index.html', 'elements-identification.html'];
 pages.forEach(page => {
@@ -34,7 +26,6 @@ pages.forEach(page => {
   console.info('Managing', page);
   // move page out of the public/dev directory
   fs.renameSync(join(demoRootDirectory, 'dev/public', page), join(demoRootDirectory, page));
-  updateAssetsLoadingFile(join(demoRootDirectory, page));
 });
 
 // TODO remove the whole dev folder

--- a/scripts/prepare-demo-for-publish.mjs
+++ b/scripts/prepare-demo-for-publish.mjs
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2022 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as fs from 'fs';
+import { join } from 'path';
+
+const demoRootDirectory = './build/demo';
+
+const updateAssetsLoadingFile = path => {
+  let content = fs.readFileSync(path, 'utf8').toString();
+  content = content.replaceAll('"/assets/', '"assets/');
+  fs.writeFileSync(path, content);
+  // eslint-disable-next-line no-console
+  console.info('Content of page updated', path);
+};
+
+// TODO for seamless maintenance, find the html files in the directory
+const pages = ['index.html', 'elements-identification.html'];
+pages.forEach(page => {
+  // eslint-disable-next-line no-console
+  console.info('Managing', page);
+  // move page out of the public/dev directory
+  fs.renameSync(join(demoRootDirectory, 'dev/public', page), join(demoRootDirectory, page));
+  updateAssetsLoadingFile(join(demoRootDirectory, page));
+});
+
+// TODO remove the whole dev folder
+fs.rmdirSync(join(demoRootDirectory, 'dev/public'));

--- a/test/config/jest-playwright.js
+++ b/test/config/jest-playwright.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const { isRunningOnCISlowOS } = require('../helpers/environment-utils');
+const { isRunningOnCISlowOS, isRunningOnCi } = require('../helpers/environment-utils');
 
 const log = require('debug')('bv:test:config:pw');
 
@@ -86,14 +86,19 @@ const computeConfigurationForDevServerUsage = defaultBrowsers => {
   log('Computing configuration for dev server usage');
   /** @type {import('jest-playwright-preset/types/global').ServerOptions} */
   const serverOptions = {
-    command: `npm run start -- --config-server-port 10002`,
-    port: 10002,
+    command: `npm start`,
+    port: 10001,
+    basePath: '/dev/public/index.html',
     // if default or tcp, the test starts right await whereas the dev server is not available on http
     // for more details, see https://github.com/process-analytics/bpmn-visualization-js/pull/1056
     protocol: 'http',
-    launchTimeout: 60_000, // high value mainly for GitHub Workflows running on macOS (slow machines) and to build the bundle before start
+    // high value mainly for GitHub Workflows running on macOS (slow machines) and to build the bundle before start
+    launchTimeout: isRunningOnCi() ? 60_000 : 10_000,
     debug: true,
     usedPortAction: 'ignore', // your tests are executed, we assume that the server is already started
+    waitOnScheme: {
+      verbose: true,
+    },
   };
   return {
     ...computeBaseConfiguration(defaultBrowsers),

--- a/test/config/jest-playwright.js
+++ b/test/config/jest-playwright.js
@@ -97,7 +97,7 @@ const computeConfigurationForDevServerUsage = defaultBrowsers => {
     debug: true,
     usedPortAction: 'ignore', // your tests are executed, we assume that the server is already started
     waitOnScheme: {
-      verbose: true,
+      verbose: false,
     },
   };
   return {

--- a/test/config/jest-playwright.js
+++ b/test/config/jest-playwright.js
@@ -86,7 +86,7 @@ const computeConfigurationForDevServerUsage = defaultBrowsers => {
   log('Computing configuration for dev server usage');
   /** @type {import('jest-playwright-preset/types/global').ServerOptions} */
   const serverOptions = {
-    command: `npm start`,
+    command: `npm run dev`,
     port: 10001,
     basePath: '/dev/public/index.html',
     // if default or tcp, the test starts right await whereas the dev server is not available on http

--- a/test/e2e/helpers/visu/bpmn-page-utils.ts
+++ b/test/e2e/helpers/visu/bpmn-page-utils.ts
@@ -13,6 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// in the future, we should find a solution to avoid using the reference everywhere in tests
+// see https://github.com/jest-community/jest-extended/issues/367
+/// <reference types="jest-extended" />
+
 import 'expect-playwright';
 import type { PageWaitForSelectorOptions } from 'expect-playwright';
 import type { ElementHandle, Page } from 'playwright';
@@ -106,7 +111,7 @@ export class PageTester {
    */
   constructor(protected targetedPageConfiguration: TargetedPageConfiguration, protected page: Page) {
     const showMousePointer = targetedPageConfiguration.showMousePointer ?? false;
-    this.baseUrl = `http://localhost:10002/${targetedPageConfiguration.pageFileName}.html?showMousePointer=${showMousePointer}`;
+    this.baseUrl = `http://localhost:10001/dev/public/${targetedPageConfiguration.pageFileName}.html?showMousePointer=${showMousePointer}`;
     this.bpmnContainerId = targetedPageConfiguration.bpmnContainerId ?? 'bpmn-container';
     this.diagramSubfolder = targetedPageConfiguration.diagramSubfolder;
     this.bpmnPage = new BpmnPage(this.bpmnContainerId, this.page);
@@ -125,8 +130,9 @@ export class PageTester {
   protected async doGotoPageAndLoadBpmnDiagram(url: string, checkResponseStatus = true): Promise<void> {
     const response = await this.page.goto(url);
     if (checkResponseStatus) {
+      // the Vite server can return http 304 for optimization
       // eslint-disable-next-line jest/no-standalone-expect
-      expect(response.status()).toBe(200);
+      expect(response.status()).toBeOneOf([200, 304]);
     }
 
     await this.bpmnPage.expectPageTitle(this.targetedPageConfiguration.expectedPageTitle);
@@ -144,7 +150,7 @@ export class PageTester {
    */
   private computePageUrl(bpmnDiagramName: string, loadOptions: LoadOptions, styleOptions?: StyleOptions, bpmndElementIdToCollapse?: string | undefined): string {
     let url = this.baseUrl;
-    url += `&url=./static/bpmn/${this.diagramSubfolder}/${bpmnDiagramName}.bpmn`;
+    url += `&url=/test/fixtures/bpmn/${this.diagramSubfolder}/${bpmnDiagramName}.bpmn`;
 
     // load query parameters
     loadOptions.fit?.type && (url += `&fitTypeOnLoad=${loadOptions.fit.type}`);

--- a/test/e2e/jest.config.js
+++ b/test/e2e/jest.config.js
@@ -34,8 +34,8 @@ module.exports = {
   coveragePathIgnorePatterns: ['/src/model'],
   coverageReporters: ['lcov', 'text-summary'],
   coverageDirectory: 'build/test-report/e2e',
-  setupFiles: ['./test/config/copy.bpmn.diagram.ts'],
   setupFilesAfterEnv: [
+    'jest-extended/all',
     'expect-playwright',
     './test/config/jest.retries.ts',
     // jest-image-snapshot configuration doesn't work with setupFiles, fix with setupFilesAfterEnv: see https://github.com/testing-library/jest-dom/issues/122#issuecomment-650520461

--- a/test/performance/jest.config.js
+++ b/test/performance/jest.config.js
@@ -30,6 +30,6 @@ module.exports = {
       tsconfig: './tsconfig.json',
     },
   },
-  setupFiles: ['./test/config/copy.bpmn.diagram.ts', './test/config/jest.retries.ts'],
+  setupFiles: ['./test/config/jest.retries.ts'],
   setupFilesAfterEnv: ['expect-playwright'],
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,9 @@
     ],
     "stripInternal": true,
     "noImplicitOverride": true,
+    // Vitejs requirements https://vitejs.dev/guide/features.html#typescript-compiler-options
+    "isolatedModules": true, // https://esbuild.github.io/content-types/#isolated-modules
+    "useDefineForClassFields": true,
   },
   "include": [
     "src/**/*",

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Bonitasoft S.A.
+ * Copyright 2022 Bonitasoft S.A.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { copySync } from 'fs-extra';
 
-copySync(`${__dirname}/../fixtures/bpmn`, `${__dirname}/../../build/public/static/bpmn/`, { overwrite: true, recursive: true });
+import { resolve } from 'path';
+
+/**
+ * @type {import('vite').UserConfig}
+ */
+const config = {
+  server: {
+    port: 10001,
+  },
+
+  // Configuration to build the demo
+  build: {
+    outDir: 'build/demo',
+    rollupOptions: {
+      input: {
+        index: resolve(__dirname, 'dev/public/index.html'),
+        'elements-identification': resolve(__dirname, 'dev/public/elements-identification.html'),
+      },
+    },
+  },
+  preview: {
+    port: 10002,
+  },
+};
+
+export default config;

--- a/vite.config.js
+++ b/vite.config.js
@@ -33,6 +33,14 @@ const config = {
         index: resolve(__dirname, 'dev/public/index.html'),
         'elements-identification': resolve(__dirname, 'dev/public/elements-identification.html'),
       },
+      // No hash in asset names. We make the demo publicly available via the examples repository and served by statically.io
+      // New versions are accessed using tags. The master branch is cachecd by statically.io and updated once a day.
+      // see https://github.com/vitejs/vite/issues/378#issuecomment-768816653
+      output: {
+        entryFileNames: `assets/[name].js`,
+        chunkFileNames: `assets/[name].js`,
+        assetFileNames: `assets/[name].[ext]`,
+      },
     },
   },
   preview: {

--- a/vite.config.js
+++ b/vite.config.js
@@ -20,6 +20,7 @@ import { resolve } from 'path';
  * @type {import('vite').UserConfig}
  */
 const config = {
+  base: './', // Base public path when served in development or production. https://vitejs.dev/config/#base
   server: {
     port: 10001,
   },

--- a/vite.config.js
+++ b/vite.config.js
@@ -15,37 +15,38 @@
  */
 
 import { resolve } from 'path';
+import { defineConfig } from 'vite';
 
-/**
- * @type {import('vite').UserConfig}
- */
-const config = {
-  base: './', // Base public path when served in development or production. https://vitejs.dev/config/#base
-  server: {
-    port: 10001,
-  },
+export default defineConfig(({ mode }) => {
+  // create the environment variable for configuration in the postcss config
+  process.env['NODE_ENV'] = mode;
 
-  // Configuration to build the demo
-  build: {
-    outDir: 'build/demo',
-    rollupOptions: {
-      input: {
-        index: resolve(__dirname, 'dev/public/index.html'),
-        'elements-identification': resolve(__dirname, 'dev/public/elements-identification.html'),
-      },
-      // No hash in asset names. We make the demo publicly available via the examples repository and served by statically.io
-      // New versions are accessed using tags. The master branch is cachecd by statically.io and updated once a day.
-      // see https://github.com/vitejs/vite/issues/378#issuecomment-768816653
-      output: {
-        entryFileNames: `assets/[name].js`,
-        chunkFileNames: `assets/[name].js`,
-        assetFileNames: `assets/[name].[ext]`,
+  return {
+    base: './', // Base public path when served in development or production. https://vitejs.dev/config/#base
+    server: {
+      port: 10001,
+    },
+
+    // Configuration to build the demo
+    build: {
+      outDir: 'build/demo',
+      rollupOptions: {
+        input: {
+          index: resolve(__dirname, 'dev/public/index.html'),
+          'elements-identification': resolve(__dirname, 'dev/public/elements-identification.html'),
+        },
+        // No hash in asset names. We make the demo publicly available via the examples repository and served by statically.io
+        // New versions are accessed using tags. The master branch is cachecd by statically.io and updated once a day.
+        // see https://github.com/vitejs/vite/issues/378#issuecomment-768816653
+        output: {
+          entryFileNames: `assets/[name].js`,
+          chunkFileNames: `assets/[name].js`,
+          assetFileNames: `assets/[name].[ext]`,
+        },
       },
     },
-  },
-  preview: {
-    port: 10002,
-  },
-};
-
-export default config;
+    preview: {
+      port: 10002,
+    },
+  };
+});


### PR DESCRIPTION
Covers #596

### Done as part of the first part this POC

- dev server with HMR: access the page with http://localhost:10001/dev/public/index.html. Bpmn diagrams used in tests can be loaded without extra processing (see e2e parts below). When updated, the change are available without extra processing as well because the dev server serves them as static assets.
- postcss/tailwindcss integration: no more custom hook in the rollup configuration nor double css generation as we had before
- e2e tests use vite
  - configuration update: path to page and diagrams, no more diagrams copy. Example: http://localhost:10001/dev/public/index.html?url=/test/fixtures/bpmn/non-regression/associations.and.annotations.01.general.bpmn
  - use vite dev server and use a single instance for dev and test
- generate the demo with vitejs: use https://vitejs.dev/guide/build.html#multi-page-app to provide the demo and the elements-identifications pages
  -  It currently requires hacks with a custom post-processing script to make it work on surge and statically.io
    - make it available with index.html, not dev/public/index.html
    - no starting slash in the url of the resources loaded by the html page
  - only 2 pages are now part of the bundled demo: index.html and elements-indentifications.html
    - use https://vitejs.dev/guide/build.html#multi-page-app to make them package within the demo bundle
    - elements-identifications: only page that demonstrate overlays, svg/png export, css styling
    - integration of other pages: feasible. To be discussed: there are missing guidance today (not related to the vitejs switch) to be used by anyone 
- clean the rollup config (no demo, only bundle)

### Decisions on 2022-05-12

- We are going to implement `Vite` for real
- continue the POC to validate the latest minor things to check
- when done, create a new PR for the final move to `Vite`

### Done as part of the 2nd part this POC

- development ts sourcemap: check if we can debug the ts code. This should work out of the box ✔️  tested in Firefox and with IntelliJ
- demo
  - simplify the generated assets path. see https://vitejs.dev/guide/build.html#public-base-path
  - can we generate assets without specific hash in filename? this will reduce the number of updated file in the examples repository when we do a new release. This won't be an issue for end-user as the url changes for each version (url includes the git tag). ✔️  Done in 1254ab7e. Tested with
    - deployed surge preview
    - locally, `npm run demo-preview`
    - locally, with non empty context. From the project root (`python3 -m http.server 8002`) and access with http://localhost:8002/build/demo/ and http://localhost:8002/build/demo/elements-identification.html
- create a index.html page at the root of the project to redirect (via meta header) to the dev/public/index.html page automagically. See https://vitejs.dev/guide/#index-html-and-project-root
- doc review contributors documentation
  - testing.md: provide a link that explain how to load a diagram from the test fixtures folder or put a link to the e2e helper code to know how to do it. Done in 2376d0ba
- postcss
  - ~experiment inline postcss configuration in vite config file: https://vitejs.dev/config/#css-postcss~ --> no, keep the dedicated file for now
  - ✔️ dedicated postcss configuration to enable /disable cssnano. See da37d761
    - cssnano should only be run when building the demo, not in development
    - investigate https://vitejs.dev/config/#conditional-config if we use inline postcss configuration or ENV variables if we use a dedicated postcss configuration file. Done with NODE_ENV variable and usage of the vite defineConfig that lets access to the vite mode.
    - alternative not used here: declare NODE_ENV before running the vite script to avoid defining the env var in the vite config file. See https://github.com/vitejs/vite/issues/696#issuecomment-672579652
- clean the configuration
- check gitpod: --> no change needed, I have been able to start the dev server and access to the proxied local dev server from my local browser
  - see https://github.com/open-sauced/open-sauced for the custom dockerfile --> not needed


### Out of the scope
- experiment using TS for vite config
- drop the rollup config for the bundles generation and make it done by vite.
  - This could be experiment later by using https://vitejs.dev/config/#conditional-config with a specific mode for instance
  - It means having flag to build both the demo and the bundles, as we previously performed with rollup
