### PR TITLE
[INFRA] List dependencies change at the end of the release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -36,10 +36,6 @@ categories:
     label: documentation
   - title: 🎮 Demo and Examples
     label: example
-  - title: 📦 Dependency updates
-    labels:
-      # Default label used by dependabot
-      - dependencies
   - title: 👻 Maintenance
     labels:
       - infra:build
@@ -47,6 +43,9 @@ categories:
       - infra:repo
       - chore
       - internal
+  - title: 📦 Dependency updates
+    labels:
+      - dependencies
 exclude-labels:
   - invalid
   - no-changelog


### PR DESCRIPTION
We mainly change dev dependencies that are only for the developers of the lib.
This list is often large and hid the maintenance efforts that was pushed back
at the very end.