### PR TITLE
[TEST] Fix imports in performance tests

### DIFF
--- a/test/performance/bpmn.load.performance.test.ts
+++ b/test/performance/bpmn.load.performance.test.ts
@@ -15,7 +15,7 @@
  */
 import * as fs from 'fs';
 import { getSimplePlatformName } from '../e2e/helpers/test-utils';
-import { PageTester } from '../e2e/helpers/visu/PageTester';
+import { PageTester } from '../e2e/helpers/visu/bpmn-page-utils';
 import { calculateMetrics, ChartData, PerformanceMetric } from './helpers/perf-utils';
 import { ChromiumMetricsCollector } from './helpers/metrics-chromium';
 

--- a/test/performance/bpmn.navigation.performance.test.ts
+++ b/test/performance/bpmn.navigation.performance.test.ts
@@ -15,7 +15,7 @@
  */
 import * as fs from 'fs';
 import { delay, getSimplePlatformName } from '../e2e/helpers/test-utils';
-import { PageTester } from '../e2e/helpers/visu/PageTester';
+import { PageTester } from '../e2e/helpers/visu/bpmn-page-utils';
 import { chromiumMouseWheel } from '../e2e/helpers/visu/playwright-utils';
 import { calculateMetrics, ChartData, PerformanceMetric } from './helpers/perf-utils';
 import { ChromiumMetricsCollector } from './helpers/metrics-chromium';


### PR DESCRIPTION
Introduced by a refactoring involving the PageTester class which is now located
in bpmn-page-utils.