### PR TITLE
[TEST] Rename 'mouse zoom' helper functions

### DIFF
--- a/test/e2e/diagram.navigation.zoom.pan.test.ts
+++ b/test/e2e/diagram.navigation.zoom.pan.test.ts
@@ -17,7 +17,7 @@ import { ElementHandle } from 'playwright-core';
 import 'jest-playwright-preset';
 import { join } from 'path';
 import { ImageSnapshotConfigurator, ImageSnapshotThresholdConfig, MultiBrowserImageSnapshotThresholds } from './helpers/visu/image-snapshot-config';
-import { chromiumZoom, getContainerCenter, itMouseWheel, mousePanning, Point } from './helpers/test-utils';
+import { getContainerCenter, itMouseZoom, mousePanning, mouseZoom, Point } from './helpers/test-utils';
 import { PageTester } from './helpers/visu/bpmn-page-utils';
 
 class ImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
@@ -72,9 +72,9 @@ describe('diagram navigation - zoom and pan', () => {
     });
   });
 
-  itMouseWheel.each(['zoom in', 'zoom out'])(`ctrl + mouse: %s`, async (zoomMode: string) => {
+  itMouseZoom.each(['zoom in', 'zoom out'])(`ctrl + mouse: %s`, async (zoomMode: string) => {
     const deltaX = zoomMode === 'zoom in' ? -100 : 100;
-    await chromiumZoom(1, { x: containerCenter.x + 200, y: containerCenter.y }, deltaX);
+    await mouseZoom(1, { x: containerCenter.x + 200, y: containerCenter.y }, deltaX);
 
     const image = await page.screenshot({ fullPage: true });
     const config = imageSnapshotConfigurator.getConfig(bpmnDiagramName);
@@ -84,12 +84,12 @@ describe('diagram navigation - zoom and pan', () => {
     });
   });
 
-  itMouseWheel.each([3, 5])(`ctrl + mouse: initial scale after zoom in and zoom out [%s times]`, async (xTimes: number) => {
+  itMouseZoom.each([3, 5])(`ctrl + mouse: initial scale after zoom in and zoom out [%s times]`, async (xTimes: number) => {
     const deltaX = -100;
     // simulate mouse+ctrl zoom
     await page.mouse.move(containerCenter.x + 200, containerCenter.y);
-    await chromiumZoom(xTimes, { x: containerCenter.x + 200, y: containerCenter.y }, deltaX);
-    await chromiumZoom(xTimes, { x: containerCenter.x + 200, y: containerCenter.y }, -deltaX);
+    await mouseZoom(xTimes, { x: containerCenter.x + 200, y: containerCenter.y }, deltaX);
+    await mouseZoom(xTimes, { x: containerCenter.x + 200, y: containerCenter.y }, -deltaX);
 
     const image = await page.screenshot({ fullPage: true });
     const config = imageSnapshotConfigurator.getConfig(bpmnDiagramName);

--- a/test/e2e/helpers/test-utils.ts
+++ b/test/e2e/helpers/test-utils.ts
@@ -86,7 +86,14 @@ async function chromiumAndFirefoxMousePanning({ originPoint, destinationPoint }:
   await page.mouse.up();
 }
 
-export async function chromiumZoom(xTimes: number, point: Point, deltaX: number): Promise<void> {
+export async function mouseZoom(xTimes: number, point: Point, deltaX: number): Promise<void> {
+  if (!isMouseZoomSupportedByTest) {
+    throw new Error(`Mouse zoom is not supported with ${getTestedBrowserFamily()}`);
+  }
+  await chromiumMouseZoom(xTimes, point, deltaX);
+}
+
+async function chromiumMouseZoom(xTimes: number, point: Point, deltaX: number): Promise<void> {
   for (let i = 0; i < xTimes; i++) {
     await chromiumMouseWheel(point.x, point.y, deltaX);
     // delay here is needed to make the tests pass on MacOS, delay must be greater than debounce timing so it surely gets triggered
@@ -94,7 +101,8 @@ export async function chromiumZoom(xTimes: number, point: Point, deltaX: number)
   }
 }
 
+const isMouseZoomSupportedByTest = getTestedBrowserFamily() === 'chromium';
 // TODO activate tests relying on mousewheel events on non Chromium browsers when playwright will support it natively: https://github.com/microsoft/playwright/issues/1115
 // inspired from https://github.com/xtermjs/xterm.js/commit/7400b888df698d15864ab2c41ad0ed0262f812fb#diff-23460af115aa97331c36c0ce462cbc4dd8067c0ddbca1e9d3de560ebf44024ee
 // Wheel events are hacked using private API that is only available in Chromium
-export const itMouseWheel = getTestedBrowserFamily() === 'chromium' ? it : it.skip;
+export const itMouseZoom = isMouseZoomSupportedByTest ? it : it.skip;

--- a/test/e2e/helpers/test-utils.ts
+++ b/test/e2e/helpers/test-utils.ts
@@ -18,7 +18,7 @@ import { ElementHandle } from 'playwright-core';
 import 'jest-playwright-preset';
 import { join } from 'path';
 import { findFiles } from '../../helpers/file-helper';
-import { chromiumMouseWheel, PanningOptions, webkitMousePanning } from './visu/playwright-utils';
+import { chromiumMouseZoom, PanningOptions, webkitMousePanning } from './visu/playwright-utils';
 
 export interface Point {
   x: number;
@@ -90,12 +90,12 @@ export async function mouseZoom(xTimes: number, point: Point, deltaX: number): P
   if (!isMouseZoomSupportedByTest) {
     throw new Error(`Mouse zoom is not supported with ${getTestedBrowserFamily()}`);
   }
-  await chromiumMouseZoom(xTimes, point, deltaX);
+  await doChromiumMouseZoom(xTimes, point, deltaX);
 }
 
-async function chromiumMouseZoom(xTimes: number, point: Point, deltaX: number): Promise<void> {
+async function doChromiumMouseZoom(xTimes: number, point: Point, deltaX: number): Promise<void> {
   for (let i = 0; i < xTimes; i++) {
-    await chromiumMouseWheel(point.x, point.y, deltaX);
+    await chromiumMouseZoom(point.x, point.y, deltaX);
     // delay here is needed to make the tests pass on MacOS, delay must be greater than debounce timing so it surely gets triggered
     await delay(100);
   }

--- a/test/e2e/helpers/visu/playwright-utils.ts
+++ b/test/e2e/helpers/visu/playwright-utils.ts
@@ -26,7 +26,7 @@ export interface PanningOptions {
 // workaround for https://github.com/microsoft/playwright/issues/1115 that only works with chromium
 // inspired from https://github.com/microsoft/playwright/issues/2642#issuecomment-647846972
 // https://github.com/microsoft/playwright/blob/v1.8.1/docs/src/api/class-cdpsession.md
-export async function chromiumMouseWheel(x: number, y: number, deltaX: number): Promise<void> {
+export async function chromiumMouseZoom(x: number, y: number, deltaX: number): Promise<void> {
   // possible improvement to investigate: can we access to the chromium server directly?
   // page._channel Proxy where Target is an EventEmitter
   // server Mouse https://github.com/microsoft/playwright/blob/v1.8.0/src/server/input.ts#L171

--- a/test/e2e/overlays.rendering.test.ts
+++ b/test/e2e/overlays.rendering.test.ts
@@ -18,7 +18,7 @@ import 'jest-playwright-preset';
 import { join } from 'path';
 import { ImageSnapshotConfigurator, ImageSnapshotThresholdConfig, MultiBrowserImageSnapshotThresholds } from './helpers/visu/image-snapshot-config';
 import { PageTester } from './helpers/visu/bpmn-page-utils';
-import { chromiumZoom, clickOnButton, getContainerCenter, itMouseWheel, mousePanning, Point } from './helpers/test-utils';
+import { clickOnButton, getContainerCenter, itMouseZoom, mousePanning, mouseZoom, Point } from './helpers/test-utils';
 import { overlayEdgePositionValues, overlayShapePositionValues } from '../helpers/overlays';
 import { OverlayEdgePosition, OverlayPosition, OverlayShapePosition } from '../../src/component/registry';
 import { ensureIsArray } from '../../src/component/helpers/array-utils';
@@ -294,8 +294,8 @@ describe('Overlay navigation', () => {
     });
   });
 
-  itMouseWheel(`zoom out`, async () => {
-    await chromiumZoom(1, { x: containerCenter.x + 200, y: containerCenter.y }, 100);
+  itMouseZoom(`zoom out`, async () => {
+    await mouseZoom(1, { x: containerCenter.x + 200, y: containerCenter.y }, 100);
 
     const image = await page.screenshot({ fullPage: true });
     const config = imageSnapshotConfigurator.getConfig(bpmnDiagramName);

--- a/test/performance/bpmn.navigation.performance.test.ts
+++ b/test/performance/bpmn.navigation.performance.test.ts
@@ -16,7 +16,7 @@
 import * as fs from 'fs';
 import { delay, getSimplePlatformName } from '../e2e/helpers/test-utils';
 import { PageTester } from '../e2e/helpers/visu/bpmn-page-utils';
-import { chromiumMouseWheel } from '../e2e/helpers/visu/playwright-utils';
+import { chromiumMouseZoom } from '../e2e/helpers/visu/playwright-utils';
 import { calculateMetrics, ChartData, PerformanceMetric } from './helpers/perf-utils';
 import { ChromiumMetricsCollector } from './helpers/metrics-chromium';
 
@@ -48,14 +48,14 @@ describe.each([1, 2, 3, 4, 5])('zoom performance', run => {
     const metricsStart = await metricsCollector.metrics();
 
     for (let i = 0; i < xTimes; i++) {
-      await chromiumMouseWheel(containerCenterX + 200, containerCenterY, deltaX);
+      await chromiumMouseZoom(containerCenterX + 200, containerCenterY, deltaX);
       if (i % 5 === 0) {
         await delay(30);
       }
     }
     await delay(100);
     for (let i = 0; i < xTimes; i++) {
-      await chromiumMouseWheel(containerCenterX + 200, containerCenterY, -deltaX);
+      await chromiumMouseZoom(containerCenterX + 200, containerCenterY, -deltaX);
       if (i % 5 === 0) {
         await delay(30);
       }


### PR DESCRIPTION
They are now aligned with the 'mouse panning' functions and have more general
names (no more reference to mouse wheel or chromium which are implementation
details).
To prevent misuse, the 'zoom' function now fails when running on non chromium
browser (we currently can not manage mouse wheel with playwright).