### PR TITLE
[REFACTOR] Simplify Json Parsing Converters

### DIFF
--- a/src/component/parser/json/converter/CategoryConverter.ts
+++ b/src/component/parser/json/converter/CategoryConverter.ts
@@ -23,7 +23,7 @@ import { TCategory } from '../../../../model/bpmn/json/baseElement/rootElement/r
  * @internal
  */
 export default class CategoryConverter {
-  constructor(readonly convertedElements: ConvertedElements) {}
+  constructor(private convertedElements: ConvertedElements) {}
 
   deserialize(definitions: TDefinitions): void {
     ensureIsArray<TCategory>(definitions.category).forEach(category => {

--- a/src/component/parser/json/converter/CollaborationConverter.ts
+++ b/src/component/parser/json/converter/CollaborationConverter.ts
@@ -27,7 +27,7 @@ import { TGroup } from '../../../../model/bpmn/json/baseElement/artifact';
  * @internal
  */
 export default class CollaborationConverter {
-  constructor(readonly convertedElements: ConvertedElements) {}
+  constructor(private convertedElements: ConvertedElements) {}
 
   deserialize(collaborations: string | TCollaboration | (string | TCollaboration)[]): void {
     ensureIsArray(collaborations).forEach(collaboration => this.parseCollaboration(collaboration));

--- a/src/component/parser/json/converter/EventDefinitionConverter.ts
+++ b/src/component/parser/json/converter/EventDefinitionConverter.ts
@@ -24,7 +24,7 @@ import { ensureIsArray } from '../../../helpers/array-utils';
  * @internal
  */
 export default class EventDefinitionConverter {
-  constructor(readonly convertedElements: ConvertedElements) {}
+  constructor(private convertedElements: ConvertedElements) {}
 
   deserialize(definitions: TDefinitions): void {
     bpmnEventKinds.forEach(eventKind => {

--- a/src/component/parser/json/converter/GlobalTaskConverter.ts
+++ b/src/component/parser/json/converter/GlobalTaskConverter.ts
@@ -25,7 +25,7 @@ import { ShapeBpmnElementKind } from '../../../../model/bpmn/internal/shape';
  * @internal
  */
 export default class GlobalTaskConverter {
-  constructor(readonly convertedElements: ConvertedElements) {}
+  constructor(private convertedElements: ConvertedElements) {}
 
   deserialize(definitions: TDefinitions): void {
     this.parseGlobalTasks(definitions.globalTask, ShapeBpmnElementKind.GLOBAL_TASK);

--- a/src/component/parser/json/converter/ProcessConverter.ts
+++ b/src/component/parser/json/converter/ProcessConverter.ts
@@ -63,7 +63,7 @@ type FlowNode = TFlowNode | TActivity | TReceiveTask | TEventBasedGateway | TTex
 export default class ProcessConverter {
   private defaultSequenceFlowIds: string[] = [];
 
-  constructor(readonly convertedElements: ConvertedElements) {}
+  constructor(private convertedElements: ConvertedElements) {}
 
   deserialize(processes: string | TProcess | (string | TProcess)[]): void {
     ensureIsArray(processes).forEach(process => this.parseProcess(process));
@@ -132,7 +132,7 @@ export default class ProcessConverter {
   }
 
   private buildShapeBpmnActivity(bpmnElement: TActivity, kind: ShapeBpmnElementKind, processId: string): ShapeBpmnActivity {
-    const markers = this.buildMarkers(bpmnElement);
+    const markers = ProcessConverter.buildMarkers(bpmnElement);
 
     if (ShapeUtil.isSubProcess(kind)) {
       return this.buildShapeBpmnSubProcess(bpmnElement, processId, markers);
@@ -153,7 +153,7 @@ export default class ProcessConverter {
     return new ShapeBpmnCallActivity(bpmnElement.id, bpmnElement.name, ShapeBpmnCallActivityKind.CALLING_GLOBAL_TASK, processId, markers, globalTaskKind);
   }
 
-  private buildMarkers(bpmnElement: TActivity): ShapeBpmnMarkerKind[] {
+  private static buildMarkers(bpmnElement: TActivity): ShapeBpmnMarkerKind[] {
     const markers: ShapeBpmnMarkerKind[] = [];
     // @ts-ignore We know that the standardLoopCharacteristics field is not on all types, but it's already tested
     const standardLoopCharacteristics = bpmnElement.standardLoopCharacteristics;


### PR DESCRIPTION
DiagramConverter: remove duplication

`convertedElements` property is now private instead of readonly because there
is no need to access it outside the class implementation

Declare static method when possible