### PR TITLE
[INFRA] Replace macOS 10.15 by macOS 11 (Big Sur) in the GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
         # syntax inspired from https://github.community/t5/GitHub-Actions/Using-a-matrix-defined-input-for-a-custom-action/m-p/32032/highlight/true#M988
         os:
           - { name: ubuntu-20.04, coverage: '-- --coverage' }
-          - { name: macos-10.15 }
+          - { name: macos-11 }
           - { name: windows-2019 }
     steps:
       - name: Checkout with shallow clone

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -35,11 +35,11 @@ jobs:
       # we want to run the full build on all os: don't cancel running jobs even if one fails
       fail-fast: false
       matrix:
-        os: [macos-10.15, ubuntu-20.04, windows-2019]
+        os: [macos-11, ubuntu-20.04, windows-2019]
         browser: [chromium, firefox]
         include:
           # only test webkit on macos
-          - os: macos-10.15
+          - os: macos-11
             browser: webkit
     steps:
       - name: Checkout


### PR DESCRIPTION
https://github.blog/changelog/2021-08-16-github-actions-macos-11-big-sur-is-generally-available-on-github-hosted-runners/