### PR TITLE
[TEST] Add more integration tests for 'requesting unknown bpmn element id'

### DIFF
--- a/test/integration/dom.after.actions.test.ts
+++ b/test/integration/dom.after.actions.test.ts
@@ -101,6 +101,12 @@ describe('Bpmn Elements registry - retrieve BPMN elements', () => {
       const bpmnElements = bpmnVisualization.bpmnElementsRegistry.getElementsByIds('unknown');
       expect(bpmnElements).toHaveLength(0);
     });
+
+    it('Pass existing and non existing ids', async () => {
+      bpmnVisualization.load(readFileSync('../fixtures/bpmn/simple-start-task-end.bpmn'));
+      const bpmnElements = bpmnVisualization.bpmnElementsRegistry.getElementsByIds(['StartEvent_1', 'unknown', 'Flow_1', 'another_unknown']);
+      expect(bpmnElements).toHaveLength(2);
+    });
   });
 
   describe('Get by kinds', () => {


### PR DESCRIPTION
We have detected a bug in the R package but existing and new tests in the lib
don't exhibit the issue. The issue is in the JS code of the R package.

covers https://github.com/process-analytics/bpmn-visualization-R/issues/44