### PR TITLE
[REFACTOR] Manage and clean some TODOs

### DIFF
--- a/src/component/BpmnVisualization.ts
+++ b/src/component/BpmnVisualization.ts
@@ -51,7 +51,6 @@ export default class BpmnVisualization {
       const renderedModel = this.bpmnModelRegistry.computeRenderedModel(bpmnModel);
       newBpmnRenderer(this.graph).render(renderedModel, options);
     } catch (e) {
-      // TODO error handling
       window.alert(`Cannot load bpmn diagram: ${e.message}`);
       throw e;
     }

--- a/src/component/mxgraph/BpmnMxGraph.ts
+++ b/src/component/mxgraph/BpmnMxGraph.ts
@@ -58,8 +58,7 @@ export class BpmnMxGraph extends mxgraph.mxGraph {
    * @internal
    */
   customFit(fitOptions: FitOptions): void {
-    // TODO avoid extra zoom/fit reset
-    // see https://github.com/process-analytics/bpmn-visualization-js/issues/888
+    // We should avoid extra zoom/fit reset. See https://github.com/process-analytics/bpmn-visualization-js/issues/888
     this.zoomActual();
 
     const type = fitOptions?.type;

--- a/src/component/mxgraph/StyleUtils.ts
+++ b/src/component/mxgraph/StyleUtils.ts
@@ -35,7 +35,7 @@ export enum StyleDefault {
   SHAPE_ACTIVITY_LEFT_MARGIN = 7,
   SHAPE_ACTIVITY_FROM_CENTER_MARGIN = 7,
   SHAPE_ACTIVITY_MARKER_ICON_MARGIN = 5,
-  SHAPE_ACTIVITY_MARKER_ICON_SIZE = 20, //TODO: this may be adjusted once #465 will be implemented see @https://github.com/process-analytics/bpmn-visualization-js/issues/465
+  SHAPE_ACTIVITY_MARKER_ICON_SIZE = 20, //TODO: this may be adjusted once #465 will be implemented see https://github.com/process-analytics/bpmn-visualization-js/issues/465
   POOL_LABEL_SIZE = 30, // most of BPMN pool are ok when setting it to 30
   POOL_LABEL_FILL_COLOR = 'none',
   LANE_LABEL_SIZE = 30, // most of BPMN lane are ok when setting it to 30

--- a/src/component/mxgraph/config/ShapeConfigurator.ts
+++ b/src/component/mxgraph/config/ShapeConfigurator.ts
@@ -88,7 +88,7 @@ export default class ShapeConfigurator {
       const canvas = new mxgraph.mxSvgCanvas2D(this.node, false);
       canvas.strokeTolerance = this.pointerEvents ? this.svgStrokeTolerance : 0;
       canvas.pointerEventsValue = this.svgPointerEvents;
-      // TODO remove this commented code (has been removed in mxgraph@4.1.1
+      // When bumping mxgraph to 4.1.1, remove this commented code. It has been removed in mxgraph@4.1.1
       //((canvas as unknown) as mxgraph.mxSvgCanvas2D).blockImagePointerEvents = isFF;
       const off = this.getSvgScreenOffset();
 

--- a/src/component/mxgraph/shape/activity-shapes.ts
+++ b/src/component/mxgraph/shape/activity-shapes.ts
@@ -89,7 +89,7 @@ export abstract class BaseActivityShape extends mxgraph.mxRectangleShape {
         canvas.translateIconOrigin(xTranslation, 0);
       };
     } else {
-      // TODO: once we support 3 markers in a group
+      // to remove once we support 3 markers in a group
       throw new Error('NOT_IMPLEMENTED - to have a group of >2 markers in a row, centered in the task, implement this piece of code');
     }
     return setIconOriginFunct;

--- a/src/component/mxgraph/shape/event-shapes.ts
+++ b/src/component/mxgraph/shape/event-shapes.ts
@@ -24,7 +24,7 @@ import { mxgraph } from '../initializer'; // for types
 abstract class EventShape extends mxgraph.mxEllipse {
   protected iconPainter = IconPainterProvider.get();
 
-  // TODO: when all/more event types will be supported, we could move to a Record/MappedType
+  // refactor: when all/more event types will be supported, we could move to a Record/MappedType
   private iconPainters: Map<ShapeBpmnEventKind, (paintParameter: PaintParameter) => void> = new Map([
     [ShapeBpmnEventKind.MESSAGE, (paintParameter: PaintParameter) => this.iconPainter.paintEnvelopeIcon({ ...paintParameter, ratioFromParent: 0.5 })],
     [ShapeBpmnEventKind.TERMINATE, (paintParameter: PaintParameter) => this.iconPainter.paintCircleIcon({ ...paintParameter, ratioFromParent: 0.6 })],

--- a/src/component/mxgraph/shape/render/BpmnCanvas.ts
+++ b/src/component/mxgraph/shape/render/BpmnCanvas.ts
@@ -74,7 +74,7 @@ export default class BpmnCanvas {
 
   constructor({ canvas, shapeConfig, iconConfig }: BpmnCanvasConfiguration) {
     this.canvas = canvas;
-    this.shapeConfiguration = shapeConfig; // TODO clone?
+    this.shapeConfiguration = shapeConfig;
 
     this.iconOriginalSize = iconConfig.originalSize;
 

--- a/src/component/options.ts
+++ b/src/component/options.ts
@@ -72,16 +72,18 @@ export interface LoadOptions {
  * @category Initialization
  */
 export interface FitOptions {
-  type?: FitType; // TODO mandatory?
+  /**
+   * @default {@link FitType.None}
+   */
+  type?: FitType;
   /**
    * Negative values fallback to default.
-   * @default 0 */
+   * @default 0
+   */
   margin?: number;
 }
 
 /**
- * @default {@link FitType.None}
- *
  * @category Initialization
  */
 export enum FitType {

--- a/src/component/parser/json/converter/ProcessConverter.ts
+++ b/src/component/parser/json/converter/ProcessConverter.ts
@@ -32,7 +32,6 @@ import {
   ShapeBpmnEventKind,
   ShapeBpmnMarkerKind,
   ShapeBpmnSubProcessKind,
-  supportedBpmnEventKinds,
 } from '../../../../model/bpmn/internal/shape';
 import { AssociationFlow, SequenceFlow } from '../../../../model/bpmn/internal/edge/Flow';
 import ShapeUtil, { BpmnEventKind } from '../../../../model/bpmn/internal/shape/ShapeUtil';
@@ -182,15 +181,13 @@ export default class ProcessConverter {
 
     if (numberOfEventDefinitions == 1) {
       const eventKind = eventDefinitions[0].kind;
-      if (supportedBpmnEventKinds.includes(eventKind)) {
-        if (ShapeUtil.isBoundaryEvent(elementKind)) {
-          return this.buildShapeBpmnBoundaryEvent(bpmnElement as TBoundaryEvent, eventKind);
-        }
-        if (ShapeUtil.isStartEvent(elementKind)) {
-          return new ShapeBpmnStartEvent(bpmnElement.id, bpmnElement.name, eventKind, processId, bpmnElement.isInterrupting);
-        }
-        return new ShapeBpmnEvent(bpmnElement.id, bpmnElement.name, elementKind, eventKind, processId);
+      if (ShapeUtil.isBoundaryEvent(elementKind)) {
+        return this.buildShapeBpmnBoundaryEvent(bpmnElement as TBoundaryEvent, eventKind);
       }
+      if (ShapeUtil.isStartEvent(elementKind)) {
+        return new ShapeBpmnStartEvent(bpmnElement.id, bpmnElement.name, eventKind, processId, bpmnElement.isInterrupting);
+      }
+      return new ShapeBpmnEvent(bpmnElement.id, bpmnElement.name, elementKind, eventKind, processId);
     }
   }
 

--- a/src/component/registry/bpmn-elements-registry.ts
+++ b/src/component/registry/bpmn-elements-registry.ts
@@ -56,9 +56,10 @@ export class BpmnElementsRegistry {
     private mxGraphCellUpdater: MxGraphCellUpdater,
   ) {}
 
-  // TODO doc, not found elements are not present in the return array
   /**
-   * Get all elements by ids.
+   * Get all elements by ids. The returned array contains elements in the order of the `bpmnElementIds` parameter.
+   *
+   * Not found elements are not returned as undefined in the array, so the returned array contains at most as much elements as the `bpmnElementIds` parameter.
    *
    * ```javascript
    * ...
@@ -91,7 +92,6 @@ export class BpmnElementsRegistry {
   getElementsByKinds(bpmnKinds: BpmnElementKind | BpmnElementKind[]): BpmnElement[] {
     return ensureIsArray<BpmnElementKind>(bpmnKinds)
       .map(kind =>
-        // TODO when implementing #953, use the model to search for Bpmn elements matching kinds instead of css selectors
         this.htmlElementRegistry.getBpmnHtmlElements(kind).map(
           htmlElement =>
             ({
@@ -252,7 +252,6 @@ class HtmlElementRegistry {
    * @param bpmnElementId the id of the BPMN element represented by the searched Html Element.
    */
   getBpmnHtmlElement(bpmnElementId: string): HTMLElement | null {
-    // TODO error management, for now we return null
     return document.querySelector<HTMLElement>(this.selectors.element(bpmnElementId));
   }
 

--- a/src/model/bpmn/internal/shape/ShapeBpmnElementKind.ts
+++ b/src/model/bpmn/internal/shape/ShapeBpmnElementKind.ts
@@ -23,6 +23,13 @@ export enum ShapeBpmnElementKind {
   POOL = 'pool',
   CALL_ACTIVITY = 'callActivity',
   SUB_PROCESS = 'subProcess',
+  // When adding support, uncomment related content in tests
+  // test/unit/component/mxgraph/renderer/StyleComputer.test.ts
+  // test/unit/component/parser/json/BpmnJsonParser.marker.test.ts (adhoc requires special checks as an additional marker should be present)
+  // Generalize test/unit/component/parser/json/BpmnJsonParser.sub.process.test.ts
+  // See also, ShapeBpmnSubProcessKind
+  // SUB_PROCESS_AD_HOC = 'adHocSubProcess',
+  // SUB_PROCESS_TRANSACTION = 'transaction',
 
   TASK = 'task',
   TASK_USER = 'userTask',
@@ -47,13 +54,14 @@ export enum ShapeBpmnElementKind {
   GATEWAY_INCLUSIVE = 'inclusiveGateway',
   GATEWAY_EVENT_BASED = 'eventBasedGateway',
 
-  // TODO: Uncomment corresponding test in test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.default.test.ts
-  // TODO: Uncomment corresponding test in test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.conditional.test.ts
-  // TODO : Uncomment corresponding line in src/model/bpmn/shape/ShapeUtil.ts
-  // TODO: Uncomment corresponding test in test/unit/component/parser/json/BpmnJsonParser.flowNode.test.ts
-  // TODO: Uncomment corresponding test in test/unit/component/parser/json/BpmnJsonParser.label.bounds.test.ts
-  // TODO: Uncomment corresponding test in test/unit/component/parser/json/BpmnJsonParser.label.font.test.ts
-  // TODO: Uncomment corresponding test in test/unit/component/parser/json/BpmnJsonParser.label.test.ts
+  // When adding support for GATEWAY_COMPLEX, uncomment corresponding test in the following files
+  // test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.default.test.ts
+  // test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.conditional.test.ts
+  // test/unit/component/parser/json/BpmnJsonParser.flowNode.test.ts
+  // test/unit/component/parser/json/BpmnJsonParser.label.bounds.test.ts
+  // test/unit/component/parser/json/BpmnJsonParser.label.font.test.ts
+  // test/unit/component/parser/json/BpmnJsonParser.label.test.ts
+  // Uncomment corresponding line in src/model/bpmn/shape/ShapeUtil.ts FLOWNODE_WITH_DEFAULT_SEQUENCE_FLOW_KINDS
   // GATEWAY_COMPLEX = 'complexGateway',
 
   EVENT_START = 'startEvent',

--- a/src/model/bpmn/internal/shape/ShapeBpmnEventKind.ts
+++ b/src/model/bpmn/internal/shape/ShapeBpmnEventKind.ts
@@ -41,23 +41,3 @@ export enum ShapeBpmnEventKind {
 export const bpmnEventKinds = Object.values(ShapeBpmnEventKind).filter(kind => {
   return kind != ShapeBpmnEventKind.NONE;
 });
-
-/**
- * List supported events in addition to the NONE event.
- *
- * Temporarily used until we support all events
- * @internal
- */
-// TODO When a new kind is supported, uncomment the corresponding line in test/unit/component/parser/json/BpmnJsonParser.event.test.ts
-export const supportedBpmnEventKinds = [
-  ShapeBpmnEventKind.TERMINATE,
-  ShapeBpmnEventKind.TIMER,
-  ShapeBpmnEventKind.MESSAGE,
-  ShapeBpmnEventKind.SIGNAL,
-  ShapeBpmnEventKind.LINK,
-  ShapeBpmnEventKind.ERROR,
-  ShapeBpmnEventKind.COMPENSATION,
-  ShapeBpmnEventKind.CANCEL,
-  ShapeBpmnEventKind.CONDITIONAL,
-  ShapeBpmnEventKind.ESCALATION,
-];

--- a/src/model/bpmn/internal/shape/ShapeBpmnSubProcessKind.ts
+++ b/src/model/bpmn/internal/shape/ShapeBpmnSubProcessKind.ts
@@ -21,6 +21,7 @@
 export enum ShapeBpmnSubProcessKind {
   EMBEDDED = 'embedded',
   EVENT = 'event',
+  // The following may be only needed for rendering, as we have special types for adHoc and transaction subprocess in ShapeBpmnElementKind
   // TRANSACTION = 'transaction',
   // AD_HOC = 'ad_hoc',
 }

--- a/src/model/bpmn/internal/shape/ShapeUtil.ts
+++ b/src/model/bpmn/internal/shape/ShapeUtil.ts
@@ -37,8 +37,6 @@ export type GlobalTaskKind =
   | ShapeBpmnElementKind.GLOBAL_TASK_USER
   | ShapeBpmnElementKind.GLOBAL_TASK_BUSINESS_RULE;
 
-// TODO move to ShapeBpmnElementKind? and rename into ShapeBpmnElementKindUtil?
-// TODO bpmnEventKinds currently hosted in ProcessConverter may be hosted here
 /**
  * @internal
  */
@@ -53,8 +51,7 @@ export default class ShapeUtil {
     ...ShapeUtil.ACTIVITY_KINDS,
     ShapeBpmnElementKind.GATEWAY_EXCLUSIVE,
     ShapeBpmnElementKind.GATEWAY_INCLUSIVE,
-
-    // TODO: Uncomment when complex gateway are supported
+    // Uncomment when supported
     // ShapeBpmnElementKind.GATEWAY_COMPLEX,
   ];
 
@@ -94,8 +91,7 @@ export default class ShapeUtil {
     return this.FLOWNODE_WITH_DEFAULT_SEQUENCE_FLOW_KINDS.includes(kind);
   }
 
-  // TODO should we clone the array to avoid modifications of this ref array by client code?
-  // topLevelBpmnEventKinds to not mixed with the bpmnEventKinds that currently are the list of non None event subtypes
+  // use the 'top level' wording to not mix with the bpmnEventKinds that currently are the list of non None event subtypes
   public static topLevelBpmnEventKinds(): ShapeBpmnElementKind[] {
     return this.EVENT_KINDS;
   }

--- a/src/model/bpmn/internal/shape/index.ts
+++ b/src/model/bpmn/internal/shape/index.ts
@@ -17,6 +17,6 @@
 export * from './ShapeBpmnCallActivityKind';
 export * from './ShapeBpmnElementKind';
 export * from './ShapeBpmnEventBasedGatewayKind';
-export * from './ShapeBpmnEventKind'; // TODO no need for internal function
+export * from './ShapeBpmnEventKind';
 export * from './ShapeBpmnMarkerKind';
 export * from './ShapeBpmnSubProcessKind';

--- a/test/integration/dom.after.actions.test.ts
+++ b/test/integration/dom.after.actions.test.ts
@@ -196,7 +196,7 @@ describe('Bpmn Elements registry - CSS class management', () => {
 
       // remove a single class from a single element
       bpmnVisualization.bpmnElementsRegistry.addCssClasses('userTask_0', 'class1');
-      htmlElementLookup.expectUserTask('userTask_0', ['class1']); // TODO do we keep this check
+      htmlElementLookup.expectUserTask('userTask_0', ['class1']);
       bpmnVisualization.bpmnElementsRegistry.removeCssClasses('userTask_0', 'class1');
       htmlElementLookup.expectUserTask('userTask_0');
 

--- a/test/unit/component/mxgraph/renderer/StyleComputer.test.ts
+++ b/test/unit/component/mxgraph/renderer/StyleComputer.test.ts
@@ -394,6 +394,9 @@ describe('Style Computer', () => {
   describe.each([
     [ShapeBpmnElementKind.CALL_ACTIVITY],
     [ShapeBpmnElementKind.SUB_PROCESS],
+    // To uncomment when it's supported
+    // [ShapeBpmnElementKind.SUB_PROCESS_AD_HOC], // this is a special case, as an additional marker should be added
+    // [ShapeBpmnElementKind.SUB_PROCESS_TRANSACTION],
     [ShapeBpmnElementKind.TASK],
     [ShapeBpmnElementKind.TASK_SERVICE],
     [ShapeBpmnElementKind.TASK_USER],
@@ -402,10 +405,6 @@ describe('Style Computer', () => {
     [ShapeBpmnElementKind.TASK_MANUAL],
     [ShapeBpmnElementKind.TASK_SCRIPT],
     [ShapeBpmnElementKind.TASK_BUSINESS_RULE],
-
-    // TODO: To uncomment when it's supported
-    //[ShapeBpmnElementKind.AD_HOC_SUB_PROCESS],
-    //[ShapeBpmnElementKind.TRANSACTION],
   ])('compute style - markers for %s', (bpmnKind: ShapeBpmnElementKind) => {
     describe.each([[ShapeBpmnMarkerKind.LOOP], [ShapeBpmnMarkerKind.MULTI_INSTANCE_SEQUENTIAL], [ShapeBpmnMarkerKind.MULTI_INSTANCE_PARALLEL]])(
       `compute style - %s marker for ${bpmnKind}`,

--- a/test/unit/component/mxgraph/shape/render/BpmnCanvas.test.ts
+++ b/test/unit/component/mxgraph/shape/render/BpmnCanvas.test.ts
@@ -36,7 +36,6 @@ describe('compute scaled icon size', () => {
       height: h,
     };
   }
-  // TODO add expect size helper function
   function expectSize(actual: Size, expected: Size): void {
     expect(actual.width).toEqual(expected.width);
     expect(actual.height).toEqual(expected.height);

--- a/test/unit/component/parser/json/BpmnJsonParser.event.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.event.test.ts
@@ -356,7 +356,7 @@ describe('parse bpmn as json for all events', () => {
       }
     });
 
-    //TODO We can delete it when all kind of event definition are implemented
+    // Only for events that support the NONE event kind
     if (expectedShapeBpmnElementKind !== ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH && expectedShapeBpmnElementKind !== ShapeBpmnElementKind.EVENT_BOUNDARY) {
       it(`should convert as NONE Shape only the '${bpmnKind}' without 'eventDefinition' & without 'eventDefinitionRef', when an array of '${bpmnKind}' (without/with one or several event definition) is an attribute of 'process'`, () => {
         const json = {

--- a/test/unit/component/parser/json/BpmnJsonParser.marker.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.marker.test.ts
@@ -23,6 +23,9 @@ import { ShapeBpmnCallActivityKind } from '../../../../../src/model/bpmn/interna
 describe.each([
   ['callActivity', ShapeBpmnElementKind.CALL_ACTIVITY],
   ['subProcess', ShapeBpmnElementKind.SUB_PROCESS],
+  // Uncomment when it's supported
+  // ['adHocSubProcess', ShapeBpmnElementKind.SUB_PROCESS_AD_HOC],
+  // ['transaction', ShapeBpmnElementKind.SUB_PROCESS_TRANSACTION],
   ['task', ShapeBpmnElementKind.TASK],
   ['serviceTask', ShapeBpmnElementKind.TASK_SERVICE],
   ['userTask', ShapeBpmnElementKind.TASK_USER],
@@ -30,11 +33,7 @@ describe.each([
   ['sendTask', ShapeBpmnElementKind.TASK_SEND],
   ['manualTask', ShapeBpmnElementKind.TASK_MANUAL],
   ['scriptTask', ShapeBpmnElementKind.TASK_SCRIPT],
-
-  // TODO: To uncomment when it's supported
   ['businessRuleTask', ShapeBpmnElementKind.TASK_BUSINESS_RULE],
-  //['adHocSubProcess', ShapeBpmnElementKind.AD_HOC_SUB_PROCESS],
-  //['transaction', ShapeBpmnElementKind.TRANSACTION],
 ])(`parse bpmn as json for '%s'`, (bpmnKind: string, expectedShapeBpmnElementKind: ShapeBpmnElementKind) => {
   describe.each([
     ['standardLoopCharacteristics', ShapeBpmnMarkerKind.LOOP],

--- a/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.conditional.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.conditional.test.ts
@@ -24,6 +24,8 @@ describe('parse bpmn as json for conditional sequence flow', () => {
   each([
     ['exclusiveGateway', SequenceFlowKind.CONDITIONAL_FROM_GATEWAY],
     ['inclusiveGateway', SequenceFlowKind.CONDITIONAL_FROM_GATEWAY],
+    // To uncomment when we support complex gateway
+    // ['complexGateway', SequenceFlowKind.CONDITIONAL_FROM_GATEWAY],
     ['task', SequenceFlowKind.CONDITIONAL_FROM_ACTIVITY],
     ['userTask', SequenceFlowKind.CONDITIONAL_FROM_ACTIVITY],
     ['serviceTask', SequenceFlowKind.CONDITIONAL_FROM_ACTIVITY],
@@ -31,11 +33,9 @@ describe('parse bpmn as json for conditional sequence flow', () => {
     ['sendTask', SequenceFlowKind.CONDITIONAL_FROM_ACTIVITY],
     ['manualTask', SequenceFlowKind.CONDITIONAL_FROM_ACTIVITY],
     ['scriptTask', SequenceFlowKind.CONDITIONAL_FROM_ACTIVITY],
+    ['businessRuleTask', SequenceFlowKind.CONDITIONAL_FROM_ACTIVITY],
     ['callActivity', SequenceFlowKind.CONDITIONAL_FROM_ACTIVITY],
     ['subProcess', SequenceFlowKind.CONDITIONAL_FROM_ACTIVITY],
-    // TODO: To uncomment when we support complex gateway
-    //['complexGateway', SequenceFlowKind.CONDITIONAL_FROM_GATEWAY],
-    ['businessRuleTask', SequenceFlowKind.CONDITIONAL_FROM_ACTIVITY],
   ]).it(
     `should convert as Edge, when an sequence flow (defined as conditional in %s) is an attribute (as object) of 'process' (as object)`,
     (sourceKind, expectedSequenceFlowKind) => {

--- a/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.default.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.default.test.ts
@@ -23,6 +23,8 @@ describe('parse bpmn as json for default sequence flow', () => {
   each([
     ['exclusiveGateway'],
     ['inclusiveGateway'],
+    // To uncomment when we support complex gateway
+    // ['complexGateway'],
     ['task'],
     ['userTask'],
     ['serviceTask'],
@@ -30,11 +32,9 @@ describe('parse bpmn as json for default sequence flow', () => {
     ['sendTask'],
     ['manualTask'],
     ['scriptTask'],
+    ['businessRuleTask'],
     ['callActivity'],
     ['subProcess'],
-    // TODO: To uncomment when we support complex gateway
-    //['complexGateway'],
-    ['businessRuleTask'],
   ]).it(`should convert as Edge, when an sequence flow (defined as default in %s) is an attribute (as object) of 'process' (as object)`, sourceKind => {
     const json = {
       definitions: {


### PR DESCRIPTION
We have too much TODO in the code, some are redundant or already described in
GitHub issues. So, perform some cleaning and do some quick fixes.

Support for new elements and related tests
  - The documentation already explains how to do it, so no need to have a TODO
  for that in the code.
  - The comments have been kept and simplified in ShapeBpmnEventKind as a
  guideline (no more split across all files) and parsing tests. There is a
  particular highlight for Subprocess.
  - parsing tests: reorder kind declaration in the 'each' statement (keep kind
  family together)

Information already in issues or documentation
  - BpmnVisualization.ts load: error handling
  - BpmnMxGraph.ts customFit: extra fit
  - ShapeConfigurator.ts: mxgraph custom code will be reviewed on mxgraph bump
  - activity-shapes and event-shapes

BpmnElementsRegistry
  - HtmlElementRegistry internal use only and null returned value documented in
  TSDoc
  - getElementsByKinds: the work to do is directly described in the issue +
  manage TODO by improving the TSDoc

ShapeUtil
  - topLevelBpmnEventKinds: improve comment about the function name
  - bpmnEventKinds already extracted from ProcessConverter
  - moving class: will be eventually done or not

Already implemented
  - BpmnCanvas.test.ts: the expectSize function already exists
  - FitOptions default value: we have decided to have a default for FitType
  which is documented in TSDoc and now at the right place (in the option, not in
  the type)

Decide to keep the existing implementation
  - ShapeUtil and BpmnCanvas: we never clone object in the lib
  - src/model/bpmn/internal/shape/index.ts
  - test/integration/dom.after.actions.test.ts