### PR TITLE
[REFACTOR] Manage some todo

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,8 +2,6 @@ root = true
 
 [*]
 charset = utf-8
-# TODO do we want to enforce this?
-# end_of_line = lf
 indent_style = space
 indent_size = 2
 max_line_length = 180

--- a/src/component/mxgraph/StyleUtils.ts
+++ b/src/component/mxgraph/StyleUtils.ts
@@ -35,7 +35,7 @@ export enum StyleDefault {
   SHAPE_ACTIVITY_LEFT_MARGIN = 7,
   SHAPE_ACTIVITY_FROM_CENTER_MARGIN = 7,
   SHAPE_ACTIVITY_MARKER_ICON_MARGIN = 5,
-  SHAPE_ACTIVITY_MARKER_ICON_SIZE = 20, //TODO: this may be adjusted once #465 will be implemented see https://github.com/process-analytics/bpmn-visualization-js/issues/465
+  SHAPE_ACTIVITY_MARKER_ICON_SIZE = 20,
   POOL_LABEL_SIZE = 30, // most of BPMN pool are ok when setting it to 30
   POOL_LABEL_FILL_COLOR = 'none',
   LANE_LABEL_SIZE = 30, // most of BPMN lane are ok when setting it to 30

--- a/src/component/mxgraph/config/StyleConfigurator.ts
+++ b/src/component/mxgraph/config/StyleConfigurator.ts
@@ -136,11 +136,9 @@ export default class StyleConfigurator {
     const style: StyleMap = {};
     style[mxgraph.mxConstants.STYLE_SHAPE] = mxgraph.mxConstants.SHAPE_SWIMLANE;
 
-    // TODO Remove when the bounds of the pool label is implemented
+    // label style
     style[mxgraph.mxConstants.STYLE_VERTICAL_ALIGN] = mxgraph.mxConstants.ALIGN_MIDDLE;
     style[mxgraph.mxConstants.STYLE_ALIGN] = mxgraph.mxConstants.ALIGN_CENTER;
-
-    // TODO manage pool text area rendering. Maybe we can calculate it from the label size/bounds
     style[mxgraph.mxConstants.STYLE_STARTSIZE] = StyleDefault.POOL_LABEL_SIZE;
     style[mxgraph.mxConstants.STYLE_FILLCOLOR] = StyleDefault.POOL_LABEL_FILL_COLOR;
 
@@ -151,14 +149,10 @@ export default class StyleConfigurator {
     const style: StyleMap = {};
     style[mxgraph.mxConstants.STYLE_SHAPE] = mxgraph.mxConstants.SHAPE_SWIMLANE;
 
-    // TODO Remove when the bounds of the lane label is implemented
+    // label style
     style[mxgraph.mxConstants.STYLE_VERTICAL_ALIGN] = mxgraph.mxConstants.ALIGN_MIDDLE;
     style[mxgraph.mxConstants.STYLE_ALIGN] = mxgraph.mxConstants.ALIGN_CENTER;
-
     style[mxgraph.mxConstants.STYLE_SWIMLANE_LINE] = 0; // hide the line between the title region and the content area
-
-    // TODO manage lane text area rendering. there is no Label neither the size available (we have only attribute name="Text of the Label")
-    // perhaps it can be calculated as a difference of starting point (either x or y) between pool, lane, sub-lane ?
     style[mxgraph.mxConstants.STYLE_STARTSIZE] = StyleDefault.LANE_LABEL_SIZE;
     style[mxgraph.mxConstants.STYLE_FILLCOLOR] = StyleDefault.LANE_LABEL_FILL_COLOR;
 


### PR DESCRIPTION
StyleDefault SHAPE_ACTIVITY_MARKER_ICON_SIZE
Implicitly managed with the issue to have a true marker fixed size.

StyleConfigurator: lane and pool label style. Documented in the issue.

editorconfig: we use os eol and let git manage eol on push
This setting may only be needed for windows, but default git checkout config
handle it correctly.
So remove the todo about setting a specific configuration.