### PR TITLE
[REFACTOR] Always configure styles out of mxgraph BPMN shapes

### DIFF
--- a/src/component/mxgraph/StyleUtils.ts
+++ b/src/component/mxgraph/StyleUtils.ts
@@ -40,6 +40,7 @@ export enum StyleDefault {
   POOL_LABEL_FILL_COLOR = 'none',
   LANE_LABEL_SIZE = 30, // most of BPMN lane are ok when setting it to 30
   LANE_LABEL_FILL_COLOR = 'none',
+  TEXT_ANNOTATION_BORDER_LENGTH = 10,
   TEXT_ANNOTATION_FILL_COLOR = 'none',
   GROUP_FILL_COLOR = 'none',
   // General

--- a/src/component/mxgraph/config/ShapeConfigurator.ts
+++ b/src/component/mxgraph/config/ShapeConfigurator.ts
@@ -17,7 +17,7 @@
 import { mxgraph } from '../initializer';
 import { mxCellState, mxImageShape, mxShape } from 'mxgraph'; // for types
 import { ShapeBpmnElementKind } from '../../../model/bpmn/internal/shape';
-import { BoundaryEventShape, CatchIntermediateEventShape, EndEventShape, StartEventShape, ThrowIntermediateEventShape } from '../shape/event-shapes';
+import { EndEventShape, EventShape, IntermediateEventShape, ThrowIntermediateEventShape } from '../shape/event-shapes';
 import { EventBasedGatewayShape, ExclusiveGatewayShape, InclusiveGatewayShape, ParallelGatewayShape } from '../shape/gateway-shapes';
 import {
   BusinessRuleTaskShape,
@@ -52,10 +52,10 @@ export default class ShapeConfigurator {
   private registerShapes(): void {
     // events
     mxgraph.mxCellRenderer.registerShape(ShapeBpmnElementKind.EVENT_END, EndEventShape);
-    mxgraph.mxCellRenderer.registerShape(ShapeBpmnElementKind.EVENT_START, StartEventShape);
+    mxgraph.mxCellRenderer.registerShape(ShapeBpmnElementKind.EVENT_START, EventShape);
     mxgraph.mxCellRenderer.registerShape(ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW, ThrowIntermediateEventShape);
-    mxgraph.mxCellRenderer.registerShape(ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH, CatchIntermediateEventShape);
-    mxgraph.mxCellRenderer.registerShape(ShapeBpmnElementKind.EVENT_BOUNDARY, BoundaryEventShape);
+    mxgraph.mxCellRenderer.registerShape(ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH, IntermediateEventShape);
+    mxgraph.mxCellRenderer.registerShape(ShapeBpmnElementKind.EVENT_BOUNDARY, IntermediateEventShape);
     // gateways
     mxgraph.mxCellRenderer.registerShape(ShapeBpmnElementKind.GATEWAY_EVENT_BASED, EventBasedGatewayShape);
     mxgraph.mxCellRenderer.registerShape(ShapeBpmnElementKind.GATEWAY_EXCLUSIVE, ExclusiveGatewayShape);

--- a/src/component/mxgraph/config/StyleConfigurator.ts
+++ b/src/component/mxgraph/config/StyleConfigurator.ts
@@ -164,6 +164,7 @@ export default class StyleConfigurator {
       const style: StyleMap = {};
       style[mxgraph.mxConstants.STYLE_SHAPE] = kind;
       style[mxgraph.mxConstants.STYLE_PERIMETER] = mxgraph.mxPerimeter.EllipsePerimeter;
+      style[mxgraph.mxConstants.STYLE_STROKEWIDTH] = kind == ShapeBpmnElementKind.EVENT_END ? StyleDefault.STROKE_WIDTH_THICK : StyleDefault.STROKE_WIDTH_THIN;
       style[mxgraph.mxConstants.STYLE_VERTICAL_LABEL_POSITION] = mxgraph.mxConstants.ALIGN_BOTTOM;
       this.putCellStyle(kind, style);
     });
@@ -176,6 +177,7 @@ export default class StyleConfigurator {
     style[mxgraph.mxConstants.STYLE_ALIGN] = mxgraph.mxConstants.ALIGN_LEFT;
     style[mxgraph.mxConstants.STYLE_SPACING_LEFT] = 5;
     style[mxgraph.mxConstants.STYLE_FILLCOLOR] = StyleDefault.TEXT_ANNOTATION_FILL_COLOR;
+    style[mxgraph.mxConstants.STYLE_STROKEWIDTH] = StyleDefault.STROKE_WIDTH_THIN;
     this.putCellStyle(ShapeBpmnElementKind.TEXT_ANNOTATION, style);
   }
 
@@ -202,6 +204,7 @@ export default class StyleConfigurator {
       style[mxgraph.mxConstants.STYLE_VERTICAL_ALIGN] = mxgraph.mxConstants.ALIGN_MIDDLE;
       style[mxgraph.mxConstants.STYLE_ABSOLUTE_ARCSIZE] = true;
       style[mxgraph.mxConstants.STYLE_ARCSIZE] = StyleDefault.SHAPE_ARC_SIZE;
+      style[mxgraph.mxConstants.STYLE_STROKEWIDTH] = kind == ShapeBpmnElementKind.CALL_ACTIVITY ? StyleDefault.STROKE_WIDTH_THICK : StyleDefault.STROKE_WIDTH_THIN;
       this.putCellStyle(kind, style);
     });
   }
@@ -211,6 +214,7 @@ export default class StyleConfigurator {
       const style: StyleMap = {};
       style[mxgraph.mxConstants.STYLE_SHAPE] = kind;
       style[mxgraph.mxConstants.STYLE_PERIMETER] = mxgraph.mxPerimeter.RhombusPerimeter;
+      style[mxgraph.mxConstants.STYLE_STROKEWIDTH] = StyleDefault.STROKE_WIDTH_THIN;
       style[mxgraph.mxConstants.STYLE_VERTICAL_ALIGN] = mxgraph.mxConstants.ALIGN_TOP;
 
       // Default label positioning

--- a/src/component/mxgraph/shape/activity-shapes.ts
+++ b/src/component/mxgraph/shape/activity-shapes.ts
@@ -20,7 +20,7 @@ import { ShapeBpmnElementKind, ShapeBpmnMarkerKind, ShapeBpmnSubProcessKind } fr
 import BpmnCanvas from './render/BpmnCanvas';
 import { orderActivityMarkers } from './render/utils';
 import { mxgraph } from '../initializer';
-import { mxAbstractCanvas2D, mxRectangle } from 'mxgraph'; // for types
+import { mxAbstractCanvas2D } from 'mxgraph'; // for types
 
 function paintEnvelopeIcon(paintParameter: PaintParameter, isFilled: boolean): void {
   IconPainterProvider.get().paintEnvelopeIcon({
@@ -37,8 +37,8 @@ function paintEnvelopeIcon(paintParameter: PaintParameter, isFilled: boolean): v
 export abstract class BaseActivityShape extends mxgraph.mxRectangleShape {
   protected iconPainter = IconPainterProvider.get();
 
-  protected constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number = StyleDefault.STROKE_WIDTH_THIN) {
-    super(bounds, fill, stroke, strokewidth);
+  public constructor() {
+    super(undefined, undefined, undefined); // the configuration is passed with the styles at runtime
     // enforced by BPMN
     this.isRounded = true;
   }
@@ -97,10 +97,6 @@ export abstract class BaseActivityShape extends mxgraph.mxRectangleShape {
 }
 
 abstract class BaseTaskShape extends BaseActivityShape {
-  protected constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number) {
-    super(bounds, fill, stroke, strokewidth);
-  }
-
   override paintForeground(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): void {
     super.paintForeground(c, x, y, w, h);
     this.paintTaskIcon(buildPaintParameter({ canvas: c, x, y, width: w, height: h, shape: this }));
@@ -113,10 +109,6 @@ abstract class BaseTaskShape extends BaseActivityShape {
  * @internal
  */
 export class TaskShape extends BaseTaskShape {
-  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number) {
-    super(bounds, fill, stroke, strokewidth);
-  }
-
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   protected paintTaskIcon(paintParameter: PaintParameter): void {
     // No symbol for the BPMN Task
@@ -128,10 +120,6 @@ export class TaskShape extends BaseTaskShape {
  * @internal
  */
 export class ServiceTaskShape extends BaseTaskShape {
-  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number) {
-    super(bounds, fill, stroke, strokewidth);
-  }
-
   protected paintTaskIcon(paintParameter: PaintParameter): void {
     this.iconPainter.paintGearIcon({ ...paintParameter, setIconOriginFunct: (canvas: BpmnCanvas) => canvas.setIconOriginToShapeTopLeftProportionally(20) });
   }
@@ -141,10 +129,6 @@ export class ServiceTaskShape extends BaseTaskShape {
  * @internal
  */
 export class UserTaskShape extends BaseTaskShape {
-  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number) {
-    super(bounds, fill, stroke, strokewidth);
-  }
-
   protected paintTaskIcon(paintParameter: PaintParameter): void {
     this.iconPainter.paintPersonIcon({ ...paintParameter, setIconOriginFunct: (canvas: BpmnCanvas) => canvas.setIconOriginToShapeTopLeftProportionally(20) });
   }
@@ -154,10 +138,6 @@ export class UserTaskShape extends BaseTaskShape {
  * @internal
  */
 export class ReceiveTaskShape extends BaseTaskShape {
-  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number) {
-    super(bounds, fill, stroke, strokewidth);
-  }
-
   protected paintTaskIcon(paintParameter: PaintParameter): void {
     if (!StyleUtils.getBpmnIsInstantiating(this.style)) {
       paintEnvelopeIcon(paintParameter, false);
@@ -195,10 +175,6 @@ export class ReceiveTaskShape extends BaseTaskShape {
  * @internal
  */
 export class SendTaskShape extends BaseTaskShape {
-  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number) {
-    super(bounds, fill, stroke, strokewidth);
-  }
-
   protected paintTaskIcon(paintParameter: PaintParameter): void {
     paintEnvelopeIcon(paintParameter, true);
   }
@@ -208,10 +184,6 @@ export class SendTaskShape extends BaseTaskShape {
  * @internal
  */
 export class ManualTaskShape extends BaseTaskShape {
-  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number) {
-    super(bounds, fill, stroke, strokewidth);
-  }
-
   protected paintTaskIcon(paintParameter: PaintParameter): void {
     this.iconPainter.paintHandIcon({ ...paintParameter, ratioFromParent: 0.18, setIconOriginFunct: (canvas: BpmnCanvas) => canvas.setIconOriginToShapeTopLeftProportionally(20) });
   }
@@ -221,10 +193,6 @@ export class ManualTaskShape extends BaseTaskShape {
  * @internal
  */
 export class ScriptTaskShape extends BaseTaskShape {
-  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number) {
-    super(bounds, fill, stroke, strokewidth);
-  }
-
   protected paintTaskIcon(paintParameter: PaintParameter): void {
     this.iconPainter.paintScriptIcon({
       ...paintParameter,
@@ -238,10 +206,6 @@ export class ScriptTaskShape extends BaseTaskShape {
  * @internal
  */
 export class CallActivityShape extends BaseActivityShape {
-  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number = StyleDefault.STROKE_WIDTH_THICK) {
-    super(bounds, fill, stroke, strokewidth);
-  }
-
   override paintForeground(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): void {
     super.paintForeground(c, x, y, w, h);
 
@@ -286,10 +250,6 @@ export class CallActivityShape extends BaseActivityShape {
  * @internal
  */
 export class SubProcessShape extends BaseActivityShape {
-  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number) {
-    super(bounds, fill, stroke, strokewidth);
-  }
-
   override paintBackground(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): void {
     const subProcessKind = StyleUtils.getBpmnSubProcessKind(this.style);
     c.save(); // ensure we can later restore the configuration
@@ -309,10 +269,6 @@ export class SubProcessShape extends BaseActivityShape {
  * @internal
  */
 export class BusinessRuleTaskShape extends BaseTaskShape {
-  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number) {
-    super(bounds, fill, stroke, strokewidth);
-  }
-
   protected paintTaskIcon(paintParameter: PaintParameter): void {
     this.iconPainter.paintTableIcon({
       ...paintParameter,

--- a/src/component/mxgraph/shape/activity-shapes.ts
+++ b/src/component/mxgraph/shape/activity-shapes.ts
@@ -37,7 +37,7 @@ function paintEnvelopeIcon(paintParameter: PaintParameter, isFilled: boolean): v
 export abstract class BaseActivityShape extends mxgraph.mxRectangleShape {
   protected iconPainter = IconPainterProvider.get();
 
-  public constructor() {
+  constructor() {
     super(undefined, undefined, undefined); // the configuration is passed with the styles at runtime
     // enforced by BPMN
     this.isRounded = true;

--- a/src/component/mxgraph/shape/event-shapes.ts
+++ b/src/component/mxgraph/shape/event-shapes.ts
@@ -18,10 +18,13 @@ import { ShapeBpmnEventKind } from '../../../model/bpmn/internal/shape';
 import { PaintParameter, buildPaintParameter, IconPainterProvider } from './render';
 import StyleUtils, { StyleDefault } from '../StyleUtils';
 import BpmnCanvas from './render/BpmnCanvas';
-import { mxAbstractCanvas2D, mxRectangle } from 'mxgraph';
+import { mxAbstractCanvas2D } from 'mxgraph';
 import { mxgraph } from '../initializer'; // for types
 
-abstract class EventShape extends mxgraph.mxEllipse {
+/**
+ * @internal
+ */
+export class EventShape extends mxgraph.mxEllipse {
   protected iconPainter = IconPainterProvider.get();
 
   // refactor: when all/more event types will be supported, we could move to a Record/MappedType
@@ -77,8 +80,8 @@ abstract class EventShape extends mxgraph.mxEllipse {
 
   protected withFilledIcon = false;
 
-  protected constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number) {
-    super(bounds, fill, stroke, strokewidth);
+  constructor() {
+    super(undefined, undefined, undefined); // the configuration is passed with the styles at runtime
   }
 
   override paintVertexShape(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): void {
@@ -127,27 +130,17 @@ abstract class EventShape extends mxgraph.mxEllipse {
 /**
  * @internal
  */
-export class StartEventShape extends EventShape {
-  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number = StyleDefault.STROKE_WIDTH_THIN) {
-    super(bounds, fill, stroke, strokewidth);
+export class EndEventShape extends EventShape {
+  constructor() {
+    super();
+    this.withFilledIcon = true;
   }
 }
 
 /**
  * @internal
  */
-export class EndEventShape extends EventShape {
-  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number = StyleDefault.STROKE_WIDTH_THICK) {
-    super(bounds, fill, stroke, strokewidth);
-    this.withFilledIcon = true;
-  }
-}
-
-abstract class IntermediateEventShape extends EventShape {
-  protected constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number = StyleDefault.STROKE_WIDTH_THIN) {
-    super(bounds, fill, stroke, strokewidth);
-  }
-
+export class IntermediateEventShape extends EventShape {
   // this implementation is adapted from the draw.io BPMN 'throwing' outlines
   // https://github.com/jgraph/drawio/blob/0e19be6b42755790a749af30450c78c0d83be765/src/main/webapp/shapes/bpmn/mxBpmnShape2.js#L431
   protected override paintOuterShape({ canvas, shapeConfig: { x, y, width, height, strokeWidth } }: PaintParameter): void {
@@ -163,27 +156,9 @@ abstract class IntermediateEventShape extends EventShape {
 /**
  * @internal
  */
-export class CatchIntermediateEventShape extends IntermediateEventShape {
-  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth?: number) {
-    super(bounds, fill, stroke, strokewidth);
-  }
-}
-
-/**
- * @internal
- */
 export class ThrowIntermediateEventShape extends IntermediateEventShape {
-  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth?: number) {
-    super(bounds, fill, stroke, strokewidth);
+  constructor() {
+    super();
     this.withFilledIcon = true;
-  }
-}
-
-/**
- * @internal
- */
-export class BoundaryEventShape extends IntermediateEventShape {
-  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth?: number) {
-    super(bounds, fill, stroke, strokewidth);
   }
 }

--- a/src/component/mxgraph/shape/gateway-shapes.ts
+++ b/src/component/mxgraph/shape/gateway-shapes.ts
@@ -17,14 +17,10 @@
 import StyleUtils, { StyleDefault } from '../StyleUtils';
 import { PaintParameter, buildPaintParameter, IconPainterProvider } from './render';
 import { mxgraph } from '../initializer';
-import { mxAbstractCanvas2D, mxRectangle } from 'mxgraph'; // for types
+import { mxAbstractCanvas2D } from 'mxgraph'; // for types
 
 abstract class GatewayShape extends mxgraph.mxRhombus {
   protected iconPainter = IconPainterProvider.get();
-
-  protected constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number) {
-    super(bounds, fill, stroke, strokewidth);
-  }
 
   protected abstract paintInnerShape(paintParameter: PaintParameter): void;
 
@@ -43,10 +39,6 @@ abstract class GatewayShape extends mxgraph.mxRhombus {
  * @internal
  */
 export class ExclusiveGatewayShape extends GatewayShape {
-  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number = StyleDefault.STROKE_WIDTH_THIN) {
-    super(bounds, fill, stroke, strokewidth);
-  }
-
   protected paintInnerShape(paintParameter: PaintParameter): void {
     this.iconPainter.paintXCrossIcon({
       ...paintParameter,
@@ -60,10 +52,6 @@ export class ExclusiveGatewayShape extends GatewayShape {
  * @internal
  */
 export class ParallelGatewayShape extends GatewayShape {
-  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number = StyleDefault.STROKE_WIDTH_THIN) {
-    super(bounds, fill, stroke, strokewidth);
-  }
-
   protected paintInnerShape(paintParameter: PaintParameter): void {
     this.iconPainter.paintPlusCrossIcon({
       ...paintParameter,
@@ -77,10 +65,6 @@ export class ParallelGatewayShape extends GatewayShape {
  * @internal
  */
 export class InclusiveGatewayShape extends GatewayShape {
-  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number = StyleDefault.STROKE_WIDTH_THIN) {
-    super(bounds, fill, stroke, strokewidth);
-  }
-
   protected paintInnerShape(paintParameter: PaintParameter): void {
     this.iconPainter.paintCircleIcon({
       ...paintParameter,
@@ -94,10 +78,6 @@ export class InclusiveGatewayShape extends GatewayShape {
  * @internal
  */
 export class EventBasedGatewayShape extends GatewayShape {
-  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number = StyleDefault.STROKE_WIDTH_THIN) {
-    super(bounds, fill, stroke, strokewidth);
-  }
-
   protected paintInnerShape(paintParameter: PaintParameter): void {
     paintParameter = { ...paintParameter, iconStyleConfig: { ...paintParameter.iconStyleConfig, strokeWidth: 1 } };
 

--- a/src/component/mxgraph/shape/text-annotation-shapes.ts
+++ b/src/component/mxgraph/shape/text-annotation-shapes.ts
@@ -16,24 +16,19 @@
 
 import { StyleDefault } from '../StyleUtils';
 import { mxgraph } from '../initializer';
-import { mxAbstractCanvas2D, mxRectangle } from 'mxgraph'; // for types
+import { mxAbstractCanvas2D } from 'mxgraph'; // for types
 
 /**
  * @internal
  */
 export class TextAnnotationShape extends mxgraph.mxRectangleShape {
-  private readonly TEXT_ANNOTATION_BORDER_LENGTH = 10;
-  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number = StyleDefault.STROKE_WIDTH_THIN) {
-    super(bounds, fill, stroke, strokewidth);
-  }
-
   override paintBackground(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): void {
     // paint sort of left square bracket shape - for text annotation
     c.begin();
-    c.moveTo(x + this.TEXT_ANNOTATION_BORDER_LENGTH, y);
+    c.moveTo(x + StyleDefault.TEXT_ANNOTATION_BORDER_LENGTH, y);
     c.lineTo(x, y);
     c.lineTo(x, y + h);
-    c.lineTo(x + this.TEXT_ANNOTATION_BORDER_LENGTH, y + h);
+    c.lineTo(x + StyleDefault.TEXT_ANNOTATION_BORDER_LENGTH, y + h);
 
     c.fillAndStroke();
   }

--- a/test/integration/matchers/toBeShape/index.ts
+++ b/test/integration/matchers/toBeShape/index.ts
@@ -29,12 +29,40 @@ import { mxgraph } from '../../../../src/component/mxgraph/initializer';
 import MatcherContext = jest.MatcherContext;
 import CustomMatcherResult = jest.CustomMatcherResult;
 
+function expectedStrokeWidth(kind: ShapeBpmnElementKind): number {
+  return [
+    ShapeBpmnElementKind.EVENT_BOUNDARY,
+    ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH,
+    ShapeBpmnElementKind.EVENT_INTERMEDIATE_THROW,
+    ShapeBpmnElementKind.EVENT_START,
+    ShapeBpmnElementKind.GATEWAY_EVENT_BASED,
+    ShapeBpmnElementKind.GATEWAY_EXCLUSIVE,
+    ShapeBpmnElementKind.GATEWAY_INCLUSIVE,
+    ShapeBpmnElementKind.GATEWAY_PARALLEL,
+    ShapeBpmnElementKind.GROUP,
+    ShapeBpmnElementKind.SUB_PROCESS,
+    ShapeBpmnElementKind.TASK,
+    ShapeBpmnElementKind.TASK_BUSINESS_RULE,
+    ShapeBpmnElementKind.TASK_MANUAL,
+    ShapeBpmnElementKind.TASK_RECEIVE,
+    ShapeBpmnElementKind.TASK_SCRIPT,
+    ShapeBpmnElementKind.TASK_SERVICE,
+    ShapeBpmnElementKind.TASK_SEND,
+    ShapeBpmnElementKind.TASK_USER,
+    ShapeBpmnElementKind.TEXT_ANNOTATION,
+  ].includes(kind)
+    ? 2
+    : [ShapeBpmnElementKind.CALL_ACTIVITY, ShapeBpmnElementKind.EVENT_END].includes(kind)
+    ? 5
+    : undefined;
+}
+
 function buildExpectedStateStyle(expectedModel: ExpectedShapeModelElement): ExpectedStateStyle {
   const expectedStateStyle = buildCommonExpectedStateStyle(expectedModel);
   expectedStateStyle.shape = !expectedModel.styleShape ? expectedModel.kind : expectedModel.styleShape;
   expectedStateStyle.verticalAlign = expectedModel.verticalAlign ? expectedModel.verticalAlign : 'middle';
   expectedStateStyle.align = expectedModel.align ? expectedModel.align : 'center';
-  expectedStateStyle.strokeWidth = expectedModel.kind == ShapeBpmnElementKind.GROUP ? 2 : undefined;
+  expectedStateStyle.strokeWidth = expectedStrokeWidth(expectedModel.kind);
 
   expectedStateStyle.fillColor = [ShapeBpmnElementKind.LANE, ShapeBpmnElementKind.POOL, ShapeBpmnElementKind.TEXT_ANNOTATION, ShapeBpmnElementKind.GROUP].includes(
     expectedModel.kind,


### PR DESCRIPTION
We don't configure styles in mxgraph BPMN shapes anymore. All styles are now
fully configured with StyleConfigurator and StyleDefault,
so the whole styling options can be changed more easily.
The shape classes have then been simplified: some have been removed and most
constructors have been removed.