### PR TITLE
[REFACTOR] Don't export mxgraph mxConstants

### DIFF
--- a/src/bpmn-visualization.ts
+++ b/src/bpmn-visualization.ts
@@ -25,8 +25,3 @@ export { StyleConfigurator } from './component/mxgraph/config/StyleConfigurator'
 export { ShapeUtil } from './model/bpmn/internal/shape/shape-utils';
 export * from './component/mxgraph/StyleUtils';
 export * from './component/mxgraph/shape/render';
-
-// TODO remove mxgraph export, this is only needed by custom theme examples using the IIFE bundle to get mxgraph constants
-// we should not export it and provide another ways in such examples
-import { mxgraph } from './component/mxgraph/initializer';
-export const mxConstants = mxgraph.mxConstants;


### PR DESCRIPTION
It was only needed by custom theme examples using the IIFE bundle to get
mxgraph constants.
The examples have been updated and now use a new way to customize the theme.

This PR rollbacks #1092 that had been introduced in [bpmn-visualization@0.12.1](
https://github.com/process-analytics/bpmn-visualization-js/releases/tag/v0.12.1) 