### PR TITLE
[REFACTOR] Simplify markers computation during rendering

### DIFF
--- a/src/component/mxgraph/shape/activity-shapes.ts
+++ b/src/component/mxgraph/shape/activity-shapes.ts
@@ -55,7 +55,7 @@ export abstract class BaseActivityShape extends mxgraph.mxRectangleShape {
       orderActivityMarkers(markers.split(',')).forEach((marker, idx, allMarkers) => {
         paintParameter = {
           ...paintParameter,
-          setIconOriginFunct: this.getIconOriginForMarkerIcon(allMarkers.length, idx + 1),
+          setIconOriginFunct: this.getMarkerIconOriginFunction(allMarkers.length, idx + 1),
         };
         paintParameter.canvas.save(); // ensure we can later restore the configuration
         switch (marker) {
@@ -78,21 +78,21 @@ export abstract class BaseActivityShape extends mxgraph.mxRectangleShape {
     }
   }
 
-  private getIconOriginForMarkerIcon(allMarkers: number, markerOrder: number): (canvas: BpmnCanvas) => void {
-    let setIconOriginFunct: (canvas: BpmnCanvas) => void;
+  private getMarkerIconOriginFunction(allMarkers: number, markerOrder: number): (canvas: BpmnCanvas) => void {
+    let setIconOriginFunction: (canvas: BpmnCanvas) => void;
     if (allMarkers === 1) {
-      setIconOriginFunct = (canvas: BpmnCanvas) => canvas.setIconOriginForIconBottomCentered();
-    } else if (allMarkers === 2) {
-      setIconOriginFunct = (canvas: BpmnCanvas) => {
+      setIconOriginFunction = (canvas: BpmnCanvas) => canvas.setIconOriginForIconBottomCentered();
+    }
+    // Here we suppose that we have 'allMarkers === 2'
+    // More markers will be supported when implementing adhoc subprocess or compensation marker
+    else {
+      setIconOriginFunction = (canvas: BpmnCanvas) => {
         canvas.setIconOriginForIconBottomCentered();
         const xTranslation = Math.pow(-1, markerOrder) * (StyleDefault.SHAPE_ACTIVITY_MARKER_ICON_SIZE / 2 + StyleDefault.SHAPE_ACTIVITY_MARKER_ICON_MARGIN);
         canvas.translateIconOrigin(xTranslation, 0);
       };
-    } else {
-      // to remove once we support 3 markers in a group
-      throw new Error('NOT_IMPLEMENTED - to have a group of >2 markers in a row, centered in the task, implement this piece of code');
     }
-    return setIconOriginFunct;
+    return setIconOriginFunction;
   }
 }
 

--- a/src/component/mxgraph/shape/render/utils.ts
+++ b/src/component/mxgraph/shape/render/utils.ts
@@ -29,12 +29,8 @@ const referenceOrderedMarkers = [
  * @internal
  */
 export function orderActivityMarkers(markers: string[]): string[] {
-  const orderedMarkers: string[] = [];
-
-  referenceOrderedMarkers.filter(marker => markers.includes(marker)).forEach(marker => orderedMarkers.push(marker));
-
+  const orderedMarkers: string[] = referenceOrderedMarkers.filter(marker => markers.includes(marker));
   // Put extra remaining at the end of the ordered markers, in the order they appear in the original array
   markers.filter(marker => !orderedMarkers.includes(marker)).forEach(marker => orderedMarkers.push(marker));
-
   return orderedMarkers;
 }


### PR DESCRIPTION
Remove the extra code for the "3 markers case".
We never have 3 markers for now, so the defensive code throwing an error is
never reached.
It will be correctly implemented when managing the initial rendering or the adhoc
subprocess or the compensation marker.

Also simplify the implementation of the 'orderActivityMarkers' function.

Covers #308, #356, #347, #355

### Rendering with more than 2 markers

This won't happen until we start working on new markers. During this implementation, instead of an error at rendering time, we will see overlapping markers. This is a good signal for developers that it is time to manage more than 2 markers in the mxgraph rendering code.

For a preview of the markers overlapping, here is what we see when we artificially add an extra marker in the code that fills the mxGraph model. The following displays the `markers.01.positioning.bpmn` BPMN diagram from the non regression visual tests.

**loop**

![markers_additional_loop](https://user-images.githubusercontent.com/27200110/134456249-b803df8c-f45b-443c-82d5-21ae51590f7c.png)

**multi-instance sequential**

![markers_additional_multi_instance_sequential](https://user-images.githubusercontent.com/27200110/134456252-4ea3f946-facd-4ef1-88b7-e12f4cb0e527.png)

### Test coverage

As the 3 markers case isn't reachable in the rendering code, so we cannot have test

SonarCloud detects it with uncovered paths. This will disappear with this Pull Request.

![image](https://user-images.githubusercontent.com/27200110/134456681-13b161c6-1a30-4e75-8939-64f262501956.png)

