### PR TITLE
[INFRA] Fix usage of the npm cache provided by the node action

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -9,18 +9,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v2
+      - name: Setup node
+        uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: '14'
+          cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
-      - name: Setup GitHub cache
-        uses: actions/cache@v2
-        with:
-          # npm cache files are stored in `~/.npm` on Linux/macOS
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
       - name: Install dependencies
         # https://playwright.dev/docs/installation/#skip-browser-downloads
         run: PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,15 +21,15 @@ jobs:
           enforce_admins: false
           branch: master
 
+      - name: Setup checkout
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_RELEASE_TOKEN }}
       - name: Setup node
         uses: actions/setup-node@v2
         with:
           node-version: '14'
           cache: 'npm'
-      - name: Setup checkout
-        uses: actions/checkout@v2
-        with:
-          token: ${{ secrets.GH_RELEASE_TOKEN }}
       - name: Config git
         run: |
           git config --local user.email "62586190+process-analytics-bot@users.noreply.github.com"


### PR DESCRIPTION
release: run checkout action prior node action (otherwise cache failure happens)
publish npm: use the new npm cache provided by the node action