### PR TITLE
[INFRA] Update Husky installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "test:bundles": "jest --runInBand --detectOpenHandles --config=./test/bundles/jest.config.js",
     "version-prepare": "node scripts/manage-version-suffix.mjs && git commit --no-verify -a -m \"[RELEASE] prepare version for release\"",
     "postversion": "node scripts/manage-version-suffix.mjs && git commit --no-verify -a -m \"[RELEASE] prepare version for new developments\"",
-    "postinstall": "husky install",
     "prepublishOnly": "pinst --disable",
     "postpublish": "pinst --enable",
     "prepare": "husky install"

--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
     "postversion": "node scripts/manage-version-suffix.mjs && git commit --no-verify -a -m \"[RELEASE] prepare version for new developments\"",
     "postinstall": "husky install",
     "prepublishOnly": "pinst --disable",
-    "postpublish": "pinst --enable"
+    "postpublish": "pinst --enable",
+    "prepare": "husky install"
   },
   "dependencies": {
     "entities": "^3.0.1",


### PR DESCRIPTION
Use the recommend way to run `husky install`.
Following : https://blog.typicode.com/husky-git-hooks-autoinstall/

Update script (remove the `postInstall` script that previously existed):
```
// package.json
{
  "scripts": {
    "prepare": "husky install"
  }
}
```
And run it locally (also run as part on npm install):
`npm run prepare`
