### PR TITLE
[REFACTOR] Remove TODO about model enum conversion

### DIFF
--- a/src/component/parser/json/converter/DiagramConverter.ts
+++ b/src/component/parser/json/converter/DiagramConverter.ts
@@ -154,8 +154,6 @@ export default class DiagramConverter {
 
         const waypoints = this.deserializeWaypoints(edge.waypoint);
         const label = this.deserializeLabel(edge.BPMNLabel, edge.id);
-
-        // TODO Remove messageVisibleKind conversion type when we merge/simplify internal model with BPMN json model
         const messageVisibleKind = edge.messageVisibleKind ? (edge.messageVisibleKind as unknown as MessageVisibleKind) : MessageVisibleKind.NONE;
 
         return new Edge(edge.id, flow, waypoints, label, messageVisibleKind);

--- a/src/component/parser/json/converter/ProcessConverter.ts
+++ b/src/component/parser/json/converter/ProcessConverter.ts
@@ -274,7 +274,6 @@ export default class ProcessConverter {
 
   private buildAssociationFlows(bpmnElements: Array<TAssociation> | TAssociation): void {
     ensureIsArray(bpmnElements).forEach(association => {
-      // TODO Remove associationDirection conversion type when we merge/simplify internal model with BPMN json model
       const direction = association.associationDirection as unknown as AssociationDirectionKind;
       this.convertedElements.registerAssociationFlow(new AssociationFlow(association.id, undefined, association.sourceRef, association.targetRef, direction));
     });


### PR DESCRIPTION
We have decided that we will keep the internal and json model separated.
So we won't merge/simplify `AssociationDirectionKind` and `MessageVisibleKind`
that will stay present in the 2 models.