### PR TITLE
[REFACTOR] Simplify parent retrieval in BpmnRenderer

### DIFF
--- a/src/component/mxgraph/BpmnRenderer.ts
+++ b/src/component/mxgraph/BpmnRenderer.ts
@@ -64,23 +64,12 @@ export class BpmnRenderer {
 
   private getParent(bpmnElement: ShapeBpmnElement): mxCell {
     const bpmnElementParent = this.getCell(bpmnElement.parentId);
-    if (bpmnElementParent) {
-      return bpmnElementParent;
-    }
-
-    if (!ShapeUtil.isBoundaryEvent(bpmnElement.kind)) {
-      return this.graph.getDefaultParent();
-    }
+    return bpmnElementParent ?? this.graph.getDefaultParent();
   }
 
   private insertShape(shape: Shape): void {
     const bpmnElement = shape.bpmnElement;
     const parent = this.getParent(bpmnElement);
-    if (!parent) {
-      // TODO error management
-      console.warn('Not possible to insert shape %s: parent cell %s is not found', bpmnElement.id, bpmnElement.parentId);
-      return;
-    }
     const bounds = shape.bounds;
     let labelBounds = shape.label?.bounds;
     // pool/lane label bounds are not managed for now (use hard coded values)


### PR DESCRIPTION
Always returns a parent, there is no need for a dedicated code for boundary
events. They are supposed to be attached to an existing parent.
More generally, if the parent id is set, it is set correctly by the parsing code.
Otherwise, it means that the parsing code contains bugs.
We don't have tests that demonstrate the need for such special use case. So
remove this defensive code and use a convenient default.

### Additional context

The defensive code has been introduced on 2020-06-23 with #323, prior having visual tests.
It was then updated on 2020-10-23 with #821. It may have been needed in the past, but tests show that we don't need it.
Notice that we already simplified the code on 2021-08-19 with #1486.

Removing the code removes a `TODO`, decreases the lib size, and increases the code coverage.
See also the [SonarCloud issue related to the console warnings TODO](https://sonarcloud.io/project/issues?id=process-analytics_bpmn-visualization-js&issues=AXelJqy8YTlMEX6v7CWX&open=AXelJqy8YTlMEX6v7CWX) used in the defensive code.

If this is a valid use-case, this is fine. In that case, create a test that shows we need the code removed in this PR.
But note that we already have a lot of integration tests in `mxGraph.model.test.ts` about the boundary events. They all check that the parent cell is set correctly in the mxGraph model.
