### PR TITLE
[TEST] Define the same signature for svg expect functions

### DIFF
--- a/test/integration/dom.after.actions.test.ts
+++ b/test/integration/dom.after.actions.test.ts
@@ -184,7 +184,7 @@ describe('Bpmn Elements registry - CSS class management', () => {
       // add several classes to several elements
       bpmnVisualization.bpmnElementsRegistry.addCssClasses(['endEvent_message_1', 'serviceTask_1_2'], ['class2', 'class3']);
       htmlElementLookup.expectServiceTask('serviceTask_1_2', { additionalClasses: ['class1', 'class2', 'class3'] });
-      htmlElementLookup.expectEndEvent('endEvent_message_1', ['class2', 'class3']);
+      htmlElementLookup.expectEndEvent('endEvent_message_1', { additionalClasses: ['class2', 'class3'] });
     });
 
     it('BPMN element does not exist', () => {
@@ -209,15 +209,15 @@ describe('Bpmn Elements registry - CSS class management', () => {
 
       // remove a single class from a single element
       bpmnVisualization.bpmnElementsRegistry.addCssClasses('userTask_0', 'class1');
-      htmlElementLookup.expectUserTask('userTask_0', ['class1']);
+      htmlElementLookup.expectUserTask('userTask_0', { additionalClasses: ['class1'] });
       bpmnVisualization.bpmnElementsRegistry.removeCssClasses('userTask_0', 'class1');
       htmlElementLookup.expectUserTask('userTask_0');
 
       // remove several classes from several elements
       bpmnVisualization.bpmnElementsRegistry.addCssClasses(['lane_01', 'userTask_0'], ['class1', 'class2', 'class3']);
       bpmnVisualization.bpmnElementsRegistry.removeCssClasses(['lane_01', 'userTask_0'], ['class1', 'class3']);
-      htmlElementLookup.expectLane('lane_01', ['class2']);
-      htmlElementLookup.expectUserTask('userTask_0', ['class2']);
+      htmlElementLookup.expectLane('lane_01', { additionalClasses: ['class2'] });
+      htmlElementLookup.expectUserTask('userTask_0', { additionalClasses: ['class2'] });
     });
 
     it('BPMN element does not exist', () => {
@@ -244,7 +244,7 @@ describe('Bpmn Elements registry - CSS class management', () => {
       // toggle a classes for several elements
       bpmnVisualization.bpmnElementsRegistry.toggleCssClasses(['lane_02', 'gateway_01'], ['class1', 'class2', 'class3']);
       bpmnVisualization.bpmnElementsRegistry.toggleCssClasses(['lane_02', 'gateway_01'], ['class1', 'class3', 'class4']);
-      htmlElementLookup.expectLane('lane_02', ['class2', 'class4']);
+      htmlElementLookup.expectLane('lane_02', { additionalClasses: ['class2', 'class4'] });
       htmlElementLookup.expectExclusiveGateway('gateway_01', { additionalClasses: ['class4'] });
     });
 

--- a/test/integration/helpers/html-utils.ts
+++ b/test/integration/helpers/html-utils.ts
@@ -16,6 +16,11 @@
 import { BpmnVisualization } from '../../../src/bpmn-visualization';
 import { BpmnQuerySelectorsForTests } from '../../helpers/query-selectors';
 
+export interface RequestedChecks {
+  readonly additionalClasses?: string[];
+  readonly overlayLabel?: string;
+}
+
 export class HtmlElementLookup {
   private bpmnQuerySelectors: BpmnQuerySelectorsForTests;
 
@@ -45,10 +50,10 @@ export class HtmlElementLookup {
     expectSvgElementClassAttribute(svgGroupElement, 'bpmn-intermediate-throw-event');
   }
 
-  expectEndEvent(bpmnId: string, additionalClasses?: string[]): void {
+  expectEndEvent(bpmnId: string, checks?: RequestedChecks): void {
     const svgGroupElement = this.findSvgElement(bpmnId);
     expectSvgEvent(svgGroupElement);
-    expectSvgElementClassAttribute(svgGroupElement, HtmlElementLookup.computeClassValue('bpmn-end-event', additionalClasses));
+    expectSvgElementClassAttribute(svgGroupElement, HtmlElementLookup.computeClassValue('bpmn-end-event', checks?.additionalClasses));
   }
 
   expectTask(bpmnId: string): void {
@@ -57,12 +62,12 @@ export class HtmlElementLookup {
     expectSvgElementClassAttribute(svgGroupElement, 'bpmn-task');
   }
 
-  expectServiceTask(bpmnId: string, options?: { additionalClasses?: string[]; overlayLabel?: string }): void {
+  expectServiceTask(bpmnId: string, checks?: RequestedChecks): void {
     const svgGroupElement = this.findSvgElement(bpmnId);
     expectSvgTask(svgGroupElement);
-    expectSvgElementClassAttribute(svgGroupElement, HtmlElementLookup.computeClassValue('bpmn-service-task', options?.additionalClasses));
+    expectSvgElementClassAttribute(svgGroupElement, HtmlElementLookup.computeClassValue('bpmn-service-task', checks?.additionalClasses));
 
-    this.expectSvgOverlay(bpmnId, options?.overlayLabel);
+    this.expectSvgOverlay(bpmnId, checks?.overlayLabel);
   }
 
   private expectSvgOverlay(bpmnId: string, overlayLabel?: string): void {
@@ -75,16 +80,16 @@ export class HtmlElementLookup {
     }
   }
 
-  expectUserTask(bpmnId: string, additionalClasses?: string[]): void {
+  expectUserTask(bpmnId: string, checks?: RequestedChecks): void {
     const svgGroupElement = this.findSvgElement(bpmnId);
     expectSvgTask(svgGroupElement);
-    expectSvgElementClassAttribute(svgGroupElement, HtmlElementLookup.computeClassValue('bpmn-user-task', additionalClasses));
+    expectSvgElementClassAttribute(svgGroupElement, HtmlElementLookup.computeClassValue('bpmn-user-task', checks?.additionalClasses));
   }
 
-  expectLane(bpmnId: string, additionalClasses?: string[]): void {
+  expectLane(bpmnId: string, checks?: RequestedChecks): void {
     const svgGroupElement = this.findSvgElement(bpmnId);
     expectSvgLane(svgGroupElement);
-    expectSvgElementClassAttribute(svgGroupElement, HtmlElementLookup.computeClassValue('bpmn-lane', additionalClasses));
+    expectSvgElementClassAttribute(svgGroupElement, HtmlElementLookup.computeClassValue('bpmn-lane', checks?.additionalClasses));
   }
 
   expectPool(bpmnId: string): void {
@@ -93,32 +98,32 @@ export class HtmlElementLookup {
     expectSvgElementClassAttribute(svgGroupElement, 'bpmn-pool');
   }
 
-  expectExclusiveGateway(bpmnId: string, options?: { additionalClasses?: string[]; overlayLabel?: string }): void {
+  expectExclusiveGateway(bpmnId: string, checks?: RequestedChecks): void {
     const svgGroupElement = this.findSvgElement(bpmnId);
     expectSvgGateway(svgGroupElement);
-    expectSvgElementClassAttribute(svgGroupElement, HtmlElementLookup.computeClassValue('bpmn-exclusive-gateway', options?.additionalClasses));
+    expectSvgElementClassAttribute(svgGroupElement, HtmlElementLookup.computeClassValue('bpmn-exclusive-gateway', checks?.additionalClasses));
 
-    this.expectSvgOverlay(bpmnId, options?.overlayLabel);
+    this.expectSvgOverlay(bpmnId, checks?.overlayLabel);
   }
 
   private static computeClassValue(bpmnClass: string, additionalClasses?: string[]): string {
     return [bpmnClass].concat(additionalClasses).filter(Boolean).join(' ');
   }
 
-  expectAssociation(bpmnId: string, options?: { overlayLabel?: string }): void {
+  expectAssociation(bpmnId: string, checks?: RequestedChecks): void {
     const svgGroupElement = this.findSvgElement(bpmnId);
     expectSvgAssociation(svgGroupElement);
     expectSvgElementClassAttribute(svgGroupElement, HtmlElementLookup.computeClassValue('bpmn-association'));
 
-    this.expectSvgOverlay(bpmnId, options?.overlayLabel);
+    this.expectSvgOverlay(bpmnId, checks?.overlayLabel);
   }
 
-  expectSequenceFlow(bpmnId: string, options?: { overlayLabel?: string }): void {
+  expectSequenceFlow(bpmnId: string, checks?: RequestedChecks): void {
     const svgGroupElement = this.findSvgElement(bpmnId);
     expectSvgSequenceFlow(svgGroupElement);
     expectSvgElementClassAttribute(svgGroupElement, HtmlElementLookup.computeClassValue('bpmn-sequence-flow'));
 
-    this.expectSvgOverlay(bpmnId, options?.overlayLabel);
+    this.expectSvgOverlay(bpmnId, checks?.overlayLabel);
   }
 }
 


### PR DESCRIPTION
Introduce a common `RequestedChecks` for methods of `HtmlElementLookup`. This
improves readability and maintenance: there is no need to add new parameters
when new checks are implemented in methods.

Prepares tests for #1621 and #1622