### PR TITLE
[EXAMPLE] Use deferred script loading

### DIFF
--- a/dev/public/diagram-navigation.html
+++ b/dev/public/diagram-navigation.html
@@ -19,6 +19,9 @@
       width: 35px;
     }
   </style>
+
+  <!-- load app -->
+  <script src="static/js/diagram-navigation.js" type="module"></script>
 </head>
 <body>
 <div class="flex-container">
@@ -131,8 +134,5 @@
 
   <div id="bpmn-container"></div>
 </div>
-
-<!-- load app -->
-<script src="static/js/diagram-navigation.js" type="module"></script>
 </body>
 </html>

--- a/dev/public/elements-identification.html
+++ b/dev/public/elements-identification.html
@@ -72,6 +72,9 @@
         stroke-width: 4px;
       }
     </style>
+
+    <!-- load app -->
+    <script src="static/js/elements-identification.js" type="module"></script>
 </head>
 <body>
     <div id="controls">
@@ -102,8 +105,5 @@
     <div id="main-container">
       <div id="bpmn-container"></div>
     </div>
-
-    <!-- load app -->
-    <script src="static/js/elements-identification.js" type="module"></script>
 </body>
 </html>

--- a/dev/public/index.html
+++ b/dev/public/index.html
@@ -9,6 +9,9 @@
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.3.1/css/all.css">
     <link href="static/css/tailwind.css" rel="stylesheet">
     <link rel="icon" href="static/img/favicon.png">
+
+    <!-- load demo -->
+    <script src="static/js/demo.js" type="module"></script>
 </head>
 <body class="overflow-hidden bg-gray-800 font-sans leading-normal tracking-normal mt-12">
     <!--Nav-->
@@ -105,8 +108,5 @@
         </div>
       </div>
     </div>
-
-    <!-- load demo -->
-    <script src="static/js/demo.js" type="module"></script>
 </body>
 </html>

--- a/dev/public/lib-integration.html
+++ b/dev/public/lib-integration.html
@@ -4,11 +4,10 @@
   <meta charset="UTF-8">
   <title>BPMN Visualization Lib Integration</title>
   <link rel="icon" href="static/img/favicon.png">
+  <!-- load app -->
+  <script src="static/js/lib-integration.js" type="module"></script>
 </head>
 <body>
   <div id="bpmn-container-custom"></div>
-
-  <!-- load app -->
-  <script src="static/js/lib-integration.js" type="module"></script>
 </body>
 </html>

--- a/dev/public/non-regression.html
+++ b/dev/public/non-regression.html
@@ -18,12 +18,11 @@
         font-weight: bold;
       }
     </style>
+    <!-- load app -->
+    <script src="static/js/non-regression.js" type="module"></script>
 </head>
 <body>
     <div id="fetch-status"></div>
     <div id="bpmn-container"></div>
-
-    <!-- load app -->
-    <script src="static/js/non-regression.js" type="module"></script>
 </body>
 </html>

--- a/dev/public/overlays.html
+++ b/dev/public/overlays.html
@@ -14,6 +14,8 @@
       background-color: MintCream;
     }
   </style>
+  <!-- load app -->
+  <script src="static/js/overlays.js" type="module"></script>
 </head>
 <body>
 <div class="flex-container">
@@ -262,8 +264,5 @@
 
   <div id="bpmn-container"></div>
 </div>
-
-<!-- load app -->
-<script src="static/js/overlays.js" type="module"></script>
 </body>
 </html>


### PR DESCRIPTION
Previously, we put the script declaration at the end of the page body, it
allowed the elimination of parser-blocking JavaScript.
The `defer` attribute is designed for such a purpose.

We only load a single module script in each page, and modules are deferred
automatically. So, we can declare the scripts in the head of the page without
using the defer attribute.

Resources:
  - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules#other_differences_between_modules_and_standard_scripts
  - https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-defer