### PR TITLE
[TEST] Reorganize utils code in integration tests

### DIFF
--- a/test/integration/helpers/html-utils.ts
+++ b/test/integration/helpers/html-utils.ts
@@ -57,7 +57,7 @@ export class HtmlElementLookup {
   expectEndEvent(bpmnId: string, checks?: RequestedChecks): void {
     const svgGroupElement = this.findSvgElement(bpmnId);
     expectSvgEvent(svgGroupElement);
-    expectSvgElementClassAttribute(svgGroupElement, HtmlElementLookup.computeClassValue('bpmn-end-event', checks?.additionalClasses));
+    expectSvgElementClassAttribute(svgGroupElement, computeClassValue('bpmn-end-event', checks?.additionalClasses));
   }
 
   expectTask(bpmnId: string): void {
@@ -69,7 +69,7 @@ export class HtmlElementLookup {
   expectServiceTask(bpmnId: string, checks?: RequestedChecks): void {
     const svgGroupElement = this.findSvgElement(bpmnId);
     expectSvgTask(svgGroupElement);
-    expectSvgElementClassAttribute(svgGroupElement, HtmlElementLookup.computeClassValue('bpmn-service-task', checks?.additionalClasses));
+    expectSvgElementClassAttribute(svgGroupElement, computeClassValue('bpmn-service-task', checks?.additionalClasses));
 
     this.expectSvgOverlay(bpmnId, checks?.overlayLabel);
   }
@@ -87,13 +87,13 @@ export class HtmlElementLookup {
   expectUserTask(bpmnId: string, checks?: RequestedChecks): void {
     const svgGroupElement = this.findSvgElement(bpmnId);
     expectSvgTask(svgGroupElement);
-    expectSvgElementClassAttribute(svgGroupElement, HtmlElementLookup.computeClassValue('bpmn-user-task', checks?.additionalClasses));
+    expectSvgElementClassAttribute(svgGroupElement, computeClassValue('bpmn-user-task', checks?.additionalClasses));
   }
 
   expectLane(bpmnId: string, checks?: RequestedChecks): void {
     const svgGroupElement = this.findSvgElement(bpmnId);
     expectSvgLane(svgGroupElement);
-    expectSvgElementClassAttribute(svgGroupElement, HtmlElementLookup.computeClassValue('bpmn-lane', checks?.additionalClasses));
+    expectSvgElementClassAttribute(svgGroupElement, computeClassValue('bpmn-lane', checks?.additionalClasses));
   }
 
   expectPool(bpmnId: string): void {
@@ -105,19 +105,15 @@ export class HtmlElementLookup {
   expectExclusiveGateway(bpmnId: string, checks?: RequestedChecks): void {
     const svgGroupElement = this.findSvgElement(bpmnId);
     expectSvgGateway(svgGroupElement);
-    expectSvgElementClassAttribute(svgGroupElement, HtmlElementLookup.computeClassValue('bpmn-exclusive-gateway', checks?.additionalClasses));
+    expectSvgElementClassAttribute(svgGroupElement, computeClassValue('bpmn-exclusive-gateway', checks?.additionalClasses));
 
     this.expectSvgOverlay(bpmnId, checks?.overlayLabel);
-  }
-
-  private static computeClassValue(bpmnClass: string, additionalClasses?: string[]): string {
-    return [bpmnClass].concat(additionalClasses).filter(Boolean).join(' ');
   }
 
   expectAssociation(bpmnId: string, checks?: RequestedChecks): void {
     const svgGroupElement = this.findSvgElement(bpmnId);
     expectSvgAssociation(svgGroupElement);
-    expectSvgElementClassAttribute(svgGroupElement, HtmlElementLookup.computeClassValue('bpmn-association'));
+    expectSvgElementClassAttribute(svgGroupElement, computeClassValue('bpmn-association'));
 
     this.expectSvgOverlay(bpmnId, checks?.overlayLabel);
   }
@@ -125,7 +121,7 @@ export class HtmlElementLookup {
   expectSequenceFlow(bpmnId: string, checks?: RequestedChecks): void {
     const svgGroupElement = this.findSvgElement(bpmnId);
     expectSvgSequenceFlow(svgGroupElement);
-    expectSvgElementClassAttribute(svgGroupElement, HtmlElementLookup.computeClassValue('bpmn-sequence-flow'));
+    expectSvgElementClassAttribute(svgGroupElement, computeClassValue('bpmn-sequence-flow'));
 
     this.expectSvgOverlay(bpmnId, checks?.overlayLabel);
   }
@@ -133,17 +129,21 @@ export class HtmlElementLookup {
   expectMessageFlow(bpmnId: string, checks?: MessageFlowRequestedChecks): void {
     const svgGroupElement = this.findSvgElement(bpmnId);
     expectSvgMessageFlow(svgGroupElement);
-    expectSvgElementClassAttribute(svgGroupElement, HtmlElementLookup.computeClassValue('bpmn-message-flow', checks?.additionalClasses));
+    expectSvgElementClassAttribute(svgGroupElement, computeClassValue('bpmn-message-flow', checks?.additionalClasses));
 
     // message flow icon
     const msgFlowIconSvgGroupElement = document.querySelector<HTMLElement>(this.bpmnQuerySelectors.element(`messageFlowIcon_of_${bpmnId}`));
     if (checks?.hasIcon) {
       expectSvgMessageFlowIcon(msgFlowIconSvgGroupElement);
-      expectSvgElementClassAttribute(msgFlowIconSvgGroupElement, HtmlElementLookup.computeClassValue('bpmn-message-flow-icon', checks?.additionalClasses));
+      expectSvgElementClassAttribute(msgFlowIconSvgGroupElement, computeClassValue('bpmn-message-flow-icon', checks?.additionalClasses));
     } else {
       expect(msgFlowIconSvgGroupElement).toBeNull();
     }
   }
+}
+
+function computeClassValue(bpmnClass: string, additionalClasses?: string[]): string {
+  return [bpmnClass].concat(additionalClasses).filter(Boolean).join(' ');
 }
 
 export function expectSvgEvent(svgGroupElement: HTMLElement): void {

--- a/test/integration/helpers/semantic-with-svg-utils.ts
+++ b/test/integration/helpers/semantic-with-svg-utils.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2021 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { BpmnElement } from '../../../src/component/registry';
+import { ExpectedBaseBpmnElement, expectEndEvent, expectPool, expectSequenceFlow, expectServiceTask, expectStartEvent, expectTask } from '../../unit/helpers/bpmn-semantic-utils';
+import { expectSvgEvent, expectSvgPool, expectSvgSequenceFlow, expectSvgTask } from './html-utils';
+
+export function expectStartEventBpmnElement(bpmnElement: BpmnElement, expected: ExpectedBaseBpmnElement): void {
+  expectStartEvent(bpmnElement.bpmnSemantic, expected);
+  expectSvgEvent(bpmnElement.htmlElement);
+}
+
+export function expectEndEventBpmnElement(bpmnElement: BpmnElement, expected: ExpectedBaseBpmnElement): void {
+  expectEndEvent(bpmnElement.bpmnSemantic, expected);
+  expectSvgEvent(bpmnElement.htmlElement);
+}
+
+export function expectSequenceFlowBpmnElement(bpmnElement: BpmnElement, expected: ExpectedBaseBpmnElement): void {
+  expectSequenceFlow(bpmnElement.bpmnSemantic, expected);
+  expectSvgSequenceFlow(bpmnElement.htmlElement);
+}
+
+export function expectTaskBpmnElement(bpmnElement: BpmnElement, expected: ExpectedBaseBpmnElement): void {
+  expectTask(bpmnElement.bpmnSemantic, expected);
+  expectSvgTask(bpmnElement.htmlElement);
+}
+
+export function expectServiceTaskBpmnElement(bpmnElement: BpmnElement, expected: ExpectedBaseBpmnElement): void {
+  expectServiceTask(bpmnElement.bpmnSemantic, expected);
+  expectSvgTask(bpmnElement.htmlElement);
+}
+
+export function expectPoolBpmnElement(bpmnElement: BpmnElement, expected: ExpectedBaseBpmnElement): void {
+  expectPool(bpmnElement.bpmnSemantic, expected);
+  expectSvgPool(bpmnElement.htmlElement);
+}


### PR DESCRIPTION
  - Move utils code out of integration test files
  - Reuse HtmlLookup instances when possible in tests
  - Move computeClassValue out of HtmlElementLookup: avoid static method call
  for clarity