### PR TITLE
[FIX] Ensure extra CSS classes are cleaned on diagram load

### DIFF
--- a/src/component/registry/bpmn-elements-registry.ts
+++ b/src/component/registry/bpmn-elements-registry.ts
@@ -54,7 +54,9 @@ export class BpmnElementsRegistry {
     private htmlElementRegistry: HtmlElementRegistry,
     private cssRegistry: CssRegistry,
     private mxGraphCellUpdater: MxGraphCellUpdater,
-  ) {}
+  ) {
+    this.bpmnModelRegistry.onSearchableModelLoad(this.cssRegistry.clear.bind(this.cssRegistry));
+  }
 
   /**
    * Get all elements by ids. The returned array contains elements in the order of the `bpmnElementIds` parameter.

--- a/src/component/registry/bpmn-elements-registry.ts
+++ b/src/component/registry/bpmn-elements-registry.ts
@@ -55,7 +55,7 @@ export class BpmnElementsRegistry {
     private cssRegistry: CssRegistry,
     private mxGraphCellUpdater: MxGraphCellUpdater,
   ) {
-    this.bpmnModelRegistry.onSearchableModelLoad(this.cssRegistry.clear.bind(this.cssRegistry));
+    this.bpmnModelRegistry.registerOnLoadCallback(this.cssRegistry.clear.bind(this.cssRegistry));
   }
 
   /**

--- a/src/component/registry/bpmn-model-registry.ts
+++ b/src/component/registry/bpmn-model-registry.ts
@@ -22,10 +22,16 @@ import ShapeBpmnElement, { ShapeBpmnSubProcess } from '../../model/bpmn/internal
 
 export class BpmnModelRegistry {
   private searchableModel: SearchableModel;
+  private loadedSearchableModelCallback: () => void;
 
   computeRenderedModel(bpmnModel: BpmnModel): RenderedModel {
     this.searchableModel = new SearchableModel(bpmnModel);
+    this.loadedSearchableModelCallback?.();
     return toRenderedModel(bpmnModel);
+  }
+
+  onSearchableModelLoad(callback: () => void): void {
+    this.loadedSearchableModelCallback = callback;
   }
 
   getBpmnSemantic(bpmnElementId: string): BpmnSemantic | undefined {

--- a/src/component/registry/bpmn-model-registry.ts
+++ b/src/component/registry/bpmn-model-registry.ts
@@ -22,16 +22,16 @@ import ShapeBpmnElement, { ShapeBpmnSubProcess } from '../../model/bpmn/internal
 
 export class BpmnModelRegistry {
   private searchableModel: SearchableModel;
-  private loadedSearchableModelCallback: () => void;
+  private onLoadCallback: () => void;
 
   computeRenderedModel(bpmnModel: BpmnModel): RenderedModel {
     this.searchableModel = new SearchableModel(bpmnModel);
-    this.loadedSearchableModelCallback?.();
+    this.onLoadCallback?.();
     return toRenderedModel(bpmnModel);
   }
 
-  onSearchableModelLoad(callback: () => void): void {
-    this.loadedSearchableModelCallback = callback;
+  registerOnLoadCallback(callback: () => void): void {
+    this.onLoadCallback = callback;
   }
 
   getBpmnSemantic(bpmnElementId: string): BpmnSemantic | undefined {

--- a/src/component/registry/css-registry.ts
+++ b/src/component/registry/css-registry.ts
@@ -23,6 +23,13 @@ export class CssRegistry {
   private classNamesByBPMNId = new Map<string, Set<string>>();
 
   /**
+   * Clear all classes that were registered.
+   */
+  clear(): void {
+    this.classNamesByBPMNId.clear();
+  }
+
+  /**
    * Get the CSS class names for a specific HTML element
    *
    * @param bpmnElementId the BPMN id of the HTML element from the DOM

--- a/test/integration/dom.after.actions.test.ts
+++ b/test/integration/dom.after.actions.test.ts
@@ -172,6 +172,26 @@ describe('Bpmn Elements registry - CSS class management', () => {
       // this call ensures that there is not issue on the rendering part
       bpmnVisualization.bpmnElementsRegistry.addCssClasses(nonExistingBpmnId, 'class1');
     });
+
+    it('Css classes are cleaned between 2 diagram loads', () => {
+      const bpmnVisualizationMultipleLoads = initializeBpmnVisualization('bpmn-container-multiple-loads');
+      const htmlElementLookup = new HtmlElementLookup(bpmnVisualizationMultipleLoads);
+
+      const bpmnDiagramContent = readFileSync('../fixtures/bpmn/simple-start-task-end.bpmn');
+      const startEventId = 'StartEvent_1';
+
+      // first load
+      bpmnVisualizationMultipleLoads.load(bpmnDiagramContent);
+      htmlElementLookup.expectStartEvent(startEventId);
+      bpmnVisualizationMultipleLoads.bpmnElementsRegistry.addCssClasses(startEventId, 'class1-added-on-first-load');
+      htmlElementLookup.expectStartEvent(startEventId, { additionalClasses: ['class1-added-on-first-load'] });
+
+      // second load
+      bpmnVisualizationMultipleLoads.load(bpmnDiagramContent);
+      htmlElementLookup.expectStartEvent(startEventId);
+      bpmnVisualizationMultipleLoads.bpmnElementsRegistry.addCssClasses(startEventId, 'class2-added-on-second-load');
+      htmlElementLookup.expectStartEvent(startEventId, { additionalClasses: ['class2-added-on-second-load'] });
+    });
   });
 
   describe('Remove classes', () => {
@@ -232,16 +252,8 @@ describe('Bpmn Elements registry - CSS class management', () => {
   });
 
   describe('Classes for Message Flow element and icon', () => {
-    // NOTE: temporary use a dedicated `BpmnVisualization` instance in each test
-    // Prevent bug to appear: classes are not purged from the internal CssRegistry on diagram load, so css classes added in a test are still present in the subsequent tests
-    function generateContainerId(testNumber: number): string {
-      return `bpmn-visualization-container-${testNumber}`;
-    }
-
     it('Add one or several classes to message flows with and without icon', () => {
-      const bpmnVisualization = initializeBpmnVisualization(generateContainerId(1));
       bpmnVisualization.load(readFileSync('../fixtures/bpmn/registry/message-flows-with-and-without-icon.bpmn'));
-      const htmlElementLookup = new HtmlElementLookup(bpmnVisualization);
 
       // default classes
       htmlElementLookup.expectMessageFlow('MessageFlow_1');
@@ -260,9 +272,7 @@ describe('Bpmn Elements registry - CSS class management', () => {
     });
 
     it('Remove one or several classes to one or several message flows with icon', () => {
-      const bpmnVisualization = initializeBpmnVisualization(generateContainerId(2));
       bpmnVisualization.load(readFileSync('../fixtures/bpmn/registry/message-flows-with-and-without-icon.bpmn'));
-      const htmlElementLookup = new HtmlElementLookup(bpmnVisualization);
 
       // remove a single class from a single element
       bpmnVisualization.bpmnElementsRegistry.addCssClasses('MessageFlow_1', 'class1');
@@ -284,9 +294,7 @@ describe('Bpmn Elements registry - CSS class management', () => {
     });
 
     it('Toggle one or several classes to one or several message flows with icon', () => {
-      const bpmnVisualization = initializeBpmnVisualization(generateContainerId(3));
       bpmnVisualization.load(readFileSync('../fixtures/bpmn/registry/message-flows-with-and-without-icon.bpmn'));
-      const htmlElementLookup = new HtmlElementLookup(bpmnVisualization);
 
       // toggle a classes for a single element
       bpmnVisualization.bpmnElementsRegistry.toggleCssClasses('MessageFlow_2_msgVisibilityKind_initiating', 'class1');

--- a/test/integration/helpers/html-utils.ts
+++ b/test/integration/helpers/html-utils.ts
@@ -42,10 +42,10 @@ export class HtmlElementLookup {
     expect(svgGroupElement).toBeUndefined();
   }
 
-  expectStartEvent(bpmnId: string): void {
+  expectStartEvent(bpmnId: string, checks?: RequestedChecks): void {
     const svgGroupElement = this.findSvgElement(bpmnId);
     expectSvgEvent(svgGroupElement);
-    expectSvgElementClassAttribute(svgGroupElement, 'bpmn-start-event');
+    expectSvgElementClassAttribute(svgGroupElement, computeClassValue('bpmn-start-event', checks?.additionalClasses));
   }
 
   expectIntermediateThrowEvent(bpmnId: string): void {

--- a/test/unit/component/registry/bpmn-model-registry.test.ts
+++ b/test/unit/component/registry/bpmn-model-registry.test.ts
@@ -59,21 +59,32 @@ function poolInModel(id: string, name: string): BpmnModel {
 }
 
 describe('Bpmn Model registry', () => {
+  it('callback is called on model load', () => {
+    const bpmnModelRegistry = new BpmnModelRegistry();
+    const callback = jest.fn();
+    bpmnModelRegistry.onSearchableModelLoad(callback);
+    bpmnModelRegistry.computeRenderedModel(startEventInModel('id', 'name'));
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
   it('search edge', () => {
     bpmnModelRegistry.computeRenderedModel(sequenceFlowInModel('seq flow id', 'seq flow name'));
     const bpmnSemantic = bpmnModelRegistry.getBpmnSemantic('seq flow id');
     expectSequenceFlow(bpmnSemantic, { id: 'seq flow id', name: 'seq flow name' });
   });
+
   it('search flownode', () => {
     bpmnModelRegistry.computeRenderedModel(startEventInModel('start event id', 'start event name'));
     const bpmnSemantic = bpmnModelRegistry.getBpmnSemantic('start event id');
     expectStartEvent(bpmnSemantic, { id: 'start event id', name: 'start event name' });
   });
+
   it('search lane', () => {
     bpmnModelRegistry.computeRenderedModel(laneInModel('lane id', 'lane name'));
     const bpmnSemantic = bpmnModelRegistry.getBpmnSemantic('lane id');
     expectLane(bpmnSemantic, { id: 'lane id', name: 'lane name' });
   });
+
   it('search pool', () => {
     bpmnModelRegistry.computeRenderedModel(poolInModel('pool id', 'pool name'));
     const bpmnSemantic = bpmnModelRegistry.getBpmnSemantic('pool id');

--- a/test/unit/component/registry/bpmn-model-registry.test.ts
+++ b/test/unit/component/registry/bpmn-model-registry.test.ts
@@ -62,7 +62,7 @@ describe('Bpmn Model registry', () => {
   it('callback is called on model load', () => {
     const bpmnModelRegistry = new BpmnModelRegistry();
     const callback = jest.fn();
-    bpmnModelRegistry.onSearchableModelLoad(callback);
+    bpmnModelRegistry.registerOnLoadCallback(callback);
     bpmnModelRegistry.computeRenderedModel(startEventInModel('id', 'name'));
     expect(callback).toHaveBeenCalledTimes(1);
   });

--- a/test/unit/component/registry/css-registry.test.ts
+++ b/test/unit/component/registry/css-registry.test.ts
@@ -15,9 +15,9 @@
  */
 import { CssRegistry } from '../../../../src/component/registry/css-registry';
 
-let cssRegistry: CssRegistry;
+const cssRegistry = new CssRegistry();
 beforeEach(() => {
-  cssRegistry = new CssRegistry();
+  cssRegistry.clear();
 });
 
 describe('manage css classes for BPMN cells', () => {
@@ -25,8 +25,29 @@ describe('manage css classes for BPMN cells', () => {
     it('getClassNames should return a empty array, when no class is registered at all', () => {
       expect(cssRegistry.getClassNames('bpmn-id-1')).toHaveLength(0);
     });
+
     it('getClassNames should return a empty array, when no class name is registered for the BPMN element', () => {
       cssRegistry.addClassNames('bpmn-id-1', ['class-name']);
+      expect(cssRegistry.getClassNames('bpmn-id-2')).toHaveLength(0);
+    });
+
+    it('getClassNames should not let modify the stored class names except when using the API', () => {
+      const bpmnElementId = 'bpmn-id-1';
+      cssRegistry.addClassNames(bpmnElementId, ['class-name']);
+      const classNames = cssRegistry.getClassNames('bpmn-id-1');
+      expect(classNames).toEqual(['class-name']);
+      classNames.push('new-class-1', 'new-class-2');
+      expect(cssRegistry.getClassNames(bpmnElementId)).toEqual(['class-name']);
+    });
+
+    it('getClassNames after clearing the whole registry', () => {
+      cssRegistry.addClassNames('bpmn-id-1', ['class1']);
+      cssRegistry.addClassNames('bpmn-id-2', ['class1', 'class2']);
+      expect(cssRegistry.getClassNames('bpmn-id-1')).toEqual(['class1']);
+      expect(cssRegistry.getClassNames('bpmn-id-2')).toEqual(['class1', 'class2']);
+
+      cssRegistry.clear();
+      expect(cssRegistry.getClassNames('bpmn-id-1')).toHaveLength(0);
       expect(cssRegistry.getClassNames('bpmn-id-2')).toHaveLength(0);
     });
   });


### PR DESCRIPTION
closes #1637

Previously, without the cache clean, classes added to a diagram were kept when
loading a new one. So, the DOM element produced after loading a new diagram
could receive an extra class added for the previous diagram.

The cache stored by CssRegistry can now be cleared, and it is cleared on new
diagram load to avoid such an issue.

In addition
  - remove the hack introduced to not face the bug when testing message flow icon
  - add a unit test to demonstrate we cannot accidentally modify the classes
  cache without using the API