### PR TITLE
[TEST] Reproduce 'BPMN text label ignored events' in example page

### DIFF
--- a/dev/public/elements-identification.html
+++ b/dev/public/elements-identification.html
@@ -76,6 +76,15 @@
         stroke: dodgerblue;
         stroke-width: 4px;
       }
+
+      /*apply shadow on hover*/
+      .detection-activity:hover,
+      .detection-gateway:hover,
+      .detection-lane:hover,
+      .detection-event:hover {
+        filter: drop-shadow(0 0 2em rgba(0, 0, 0));
+      }
+
     </style>
 
     <!-- load app -->


### PR DESCRIPTION
Style on hover is not applied passing on the text.

The style is inspired of what we did in https://github.com/process-analytics/bpmn-visualization-examples/pull/265.

Covers #920

![GH_PR_1641_style_hover](https://user-images.githubusercontent.com/27200110/143068869-d7c9dd46-1cb1-4529-a677-a93b2d9acb99.gif)
Can be accessed locally using http://localhost:10001/elements-identification.html?url=./static/diagrams/labels.01.general.bpmn