### PR TITLE
[DOC] Improve API documentation visibility

### DIFF
--- a/docs/users/index.adoc
+++ b/docs/users/index.adoc
@@ -3,7 +3,7 @@
 // see: https://asciidoctor.org/docs/user-manual/#table-of-contents-summary
 :toc-title: Table of Contents
 // how many headline levels to display in the table of contents?
-:toclevels: 2
+:toclevels: 3
 // https://asciidoctor.org/docs/user-manual/#sections-summary
 // turn numbering on or off (:sectnums!:)
 :sectnums:

--- a/docs/users/overview.adoc
+++ b/docs/users/overview.adoc
@@ -15,7 +15,9 @@ in various bundle formats.
 
 ==== API
 The API documentation is provided directly in the package thanks to the TypeScript declaration files that can be used in IDE for code assist. +
-There is also an HTML version which is available in the link:./api/index.html[API HTML documentation, window="_blank"].
+
+[sidebar]
+There is also an HTML version which is available in link:./api/index.html[the API HTML documentation, window="_blank"].
 
 ==== More technical details
 For more technical details and how-to, go to the https://github.com/process-analytics/bpmn-visualization-examples/[bpmn-visualization-examples]


### PR DESCRIPTION
Display more levels in the TOC, so there is an entry in the TOC about the API.
Make the HTML API documentation link more visible in the documentation content.