### PR TITLE
[FIX] Export some missing flow kinds

### DIFF
--- a/src/model/bpmn/internal/edge/kinds.ts
+++ b/src/model/bpmn/internal/edge/kinds.ts
@@ -15,8 +15,8 @@
  */
 
 /**
- * The real name of the field in the BPMN XSD
- * @internal
+ * Enum values are using the real name of the field in the BPMN XSD.
+ * @category BPMN
  */
 export enum AssociationDirectionKind {
   NONE = 'None',
@@ -25,7 +25,7 @@ export enum AssociationDirectionKind {
 }
 
 /**
- * The real name of the field in the BPMN XSD.
+ * Enum values are using the real name of the field in the BPMN XSD.
  * @category BPMN
  */
 export enum FlowKind {
@@ -35,7 +35,7 @@ export enum FlowKind {
 }
 
 /**
- * The real value of the visible message field in the BPMN XSD, except 'None'.
+ * Enum values are using the real name of the `visible message` field in the BPMN XSD, except for `none` that is not present in the specification.
  * @category BPMN
  */
 export enum MessageVisibleKind {
@@ -45,7 +45,8 @@ export enum MessageVisibleKind {
 }
 
 /**
- * @internal
+ * Enum values are used internally to identify sequence the flow markers and to manage their related style.
+ * @category BPMN
  */
 export enum SequenceFlowKind {
   NORMAL = 'normal',

--- a/src/model/bpmn/internal/index.ts
+++ b/src/model/bpmn/internal/index.ts
@@ -15,9 +15,9 @@
  */
 
 export * from './shape';
+export * from './edge/kinds';
 
 import { FlowKind } from './edge/kinds';
-export { FlowKind };
 import { ShapeBpmnElementKind } from './shape';
 /**
  * @category BPMN

--- a/test/integration/mxGraph.model.bpmn.elements.test.ts
+++ b/test/integration/mxGraph.model.bpmn.elements.test.ts
@@ -15,13 +15,14 @@
  */
 import {
   MarkerIdentifier,
+  MessageVisibleKind,
+  SequenceFlowKind,
   ShapeBpmnElementKind,
   ShapeBpmnEventBasedGatewayKind,
   ShapeBpmnEventDefinitionKind,
   ShapeBpmnMarkerKind,
   ShapeBpmnSubProcessKind,
 } from '../../src/bpmn-visualization';
-import { MessageVisibleKind, SequenceFlowKind } from '../../src/model/bpmn/internal/edge/kinds';
 import { readFileSync } from '../helpers/file-helper';
 import { bpmnVisualization, ExpectedShapeModelElement } from './helpers/model-expect';
 import { mxgraph } from '../../src/component/mxgraph/initializer';


### PR DESCRIPTION
They are required at least for full styling capacities
  - AssociationDirectionKind
  - MessageVisibleKind
  - SequenceFlowKind

They are now part of the API documentation generated by Typedoc.