### PR TITLE
[DOC] Centralize the documentation of default styles

### DIFF
--- a/docs/users/bpmn-support.adoc
+++ b/docs/users/bpmn-support.adoc
@@ -30,7 +30,7 @@ By default, the rendering uses the following settings:
 
 * fill color: `white` 
 * stroke color: `black` 
-* font
+* font:
 ** size: `11`
 ** family: `Arial, Helvetica, sans-serif`
 

--- a/docs/users/bpmn-support.adoc
+++ b/docs/users/bpmn-support.adoc
@@ -15,8 +15,6 @@ NOTE: The BPMN support roadmap is available in https://github.com/process-analyt
 The following presents BPMN elements that can be rendered by the `bpmn-visualization` and states which is their rendering status i.e. if
 the BPMN elements are rendered with their final shapes.
 
-The default rendering uses `white` as fill color and `black` as stroke color.
-
 [TIP]
 .Legend for rendering status
 ====
@@ -26,6 +24,17 @@ The default rendering uses `white` as fill color and `black` as stroke color.
 * no status means that are arbitrary rendering is used (i.e. not following the BPMN specification requirements), generally using a dedicated color to identify the shape among others
 ====
 
+.Default rendering style
+****
+By default, the rendering uses the following settings:
+
+* fill color: `white` 
+* stroke color: `black` 
+* font
+** size: `11`
+** family: `Arial, Helvetica, sans-serif`
+
+****
 
 === Containers
 
@@ -507,11 +516,11 @@ The event definition can be defined on the event or on the definitions.
 
 |Shape Label
 |icon:check-circle-o[]
-|By default the size of the font is: 11 and family is set to : 'Arial, Helvetica, sans-serif' +
+|
 
 |Edge Label
 |icon:check-circle-o[]
-|By default the size of the font is: 11 and family is set to : 'Arial, Helvetica, sans-serif' +
+|
 |===
 
 
@@ -532,7 +541,7 @@ The event definition can be defined on the event or on the definitions.
 
 |Text Annotation
 |icon:check-circle-o[]
-|By default the size of the font is: 11 and family is set to : 'Arial, Helvetica, sans-serif' +
+|
 |===
 
 


### PR DESCRIPTION
Label fonts default were documented several times, the fill and stroke color
defaults weren't visible.
We now have a dedicated block for documenting defaults.