### PR TITLE
[FIX] Fixes ignored pointerEvents for BPMN Label

### DIFF
--- a/src/component/mxgraph/config/ShapeConfigurator.ts
+++ b/src/component/mxgraph/config/ShapeConfigurator.ts
@@ -44,6 +44,7 @@ import { BpmnConnector } from '../shape/edges';
  */
 export default class ShapeConfigurator {
   configureShapes(): void {
+    this.initMxSvgCanvasPrototype();
     this.initMxShapePrototype();
     this.registerShapes();
     this.initMxCellRendererCreateCellOverlays();
@@ -81,7 +82,138 @@ export default class ShapeConfigurator {
     mxgraph.mxCellRenderer.registerShape(BpmnStyleIdentifier.MESSAGE_FLOW_ICON, MessageFlowIconShape);
   }
 
-  // TODO hack Fixes ignored pointerEvents flag for text in SVG
+  // TODO hack
+  private initMxSvgCanvasPrototype(): void {
+    // Implementation taken from https://github.com/jgraph/mxgraph/blob/v4.1.0/javascript/src/js/util/mxSvgCanvas2D.js#L1615 and adapted with the fix provided in mxgraph@4.2.1
+    // "Fixes ignored pointerEvents flag for text in SVG"
+    // To remove when upgrading to mxgraph@4.2.1
+    // See https://github.com/process-analytics/bpmn-visualization-js/issues/920 and https://github.com/process-analytics/bpmn-visualization-js/issues/919
+    mxgraph.mxSvgCanvas2D.prototype.plainText = function (x, y, w, h, str, align, valign, wrap, overflow, clip, rotation, dir) {
+      rotation = rotation != null ? rotation : 0;
+      const s = this.state;
+      const size = s.fontSize;
+      const node = this.createElement('g');
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore if transform doesn't exist, default to ''. Possible missing type in typed-mxgraph?
+      let tr: string = s.transform || '';
+      this.updateFont(node);
+
+      // Ignores pointer events
+      // eslint-disable-next-line no-console
+      console.info('@@Called overridden mxSvgCanvas2D.prototype.plainText@@ custom fix cherry-pick from 4.2.1');
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore this.originalRoot not in typed-mxgraph
+      if (!this.pointerEvents && this.originalRoot == null) {
+        node.setAttribute('pointer-events', 'none');
+      }
+
+      // Non-rotated text
+      if (rotation != 0) {
+        tr += 'rotate(' + rotation + ',' + this.format(x * s.scale) + ',' + this.format(y * s.scale) + ')';
+      }
+
+      if (dir != null) {
+        node.setAttribute('direction', dir);
+      }
+
+      if (clip && w > 0 && h > 0) {
+        let cx = x;
+        let cy = y;
+
+        if (align == mxgraph.mxConstants.ALIGN_CENTER) {
+          cx -= w / 2;
+        } else if (align == mxgraph.mxConstants.ALIGN_RIGHT) {
+          cx -= w;
+        }
+
+        if (overflow != 'fill') {
+          if (valign == mxgraph.mxConstants.ALIGN_MIDDLE) {
+            cy -= h / 2;
+          } else if (valign == mxgraph.mxConstants.ALIGN_BOTTOM) {
+            cy -= h;
+          }
+        }
+
+        // LATER: Remove spacing from clip rectangle
+        const c = this.createClip(cx * s.scale - 2, cy * s.scale - 2, w * s.scale + 4, h * s.scale + 4);
+
+        if (this.defs != null) {
+          this.defs.appendChild(c);
+        } else {
+          // Makes sure clip is removed with referencing node
+          this.root.appendChild(c);
+        }
+
+        if (!mxgraph.mxClient.IS_CHROMEAPP && !mxgraph.mxClient.IS_IE && !mxgraph.mxClient.IS_IE11 && !mxgraph.mxClient.IS_EDGE && this.root.ownerDocument == document) {
+          // Workaround for potential base tag
+          const base = this.getBaseUrl().replace(/([\(\)])/g, '\\$1');
+          node.setAttribute('clip-path', 'url(' + base + '#' + c.getAttribute('id') + ')');
+        } else {
+          node.setAttribute('clip-path', 'url(#' + c.getAttribute('id') + ')');
+        }
+      }
+
+      // Default is left
+      const anchor = align == mxgraph.mxConstants.ALIGN_RIGHT ? 'end' : align == mxgraph.mxConstants.ALIGN_CENTER ? 'middle' : 'start';
+
+      // Text-anchor start is default in SVG
+      if (anchor != 'start') {
+        node.setAttribute('text-anchor', anchor);
+      }
+
+      if (!this.styleEnabled || size != mxgraph.mxConstants.DEFAULT_FONTSIZE) {
+        node.setAttribute('font-size', size * s.scale + 'px');
+      }
+
+      if (tr.length > 0) {
+        node.setAttribute('transform', tr);
+      }
+
+      if (s.alpha < 1) {
+        node.setAttribute('opacity', String(s.alpha));
+      }
+
+      const lines = str.split('\n');
+      const lh = Math.round(size * mxgraph.mxConstants.LINE_HEIGHT);
+      const textHeight = size + (lines.length - 1) * lh;
+
+      let cy = y + size - 1;
+
+      if (valign == mxgraph.mxConstants.ALIGN_MIDDLE) {
+        if (overflow == 'fill') {
+          cy -= h / 2;
+        } else {
+          const dy = (this.matchHtmlAlignment && clip && h > 0 ? Math.min(textHeight, h) : textHeight) / 2;
+          cy -= dy;
+        }
+      } else if (valign == mxgraph.mxConstants.ALIGN_BOTTOM) {
+        if (overflow == 'fill') {
+          cy -= h;
+        } else {
+          const dy = this.matchHtmlAlignment && clip && h > 0 ? Math.min(textHeight, h) : textHeight;
+          cy -= dy + 1;
+        }
+      }
+
+      for (let i = 0; i < lines.length; i++) {
+        // Workaround for bounding box of empty lines and spaces
+        if (lines[i].length > 0 && mxgraph.mxUtils.trim(lines[i]).length > 0) {
+          const text = this.createElement('text');
+          // LATER: Match horizontal HTML alignment
+          text.setAttribute('x', String(this.format(x * s.scale) + this.textOffset));
+          text.setAttribute('y', String(this.format(cy * s.scale) + this.textOffset));
+
+          mxgraph.mxUtils.write(text, lines[i]);
+          node.appendChild(text);
+        }
+
+        cy += lh;
+      }
+
+      this.root.appendChild(node);
+      this.addTextBackground(node, str, x, y, w, overflow == 'fill' ? h : textHeight, align, valign, overflow);
+    };
+  }
 
   private initMxShapePrototype(): void {
     // The following is copied from the mxgraph mxShape implementation then converted to TypeScript and enriched for bpmn-visualization

--- a/src/component/mxgraph/config/ShapeConfigurator.ts
+++ b/src/component/mxgraph/config/ShapeConfigurator.ts
@@ -81,6 +81,8 @@ export default class ShapeConfigurator {
     mxgraph.mxCellRenderer.registerShape(BpmnStyleIdentifier.MESSAGE_FLOW_ICON, MessageFlowIconShape);
   }
 
+  // TODO hack Fixes ignored pointerEvents flag for text in SVG
+
   private initMxShapePrototype(): void {
     // The following is copied from the mxgraph mxShape implementation then converted to TypeScript and enriched for bpmn-visualization
     // It is needed for adding the custom attributes that permits identification of the BPMN elements in the DOM

--- a/src/component/mxgraph/config/ShapeConfigurator.ts
+++ b/src/component/mxgraph/config/ShapeConfigurator.ts
@@ -99,7 +99,7 @@ export default class ShapeConfigurator {
         '; line-height: ' +
         lh +
         // START Fix for issue #920 (https://github.com/process-analytics/bpmn-visualization-js/issues/920)
-        // This cannot be generalize for all mxgraph use cases. For instance, in an editor mode, we should be able to edit the text by clicking on it.
+        // This cannot be generalized for all mxgraph use cases. For instance, in an editor mode, we should be able to edit the text by clicking on it.
         // Setting to 'none' prevent to capture click.
         '; pointer-events: none' +
         // (this.pointerEvents ? this.pointerEventsValue : 'none') +


### PR DESCRIPTION
Closes #920


### Screenshots

Can be accessed locally using http://localhost:10001/elements-identification.html?url=./static/diagrams/labels.01.general.bpmn

Before (#1641) | Now
-------- | --------
![GH_PR_1641_style_hover](https://user-images.githubusercontent.com/27200110/143068869-d7c9dd46-1cb1-4529-a677-a93b2d9acb99.gif) | ![GH_PR_1645_style_hover](https://user-images.githubusercontent.com/27200110/143308202-8130e34d-f391-4aed-8e3a-b8fa074cb89a.gif)



### Implementation notes

Initially, I thought that a mxGraph version bug would fix the problem. I have tested to cherry pick a fix from mxgraph 4.2.1 here, but it didn't work. After a deeper review, it if for SVG text node (this is what we use for overlays), not for foreignObject that we are using for label. See 3b5938b.
So, I reimplement `mxSvgCanvas.getTextCss` and to set the `event-pointers` style property to `none`.