### PR TITLE
[FIX] Always apply extra CSS classes to label nodes

### DIFF
--- a/dev/public/elements-identification.html
+++ b/dev/public/elements-identification.html
@@ -34,6 +34,10 @@
         width: 70%;
       }
 
+      :root {
+        --color-flow: dodgerblue;
+      }
+
       /* activity */
       .detection-activity > rect:nth-child(1) {
         fill: aquamarine;
@@ -48,8 +52,11 @@
         stroke: red;
       }
       /* lane */
-      .detection-lane > path:nth-child(2), /* label */
-      .detection-lane > path:nth-child(4) {
+      .detection-lane > path:nth-child(2), /* label zone */
+      .detection-lane > path:nth-child(4),
+      /* pool */
+      .detection-pool > path:nth-child(2), /* label zone */
+      .detection-pool > path:nth-child(4) {
         fill: palevioletred;
       }
       /* sequence flow arrow */
@@ -58,7 +65,7 @@
       .bpmn-message-flow.detection-flow > ellipse,
       /* message flow arrow */
       .bpmn-message-flow.detection-flow > path:nth-child(4) {
-        fill: dodgerblue;
+        fill: var(--color-flow);
       }
        /* sequence flow line */
       .bpmn-sequence-flow.detection-flow > path:nth-child(2),
@@ -73,18 +80,32 @@
         /* message flow icon */
       .detection-flow.bpmn-message-flow-icon > rect,
       .detection-flow.bpmn-message-flow-icon > path {
-        stroke: dodgerblue;
+        stroke: var(--color-flow);
         stroke-width: 4px;
       }
 
-      /*apply shadow on hover*/
+      /* apply shadow on hover */
       .detection-activity:hover,
+      .detection-event:hover,
       .detection-gateway:hover,
       .detection-lane:hover,
-      .detection-event:hover {
+      .detection-pool:hover {
         filter: drop-shadow(0 0 2em rgba(0, 0, 0));
       }
 
+      /* for labels */
+      .detection-activity.bpmn-label > g div,
+      .detection-event.bpmn-label > g div,
+      .detection-gateway.bpmn-label > g div {
+        color: red !important;
+      }
+      .detection-lane.bpmn-label > g div,
+      .detection-pool.bpmn-label > g div {
+        color: white !important;
+      }
+      .detection-flow.bpmn-label > g div {
+        color: var(--color-flow) !important;
+      }
     </style>
 
     <!-- load app -->
@@ -105,6 +126,7 @@
         <option value="inclusiveGateway">Inclusive Gateway</option>
         <option value="parallelGateway">Parallel Gateway</option>
         <option value="lane">Lane</option>
+        <option value="pool">Pool</option>
         <option value="messageFlow">Message Flow</option>
         <option value="sequenceFlow">Sequence Flow</option>
       </select>

--- a/dev/public/static/js/elements-identification.js
+++ b/dev/public/static/js/elements-identification.js
@@ -103,6 +103,8 @@ function getCustomCssClassName(bpmnKind) {
     return 'detection-event';
   } else if (bpmnKind.includes('lane')) {
     return 'detection-lane';
+  } else if (bpmnKind.includes('pool')) {
+    return 'detection-pool';
   } else if (bpmnKind.includes('Flow')) {
     return 'detection-flow';
   }
@@ -137,7 +139,7 @@ function getOverlay(bpmnKind) {
     };
   } else if (bpmnKind.includes('Event')) {
     return { position: 'bottom-left', label: '15' };
-  } else if (bpmnKind.includes('lane')) {
+  } else if (bpmnKind.includes('lane') || bpmnKind.includes('pool')) {
     return { position: 'bottom-right', label: '100' };
   } else if (bpmnKind.includes('Flow')) {
     return {

--- a/src/component/mxgraph/MxGraphCellUpdater.ts
+++ b/src/component/mxgraph/MxGraphCellUpdater.ts
@@ -46,8 +46,9 @@ export default class MxGraphCellUpdater {
     const view = this.graph.getView();
     const state = view.getState(mxCell);
     state.style[BpmnStyleIdentifier.EXTRA_CSS_CLASSES] = cssClasses;
-    state.shape.apply(state);
     state.shape.redraw();
+    // Ensure that label classes are also updated. When there is no label, state.text is null
+    state.text?.redraw();
   }
 
   addOverlays(bpmnElementId: string, overlays: Overlay | Overlay[]): void {

--- a/src/component/registry/query-selectors.ts
+++ b/src/component/registry/query-selectors.ts
@@ -28,9 +28,11 @@
  *   </svg>
  * </div>
  * ```
- * mxGraph generates the following SVG groups
+ * mxGraph generates the following SVG groups (see https://github.com/jgraph/mxgraph/blob/v4.2.2/javascript/src/js/view/mxGraphView.js#L2862)
+ *   - 1st: for background image
  *   - 2nd: elements of the graph (shapes and edges)
  *   - 3rd: overlays
+ *   - 4th: decorators
  *
  * After loading, the DOM looks like:
  * ```html

--- a/test/e2e/helpers/visu/bpmn-page-utils.ts
+++ b/test/e2e/helpers/visu/bpmn-page-utils.ts
@@ -152,9 +152,8 @@ export class BpmnPageSvgTester extends PageTester {
     if (!expectedText) {
       return;
     }
-    const svgElementHandle = await this.currentPage.waitForSelector(this.bpmnQuerySelectors.labelOfElement(bpmnId));
-    // contains 3 div
-    expect(await svgElementHandle.evaluate(node => (node.firstChild.firstChild.firstChild as HTMLElement).innerHTML)).toBe(expectedText);
+    const labelLastDivElementHandle = await this.currentPage.waitForSelector(this.bpmnQuerySelectors.labelLastDiv(bpmnId));
+    expect(await labelLastDivElementHandle.evaluate(node => node.innerHTML)).toBe(expectedText);
   }
 
   async expectEvent(bpmnId: string, expectedText: string, isStartEvent = true): Promise<void> {

--- a/test/helpers/query-selectors.ts
+++ b/test/helpers/query-selectors.ts
@@ -23,8 +23,12 @@ export class BpmnQuerySelectorsForTests extends BpmnQuerySelectors {
     return `#${this.containerId} > svg > g > g > g[data-bpmn-id]`;
   }
 
-  labelOfElement(bpmnElementId: string): string {
-    return `#${this.containerId} > svg > g > g > g[data-bpmn-id="${bpmnElementId}"].bpmn-label > g > foreignObject`;
+  labelLastDiv(bpmnElementId: string): string {
+    return `${this.labelSvgGroup(bpmnElementId)} > g > foreignObject > div > div > div`;
+  }
+
+  labelSvgGroup(bpmnElementId: string): string {
+    return `#${this.containerId} > svg > g > g > g[data-bpmn-id="${bpmnElementId}"].bpmn-label`;
   }
 
   /**

--- a/test/integration/dom.after.actions.test.ts
+++ b/test/integration/dom.after.actions.test.ts
@@ -25,6 +25,13 @@ import {
   expectStartEventBpmnElement,
   expectTaskBpmnElement,
 } from './helpers/semantic-with-svg-utils';
+import { mxgraph } from '../../src/component/mxgraph/initializer';
+
+beforeAll(() => {
+  // Force usage of ForeignObject
+  // By default, mxGraph detects no ForeignObject support when running tests in jsdom environment
+  mxgraph.mxClient.NO_FO = false;
+});
 
 const bpmnVisualization = initializeBpmnVisualization();
 const htmlElementLookup = new HtmlElementLookup(bpmnVisualization);
@@ -151,17 +158,19 @@ describe('Bpmn Elements registry - CSS class management', () => {
       bpmnVisualization.load(readFileSync('../fixtures/bpmn/registry/1-pool-3-lanes-message-start-end-intermediate-events.bpmn'));
 
       // default classes
-      htmlElementLookup.expectServiceTask('serviceTask_1_2');
-      htmlElementLookup.expectEndEvent('endEvent_message_1');
+      htmlElementLookup.expectServiceTask('serviceTask_1_2', { label: 'Service Task 1.2' });
+      htmlElementLookup.expectEndEvent('endEvent_message_1', { label: 'message end 2' });
+      htmlElementLookup.expectSequenceFlow('Flow_1bewc4s', { label: 'link' });
 
       // add a single class to a single element
       bpmnVisualization.bpmnElementsRegistry.addCssClasses('serviceTask_1_2', 'class1');
-      htmlElementLookup.expectServiceTask('serviceTask_1_2', { additionalClasses: ['class1'] });
+      htmlElementLookup.expectServiceTask('serviceTask_1_2', { label: 'Service Task 1.2', additionalClasses: ['class1'] });
 
       // add several classes to several elements
-      bpmnVisualization.bpmnElementsRegistry.addCssClasses(['endEvent_message_1', 'serviceTask_1_2'], ['class2', 'class3']);
-      htmlElementLookup.expectServiceTask('serviceTask_1_2', { additionalClasses: ['class1', 'class2', 'class3'] });
-      htmlElementLookup.expectEndEvent('endEvent_message_1', { additionalClasses: ['class2', 'class3'] });
+      bpmnVisualization.bpmnElementsRegistry.addCssClasses(['endEvent_message_1', 'serviceTask_1_2', 'Flow_1bewc4s'], ['class2', 'class3']);
+      htmlElementLookup.expectServiceTask('serviceTask_1_2', { label: 'Service Task 1.2', additionalClasses: ['class1', 'class2', 'class3'] });
+      htmlElementLookup.expectEndEvent('endEvent_message_1', { label: 'message end 2', additionalClasses: ['class2', 'class3'] });
+      htmlElementLookup.expectSequenceFlow('Flow_1bewc4s', { label: 'link', additionalClasses: ['class2', 'class3'] });
     });
 
     it('BPMN element does not exist', () => {
@@ -199,20 +208,20 @@ describe('Bpmn Elements registry - CSS class management', () => {
       bpmnVisualization.load(readFileSync('../fixtures/bpmn/registry/1-pool-3-lanes-message-start-end-intermediate-events.bpmn'));
 
       // default classes
-      htmlElementLookup.expectUserTask('userTask_0');
-      htmlElementLookup.expectLane('lane_01');
+      htmlElementLookup.expectUserTask('userTask_0', { label: 'User Task 0' });
+      htmlElementLookup.expectLane('lane_01', { label: 'Lane 3' });
 
       // remove a single class from a single element
       bpmnVisualization.bpmnElementsRegistry.addCssClasses('userTask_0', 'class1');
-      htmlElementLookup.expectUserTask('userTask_0', { additionalClasses: ['class1'] });
+      htmlElementLookup.expectUserTask('userTask_0', { label: 'User Task 0', additionalClasses: ['class1'] });
       bpmnVisualization.bpmnElementsRegistry.removeCssClasses('userTask_0', 'class1');
-      htmlElementLookup.expectUserTask('userTask_0');
+      htmlElementLookup.expectUserTask('userTask_0', { label: 'User Task 0' });
 
       // remove several classes from several elements
       bpmnVisualization.bpmnElementsRegistry.addCssClasses(['lane_01', 'userTask_0'], ['class1', 'class2', 'class3']);
       bpmnVisualization.bpmnElementsRegistry.removeCssClasses(['lane_01', 'userTask_0'], ['class1', 'class3']);
-      htmlElementLookup.expectLane('lane_01', { additionalClasses: ['class2'] });
-      htmlElementLookup.expectUserTask('userTask_0', { additionalClasses: ['class2'] });
+      htmlElementLookup.expectLane('lane_01', { label: 'Lane 3', additionalClasses: ['class2'] });
+      htmlElementLookup.expectUserTask('userTask_0', { label: 'User Task 0', additionalClasses: ['class2'] });
     });
 
     it('BPMN element does not exist', () => {
@@ -232,13 +241,13 @@ describe('Bpmn Elements registry - CSS class management', () => {
       // toggle a classes for a single element
       bpmnVisualization.bpmnElementsRegistry.toggleCssClasses('gateway_01', 'class1');
       bpmnVisualization.bpmnElementsRegistry.toggleCssClasses('gateway_01', ['class1', 'class2']);
-      htmlElementLookup.expectExclusiveGateway('gateway_01', { additionalClasses: ['class2'] });
+      htmlElementLookup.expectExclusiveGateway('gateway_01', { label: 'gateway 1', additionalClasses: ['class2'] });
 
       // toggle a classes for several elements
       bpmnVisualization.bpmnElementsRegistry.toggleCssClasses(['lane_02', 'gateway_01'], ['class1', 'class2', 'class3']);
       bpmnVisualization.bpmnElementsRegistry.toggleCssClasses(['lane_02', 'gateway_01'], ['class1', 'class3', 'class4']);
-      htmlElementLookup.expectLane('lane_02', { additionalClasses: ['class2', 'class4'] });
-      htmlElementLookup.expectExclusiveGateway('gateway_01', { additionalClasses: ['class4'] });
+      htmlElementLookup.expectLane('lane_02', { label: 'Lane 2', additionalClasses: ['class2', 'class4'] });
+      htmlElementLookup.expectExclusiveGateway('gateway_01', { label: 'gateway 1', additionalClasses: ['class4'] });
     });
 
     it('BPMN element does not exist', () => {

--- a/test/integration/helpers/html-utils.ts
+++ b/test/integration/helpers/html-utils.ts
@@ -18,6 +18,7 @@ import { BpmnQuerySelectorsForTests } from '../../helpers/query-selectors';
 
 export interface RequestedChecks {
   readonly additionalClasses?: string[];
+  readonly label?: string;
   readonly overlayLabel?: string;
 }
 
@@ -32,88 +33,99 @@ export class HtmlElementLookup {
     this.bpmnQuerySelectors = new BpmnQuerySelectorsForTests(bpmnVisualization.graph.container.id);
   }
 
-  private findSvgElement(bpmnId: string): HTMLElement {
-    const bpmnElements = this.bpmnVisualization.bpmnElementsRegistry.getElementsByIds(bpmnId);
-    return bpmnElements.length == 0 ? undefined : bpmnElements[0].htmlElement;
-  }
-
   expectNoElement(bpmnId: string): void {
     const svgGroupElement = this.findSvgElement(bpmnId);
     expect(svgGroupElement).toBeUndefined();
   }
 
-  expectStartEvent(bpmnId: string, checks?: RequestedChecks): void {
+  // ===========================================================================
+  // EVENTS
+  // ===========================================================================
+
+  private expectEventType(bpmnId: string, bpmnClass: string, checks?: RequestedChecks): void {
     const svgGroupElement = this.findSvgElement(bpmnId);
     expectSvgEvent(svgGroupElement);
-    expectSvgElementClassAttribute(svgGroupElement, computeClassValue('bpmn-start-event', checks?.additionalClasses));
+    expectClassAttribute(svgGroupElement, computeClassValue(bpmnClass, checks?.additionalClasses));
+    this.expectSvgLabel(bpmnId, bpmnClass, checks?.label, checks?.additionalClasses);
+  }
+
+  expectStartEvent(bpmnId: string, checks?: RequestedChecks): void {
+    this.expectEventType(bpmnId, 'bpmn-start-event', checks);
   }
 
   expectIntermediateThrowEvent(bpmnId: string): void {
-    const svgGroupElement = this.findSvgElement(bpmnId);
-    expectSvgEvent(svgGroupElement);
-    expectSvgElementClassAttribute(svgGroupElement, 'bpmn-intermediate-throw-event');
+    this.expectEventType(bpmnId, 'bpmn-intermediate-throw-event');
   }
 
   expectEndEvent(bpmnId: string, checks?: RequestedChecks): void {
-    const svgGroupElement = this.findSvgElement(bpmnId);
-    expectSvgEvent(svgGroupElement);
-    expectSvgElementClassAttribute(svgGroupElement, computeClassValue('bpmn-end-event', checks?.additionalClasses));
+    this.expectEventType(bpmnId, 'bpmn-end-event', checks);
   }
 
-  expectTask(bpmnId: string): void {
+  // ===========================================================================
+  // TASKS
+  // ===========================================================================
+
+  private expectTaskType(bpmnId: string, bpmnClass: string, checks?: RequestedChecks): void {
     const svgGroupElement = this.findSvgElement(bpmnId);
     expectSvgTask(svgGroupElement);
-    expectSvgElementClassAttribute(svgGroupElement, 'bpmn-task');
-  }
+    expectClassAttribute(svgGroupElement, computeClassValue(bpmnClass, checks?.additionalClasses));
 
-  expectServiceTask(bpmnId: string, checks?: RequestedChecks): void {
-    const svgGroupElement = this.findSvgElement(bpmnId);
-    expectSvgTask(svgGroupElement);
-    expectSvgElementClassAttribute(svgGroupElement, computeClassValue('bpmn-service-task', checks?.additionalClasses));
-
+    this.expectSvgLabel(bpmnId, bpmnClass, checks?.label, checks?.additionalClasses);
     this.expectSvgOverlay(bpmnId, checks?.overlayLabel);
   }
 
-  private expectSvgOverlay(bpmnId: string, overlayLabel?: string): void {
-    const overlayGroupElement = document.querySelector<SVGGElement>(this.bpmnQuerySelectors.overlays(bpmnId));
-    if (overlayLabel) {
-      expect(overlayGroupElement.querySelector('g > text').innerHTML).toEqual(overlayLabel);
-      expectSvgElementClassAttribute(overlayGroupElement, 'overlay-badge');
-    } else {
-      expect(overlayGroupElement).toBeNull();
-    }
+  expectTask(bpmnId: string): void {
+    this.expectTaskType(bpmnId, 'bpmn-task');
+  }
+
+  expectServiceTask(bpmnId: string, checks?: RequestedChecks): void {
+    this.expectTaskType(bpmnId, 'bpmn-service-task', checks);
   }
 
   expectUserTask(bpmnId: string, checks?: RequestedChecks): void {
-    const svgGroupElement = this.findSvgElement(bpmnId);
-    expectSvgTask(svgGroupElement);
-    expectSvgElementClassAttribute(svgGroupElement, computeClassValue('bpmn-user-task', checks?.additionalClasses));
+    this.expectTaskType(bpmnId, 'bpmn-user-task', checks);
   }
+
+  // ===========================================================================
+  // CONTAINERS
+  // ===========================================================================
 
   expectLane(bpmnId: string, checks?: RequestedChecks): void {
     const svgGroupElement = this.findSvgElement(bpmnId);
     expectSvgLane(svgGroupElement);
-    expectSvgElementClassAttribute(svgGroupElement, computeClassValue('bpmn-lane', checks?.additionalClasses));
+    const bpmnClass = 'bpmn-lane';
+    expectClassAttribute(svgGroupElement, computeClassValue(bpmnClass, checks?.additionalClasses));
+    this.expectSvgLabel(bpmnId, bpmnClass, checks?.label, checks?.additionalClasses);
   }
 
   expectPool(bpmnId: string): void {
     const svgGroupElement = this.findSvgElement(bpmnId);
     expectSvgPool(svgGroupElement);
-    expectSvgElementClassAttribute(svgGroupElement, 'bpmn-pool');
+    expectClassAttribute(svgGroupElement, 'bpmn-pool');
   }
+
+  // ===========================================================================
+  // GATEWAYS
+  // ===========================================================================
 
   expectExclusiveGateway(bpmnId: string, checks?: RequestedChecks): void {
     const svgGroupElement = this.findSvgElement(bpmnId);
     expectSvgGateway(svgGroupElement);
-    expectSvgElementClassAttribute(svgGroupElement, computeClassValue('bpmn-exclusive-gateway', checks?.additionalClasses));
+    const bpmnClass = 'bpmn-exclusive-gateway';
+    expectClassAttribute(svgGroupElement, computeClassValue(bpmnClass, checks?.additionalClasses));
 
+    this.expectSvgLabel(bpmnId, bpmnClass, checks?.label, checks?.additionalClasses);
     this.expectSvgOverlay(bpmnId, checks?.overlayLabel);
   }
+
+  // ===========================================================================
+  // FLOWS
+  // ===========================================================================
 
   expectAssociation(bpmnId: string, checks?: RequestedChecks): void {
     const svgGroupElement = this.findSvgElement(bpmnId);
     expectSvgAssociation(svgGroupElement);
-    expectSvgElementClassAttribute(svgGroupElement, computeClassValue('bpmn-association'));
+    expectClassAttribute(svgGroupElement, computeClassValue('bpmn-association'));
 
     this.expectSvgOverlay(bpmnId, checks?.overlayLabel);
   }
@@ -121,24 +133,55 @@ export class HtmlElementLookup {
   expectSequenceFlow(bpmnId: string, checks?: RequestedChecks): void {
     const svgGroupElement = this.findSvgElement(bpmnId);
     expectSvgSequenceFlow(svgGroupElement);
-    expectSvgElementClassAttribute(svgGroupElement, computeClassValue('bpmn-sequence-flow'));
+    const bpmnClass = 'bpmn-sequence-flow';
+    expectClassAttribute(svgGroupElement, computeClassValue(bpmnClass, checks?.additionalClasses));
 
+    this.expectSvgLabel(bpmnId, bpmnClass, checks?.label, checks?.additionalClasses);
     this.expectSvgOverlay(bpmnId, checks?.overlayLabel);
   }
 
   expectMessageFlow(bpmnId: string, checks?: MessageFlowRequestedChecks): void {
     const svgGroupElement = this.findSvgElement(bpmnId);
     expectSvgMessageFlow(svgGroupElement);
-    expectSvgElementClassAttribute(svgGroupElement, computeClassValue('bpmn-message-flow', checks?.additionalClasses));
+    expectClassAttribute(svgGroupElement, computeClassValue('bpmn-message-flow', checks?.additionalClasses));
 
     // message flow icon
     const msgFlowIconSvgGroupElement = document.querySelector<HTMLElement>(this.bpmnQuerySelectors.element(`messageFlowIcon_of_${bpmnId}`));
     if (checks?.hasIcon) {
       expectSvgMessageFlowIcon(msgFlowIconSvgGroupElement);
-      expectSvgElementClassAttribute(msgFlowIconSvgGroupElement, computeClassValue('bpmn-message-flow-icon', checks?.additionalClasses));
+      expectClassAttribute(msgFlowIconSvgGroupElement, computeClassValue('bpmn-message-flow-icon', checks?.additionalClasses));
     } else {
       expect(msgFlowIconSvgGroupElement).toBeNull();
     }
+  }
+
+  // ===========================================================================
+  // UTILS
+  // ===========================================================================
+
+  private findSvgElement(bpmnId: string): HTMLElement {
+    const bpmnElements = this.bpmnVisualization.bpmnElementsRegistry.getElementsByIds(bpmnId);
+    return bpmnElements.length == 0 ? undefined : bpmnElements[0].htmlElement;
+  }
+
+  private expectSvgOverlay(bpmnId: string, overlayLabel?: string): void {
+    const overlayGroupElement = document.querySelector<SVGGElement>(this.bpmnQuerySelectors.overlays(bpmnId));
+    if (overlayLabel) {
+      expect(overlayGroupElement.querySelector('g > text').innerHTML).toEqual(overlayLabel);
+      expectClassAttribute(overlayGroupElement, 'overlay-badge');
+    } else {
+      expect(overlayGroupElement).toBeNull();
+    }
+  }
+
+  private expectSvgLabel(bpmnId: string, bpmnClass: string, label?: string, additionalClasses?: string[]): void {
+    if (!label) {
+      return;
+    }
+    const labelLastDivElement = document.querySelector<HTMLElement>(this.bpmnQuerySelectors.labelLastDiv(bpmnId));
+    expect(labelLastDivElement.innerHTML).toEqual(label);
+    const labelSvgGroup = document.querySelector<HTMLElement>(this.bpmnQuerySelectors.labelSvgGroup(bpmnId));
+    expectClassAttribute(labelSvgGroup, computeClassValue(bpmnClass, ['bpmn-label', ...(additionalClasses ?? [])]));
   }
 }
 
@@ -190,7 +233,7 @@ function expectSvgFirstChildNodeName(svgGroupElement: HTMLElement, name: string)
   expect(firstChild.nodeName).toEqual(name);
 }
 
-export function expectSvgElementClassAttribute(svgElement: HTMLElement | SVGElement, value: string): void {
+function expectClassAttribute(svgElement: HTMLElement | SVGElement, value: string): void {
   expect(svgElement).not.toBeUndefined();
   expect(svgElement.getAttribute('class')).toEqual(value);
 }


### PR DESCRIPTION
The extra css classes added via the API weren't applied to label except when
triggering a full diagram redraw i.e. on zoom or panning.

Most of the work done here involved reproducing the issue with integration tests.
They required to tweak the mxGraph configuration as mxGraph was not generating
foreign objects. This seems due to the jsdom environment. Forcing `NO_FO` to
`false` switch the label generation to what we have in the browser.
The integration tests now test the label text and css classes for lane, user
task, sequence flow, start and end events.

In MxCellUpdater, remove call to `state.shape.apply(state)`
This code applied the style of the given `mxCellState` to the shape and only
default styles known by mxGraph.
The 'extra css style' is not taken from the shape but from the state. See the
overridden implementation of `mxgraph.mxShape.prototype.createSvgCanvas` defined
in `ShapeConfigurator` for more details.
All tests pass after the removal, without changes in tests.
Manual tests performed on zoom and panning with the elements-identification.html
test pages are still ok (the CSS classes are still in the DOM).

Additional changes:
  - Add information about the svg groups created by mxgraph
  - Update the `query selectors` used in tests. Simplify definition and maximize
  share between integration and e2e tests to simplify maintenance.
  - html-utils.ts: refactor to avoid duplications. More refactor will be done
  in the future.
  - Add css style for labels in elements-identification.html and also detect Pool

closes #1621

### Screenshots

http://localhost:10001/elements-identification.html?url=./static/diagrams/registry/1-pool-3-lanes-message-start-end-intermediate-events.bpmn

![Apply_style_to_labels](https://user-images.githubusercontent.com/27200110/143884890-4e6c12c8-165d-4114-b4ef-b5815cbdb9f7.gif)


### DOM generated by the Integration Tests

**_No foreignObject, prior forcing mxGraph with `NO_FO=false`_**

```svg
<div id="bpmn-container" ...>
  <svg ...>
    <g>
      <g></g>
      <g>
        <g ... class="bpmn-pool" data-bpmn-id="Participant_1">
        </g>
      </g>
      <!-- more content here -->
    </g>
  </svg>
  <div ...">
    <div ...">
      <div ...>Pool 1</div>
    </div>
  </div>
</div>
```


**_Labels with foreignObject, now in integration tests, like in the browser_**

```svg
<div id="bpmn-container" ...>
  <svg ...>
    <g>
      <g></g>
      <g>
        <g ... class="bpmn-pool" data-bpmn-id="Participant_1">
        </g>
      </g>
      <g style="" class="bpmn-pool bpmn-label" data-bpmn-id="Participant_1">
        <g ...>
          <foreignObject ...>
            <div ...>
              <div ...>
                <div ...>Pool 1</div>
              </div>
            </div>
          </foreignObject>
        </g>
      </g>
      <!-- more content here -->
    </g>
  </svg>
</div>
```

### Side effects

According to [SonarCloud](https://sonarcloud.io/summary/new_code?id=process-analytics_bpmn-visualization-js&pullRequest=1655), coverage should increase from `93.5%` to `94.3%`.

![image](https://user-images.githubusercontent.com/27200110/143912695-2a584cb1-05f8-46a4-bce4-674a190559c3.png)

