### PR TITLE
[REFACTOR] Rename the 'load' method in ModelRegistry

### DIFF
--- a/src/component/BpmnVisualization.ts
+++ b/src/component/BpmnVisualization.ts
@@ -67,7 +67,7 @@ export class BpmnVisualization {
   load(xml: string, options?: LoadOptions): void {
     try {
       const bpmnModel = newBpmnParser().parse(xml);
-      const renderedModel = this.bpmnModelRegistry.computeRenderedModel(bpmnModel);
+      const renderedModel = this.bpmnModelRegistry.load(bpmnModel);
       newBpmnRenderer(this.graph).render(renderedModel, options);
     } catch (e) {
       window.alert(`Cannot load bpmn diagram: ${e.message}`);

--- a/src/component/registry/bpmn-model-registry.ts
+++ b/src/component/registry/bpmn-model-registry.ts
@@ -24,7 +24,7 @@ export class BpmnModelRegistry {
   private searchableModel: SearchableModel;
   private onLoadCallback: () => void;
 
-  computeRenderedModel(bpmnModel: BpmnModel): RenderedModel {
+  load(bpmnModel: BpmnModel): RenderedModel {
     this.searchableModel = new SearchableModel(bpmnModel);
     this.onLoadCallback?.();
     return toRenderedModel(bpmnModel);

--- a/test/unit/component/registry/bpmn-model-registry.test.ts
+++ b/test/unit/component/registry/bpmn-model-registry.test.ts
@@ -63,30 +63,30 @@ describe('Bpmn Model registry', () => {
     const bpmnModelRegistry = new BpmnModelRegistry();
     const callback = jest.fn();
     bpmnModelRegistry.registerOnLoadCallback(callback);
-    bpmnModelRegistry.computeRenderedModel(startEventInModel('id', 'name'));
+    bpmnModelRegistry.load(startEventInModel('id', 'name'));
     expect(callback).toHaveBeenCalledTimes(1);
   });
 
   it('search edge', () => {
-    bpmnModelRegistry.computeRenderedModel(sequenceFlowInModel('seq flow id', 'seq flow name'));
+    bpmnModelRegistry.load(sequenceFlowInModel('seq flow id', 'seq flow name'));
     const bpmnSemantic = bpmnModelRegistry.getBpmnSemantic('seq flow id');
     expectSequenceFlow(bpmnSemantic, { id: 'seq flow id', name: 'seq flow name' });
   });
 
   it('search flownode', () => {
-    bpmnModelRegistry.computeRenderedModel(startEventInModel('start event id', 'start event name'));
+    bpmnModelRegistry.load(startEventInModel('start event id', 'start event name'));
     const bpmnSemantic = bpmnModelRegistry.getBpmnSemantic('start event id');
     expectStartEvent(bpmnSemantic, { id: 'start event id', name: 'start event name' });
   });
 
   it('search lane', () => {
-    bpmnModelRegistry.computeRenderedModel(laneInModel('lane id', 'lane name'));
+    bpmnModelRegistry.load(laneInModel('lane id', 'lane name'));
     const bpmnSemantic = bpmnModelRegistry.getBpmnSemantic('lane id');
     expectLane(bpmnSemantic, { id: 'lane id', name: 'lane name' });
   });
 
   it('search pool', () => {
-    bpmnModelRegistry.computeRenderedModel(poolInModel('pool id', 'pool name'));
+    bpmnModelRegistry.load(poolInModel('pool id', 'pool name'));
     const bpmnSemantic = bpmnModelRegistry.getBpmnSemantic('pool id');
     expectPool(bpmnSemantic, { id: 'pool id', name: 'pool name' });
   });


### PR DESCRIPTION
The new name better explains what the method does and is now consistent with the
callback property.