### PR TITLE
[FIX] Prevent external modification of reference shape kinds

### DIFF
--- a/src/model/bpmn/internal/shape/utils.ts
+++ b/src/model/bpmn/internal/shape/utils.ts
@@ -28,7 +28,7 @@ export class ShapeUtil {
   }
 
   static eventKinds(): ShapeBpmnElementKind[] {
-    return EVENT_KINDS;
+    return [...EVENT_KINDS];
   }
 
   static isBoundaryEvent(kind: ShapeBpmnElementKind): boolean {
@@ -56,7 +56,7 @@ export class ShapeUtil {
   }
 
   static activityKinds(): ShapeBpmnElementKind[] {
-    return ACTIVITY_KINDS;
+    return [...ACTIVITY_KINDS];
   }
 
   static isWithDefaultSequenceFlow(kind: ShapeBpmnElementKind): boolean {
@@ -73,11 +73,11 @@ export class ShapeUtil {
    * Returns all kinds related to a task, for instance {@link ShapeBpmnElementKind.TASK}, {@link ShapeBpmnElementKind.TASK_SEND}, but not a {@link ShapeBpmnElementKind.GLOBAL_TASK}.
    */
   static taskKinds(): ShapeBpmnElementKind[] {
-    return TASK_KINDS;
+    return [...TASK_KINDS];
   }
 
   static gatewayKinds(): ShapeBpmnElementKind[] {
-    return GATEWAY_KINDS;
+    return [...GATEWAY_KINDS];
   }
 
   static isGateway(kind: ShapeBpmnElementKind | string): boolean {

--- a/test/unit/model/bpmn/internal/shape/utils.test.ts
+++ b/test/unit/model/bpmn/internal/shape/utils.test.ts
@@ -45,4 +45,37 @@ describe('ShapeUtil', () => {
       expect(ShapeUtil.isPoolOrLane(bpmnKind)).toBeFalsy();
     });
   });
+
+  describe('Reference kinds cannot be modified', () => {
+    it.each`
+      kind            | kindsFunction
+      ${'activities'} | ${() => ShapeUtil.activityKinds()}
+      ${'events'}     | ${() => ShapeUtil.eventKinds()}
+      ${'flow nodes'} | ${() => ShapeUtil.flowNodeKinds()}
+      ${'gateways'}   | ${() => ShapeUtil.gatewayKinds()}
+      ${'tasks'}      | ${() => ShapeUtil.taskKinds()}
+    `(
+      '$kind',
+      (
+        // kind is used to generate the function name
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        { kind, kindsFunction }: { kind: string; kindsFunction: () => string[] },
+      ) => {
+        const kinds = kindsFunction();
+
+        const initialKinds = [...kinds];
+        expect(kinds).toEqual(initialKinds);
+        expect(kinds).not.toBe(initialKinds);
+
+        // ensure the reference kinds is modified
+        const initialLength = kinds.length;
+        expect(kinds.push(null)).toEqual(initialLength + 1);
+        expect(kinds).not.toEqual(initialKinds);
+
+        const newKinds = kindsFunction();
+        expect(newKinds).not.toBe(kinds);
+        expect(newKinds).toEqual(initialKinds);
+      },
+    );
+  });
 });


### PR DESCRIPTION
The internal arrays were leaked outside the lib, so an accidental modification of the returned array was persisted.
After such a modification, the parsing and the rendering may not work correctly, especially if some elements were removed.
`ShapeUtil` now always returns a copy of a reference array instead of the array itself.