### PR TITLE
[EXAMPLE] Use specific stroke and fill colors for msg flow icons

### DIFF
--- a/dev/public/elements-identification.html
+++ b/dev/public/elements-identification.html
@@ -36,6 +36,7 @@
 
       :root {
         --color-flow: dodgerblue;
+        --color-msg-flow-icon: orange;
       }
 
       /* activity */
@@ -73,19 +74,23 @@
         /* message flow line */
       .bpmn-message-flow.detection > path:nth-child(2),
         /* message flow arrow */
-      .bpmn-message-flow.detection> path:nth-child(4),
-        /* message flow icon */
-      .detection.bpmn-message-flow-icon > rect,
-      .detection.bpmn-message-flow-icon > path {
+      .bpmn-message-flow.detection> path:nth-child(4) {
         stroke: var(--color-flow);
         stroke-width: 4px;
       }
+
+      /* message flow icon */
+      .detection.bpmn-message-flow-icon > rect,
+      .detection.bpmn-message-flow-icon > path {
+        stroke: var(--color-msg-flow-icon);
+        stroke-width: 3px;
+      }
       /* special for msg flow icon non-initiating */
       .detection.bpmn-message-flow-icon.bpmn-icon-non-initiating > rect {
-        fill: var(--color-flow) !important;
+        fill: var(--color-msg-flow-icon);
       }
       .detection.bpmn-message-flow-icon.bpmn-icon-non-initiating > path {
-        stroke: white !important;
+        stroke: white;
       }
 
       /* apply shadow on hover */


### PR DESCRIPTION
Update `elements-identification.html` to better demonstrates that we have dedicated CSS classes to style the icon regardless of the style of the message flow.

### Screenshots

http://localhost:10001/elements-identification.html?url=./static/diagrams/registry/message-flows-with-and-without-icon.bpmn

#1640 | now| 
-------- | -----------
![GH_PR_1640_msg_flow_icon_style](https://user-images.githubusercontent.com/27200110/144811076-bbf4c753-087e-4fa5-bf8f-bda01833bf03.png) | ![message flow icon specific fill and stroke colors](https://user-images.githubusercontent.com/27200110/144976384-7978466f-0b91-453a-9c2c-c03103263c8f.png)


As a reminder, hover on icon and flows are not the same

![show that hover on icon and flows are not the same](https://user-images.githubusercontent.com/27200110/144976383-8cfdb09b-cd84-4e21-8765-9a4b1db83bf7.gif)


