### PR TITLE
[INFRA] Replace the Playwright GitHub Action by the Playwright CLI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,8 @@ jobs:
       - name: Build bundles
         run: npm run build-bundles
       # install OS dependencies required by browsers on the GitHub runner
-      - uses: microsoft/playwright-github-action@v1.5.0
+      - name: Install the dependencies for all browsers
+        run: npx playwright install-deps
       - name: Test bundles
         id: 'test_bundles'
         run: npm run test:bundles

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -52,7 +52,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
       # install OS dependencies required by browsers on the GitHub runner
-      - uses: microsoft/playwright-github-action@v1.5.0
+      - name: Install the dependencies for ${{matrix.browser}} only
+        run: npx playwright install-deps ${{matrix.browser}}
       - name: Test Application End to End
         id: 'test_e2e'
         env:


### PR DESCRIPTION
Replace the Playwright GitHub Action by the Playwright CLI, like it's recommended by the [documentation of the Github Action](https://github.com/microsoft/playwright-github-action) and following the [documentation of the CLI](https://playwright.dev/docs/cli/#install-system-dependencies).