### PR TITLE
[INFRA] Use expect-playwright in tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "eslint-plugin-notice": "^0.9.10",
         "eslint-plugin-playwright": "^0.6.0",
         "eslint-plugin-prettier": "^4.0.0",
+        "expect-playwright": "^0.8.0",
         "fs-extra": "^10.0.0",
         "husky": "^7.0.4",
         "jest": "^27.4.3",
@@ -4896,9 +4897,10 @@
       }
     },
     "node_modules/expect-playwright": {
-      "version": "0.7.2",
-      "dev": true,
-      "license": "MIT"
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/expect-playwright/-/expect-playwright-0.8.0.tgz",
+      "integrity": "sha512-+kn8561vHAY+dt+0gMqqj1oY+g5xWrsuGMk4QGxotT2WS545nVqqjs37z6hrYfIuucwqthzwJfCJUEYqixyljg==",
+      "dev": true
     },
     "node_modules/expect/node_modules/ansi-styles": {
       "version": "5.2.0",
@@ -7227,6 +7229,12 @@
         "jest-environment-node": ">=26.6.3",
         "jest-runner": ">=26.6.3"
       }
+    },
+    "node_modules/jest-playwright-preset/node_modules/expect-playwright": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/expect-playwright/-/expect-playwright-0.7.2.tgz",
+      "integrity": "sha512-5o9si+8SUi68QVI0CRVv8tvTjZinpJWRSfQ3GP6v0DvlK55lDgFvD79r6A/NU+EUawrBc62qP30MxzOUnXNJZQ==",
+      "dev": true
     },
     "node_modules/jest-pnp-resolver": {
       "version": "1.2.2",
@@ -15259,7 +15267,9 @@
       }
     },
     "expect-playwright": {
-      "version": "0.7.2",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/expect-playwright/-/expect-playwright-0.8.0.tgz",
+      "integrity": "sha512-+kn8561vHAY+dt+0gMqqj1oY+g5xWrsuGMk4QGxotT2WS545nVqqjs37z6hrYfIuucwqthzwJfCJUEYqixyljg==",
       "dev": true
     },
     "extract-zip": {
@@ -16794,6 +16804,14 @@
         "playwright-core": ">=1.2.0",
         "rimraf": "^3.0.2",
         "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "expect-playwright": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/expect-playwright/-/expect-playwright-0.7.2.tgz",
+          "integrity": "sha512-5o9si+8SUi68QVI0CRVv8tvTjZinpJWRSfQ3GP6v0DvlK55lDgFvD79r6A/NU+EUawrBc62qP30MxzOUnXNJZQ==",
+          "dev": true
+        }
       }
     },
     "jest-pnp-resolver": {

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "eslint-plugin-notice": "^0.9.10",
     "eslint-plugin-playwright": "^0.6.0",
     "eslint-plugin-prettier": "^4.0.0",
+    "expect-playwright": "^0.8.0",
     "fs-extra": "^10.0.0",
     "husky": "^7.0.4",
     "jest": "^27.4.3",

--- a/test/bundles/bundles.test.ts
+++ b/test/bundles/bundles.test.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 import { existsSync } from 'fs';
-import { resolve } from 'path';
 import 'jest-playwright-preset';
+import { resolve } from 'path';
+import { Page } from 'playwright';
 import { BpmnPageSvgTester } from '../e2e/helpers/visu/bpmn-page-utils';
-import { ElementHandle, Page } from 'playwright';
 
 describe('bundles', () => {
   describe('All bundles have been generated', () => {
@@ -56,8 +56,8 @@ describe('bundles', () => {
 });
 
 class BpmnStaticPageSvgTester extends BpmnPageSvgTester {
-  override async loadBPMNDiagramInRefreshedPage(): Promise<ElementHandle<SVGElement | HTMLElement>> {
+  override async loadBPMNDiagramInRefreshedPage(): Promise<void> {
     const url = `file://${resolve(__dirname, `static/${this.targetedPage.pageFileName}.html`)}`;
-    return super.doLoadBPMNDiagramInRefreshedPage(url, false);
+    super.doLoadBPMNDiagramInRefreshedPage(url, false);
   }
 }

--- a/test/bundles/jest.config.js
+++ b/test/bundles/jest.config.js
@@ -30,6 +30,7 @@ module.exports = {
       tsconfig: '<rootDir>/tsconfig.jest.json',
     },
   },
+  setupFilesAfterEnv: ['expect-playwright'],
   reporters: [
     'default',
     [

--- a/test/bundles/jest.config.js
+++ b/test/bundles/jest.config.js
@@ -27,7 +27,7 @@ module.exports = {
   },
   globals: {
     'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.jest.json',
+      tsconfig: '<rootDir>/tsconfig.test.json',
     },
   },
   setupFilesAfterEnv: ['expect-playwright'],

--- a/test/e2e/diagram.navigation.zoom.pan.test.ts
+++ b/test/e2e/diagram.navigation.zoom.pan.test.ts
@@ -15,9 +15,9 @@
  */
 import 'jest-playwright-preset';
 import { join } from 'path';
-import { ImageSnapshotConfigurator, ImageSnapshotThresholdConfig, MultiBrowserImageSnapshotThresholds } from './helpers/visu/image-snapshot-config';
 import { getContainerCenter, mousePanning, mouseZoom, Point } from './helpers/test-utils';
 import { PageTester } from './helpers/visu/bpmn-page-utils';
+import { ImageSnapshotConfigurator, ImageSnapshotThresholdConfig, MultiBrowserImageSnapshotThresholds } from './helpers/visu/image-snapshot-config';
 
 class ImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
   constructor() {
@@ -62,8 +62,8 @@ describe('diagram navigation - zoom and pan', () => {
   let containerCenter: Point;
 
   beforeEach(async () => {
-    const bpmnContainerElementHandle = await pageTester.loadBPMNDiagramInRefreshedPage(bpmnDiagramName);
-    containerCenter = await getContainerCenter(bpmnContainerElementHandle);
+    await pageTester.loadBPMNDiagramInRefreshedPage(bpmnDiagramName);
+    containerCenter = await getContainerCenter();
   });
 
   it('mouse panning', async () => {

--- a/test/e2e/diagram.navigation.zoom.pan.test.ts
+++ b/test/e2e/diagram.navigation.zoom.pan.test.ts
@@ -15,7 +15,7 @@
  */
 import 'jest-playwright-preset';
 import { join } from 'path';
-import { getContainerCenter, mousePanning, mouseZoom, Point } from './helpers/test-utils';
+import { mousePanning, mouseZoom, Point } from './helpers/test-utils';
 import { PageTester } from './helpers/visu/bpmn-page-utils';
 import { ImageSnapshotConfigurator, ImageSnapshotThresholdConfig, MultiBrowserImageSnapshotThresholds } from './helpers/visu/image-snapshot-config';
 
@@ -63,7 +63,7 @@ describe('diagram navigation - zoom and pan', () => {
 
   beforeEach(async () => {
     await pageTester.loadBPMNDiagramInRefreshedPage(bpmnDiagramName);
-    containerCenter = await getContainerCenter();
+    containerCenter = await pageTester.getContainerCenter();
   });
 
   it('mouse panning', async () => {

--- a/test/e2e/helpers/test-utils.ts
+++ b/test/e2e/helpers/test-utils.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 import debugLogger from 'debug';
-import { ElementHandle, Mouse } from 'playwright';
 import 'jest-playwright-preset';
 import { join } from 'path';
+import { ElementHandle, Mouse } from 'playwright';
 import { findFiles } from '../../helpers/file-helper';
 
 export interface Point {
@@ -57,7 +57,8 @@ export function getBpmnDiagramNames(directoryName: string): string[] {
     .map(filename => filename.split('.').slice(0, -1).join('.'));
 }
 
-export async function getContainerCenter(containerElement: ElementHandle<SVGElement | HTMLElement>): Promise<Point> {
+export async function getContainerCenter(): Promise<Point> {
+  const containerElement: ElementHandle<SVGElement | HTMLElement> = await page.waitForSelector('#bpmn-container');
   const rect = await containerElement.boundingBox();
   return { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 };
 }

--- a/test/e2e/helpers/test-utils.ts
+++ b/test/e2e/helpers/test-utils.ts
@@ -16,7 +16,7 @@
 import debugLogger from 'debug';
 import 'jest-playwright-preset';
 import { join } from 'path';
-import { ElementHandle, Mouse } from 'playwright';
+import { Mouse } from 'playwright';
 import { findFiles } from '../../helpers/file-helper';
 
 export interface Point {
@@ -55,12 +55,6 @@ export function getBpmnDiagramNames(directoryName: string): string[] {
   return findFiles(join('../fixtures/bpmn/', directoryName))
     .filter(filename => filename.endsWith('.bpmn'))
     .map(filename => filename.split('.').slice(0, -1).join('.'));
-}
-
-export async function getContainerCenter(): Promise<Point> {
-  const containerElement: ElementHandle<SVGElement | HTMLElement> = await page.waitForSelector('#bpmn-container');
-  const rect = await containerElement.boundingBox();
-  return { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 };
 }
 
 export async function clickOnButton(buttonId: string): Promise<void> {

--- a/test/e2e/helpers/visu/bpmn-page-utils.ts
+++ b/test/e2e/helpers/visu/bpmn-page-utils.ts
@@ -147,10 +147,6 @@ export class BpmnPageSvgTester extends PageTester {
     });
   }
 
-  async expectLabel(bpmnId: string, expectedText: string): Promise<void> {
-    await expect(this.currentPage).toMatchText(this.bpmnQuerySelectors.labelLastDiv(bpmnId), expectedText);
-  }
-
   async expectEvent(bpmnId: string, expectedText: string, isStartEvent = true): Promise<void> {
     const selector = this.bpmnQuerySelectors.element(bpmnId);
     await expectClassAttribute(this.currentPage, selector, `bpmn-type-event ${isStartEvent ? 'bpmn-start-event' : 'bpmn-end-event'} bpmn-event-def-none`);
@@ -158,7 +154,7 @@ export class BpmnPageSvgTester extends PageTester {
     await expectFirstChildAttribute(this.currentPage, selector, 'rx', '18');
     await expectFirstChildAttribute(this.currentPage, selector, 'ry', '18');
 
-    await this.expectLabel(bpmnId, expectedText);
+    await expectLabel(this.currentPage, this.bpmnQuerySelectors, bpmnId, expectedText);
   }
 
   async expectTask(bpmnId: string, expectedText: string): Promise<void> {
@@ -167,14 +163,14 @@ export class BpmnPageSvgTester extends PageTester {
     await expectFirstChildNodeName(this.currentPage, selector, 'rect');
     await expectFirstChildAttribute(this.currentPage, selector, 'width', '100');
     await expectFirstChildAttribute(this.currentPage, selector, 'height', '80');
-    await this.expectLabel(bpmnId, expectedText);
+    await expectLabel(this.currentPage, this.bpmnQuerySelectors, bpmnId, expectedText);
   }
 
   async expectSequenceFlow(bpmnId: string, expectedText?: string): Promise<void> {
     const selector = this.bpmnQuerySelectors.element(bpmnId);
     await expectClassAttribute(this.currentPage, selector, 'bpmn-type-flow bpmn-sequence-flow');
     await expectFirstChildNodeName(this.currentPage, selector, 'path');
-    expectedText && (await this.expectLabel(bpmnId, expectedText));
+    expectedText && (await expectLabel(this.currentPage, this.bpmnQuerySelectors, bpmnId, expectedText));
   }
 }
 
@@ -188,5 +184,9 @@ async function expectFirstChildNodeName(currentPage: Page, selector: string, nod
 
 async function expectFirstChildAttribute(currentPage: Page, selector: string, attributeName: string, value: string): Promise<void> {
   await expect(currentPage).toMatchAttribute(`${selector} > :first-child`, attributeName, value);
+}
+
+async function expectLabel(currentPage: Page, bpmnQuerySelectors: BpmnQuerySelectorsForTests, bpmnId: string, expectedText: string): Promise<void> {
+  await expect(currentPage).toMatchText(bpmnQuerySelectors.labelLastDiv(bpmnId), expectedText);
 }
 /* eslint-enable jest/no-standalone-expect */

--- a/test/e2e/helpers/visu/bpmn-page-utils.ts
+++ b/test/e2e/helpers/visu/bpmn-page-utils.ts
@@ -15,9 +15,10 @@
  */
 import 'expect-playwright';
 import 'jest-playwright-preset';
-import { Page } from 'playwright';
+import { ElementHandle, Page } from 'playwright';
 import { FitType, LoadOptions } from '../../../../src/component/options';
 import { BpmnQuerySelectorsForTests } from '../../../helpers/query-selectors';
+import { Point } from '../test-utils';
 
 /* eslint-disable jest/no-standalone-expect */
 
@@ -125,6 +126,12 @@ export class PageTester {
     url += `&style.seqFlow.light.colors=${styleOptions?.sequenceFlow?.useLightColors}`;
     url += `&style.container.alternative.background.color=${styleOptions?.bpmnContainer?.useAlternativeBackgroundColor}`;
     return url;
+  }
+
+  async getContainerCenter(): Promise<Point> {
+    const containerElement: ElementHandle<SVGElement | HTMLElement> = await page.waitForSelector(`#${this.bpmnContainerId}`);
+    const rect = await containerElement.boundingBox();
+    return { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 };
   }
 }
 

--- a/test/e2e/helpers/visu/bpmn-page-utils.ts
+++ b/test/e2e/helpers/visu/bpmn-page-utils.ts
@@ -160,8 +160,7 @@ export class BpmnPageSvgTester extends PageTester {
     await expectFirstChildNodeName(this.currentPage, selector, 'ellipse');
     await expectFirstChildAttribute(this.currentPage, selector, 'rx', '18');
     await expectFirstChildAttribute(this.currentPage, selector, 'ry', '18');
-
-    await expectLabel(this.currentPage, this.bpmnQuerySelectors, bpmnId, expectedText);
+    await this.checkLabel(bpmnId, expectedText);
   }
 
   async expectTask(bpmnId: string, expectedText: string): Promise<void> {
@@ -170,30 +169,33 @@ export class BpmnPageSvgTester extends PageTester {
     await expectFirstChildNodeName(this.currentPage, selector, 'rect');
     await expectFirstChildAttribute(this.currentPage, selector, 'width', '100');
     await expectFirstChildAttribute(this.currentPage, selector, 'height', '80');
-    await expectLabel(this.currentPage, this.bpmnQuerySelectors, bpmnId, expectedText);
+    await this.checkLabel(bpmnId, expectedText);
   }
 
   async expectSequenceFlow(bpmnId: string, expectedText?: string): Promise<void> {
     const selector = this.bpmnQuerySelectors.element(bpmnId);
     await expectClassAttribute(this.currentPage, selector, 'bpmn-type-flow bpmn-sequence-flow');
     await expectFirstChildNodeName(this.currentPage, selector, 'path');
-    expectedText && (await expectLabel(this.currentPage, this.bpmnQuerySelectors, bpmnId, expectedText));
+    await this.checkLabel(bpmnId, expectedText);
+  }
+
+  async checkLabel(bpmnId: string, expectedText?: string): Promise<void> {
+    if (!expectedText) {
+      return;
+    }
+    await expect(this.currentPage).toMatchText(this.bpmnQuerySelectors.labelLastDiv(bpmnId), expectedText);
   }
 }
 
-async function expectClassAttribute(currentPage: Page, selector: string, value: string): Promise<void> {
-  await expect(currentPage).toMatchAttribute(selector, 'class', value);
+async function expectClassAttribute(page: Page, selector: string, value: string): Promise<void> {
+  await expect(page).toMatchAttribute(selector, 'class', value);
 }
 
-async function expectFirstChildNodeName(currentPage: Page, selector: string, nodeName: string): Promise<void> {
-  await expect(currentPage).toHaveSelectorCount(`${selector} > ${nodeName}:first-child`, 1);
+async function expectFirstChildNodeName(page: Page, selector: string, nodeName: string): Promise<void> {
+  await expect(page).toHaveSelectorCount(`${selector} > ${nodeName}:first-child`, 1);
 }
 
-async function expectFirstChildAttribute(currentPage: Page, selector: string, attributeName: string, value: string): Promise<void> {
-  await expect(currentPage).toMatchAttribute(`${selector} > :first-child`, attributeName, value);
-}
-
-async function expectLabel(currentPage: Page, bpmnQuerySelectors: BpmnQuerySelectorsForTests, bpmnId: string, expectedText: string): Promise<void> {
-  await expect(currentPage).toMatchText(bpmnQuerySelectors.labelLastDiv(bpmnId), expectedText);
+async function expectFirstChildAttribute(page: Page, selector: string, attributeName: string, value: string): Promise<void> {
+  await expect(page).toMatchAttribute(`${selector} > :first-child`, attributeName, value);
 }
 /* eslint-enable jest/no-standalone-expect */

--- a/test/e2e/jest.config.js
+++ b/test/e2e/jest.config.js
@@ -36,6 +36,7 @@ module.exports = {
   coverageDirectory: 'build/test-report/e2e',
   setupFiles: ['./test/e2e/config/copy.bpmn.diagram.ts'],
   setupFilesAfterEnv: [
+    'expect-playwright',
     // jest-image-snapshot configuration doesn't work with setupFiles, fix with setupFilesAfterEnv: see https://github.com/testing-library/jest-dom/issues/122#issuecomment-650520461
     './test/e2e/config/jest.image.ts',
     // need playwright globals to be available, so after environment

--- a/test/e2e/jest.config.js
+++ b/test/e2e/jest.config.js
@@ -27,7 +27,7 @@ module.exports = {
   },
   globals: {
     'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.jest.json',
+      tsconfig: '<rootDir>/tsconfig.test.json',
     },
   },
   collectCoverageFrom: ['src/**/*.{ts,js}'],

--- a/test/e2e/overlays.rendering.test.ts
+++ b/test/e2e/overlays.rendering.test.ts
@@ -18,7 +18,7 @@ import { join } from 'path';
 import { ensureIsArray } from '../../src/component/helpers/array-utils';
 import { OverlayEdgePosition, OverlayPosition, OverlayShapePosition } from '../../src/component/registry';
 import { overlayEdgePositionValues, overlayShapePositionValues } from '../helpers/overlays';
-import { clickOnButton, getContainerCenter, mousePanning, mouseZoom, Point } from './helpers/test-utils';
+import { clickOnButton, mousePanning, mouseZoom, Point } from './helpers/test-utils';
 import { PageTester } from './helpers/visu/bpmn-page-utils';
 import { ImageSnapshotConfigurator, ImageSnapshotThresholdConfig, MultiBrowserImageSnapshotThresholds } from './helpers/visu/image-snapshot-config';
 
@@ -318,7 +318,7 @@ describe('Overlay navigation', () => {
 
   beforeEach(async () => {
     await pageTester.loadBPMNDiagramInRefreshedPage(bpmnDiagramName);
-    containerCenter = await getContainerCenter();
+    containerCenter = await pageTester.getContainerCenter();
 
     await addOverlays('StartEvent_1', 'bottom-center');
     await addOverlays('Activity_1', 'middle-right');

--- a/test/e2e/overlays.rendering.test.ts
+++ b/test/e2e/overlays.rendering.test.ts
@@ -15,12 +15,12 @@
  */
 import 'jest-playwright-preset';
 import { join } from 'path';
-import { ImageSnapshotConfigurator, ImageSnapshotThresholdConfig, MultiBrowserImageSnapshotThresholds } from './helpers/visu/image-snapshot-config';
-import { PageTester } from './helpers/visu/bpmn-page-utils';
-import { clickOnButton, getContainerCenter, mousePanning, mouseZoom, Point } from './helpers/test-utils';
-import { overlayEdgePositionValues, overlayShapePositionValues } from '../helpers/overlays';
-import { OverlayEdgePosition, OverlayPosition, OverlayShapePosition } from '../../src/component/registry';
 import { ensureIsArray } from '../../src/component/helpers/array-utils';
+import { OverlayEdgePosition, OverlayPosition, OverlayShapePosition } from '../../src/component/registry';
+import { overlayEdgePositionValues, overlayShapePositionValues } from '../helpers/overlays';
+import { clickOnButton, getContainerCenter, mousePanning, mouseZoom, Point } from './helpers/test-utils';
+import { PageTester } from './helpers/visu/bpmn-page-utils';
+import { ImageSnapshotConfigurator, ImageSnapshotThresholdConfig, MultiBrowserImageSnapshotThresholds } from './helpers/visu/image-snapshot-config';
 
 class ImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
   constructor() {
@@ -317,8 +317,8 @@ describe('Overlay navigation', () => {
   const imageSnapshotConfigurator = new ImageSnapshotConfigurator(new OverlayNavigationImageSnapshotThresholds(), 'overlays');
 
   beforeEach(async () => {
-    const bpmnContainerElementHandle = await pageTester.loadBPMNDiagramInRefreshedPage(bpmnDiagramName);
-    containerCenter = await getContainerCenter(bpmnContainerElementHandle);
+    await pageTester.loadBPMNDiagramInRefreshedPage(bpmnDiagramName);
+    containerCenter = await getContainerCenter();
 
     await addOverlays('StartEvent_1', 'bottom-center');
     await addOverlays('Activity_1', 'middle-right');

--- a/test/integration/jest.config.js
+++ b/test/integration/jest.config.js
@@ -25,7 +25,7 @@ module.exports = {
   },
   globals: {
     'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.jest.json',
+      tsconfig: '<rootDir>/tsconfig.test.json',
     },
   },
   collectCoverageFrom: ['src/**/*.{ts,js}'],

--- a/test/performance/bpmn.navigation.performance.test.ts
+++ b/test/performance/bpmn.navigation.performance.test.ts
@@ -15,10 +15,10 @@
  */
 import * as fs from 'fs';
 import { Page } from 'playwright';
-import { delay, getSimplePlatformName, mouseZoomNoDelay } from '../e2e/helpers/test-utils';
+import { delay, getContainerCenter, getSimplePlatformName, mouseZoomNoDelay, Point } from '../e2e/helpers/test-utils';
 import { PageTester } from '../e2e/helpers/visu/bpmn-page-utils';
-import { calculateMetrics, ChartData, PerformanceMetric } from './helpers/perf-utils';
 import { ChromiumMetricsCollector } from './helpers/metrics-chromium';
+import { calculateMetrics, ChartData, PerformanceMetric } from './helpers/perf-utils';
 
 const platform = getSimplePlatformName();
 const performanceDataFilePath = './test/performance/data/' + platform + '/data.js';
@@ -33,14 +33,11 @@ describe.each([1, 2, 3, 4, 5])('zoom performance', run => {
   const pageTester = new PageTester({ pageFileName: 'diagram-navigation', expectedPageTitle: 'BPMN Visualization - Diagram Navigation' });
 
   const fileName = 'B.2.0';
-  let containerCenterX: number;
-  let containerCenterY: number;
+  let containerCenter: Point;
 
   beforeEach(async () => {
-    const bpmnContainerElementHandle = await pageTester.loadBPMNDiagramInRefreshedPage(fileName);
-    const bounding_box = await bpmnContainerElementHandle.boundingBox();
-    containerCenterX = bounding_box.x + bounding_box.width / 2;
-    containerCenterY = bounding_box.y + bounding_box.height / 2;
+    await pageTester.loadBPMNDiagramInRefreshedPage(fileName);
+    containerCenter = await getContainerCenter();
   });
 
   it.each([30])(`ctrl + mouse: check performance while performing zoom in and zoom out [%s times]`, async (xTimes: number) => {
@@ -48,14 +45,14 @@ describe.each([1, 2, 3, 4, 5])('zoom performance', run => {
     const metricsStart = await metricsCollector.metrics();
 
     for (let i = 0; i < xTimes; i++) {
-      await mouseZoomNoDelay({ x: containerCenterX + 200, y: containerCenterY }, deltaX);
+      await mouseZoomNoDelay({ x: containerCenter.x + 200, y: containerCenter.y }, deltaX);
       if (i % 5 === 0) {
         await delay(30);
       }
     }
     await delay(100);
     for (let i = 0; i < xTimes; i++) {
-      await mouseZoomNoDelay({ x: containerCenterX + 200, y: containerCenterY }, -deltaX);
+      await mouseZoomNoDelay({ x: containerCenter.x + 200, y: containerCenter.y }, -deltaX);
       if (i % 5 === 0) {
         await delay(30);
       }

--- a/test/performance/bpmn.navigation.performance.test.ts
+++ b/test/performance/bpmn.navigation.performance.test.ts
@@ -15,7 +15,7 @@
  */
 import * as fs from 'fs';
 import { Page } from 'playwright';
-import { delay, getContainerCenter, getSimplePlatformName, mouseZoomNoDelay, Point } from '../e2e/helpers/test-utils';
+import { delay, getSimplePlatformName, mouseZoomNoDelay, Point } from '../e2e/helpers/test-utils';
 import { PageTester } from '../e2e/helpers/visu/bpmn-page-utils';
 import { ChromiumMetricsCollector } from './helpers/metrics-chromium';
 import { calculateMetrics, ChartData, PerformanceMetric } from './helpers/perf-utils';
@@ -37,7 +37,7 @@ describe.each([1, 2, 3, 4, 5])('zoom performance', run => {
 
   beforeEach(async () => {
     await pageTester.loadBPMNDiagramInRefreshedPage(fileName);
-    containerCenter = await getContainerCenter();
+    containerCenter = await pageTester.getContainerCenter();
   });
 
   it.each([30])(`ctrl + mouse: check performance while performing zoom in and zoom out [%s times]`, async (xTimes: number) => {

--- a/test/performance/jest.config.js
+++ b/test/performance/jest.config.js
@@ -27,7 +27,7 @@ module.exports = {
   },
   globals: {
     'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.jest.json',
+      tsconfig: '<rootDir>/tsconfig.test.json',
     },
   },
   setupFiles: ['./test/e2e/config/copy.bpmn.diagram.ts'],

--- a/test/performance/jest.config.js
+++ b/test/performance/jest.config.js
@@ -31,4 +31,5 @@ module.exports = {
     },
   },
   setupFiles: ['./test/e2e/config/copy.bpmn.diagram.ts'],
+  setupFilesAfterEnv: ['expect-playwright'],
 };

--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -24,7 +24,7 @@ module.exports = {
   },
   globals: {
     'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.jest.json',
+      tsconfig: '<rootDir>/tsconfig.test.json',
     },
   },
   collectCoverageFrom: ['src/**/*.{ts,js}'],

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "./tsconfig",
   "compilerOptions": {
     "sourceMap": true
   }


### PR DESCRIPTION
In this PR, you can find:
- The installation & the configuration of the [expect-playwright](https://github.com/playwright-community/expect-playwright) dependency
- The renaming of `tsconfig.jest.json` file in `tsconfig.test.json` in order to respect the IntelliJ convention for multiple tsconfig files
- The usage of the `expect-playwright` assertions
- and some refactoring

To check if a test failed, I replace some assertions by a wrong CSS selector, and other with a wrong expected value.