### PR TITLE
[TEST] Avoid usage of the Playwright page global in PageTester

### DIFF
--- a/test/e2e/bpmn.rendering.test.ts
+++ b/test/e2e/bpmn.rendering.test.ts
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 import 'jest-playwright-preset';
+import { Page } from 'playwright';
+import { getBpmnDiagramNames } from './helpers/test-utils';
+import { PageTester, StyleOptions } from './helpers/visu/bpmn-page-utils';
 import {
   defaultChromiumFailureThreshold,
   ImageSnapshotConfigurator,
   ImageSnapshotThresholdConfig,
   MultiBrowserImageSnapshotThresholds,
 } from './helpers/visu/image-snapshot-config';
-import { PageTester, StyleOptions } from './helpers/visu/bpmn-page-utils';
-import { getBpmnDiagramNames } from './helpers/test-utils';
 
 class ImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
   // threshold for webkit is taken from macOS only
@@ -336,7 +337,7 @@ const styleOptionsPerDiagram = new Map<string, StyleOptions>([
 describe('BPMN rendering', () => {
   const imageSnapshotConfigurator = new ImageSnapshotConfigurator(new ImageSnapshotThresholds(), 'bpmn');
 
-  const pageTester = new PageTester({ pageFileName: 'non-regression', expectedPageTitle: 'BPMN Visualization Non Regression' });
+  const pageTester = new PageTester({ pageFileName: 'non-regression', expectedPageTitle: 'BPMN Visualization Non Regression' }, <Page>page);
   const bpmnDiagramNames = getBpmnDiagramNames('non-regression');
 
   it('check bpmn non-regression files availability', () => {

--- a/test/e2e/diagram.navigation.fit.test.ts
+++ b/test/e2e/diagram.navigation.fit.test.ts
@@ -13,13 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { join } from 'path';
 import { MatchImageSnapshotOptions } from 'jest-image-snapshot';
 import 'jest-playwright-preset';
+import { join } from 'path';
+import { Page } from 'playwright';
 import { FitType } from '../../src/component/options';
-import { ImageSnapshotConfigurator, ImageSnapshotThresholdConfig, MultiBrowserImageSnapshotThresholds } from './helpers/visu/image-snapshot-config';
-import { PageTester } from './helpers/visu/bpmn-page-utils';
 import { clickOnButton, getBpmnDiagramNames } from './helpers/test-utils';
+import { PageTester } from './helpers/visu/bpmn-page-utils';
+import { ImageSnapshotConfigurator, ImageSnapshotThresholdConfig, MultiBrowserImageSnapshotThresholds } from './helpers/visu/image-snapshot-config';
 
 class FitImageSnapshotConfigurator extends ImageSnapshotConfigurator {
   override getConfig(param: {
@@ -139,7 +140,7 @@ class ImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
 describe('diagram navigation - fit', () => {
   const imageSnapshotConfigurator = new FitImageSnapshotConfigurator(new ImageSnapshotThresholds(), 'fit');
 
-  const pageTester = new PageTester({ pageFileName: 'diagram-navigation', expectedPageTitle: 'BPMN Visualization - Diagram Navigation' });
+  const pageTester = new PageTester({ pageFileName: 'diagram-navigation', expectedPageTitle: 'BPMN Visualization - Diagram Navigation' }, <Page>page);
 
   const fitTypes: FitType[] = [FitType.None, FitType.HorizontalVertical, FitType.Horizontal, FitType.Vertical, FitType.Center];
   describe.each(fitTypes)('load options - fit %s', (onLoadFitType: FitType) => {

--- a/test/e2e/diagram.navigation.zoom.pan.test.ts
+++ b/test/e2e/diagram.navigation.zoom.pan.test.ts
@@ -15,6 +15,7 @@
  */
 import 'jest-playwright-preset';
 import { join } from 'path';
+import { Page } from 'playwright';
 import { mousePanning, mouseZoom, Point } from './helpers/test-utils';
 import { PageTester } from './helpers/visu/bpmn-page-utils';
 import { ImageSnapshotConfigurator, ImageSnapshotThresholdConfig, MultiBrowserImageSnapshotThresholds } from './helpers/visu/image-snapshot-config';
@@ -56,7 +57,7 @@ class ImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
 describe('diagram navigation - zoom and pan', () => {
   const imageSnapshotConfigurator = new ImageSnapshotConfigurator(new ImageSnapshotThresholds(), 'navigation');
   // to have mouse pointer visible during headless test - add 'showMousePointer: true' as parameter
-  const pageTester = new PageTester({ pageFileName: 'diagram-navigation', expectedPageTitle: 'BPMN Visualization - Diagram Navigation' });
+  const pageTester = new PageTester({ pageFileName: 'diagram-navigation', expectedPageTitle: 'BPMN Visualization - Diagram Navigation' }, <Page>page);
 
   const bpmnDiagramName = 'simple.2.start.events.1.task';
   let containerCenter: Point;

--- a/test/e2e/helpers/visu/bpmn-page-utils.ts
+++ b/test/e2e/helpers/visu/bpmn-page-utils.ts
@@ -88,11 +88,11 @@ export class PageTester {
   /**
    * Configure how the BPMN file is loaded by the test page.
    */
-  constructor(readonly targetedPage: TargetedPage, protected currentPage: Page) {
+  constructor(readonly targetedPage: TargetedPage, protected page: Page) {
     const showMousePointer = targetedPage.showMousePointer ?? false;
     this.baseUrl = `http://localhost:10002/${targetedPage.pageFileName}.html?showMousePointer=${showMousePointer}`;
     this.bpmnContainerId = targetedPage.bpmnContainerId ?? 'bpmn-container';
-    this.bpmnPage = new BpmnPage(this.bpmnContainerId, this.currentPage);
+    this.bpmnPage = new BpmnPage(this.bpmnContainerId, this.page);
   }
 
   async loadBPMNDiagramInRefreshedPage(bpmnDiagramName: string, pageOptions?: PageOptions): Promise<void> {
@@ -101,7 +101,7 @@ export class PageTester {
   }
 
   protected async doLoadBPMNDiagramInRefreshedPage(url: string, checkResponseStatus = true): Promise<void> {
-    const response = await this.currentPage.goto(url);
+    const response = await this.page.goto(url);
     if (checkResponseStatus) {
       expect(response.status()).toBe(200);
     }
@@ -128,7 +128,7 @@ export class PageTester {
   }
 
   async getContainerCenter(): Promise<Point> {
-    const containerElement: ElementHandle<SVGElement | HTMLElement> = await this.currentPage.waitForSelector(`#${this.bpmnContainerId}`);
+    const containerElement: ElementHandle<SVGElement | HTMLElement> = await this.page.waitForSelector(`#${this.bpmnContainerId}`);
     const rect = await containerElement.boundingBox();
     return { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 };
   }
@@ -137,8 +137,8 @@ export class PageTester {
 export class BpmnPageSvgTester extends PageTester {
   private bpmnQuerySelectors: BpmnQuerySelectorsForTests;
 
-  constructor(targetedPage: TargetedPage, currentPage: Page) {
-    super(targetedPage, currentPage);
+  constructor(targetedPage: TargetedPage, page: Page) {
+    super(targetedPage, page);
     // TODO duplicated with BpmnPage
     this.bpmnQuerySelectors = new BpmnQuerySelectorsForTests(this.bpmnContainerId);
   }
@@ -155,26 +155,26 @@ export class BpmnPageSvgTester extends PageTester {
 
   async expectEvent(bpmnId: string, expectedText: string, isStartEvent = true): Promise<void> {
     const selector = this.bpmnQuerySelectors.element(bpmnId);
-    await expectClassAttribute(this.currentPage, selector, `bpmn-type-event ${isStartEvent ? 'bpmn-start-event' : 'bpmn-end-event'} bpmn-event-def-none`);
-    await expectFirstChildNodeName(this.currentPage, selector, 'ellipse');
-    await expectFirstChildAttribute(this.currentPage, selector, 'rx', '18');
-    await expectFirstChildAttribute(this.currentPage, selector, 'ry', '18');
+    await expectClassAttribute(this.page, selector, `bpmn-type-event ${isStartEvent ? 'bpmn-start-event' : 'bpmn-end-event'} bpmn-event-def-none`);
+    await expectFirstChildNodeName(this.page, selector, 'ellipse');
+    await expectFirstChildAttribute(this.page, selector, 'rx', '18');
+    await expectFirstChildAttribute(this.page, selector, 'ry', '18');
     await this.checkLabel(bpmnId, expectedText);
   }
 
   async expectTask(bpmnId: string, expectedText: string): Promise<void> {
     const selector = this.bpmnQuerySelectors.element(bpmnId);
-    await expectClassAttribute(this.currentPage, selector, 'bpmn-type-activity bpmn-type-task bpmn-task');
-    await expectFirstChildNodeName(this.currentPage, selector, 'rect');
-    await expectFirstChildAttribute(this.currentPage, selector, 'width', '100');
-    await expectFirstChildAttribute(this.currentPage, selector, 'height', '80');
+    await expectClassAttribute(this.page, selector, 'bpmn-type-activity bpmn-type-task bpmn-task');
+    await expectFirstChildNodeName(this.page, selector, 'rect');
+    await expectFirstChildAttribute(this.page, selector, 'width', '100');
+    await expectFirstChildAttribute(this.page, selector, 'height', '80');
     await this.checkLabel(bpmnId, expectedText);
   }
 
   async expectSequenceFlow(bpmnId: string, expectedText?: string): Promise<void> {
     const selector = this.bpmnQuerySelectors.element(bpmnId);
-    await expectClassAttribute(this.currentPage, selector, 'bpmn-type-flow bpmn-sequence-flow');
-    await expectFirstChildNodeName(this.currentPage, selector, 'path');
+    await expectClassAttribute(this.page, selector, 'bpmn-type-flow bpmn-sequence-flow');
+    await expectFirstChildNodeName(this.page, selector, 'path');
     await this.checkLabel(bpmnId, expectedText);
   }
 
@@ -182,7 +182,7 @@ export class BpmnPageSvgTester extends PageTester {
     if (!expectedText) {
       return;
     }
-    await expect(this.currentPage).toMatchText(this.bpmnQuerySelectors.labelLastDiv(bpmnId), expectedText);
+    await expect(this.page).toMatchText(this.bpmnQuerySelectors.labelLastDiv(bpmnId), expectedText);
   }
 }
 

--- a/test/e2e/overlays.rendering.test.ts
+++ b/test/e2e/overlays.rendering.test.ts
@@ -15,6 +15,7 @@
  */
 import 'jest-playwright-preset';
 import { join } from 'path';
+import { Page } from 'playwright';
 import { ensureIsArray } from '../../src/component/helpers/array-utils';
 import { OverlayEdgePosition, OverlayPosition, OverlayShapePosition } from '../../src/component/registry';
 import { overlayEdgePositionValues, overlayShapePositionValues } from '../helpers/overlays';
@@ -158,7 +159,7 @@ async function removeAllOverlays(bpmnElementId: string): Promise<void> {
 const imageSnapshotConfigurator = new ImageSnapshotConfigurator(new ImageSnapshotThresholds(), 'overlays');
 
 // to have mouse pointer visible during headless test - add 'showMousePointer: true' as parameter
-const pageTester = new PageTester({ pageFileName: 'overlays', expectedPageTitle: 'BPMN Visualization - Overlays' });
+const pageTester = new PageTester({ pageFileName: 'overlays', expectedPageTitle: 'BPMN Visualization - Overlays' }, <Page>page);
 
 describe('BPMN Shapes with overlays', () => {
   const bpmnDiagramName = 'overlays.start.flow.task.gateway';

--- a/test/performance/bpmn.load.performance.test.ts
+++ b/test/performance/bpmn.load.performance.test.ts
@@ -17,8 +17,8 @@ import * as fs from 'fs';
 import { Page } from 'playwright';
 import { getSimplePlatformName } from '../e2e/helpers/test-utils';
 import { PageTester } from '../e2e/helpers/visu/bpmn-page-utils';
-import { calculateMetrics, ChartData, PerformanceMetric } from './helpers/perf-utils';
 import { ChromiumMetricsCollector } from './helpers/metrics-chromium';
+import { calculateMetrics, ChartData, PerformanceMetric } from './helpers/perf-utils';
 
 const platform = getSimplePlatformName();
 const performanceDataFilePath = './test/performance/data/' + platform + '/data.js';
@@ -30,7 +30,7 @@ beforeAll(async () => {
 });
 describe.each([1, 2, 3, 4, 5])('load performance', run => {
   // to have mouse pointer visible during headless test - add 'showMousePointer: true' as parameter
-  const pageTester = new PageTester({ pageFileName: 'diagram-navigation', expectedPageTitle: 'BPMN Visualization - Diagram Navigation' });
+  const pageTester = new PageTester({ pageFileName: 'diagram-navigation', expectedPageTitle: 'BPMN Visualization - Diagram Navigation' }, <Page>page);
   const fileName = 'B.2.0';
 
   it.each([1])('check performance for file loading and displaying diagram with FitType.HorizontalVertical', async () => {

--- a/test/performance/bpmn.navigation.performance.test.ts
+++ b/test/performance/bpmn.navigation.performance.test.ts
@@ -30,7 +30,7 @@ beforeAll(async () => {
 });
 describe.each([1, 2, 3, 4, 5])('zoom performance', run => {
   // to have mouse pointer visible during headless test - add 'showMousePointer: true' as parameter
-  const pageTester = new PageTester({ pageFileName: 'diagram-navigation', expectedPageTitle: 'BPMN Visualization - Diagram Navigation' });
+  const pageTester = new PageTester({ pageFileName: 'diagram-navigation', expectedPageTitle: 'BPMN Visualization - Diagram Navigation' }, <Page>page);
 
   const fileName = 'B.2.0';
   let containerCenter: Point;


### PR DESCRIPTION
We don't like using globals and this change prepares an eventual move to `playwright-test` which doesn't provide a `Page` global.
This was already done in `PageTester` subclasses, so this is now more consistent.