### PR TITLE
[TEST] Avoid usage of the PW page global in utils functions

### DIFF
--- a/test/e2e/diagram.navigation.fit.test.ts
+++ b/test/e2e/diagram.navigation.fit.test.ts
@@ -172,7 +172,7 @@ describe('diagram navigation - fit', () => {
             },
           },
         });
-        await clickOnButton(afterLoadFitType);
+        await clickOnButton(page, afterLoadFitType);
 
         const image = await page.screenshot({ fullPage: true });
 

--- a/test/e2e/diagram.navigation.zoom.pan.test.ts
+++ b/test/e2e/diagram.navigation.zoom.pan.test.ts
@@ -68,7 +68,7 @@ describe('diagram navigation - zoom and pan', () => {
   });
 
   it('mouse panning', async () => {
-    await mousePanning({ originPoint: containerCenter, destinationPoint: { x: containerCenter.x + 150, y: containerCenter.y + 40 } });
+    await mousePanning(page, { originPoint: containerCenter, destinationPoint: { x: containerCenter.x + 150, y: containerCenter.y + 40 } });
 
     const image = await page.screenshot({ fullPage: true });
     const config = imageSnapshotConfigurator.getConfig(bpmnDiagramName);
@@ -80,7 +80,7 @@ describe('diagram navigation - zoom and pan', () => {
 
   it.each(['zoom in', 'zoom out'])(`ctrl + mouse: %s`, async (zoomMode: string) => {
     const deltaX = zoomMode === 'zoom in' ? -100 : 100;
-    await mouseZoom(1, { x: containerCenter.x + 200, y: containerCenter.y }, deltaX);
+    await mouseZoom(page, 1, { x: containerCenter.x + 200, y: containerCenter.y }, deltaX);
 
     const image = await page.screenshot({ fullPage: true });
     const config = imageSnapshotConfigurator.getConfig(bpmnDiagramName);
@@ -94,8 +94,8 @@ describe('diagram navigation - zoom and pan', () => {
     const deltaX = -100;
     // simulate mouse+ctrl zoom
     await page.mouse.move(containerCenter.x + 200, containerCenter.y);
-    await mouseZoom(xTimes, { x: containerCenter.x + 200, y: containerCenter.y }, deltaX);
-    await mouseZoom(xTimes, { x: containerCenter.x + 200, y: containerCenter.y }, -deltaX);
+    await mouseZoom(page, xTimes, { x: containerCenter.x + 200, y: containerCenter.y }, deltaX);
+    await mouseZoom(page, xTimes, { x: containerCenter.x + 200, y: containerCenter.y }, -deltaX);
 
     const image = await page.screenshot({ fullPage: true });
     const config = imageSnapshotConfigurator.getConfig(bpmnDiagramName);

--- a/test/e2e/helpers/test-utils.ts
+++ b/test/e2e/helpers/test-utils.ts
@@ -16,7 +16,7 @@
 import debugLogger from 'debug';
 import 'jest-playwright-preset';
 import { join } from 'path';
-import { Mouse } from 'playwright';
+import { Mouse, Page } from 'playwright';
 import { findFiles } from '../../helpers/file-helper';
 
 export interface Point {
@@ -57,7 +57,7 @@ export function getBpmnDiagramNames(directoryName: string): string[] {
     .map(filename => filename.split('.').slice(0, -1).join('.'));
 }
 
-export async function clickOnButton(buttonId: string): Promise<void> {
+export async function clickOnButton(page: Page, buttonId: string): Promise<void> {
   await page.click(`#${buttonId}`);
   // To unselect the button
   await page.mouse.click(0, 0);
@@ -68,7 +68,7 @@ export interface PanningOptions {
   destinationPoint: Point;
 }
 
-export async function mousePanning({ originPoint, destinationPoint }: PanningOptions): Promise<void> {
+export async function mousePanning(page: Page, { originPoint, destinationPoint }: PanningOptions): Promise<void> {
   // simulate mouse panning
   await page.mouse.move(originPoint.x, originPoint.y);
   await page.mouse.down();
@@ -76,15 +76,15 @@ export async function mousePanning({ originPoint, destinationPoint }: PanningOpt
   await page.mouse.up();
 }
 
-export async function mouseZoom(xTimes: number, point: Point, deltaX: number): Promise<void> {
+export async function mouseZoom(page: Page, xTimes: number, point: Point, deltaX: number): Promise<void> {
   for (let i = 0; i < xTimes; i++) {
-    await mouseZoomNoDelay(point, deltaX);
+    await mouseZoomNoDelay(page, point, deltaX);
     // delay here is needed to make the tests pass on MacOS, delay must be greater than debounce timing so it surely gets triggered
     await delay(150);
   }
 }
 
-export async function mouseZoomNoDelay(point: Point, deltaX: number): Promise<void> {
+export async function mouseZoomNoDelay(page: Page, point: Point, deltaX: number): Promise<void> {
   await page.mouse.move(point.x, point.y);
   await page.keyboard.down('Control');
   await (page.mouse as Mouse).wheel(deltaX, 0);

--- a/test/e2e/helpers/visu/bpmn-page-utils.ts
+++ b/test/e2e/helpers/visu/bpmn-page-utils.ts
@@ -29,23 +29,23 @@ export interface PageWaitForSelectorOptions {
 class BpmnPage {
   private bpmnQuerySelectors: BpmnQuerySelectorsForTests;
 
-  constructor(private bpmnContainerId: string, private currentPage: Page) {
+  constructor(private bpmnContainerId: string, private page: Page) {
     this.bpmnQuerySelectors = new BpmnQuerySelectorsForTests(this.bpmnContainerId);
   }
 
   async expectAvailableBpmnContainer(options?: PageWaitForSelectorOptions): Promise<void> {
-    await expect(this.currentPage).toMatchAttribute(`#${this.bpmnContainerId}`, 'style', /cursor: default/, options);
+    await expect(this.page).toMatchAttribute(`#${this.bpmnContainerId}`, 'style', /cursor: default/, options);
   }
 
   async expectPageTitle(title: string): Promise<void> {
-    await expect(this.currentPage.title()).resolves.toEqual(title);
+    await expect(this.page.title()).resolves.toEqual(title);
   }
 
   /**
    * This checks that a least one BPMN element is available in the DOM as a SVG element. This ensure that the mxGraph rendering has been done.
    */
   async expectExistingBpmnElement(options?: PageWaitForSelectorOptions): Promise<void> {
-    await expect(this.currentPage).toHaveSelector(this.bpmnQuerySelectors.existingElement(), options);
+    await expect(this.page).toHaveSelector(this.bpmnQuerySelectors.existingElement(), options);
   }
 }
 

--- a/test/e2e/overlays.rendering.test.ts
+++ b/test/e2e/overlays.rendering.test.ts
@@ -139,7 +139,7 @@ async function addOverlays(bpmnElementIds: string | string[], positions: Overlay
   for (const bpmnElementId of ensureIsArray<string>(bpmnElementIds)) {
     await page.fill('#bpmn-id-input', bpmnElementId);
     for (const position of positions) {
-      await clickOnButton(position);
+      await clickOnButton(page, position);
     }
   }
 }
@@ -147,13 +147,13 @@ async function addOverlays(bpmnElementIds: string | string[], positions: Overlay
 async function addStylingOverlay(bpmnElementIds: string[], style: string): Promise<void> {
   for (const bpmnElementId of bpmnElementIds) {
     await page.fill('#bpmn-id-input', bpmnElementId);
-    await clickOnButton(style);
+    await clickOnButton(page, style);
   }
 }
 
 async function removeAllOverlays(bpmnElementId: string): Promise<void> {
   await page.fill('#bpmn-id-input', bpmnElementId);
-  await clickOnButton('clear');
+  await clickOnButton(page, 'clear');
 }
 
 const imageSnapshotConfigurator = new ImageSnapshotConfigurator(new ImageSnapshotThresholds(), 'overlays');
@@ -328,7 +328,7 @@ describe('Overlay navigation', () => {
   });
 
   it('panning', async () => {
-    await mousePanning({ originPoint: containerCenter, destinationPoint: { x: containerCenter.x + 150, y: containerCenter.y + 40 } });
+    await mousePanning(page, { originPoint: containerCenter, destinationPoint: { x: containerCenter.x + 150, y: containerCenter.y + 40 } });
 
     const image = await page.screenshot({ fullPage: true });
     const config = imageSnapshotConfigurator.getConfig(bpmnDiagramName);
@@ -339,7 +339,7 @@ describe('Overlay navigation', () => {
   });
 
   it(`zoom out`, async () => {
-    await mouseZoom(1, { x: containerCenter.x + 200, y: containerCenter.y }, 100);
+    await mouseZoom(page, 1, { x: containerCenter.x + 200, y: containerCenter.y }, 100);
 
     const image = await page.screenshot({ fullPage: true });
     const config = imageSnapshotConfigurator.getConfig(bpmnDiagramName);

--- a/test/performance/bpmn.navigation.performance.test.ts
+++ b/test/performance/bpmn.navigation.performance.test.ts
@@ -46,14 +46,14 @@ describe.each([1, 2, 3, 4, 5])('zoom performance', run => {
     const metricsStart = await metricsCollector.metrics();
 
     for (let i = 0; i < xTimes; i++) {
-      await mouseZoomNoDelay({ x: containerCenter.x + 200, y: containerCenter.y }, deltaX);
+      await mouseZoomNoDelay(page, { x: containerCenter.x + 200, y: containerCenter.y }, deltaX);
       if (i % 5 === 0) {
         await delay(30);
       }
     }
     await delay(100);
     for (let i = 0; i < xTimes; i++) {
-      await mouseZoomNoDelay({ x: containerCenter.x + 200, y: containerCenter.y }, -deltaX);
+      await mouseZoomNoDelay(page, { x: containerCenter.x + 200, y: containerCenter.y }, -deltaX);
       if (i % 5 === 0) {
         await delay(30);
       }


### PR DESCRIPTION
We don't like using globals and this change prepares an eventual move to `playwright-test` which doesn't provide a `Page` global.
Also update the `BpmnPage.page` property for consistency with other classes.