### PR TITLE
[REFACTOR] Fix remaining SonarCloud issues

### DIFF
--- a/src/component/mxgraph/BpmnMxGraph.ts
+++ b/src/component/mxgraph/BpmnMxGraph.ts
@@ -19,7 +19,6 @@ import { ensurePositiveValue, ensureValidZoomConfiguration } from '../helpers/va
 import debounce from 'lodash.debounce';
 import throttle from 'lodash.throttle';
 import { mxgraph } from './initializer';
-import type { mxMouseEvent } from 'mxgraph';
 
 export class BpmnMxGraph extends mxgraph.mxGraph {
   private cumulativeZoomFactor = 1;
@@ -135,11 +134,10 @@ export class BpmnMxGraph extends mxgraph.mxGraph {
 
   private getZoomHandler(calculateFactorOnly: boolean) {
     return (event: Event, up: boolean) => {
-      // TODO review type: this hack is due to typed-mxgraph
-      const evt = event as unknown as MouseEvent;
-      if (mxgraph.mxEvent.isConsumed(evt as unknown as mxMouseEvent)) {
+      if (mxgraph.mxEvent.isConsumed(event)) {
         return;
       }
+      const evt = event as MouseEvent;
       // only the ctrl key
       const isZoomWheelEvent = evt.ctrlKey && !evt.altKey && !evt.shiftKey && !evt.metaKey;
       if (isZoomWheelEvent) {

--- a/src/component/mxgraph/shape/event-shapes.ts
+++ b/src/component/mxgraph/shape/event-shapes.ts
@@ -85,7 +85,6 @@ export class EventShape extends mxgraph.mxEllipse {
   }
 
   override paintVertexShape(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): void {
-    this.markNonFullyRenderedEvents(c);
     const paintParameter = buildPaintParameter({ canvas: c, x, y, width: w, height: h, shape: this, isFilled: this.withFilledIcon });
 
     EventShape.setDashedOuterShapePattern(paintParameter, StyleUtils.getBpmnIsInterrupting(this.style));
@@ -93,16 +92,6 @@ export class EventShape extends mxgraph.mxEllipse {
     EventShape.restoreOriginalOuterShapePattern(paintParameter);
 
     this.paintInnerShape(paintParameter);
-  }
-
-  // This will be removed after implementation of all supported events
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  private markNonFullyRenderedEvents(c: mxAbstractCanvas2D): void {
-    // const eventDefinitionKind = StyleUtils.getBpmnEventDefinitionKind(this.style);
-    // if (eventDefinitionKind == ShapeBpmnEventDefinitionKind.CONDITIONAL) {
-    //   c.setFillColor('deeppink');
-    //   c.setFillAlpha(0.3);
-    // }
   }
 
   protected paintOuterShape({ canvas, shapeConfig: { x, y, width, height } }: PaintParameter): void {


### PR DESCRIPTION
EventShape: remove commented code. We currently have no plan about implementing the remaining event definitions. We will add the code again when/if we decide to add the missing definitions.

BpmnMxGraph: remove unnecessary cast and remove TODO.
typed-mxgraph method signature has been fixed, so we don't need the workaround we previously used.