### PR TITLE
[DOC] Reference the BPMN Support doc instead of source in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ You can find more detail in our [Contributing guide](CONTRIBUTING.md). Participa
 `bpmn-visualization` is released under the [Apache 2.0](LICENSE) license. \
 Copyright &copy; 2020-present, Bonitasoft S.A.
 
-Some BPMN icons used by `bpmn-visualization` are derived from existing projects. See the [BPMN Support page](docs/users/bpmn-support.adoc)
+Some BPMN icons used by `bpmn-visualization` are derived from existing projects. See the [BPMN Support documentation](https://process-analytics.github.io/bpmn-visualization-js/#supported-bpmn-elements)
 for more details:
 - [draw.io](https://github.com/jgraph/drawio) (Apache-2.0)
 - [flaticon](https://www.flaticon.com) ([freepikcompany license](https://www.freepikcompany.com/legal#nav-flaticon))


### PR DESCRIPTION
The README is bundled in the npm package. In that case, the other documentation
source files are not available. There are online services that use the README
as the home page of the library (npmjs, skypack and others). In that case, the
link to the BPMN Support documentation is broken.
The direct use of the documentation url fixes the issue.

See https://www.skypack.dev/view/bpmn-visualization for instance.