### PR TITLE
[TEST] Refactor the playwright configuration computation

### DIFF
--- a/test/bundles/jest-playwright.config.js
+++ b/test/bundles/jest-playwright.config.js
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-module.exports = require('../helpers/config/jest-playwright').computeConfigurationForStaticUsage();
+module.exports = require('../helpers/config/jest-playwright').computeConfiguration({ startWebServer: false, defaultBrowsers: 'chromium,firefox,webkit' });

--- a/test/e2e/config/playwright.ts
+++ b/test/e2e/config/playwright.ts
@@ -17,7 +17,6 @@ import debugLogger from 'debug';
 import 'jest-playwright-preset';
 
 // Allow getting browser console logs
-// this is from https://playwright.dev/docs/api/class-page#pageonconsole
-// see https://github.com/microsoft/playwright/issues/4498 and https://github.com/microsoft/playwright/issues/4125
+// this is from https://playwright.dev/docs/api/class-page#page-event-console
 const browserLog = debugLogger('bv:test:browser');
 page.on('console', msg => browserLog('<%s> %s', msg.type(), msg.text()));

--- a/test/e2e/jest-playwright.config.js
+++ b/test/e2e/jest-playwright.config.js
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-module.exports = require('../helpers/config/jest-playwright').computeConfigurationForDevServerUsage();
+module.exports = require('../helpers/config/jest-playwright').computeConfiguration({ defaultBrowsers: 'chromium' });

--- a/test/helpers/config/jest-playwright.js
+++ b/test/helpers/config/jest-playwright.js
@@ -37,7 +37,7 @@ const computeBrowsersAndChannelConfiguration = defaultBrowsers => {
   return config;
 };
 
-const computeLaunchOptionsAndBrowsersConfiguration = (defaultBrowsers = 'chromium,firefox,webkit') => {
+const computeLaunchOptionsAndBrowsersConfiguration = defaultBrowsers => {
   log('Computing launchOptions and browsers configuration');
 
   /** @type {import('playwright-core/types/types').LaunchOptions} */
@@ -62,32 +62,14 @@ const computeLaunchOptionsAndBrowsersConfiguration = (defaultBrowsers = 'chromiu
   return config;
 };
 
-const computeServerOptions = () => {
-  log('Computing serverOptions');
-  const options = {
-    command: `npm run start -- --config-server-port 10002`,
-    port: 10002,
-    protocol: 'http', // if default or tcp, the test starts right await whereas the dev server is not available on http
-    launchTimeout: 60000, // high value mainly for GitHub Workflows running on macOS (slow machines) and to build the bundle before start
-    debug: true,
-    usedPortAction: 'ignore', // your tests are executed, we assume that the server is already started
-  };
-  log('Computed serverOptions', options);
-  return options;
+const computeConfigurationForStaticUsage = defaultBrowsers => {
+  log('Computing configuration for static usage');
+  return computeBaseConfiguration(defaultBrowsers);
 };
 
-const computeConfigurationForStaticUsage = () => {
-  const { browsers, launchOptions } = computeLaunchOptionsAndBrowsersConfiguration();
-  return {
-    launchOptions: launchOptions,
-    browsers: browsers,
-  };
-};
-
-const computeConfigurationForDevServerUsage = defaultBrowsers => {
+const computeBaseConfiguration = defaultBrowsers => {
   const { browsers, launchOptions } = computeLaunchOptionsAndBrowsersConfiguration(defaultBrowsers);
   return {
-    serverOptions: computeServerOptions(),
     launchOptions: launchOptions,
     launchType: 'LAUNCH',
     contextOptions: {
@@ -100,5 +82,32 @@ const computeConfigurationForDevServerUsage = defaultBrowsers => {
   };
 };
 
-exports.computeConfigurationForStaticUsage = computeConfigurationForStaticUsage;
-exports.computeConfigurationForDevServerUsage = computeConfigurationForDevServerUsage;
+const computeConfigurationForDevServerUsage = defaultBrowsers => {
+  log('Computing configuration for dev server usage');
+  return {
+    ...computeBaseConfiguration(defaultBrowsers),
+    serverOptions: {
+      command: `npm run start -- --config-server-port 10002`,
+      port: 10002,
+      // if default or tcp, the test starts right await whereas the dev server is not available on http
+      // for more details, see https://github.com/process-analytics/bpmn-visualization-js/pull/1056
+      protocol: 'http',
+      launchTimeout: 60_000, // high value mainly for GitHub Workflows running on macOS (slow machines) and to build the bundle before start
+      debug: true,
+      usedPortAction: 'ignore', // your tests are executed, we assume that the server is already started
+    },
+  };
+};
+
+const computeConfiguration = options => {
+  let configuration;
+  if (options.startWebServer ?? true) {
+    configuration = computeConfigurationForDevServerUsage(options.defaultBrowsers);
+  } else {
+    configuration = computeConfigurationForStaticUsage(options.defaultBrowsers);
+  }
+  log('Computed configuration', configuration);
+  return configuration;
+};
+
+exports.computeConfiguration = computeConfiguration;

--- a/test/performance/jest-playwright.config.js
+++ b/test/performance/jest-playwright.config.js
@@ -15,4 +15,4 @@
  */
 
 // only collect on chromium for now
-module.exports = module.exports = require('../helpers/config/jest-playwright').computeConfigurationForDevServerUsage('chromium');
+module.exports = module.exports = require('../helpers/config/jest-playwright').computeConfiguration({ defaultBrowsers: 'chromium' });


### PR DESCRIPTION
Provide a single function to compute the configuration and introduce options.
Also fix the default browsers list for end-to-end tests. After the previous
refactoring, it was 'chromium,firefox,webkit' instead of 'chromium'.

Add comments to better explain
  - why we override the protocol serverOptions in the jest playwright config
  - how we retrieve the browser console logs to log them in the node console

Based in lessons learned in #1709