### PR TITLE
[TEST] Improve and refactor PageTester related code

### DIFF
--- a/test/bundles/bundles.test.ts
+++ b/test/bundles/bundles.test.ts
@@ -45,7 +45,7 @@ describe('bundles', () => {
       { pageFileName: 'lib-integration-iife', expectedPageTitle: 'BPMN Visualization IIFE bundle', bpmnContainerId: 'bpmn-container-for-iife-bundle' },
       <Page>page,
     );
-    await pageTester.loadBPMNDiagramInRefreshedPage();
+    await pageTester.gotoPageAndLoadBpmnDiagram();
 
     await pageTester.expectEvent('StartEvent_1', 'Start Event 1');
     await pageTester.expectSequenceFlow('Flow_1', 'Sequence Flow 1');
@@ -56,8 +56,8 @@ describe('bundles', () => {
 });
 
 class BpmnStaticPageSvgTester extends BpmnPageSvgTester {
-  override async loadBPMNDiagramInRefreshedPage(): Promise<void> {
-    const url = `file://${resolve(__dirname, `static/${this.targetedPage.pageFileName}.html`)}`;
-    super.doLoadBPMNDiagramInRefreshedPage(url, false);
+  override async gotoPageAndLoadBpmnDiagram(): Promise<void> {
+    const url = `file://${resolve(__dirname, `static/${this.targetedPageConfiguration.pageFileName}.html`)}`;
+    await super.doGotoPageAndLoadBpmnDiagram(url, false);
   }
 }

--- a/test/e2e/bpmn.rendering.test.ts
+++ b/test/e2e/bpmn.rendering.test.ts
@@ -339,7 +339,7 @@ describe('BPMN rendering', () => {
   });
 
   it.each(bpmnDiagramNames)(`%s`, async (bpmnDiagramName: string) => {
-    await pageTester.loadBPMNDiagramInRefreshedPage(bpmnDiagramName, {
+    await pageTester.gotoPageAndLoadBpmnDiagram(bpmnDiagramName, {
       styleOptions: styleOptionsPerDiagram.get(bpmnDiagramName),
     });
 

--- a/test/e2e/bpmn.theme.test.ts
+++ b/test/e2e/bpmn.theme.test.ts
@@ -45,7 +45,7 @@ describe('BPMN theme', () => {
   const useCases = Array.from(styleOptionsPerUseCase.keys());
 
   it.each(useCases)(`Use case %s`, async (useCase: string) => {
-    await pageTester.loadBPMNDiagramInRefreshedPage('01.most.bpmn.types.without.label', {
+    await pageTester.gotoPageAndLoadBpmnDiagram('01.most.bpmn.types.without.label', {
       styleOptions: styleOptionsPerUseCase.get(useCase),
     });
 

--- a/test/e2e/diagram.navigation.fit.test.ts
+++ b/test/e2e/diagram.navigation.fit.test.ts
@@ -18,7 +18,7 @@ import 'jest-playwright-preset';
 import { join } from 'path';
 import { Page } from 'playwright';
 import { FitType } from '../../src/component/options';
-import { clickOnButton, getBpmnDiagramNames } from './helpers/test-utils';
+import { getBpmnDiagramNames } from './helpers/test-utils';
 import { PageTester } from './helpers/visu/bpmn-page-utils';
 import { ImageSnapshotConfigurator, ImageSnapshotThresholdConfig, MultiBrowserImageSnapshotThresholds } from './helpers/visu/image-snapshot-config';
 
@@ -146,7 +146,7 @@ describe('diagram navigation - fit', () => {
   describe.each(fitTypes)('load options - fit %s', (onLoadFitType: FitType) => {
     describe.each(bpmnDiagramNames)('diagram %s', (bpmnDiagramName: string) => {
       it('load', async () => {
-        await pageTester.loadBPMNDiagramInRefreshedPage(bpmnDiagramName, {
+        await pageTester.gotoPageAndLoadBpmnDiagram(bpmnDiagramName, {
           loadOptions: {
             fit: {
               type: onLoadFitType,
@@ -165,14 +165,14 @@ describe('diagram navigation - fit', () => {
       });
 
       it.each(fitTypes)(`load + fit %s`, async (afterLoadFitType: FitType) => {
-        await pageTester.loadBPMNDiagramInRefreshedPage(bpmnDiagramName, {
+        await pageTester.gotoPageAndLoadBpmnDiagram(bpmnDiagramName, {
           loadOptions: {
             fit: {
               type: onLoadFitType,
             },
           },
         });
-        await clickOnButton(page, afterLoadFitType);
+        await pageTester.clickOnButton(afterLoadFitType);
 
         const image = await page.screenshot({ fullPage: true });
 
@@ -190,7 +190,7 @@ describe('diagram navigation - fit', () => {
         (onLoadFitType === FitType.Vertical && bpmnDiagramName === 'vertical')
       ) {
         it.each([-100, 0, 20, 50, null])('load with margin %s', async (margin: number) => {
-          await pageTester.loadBPMNDiagramInRefreshedPage(bpmnDiagramName, {
+          await pageTester.gotoPageAndLoadBpmnDiagram(bpmnDiagramName, {
             loadOptions: {
               fit: {
                 type: onLoadFitType,

--- a/test/e2e/generated.svg.test.ts
+++ b/test/e2e/generated.svg.test.ts
@@ -20,7 +20,7 @@ import { BpmnPageSvgTester } from './helpers/visu/bpmn-page-utils';
 describe('Check generated SVG in demo page', () => {
   it('should display diagram in page', async () => {
     const pageTester = new BpmnPageSvgTester({ pageFileName: 'index', expectedPageTitle: 'BPMN Visualization Demo' }, <Page>page);
-    await pageTester.loadBPMNDiagramInRefreshedPage('simple-start-task-end');
+    await pageTester.gotoPageAndLoadBpmnDiagram('simple-start-task-end');
 
     await pageTester.expectEvent('StartEvent_1', 'Start Event 1');
     await pageTester.expectSequenceFlow('Flow_1', 'Sequence Flow 1');
@@ -36,7 +36,7 @@ describe('Check generated SVG in lib-integration page', () => {
       { pageFileName: 'lib-integration', expectedPageTitle: 'BPMN Visualization Lib Integration', bpmnContainerId: 'bpmn-container-custom' },
       <Page>page,
     );
-    await pageTester.loadBPMNDiagramInRefreshedPage();
+    await pageTester.gotoPageAndLoadBpmnDiagram();
 
     await pageTester.expectEvent('StartEvent_1', 'Start Event Only');
   });

--- a/test/e2e/helpers/test-utils.ts
+++ b/test/e2e/helpers/test-utils.ts
@@ -16,16 +16,7 @@
 import debugLogger from 'debug';
 import 'jest-playwright-preset';
 import { join } from 'path';
-import { Mouse, Page } from 'playwright';
 import { findFiles } from '../../helpers/file-helper';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore js file with commonjs export
-import envUtils = require('../../helpers/environment-utils.js');
-
-export interface Point {
-  x: number;
-  y: number;
-}
 
 export const configLog = debugLogger('bv:test:config');
 
@@ -58,38 +49,4 @@ export function getBpmnDiagramNames(directoryName: string): string[] {
   return findFiles(join('../fixtures/bpmn/', directoryName))
     .filter(filename => filename.endsWith('.bpmn'))
     .map(filename => filename.split('.').slice(0, -1).join('.'));
-}
-
-export async function clickOnButton(page: Page, buttonId: string): Promise<void> {
-  await page.click(`#${buttonId}`);
-  // To unselect the button
-  await page.mouse.click(0, 0);
-}
-
-export interface PanningOptions {
-  originPoint: Point;
-  destinationPoint: Point;
-}
-
-export async function mousePanning(page: Page, { originPoint, destinationPoint }: PanningOptions): Promise<void> {
-  // simulate mouse panning
-  await page.mouse.move(originPoint.x, originPoint.y);
-  await page.mouse.down();
-  await page.mouse.move(destinationPoint.x, destinationPoint.y);
-  await page.mouse.up();
-}
-
-export async function mouseZoom(page: Page, xTimes: number, point: Point, deltaX: number): Promise<void> {
-  for (let i = 0; i < xTimes; i++) {
-    await mouseZoomNoDelay(page, point, deltaX);
-    // delay here is needed to make the tests pass on MacOS, delay must be greater than debounce timing so it surely gets triggered
-    await delay(envUtils.isRunningOnCISlowOS() ? 300 : 150);
-  }
-}
-
-export async function mouseZoomNoDelay(page: Page, point: Point, deltaX: number): Promise<void> {
-  await page.mouse.move(point.x, point.y);
-  await page.keyboard.down('Control');
-  await (page.mouse as Mouse).wheel(deltaX, 0);
-  await page.keyboard.up('Control');
 }

--- a/test/e2e/helpers/visu/bpmn-page-utils.ts
+++ b/test/e2e/helpers/visu/bpmn-page-utils.ts
@@ -14,17 +14,16 @@
  * limitations under the License.
  */
 import 'expect-playwright';
-import { ElementHandle, Page } from 'playwright';
+import { PageWaitForSelectorOptions } from 'expect-playwright';
+import { ElementHandle, Mouse, Page } from 'playwright';
 import { FitType, LoadOptions } from '../../../../src/component/options';
 import { BpmnQuerySelectorsForTests } from '../../../helpers/query-selectors';
-import { Point } from '../test-utils';
+import { delay } from '../test-utils';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore js file with commonjs export
+import envUtils = require('../../../helpers/environment-utils.js');
 
 /* eslint-disable jest/no-standalone-expect */
-
-// PageWaitForSelectorOptions is not exported by playwright
-export interface PageWaitForSelectorOptions {
-  timeout?: number;
-}
 
 class BpmnPage {
   private bpmnQuerySelectors: BpmnQuerySelectorsForTests;
@@ -49,10 +48,10 @@ class BpmnPage {
   }
 }
 
-export interface TargetedPage {
+export interface TargetedPageConfiguration {
   /** the name of the page file without extension */
   pageFileName: string;
-  /** the expected of the page title after the page loading */
+  /** the expected page title, checked after page loading */
   expectedPageTitle: string;
   /**
    * Id of the container in the page attached to bpmn-visualization
@@ -81,6 +80,16 @@ export interface PageOptions {
   styleOptions?: StyleOptions;
 }
 
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export interface PanningOptions {
+  originPoint: Point;
+  destinationPoint: Point;
+}
+
 export class PageTester {
   private readonly baseUrl: string;
   protected bpmnPage: BpmnPage;
@@ -89,25 +98,25 @@ export class PageTester {
   /**
    * Configure how the BPMN file is loaded by the test page.
    */
-  constructor(readonly targetedPage: TargetedPage, protected page: Page) {
-    const showMousePointer = targetedPage.showMousePointer ?? false;
-    this.baseUrl = `http://localhost:10002/${targetedPage.pageFileName}.html?showMousePointer=${showMousePointer}`;
-    this.bpmnContainerId = targetedPage.bpmnContainerId ?? 'bpmn-container';
+  constructor(protected targetedPageConfiguration: TargetedPageConfiguration, protected page: Page) {
+    const showMousePointer = targetedPageConfiguration.showMousePointer ?? false;
+    this.baseUrl = `http://localhost:10002/${targetedPageConfiguration.pageFileName}.html?showMousePointer=${showMousePointer}`;
+    this.bpmnContainerId = targetedPageConfiguration.bpmnContainerId ?? 'bpmn-container';
     this.bpmnPage = new BpmnPage(this.bpmnContainerId, this.page);
   }
 
-  async loadBPMNDiagramInRefreshedPage(bpmnDiagramName: string, pageOptions?: PageOptions): Promise<void> {
-    const url = this.getPageUrl(bpmnDiagramName, pageOptions?.loadOptions ?? { fit: { type: FitType.HorizontalVertical } }, pageOptions?.styleOptions);
-    await this.doLoadBPMNDiagramInRefreshedPage(url);
+  async gotoPageAndLoadBpmnDiagram(bpmnDiagramName: string, pageOptions?: PageOptions): Promise<void> {
+    const url = this.computePageUrl(bpmnDiagramName, pageOptions?.loadOptions ?? { fit: { type: FitType.HorizontalVertical } }, pageOptions?.styleOptions);
+    await this.doGotoPageAndLoadBpmnDiagram(url);
   }
 
-  protected async doLoadBPMNDiagramInRefreshedPage(url: string, checkResponseStatus = true): Promise<void> {
+  protected async doGotoPageAndLoadBpmnDiagram(url: string, checkResponseStatus = true): Promise<void> {
     const response = await this.page.goto(url);
     if (checkResponseStatus) {
       expect(response.status()).toBe(200);
     }
 
-    await this.bpmnPage.expectPageTitle(this.targetedPage.expectedPageTitle);
+    await this.bpmnPage.expectPageTitle(this.targetedPageConfiguration.expectedPageTitle);
 
     const waitForSelectorOptions = { timeout: 5_000 };
     await this.bpmnPage.expectAvailableBpmnContainer(waitForSelectorOptions);
@@ -119,7 +128,7 @@ export class PageTester {
    * @param loadOptions optional fit options
    * @param styleOptions optional style options
    */
-  private getPageUrl(bpmnDiagramName: string, loadOptions: LoadOptions, styleOptions?: StyleOptions): string {
+  private computePageUrl(bpmnDiagramName: string, loadOptions: LoadOptions, styleOptions?: StyleOptions): string {
     let url = this.baseUrl;
     url += `&fitTypeOnLoad=${loadOptions.fit?.type}&fitMargin=${loadOptions.fit?.margin}`;
     url += `&url=./static/diagrams/${bpmnDiagramName}.bpmn`;
@@ -138,19 +147,46 @@ export class PageTester {
     const rect = await containerElement.boundingBox();
     return { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 };
   }
+
+  async clickOnButton(buttonId: string): Promise<void> {
+    await this.page.click(`#${buttonId}`);
+    await this.page.mouse.click(0, 0); // Unselect the button
+  }
+
+  async mousePanning({ originPoint, destinationPoint }: PanningOptions): Promise<void> {
+    await this.page.mouse.move(originPoint.x, originPoint.y);
+    await this.page.mouse.down();
+    await this.page.mouse.move(destinationPoint.x, destinationPoint.y);
+    await this.page.mouse.up();
+  }
+
+  async mouseZoomNoDelay(point: Point, deltaX: number): Promise<void> {
+    await this.page.mouse.move(point.x, point.y);
+    await this.page.keyboard.down('Control');
+    await this.page.mouse.wheel(deltaX, 0);
+    await this.page.keyboard.up('Control');
+  }
+
+  async mouseZoom(xTimes: number, point: Point, deltaX: number): Promise<void> {
+    for (let i = 0; i < xTimes; i++) {
+      await this.mouseZoomNoDelay(point, deltaX);
+      // delay here is needed to make the tests pass on macOS, delay must be greater than debounce timing, so it surely gets triggered
+      await delay(envUtils.isRunningOnCISlowOS() ? 300 : 150);
+    }
+  }
 }
 
 export class BpmnPageSvgTester extends PageTester {
   private bpmnQuerySelectors: BpmnQuerySelectorsForTests;
 
-  constructor(targetedPage: TargetedPage, page: Page) {
+  constructor(targetedPage: TargetedPageConfiguration, page: Page) {
     super(targetedPage, page);
     // TODO duplicated with BpmnPage
     this.bpmnQuerySelectors = new BpmnQuerySelectorsForTests(this.bpmnContainerId);
   }
 
-  override async loadBPMNDiagramInRefreshedPage(bpmnDiagramName?: string): Promise<void> {
-    await super.loadBPMNDiagramInRefreshedPage(bpmnDiagramName ?? 'not-used-dedicated-diagram-loaded-by-the-page', {
+  override async gotoPageAndLoadBpmnDiagram(bpmnDiagramName?: string): Promise<void> {
+    await super.gotoPageAndLoadBpmnDiagram(bpmnDiagramName ?? 'not-used-dedicated-diagram-loaded-by-the-page', {
       loadOptions: {
         fit: {
           type: FitType.None,

--- a/test/performance/bpmn.load.performance.test.ts
+++ b/test/performance/bpmn.load.performance.test.ts
@@ -29,13 +29,12 @@ beforeAll(async () => {
   metricsCollector = await ChromiumMetricsCollector.create(<Page>page);
 });
 describe.each([1, 2, 3, 4, 5])('load performance', run => {
-  // to have mouse pointer visible during headless test - add 'showMousePointer: true' as parameter
   const pageTester = new PageTester({ pageFileName: 'diagram-navigation', expectedPageTitle: 'BPMN Visualization - Diagram Navigation' }, <Page>page);
-  const fileName = 'B.2.0';
+  const bpmnDiagramName = 'B.2.0';
 
   it('check performance for file loading and displaying diagram with FitType.HorizontalVertical', async () => {
     const metricsStart = await metricsCollector.metrics();
-    await pageTester.loadBPMNDiagramInRefreshedPage(fileName);
+    await pageTester.gotoPageAndLoadBpmnDiagram(bpmnDiagramName);
     const metricsEnd = await metricsCollector.metrics();
 
     const metric = { ...calculateMetrics(metricsStart, metricsEnd), run: run };

--- a/test/performance/bpmn.navigation.performance.test.ts
+++ b/test/performance/bpmn.navigation.performance.test.ts
@@ -15,8 +15,8 @@
  */
 import * as fs from 'fs';
 import { Page } from 'playwright';
-import { delay, getSimplePlatformName, mouseZoomNoDelay, Point } from '../e2e/helpers/test-utils';
-import { PageTester } from '../e2e/helpers/visu/bpmn-page-utils';
+import { delay, getSimplePlatformName } from '../e2e/helpers/test-utils';
+import { PageTester, Point } from '../e2e/helpers/visu/bpmn-page-utils';
 import { ChromiumMetricsCollector } from './helpers/metrics-chromium';
 import { calculateMetrics, ChartData, PerformanceMetric } from './helpers/perf-utils';
 
@@ -29,14 +29,13 @@ beforeAll(async () => {
   metricsCollector = await ChromiumMetricsCollector.create(<Page>page);
 });
 describe.each([1, 2, 3, 4, 5])('zoom performance', run => {
-  // to have mouse pointer visible during headless test - add 'showMousePointer: true' as parameter
   const pageTester = new PageTester({ pageFileName: 'diagram-navigation', expectedPageTitle: 'BPMN Visualization - Diagram Navigation' }, <Page>page);
 
-  const fileName = 'B.2.0';
+  const bpmnDiagramName = 'B.2.0';
   let containerCenter: Point;
 
   beforeEach(async () => {
-    await pageTester.loadBPMNDiagramInRefreshedPage(fileName);
+    await pageTester.gotoPageAndLoadBpmnDiagram(bpmnDiagramName);
     containerCenter = await pageTester.getContainerCenter();
   });
 
@@ -46,14 +45,14 @@ describe.each([1, 2, 3, 4, 5])('zoom performance', run => {
     const metricsStart = await metricsCollector.metrics();
 
     for (let i = 0; i < xTimes; i++) {
-      await mouseZoomNoDelay(page, { x: containerCenter.x + 200, y: containerCenter.y }, deltaX);
+      await pageTester.mouseZoomNoDelay({ x: containerCenter.x + 200, y: containerCenter.y }, deltaX);
       if (i % 5 === 0) {
         await delay(30);
       }
     }
     await delay(100);
     for (let i = 0; i < xTimes; i++) {
-      await mouseZoomNoDelay(page, { x: containerCenter.x + 200, y: containerCenter.y }, -deltaX);
+      await pageTester.mouseZoomNoDelay({ x: containerCenter.x + 200, y: containerCenter.y }, -deltaX);
       if (i % 5 === 0) {
         await delay(30);
       }


### PR DESCRIPTION
Move util functions into PageTester to better follow the Page Object pattern and
avoid having to pass the Playwright 'page' instance to each function call
  - clickOnButton
  - mousePanning
  - mouseZoomNoDelay
  - mouseZoom

Other refactor
  - Rename method loading the bpmn diagram in the newly loaded page to better
  explain the purpose of the method
  - Types and interfaces: simplification and rename

Overlays test: introduce the OverlaysPageTester class to better follow the page
object pattern and simplify function calls. The following functions are now part
of the class
  - addOverlays
  - removeAllOverlays
  - addStylingOverlay

### Resources
Playwright Page Object Models
- https://playwright.dev/docs/pom
- https://playwright.dev/docs/test-pom