### PR TITLE
[REFACTOR] Rename classes and functions related to mxGraph

### DIFF
--- a/src/component/BpmnVisualization.ts
+++ b/src/component/BpmnVisualization.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import MxGraphConfigurator from './mxgraph/MxGraphConfigurator';
+import GraphConfigurator from './mxgraph/GraphConfigurator';
 import { newBpmnRenderer } from './mxgraph/BpmnRenderer';
 import { newBpmnParser } from './parser/BpmnParser';
-import type { BpmnMxGraph } from './mxgraph/BpmnMxGraph';
+import type { BpmnGraph } from './mxgraph/BpmnGraph';
 import type { FitOptions, GlobalOptions, LoadOptions } from './options';
 import type { BpmnElementsRegistry } from './registry';
 import { newBpmnElementsRegistry } from './registry/bpmn-elements-registry';
@@ -39,7 +39,7 @@ export class BpmnVisualization {
    * It is for **advanced users**, so please use the lib API first and access to the `mxGraph` instance only when there is no alternative.
    * @experimental subject to change, could be removed or made available in another way.
    */
-  readonly graph: BpmnMxGraph;
+  readonly graph: BpmnGraph;
 
   /**
    * Interact with BPMN diagram elements rendered in the page.
@@ -51,7 +51,7 @@ export class BpmnVisualization {
 
   constructor(options: GlobalOptions) {
     // mxgraph configuration
-    const configurator = new MxGraphConfigurator(htmlElement(options?.container));
+    const configurator = new GraphConfigurator(htmlElement(options?.container));
     this.graph = configurator.configure(options);
     // other configurations
     this.bpmnModelRegistry = new BpmnModelRegistry();

--- a/src/component/mxgraph/BpmnGraph.ts
+++ b/src/component/mxgraph/BpmnGraph.ts
@@ -21,7 +21,7 @@ import debounce from 'lodash.debounce';
 import throttle from 'lodash.throttle';
 import { mxgraph } from './initializer';
 
-export class BpmnMxGraph extends mxgraph.mxGraph {
+export class BpmnGraph extends mxgraph.mxGraph {
   private cumulativeZoomFactor = 1;
 
   /**

--- a/src/component/mxgraph/BpmnRenderer.ts
+++ b/src/component/mxgraph/BpmnRenderer.ts
@@ -23,7 +23,7 @@ import CoordinatesTranslator from './renderer/CoordinatesTranslator';
 import StyleComputer from './renderer/StyleComputer';
 import { MessageFlow } from '../../model/bpmn/internal/edge/flows';
 import { MessageVisibleKind } from '../../model/bpmn/internal/edge/kinds';
-import type { BpmnMxGraph } from './BpmnMxGraph';
+import type { BpmnGraph } from './BpmnGraph';
 import type { LoadOptions } from '../options';
 import type { RenderedModel } from '../registry/bpmn-model-registry';
 import { mxgraph } from './initializer';
@@ -33,7 +33,7 @@ import type { mxCell } from 'mxgraph';
  * @internal
  */
 export class BpmnRenderer {
-  constructor(readonly graph: BpmnMxGraph, readonly coordinatesTranslator: CoordinatesTranslator, readonly styleComputer: StyleComputer) {}
+  constructor(readonly graph: BpmnGraph, readonly coordinatesTranslator: CoordinatesTranslator, readonly styleComputer: StyleComputer) {}
 
   render(renderedModel: RenderedModel, loadOptions?: LoadOptions): void {
     this.insertShapesAndEdges(renderedModel);
@@ -144,7 +144,7 @@ export class BpmnRenderer {
 /**
  * @internal
  */
-export function newBpmnRenderer(graph: BpmnMxGraph): BpmnRenderer {
+export function newBpmnRenderer(graph: BpmnGraph): BpmnRenderer {
   return new BpmnRenderer(graph, new CoordinatesTranslator(graph), new StyleComputer());
 }
 

--- a/src/component/mxgraph/GraphCellUpdater.ts
+++ b/src/component/mxgraph/GraphCellUpdater.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { BpmnMxGraph } from './BpmnMxGraph';
+import type { BpmnGraph } from './BpmnGraph';
 import { BpmnStyleIdentifier } from './style';
 import type { Overlay } from '../registry';
 import { MxGraphCustomOverlay } from './overlay/custom-overlay';
@@ -22,15 +22,15 @@ import { ensureIsArray } from '../helpers/array-utils';
 import { OverlayConverter } from './overlay/OverlayConverter';
 import { messageFowIconId } from './BpmnRenderer';
 
-export function newMxGraphCellUpdater(graph: BpmnMxGraph): MxGraphCellUpdater {
-  return new MxGraphCellUpdater(graph, new OverlayConverter());
+export function newGraphCellUpdater(graph: BpmnGraph): GraphCellUpdater {
+  return new GraphCellUpdater(graph, new OverlayConverter());
 }
 
 /**
  * @internal
  */
-export default class MxGraphCellUpdater {
-  constructor(readonly graph: BpmnMxGraph, readonly overlayConverter: OverlayConverter) {}
+export default class GraphCellUpdater {
+  constructor(readonly graph: BpmnGraph, readonly overlayConverter: OverlayConverter) {}
 
   updateAndRefreshCssClassesOfCell(bpmnElementId: string, cssClasses: string[]): void {
     this.updateAndRefreshCssClassesOfElement(bpmnElementId, cssClasses);

--- a/src/component/mxgraph/GraphConfigurator.ts
+++ b/src/component/mxgraph/GraphConfigurator.ts
@@ -18,7 +18,7 @@ import { StyleConfigurator } from './config/StyleConfigurator';
 import ShapeConfigurator from './config/ShapeConfigurator';
 import MarkerConfigurator from './config/MarkerConfigurator';
 import type { GlobalOptions } from '../options';
-import { BpmnMxGraph } from './BpmnMxGraph';
+import { BpmnGraph } from './BpmnGraph';
 import { mxgraph } from './initializer';
 import type { mxMouseEvent } from 'mxgraph';
 
@@ -30,14 +30,14 @@ import type { mxMouseEvent } from 'mxgraph';
  *     <li>markers
  * @internal
  */
-export default class MxGraphConfigurator {
-  private readonly graph: BpmnMxGraph;
+export default class GraphConfigurator {
+  private readonly graph: BpmnGraph;
 
   constructor(readonly container: HTMLElement) {
-    this.graph = new BpmnMxGraph(container);
+    this.graph = new BpmnGraph(container);
   }
 
-  configure(options: GlobalOptions): BpmnMxGraph {
+  configure(options: GlobalOptions): BpmnGraph {
     this.configureGraph();
     this.configureNavigationSupport(options);
     new StyleConfigurator(this.graph).configureStyles();
@@ -87,12 +87,12 @@ export default class MxGraphConfigurator {
     }
   }
 
-  private getPanningHandler(cursor: 'grab' | 'default'): OmitThisParameter<(this: BpmnMxGraph) => void> {
+  private getPanningHandler(cursor: 'grab' | 'default'): OmitThisParameter<(this: BpmnGraph) => void> {
     return this.getPanningHandlerCallback(cursor).bind(this.graph);
   }
 
   private getPanningHandlerCallback(cursor: 'grab' | 'default'): () => void {
-    return function (this: BpmnMxGraph): void {
+    return function (this: BpmnGraph): void {
       this.isEnabled() && (this.container.style.cursor = cursor);
     };
   }

--- a/src/component/mxgraph/config/StyleConfigurator.ts
+++ b/src/component/mxgraph/config/StyleConfigurator.ts
@@ -16,7 +16,7 @@
 
 import { AssociationDirectionKind, FlowKind, SequenceFlowKind, ShapeBpmnElementKind, ShapeUtil } from '../../../model/bpmn/internal';
 import { BpmnStyleIdentifier, MarkerIdentifier, StyleDefault } from '../style';
-import type { BpmnMxGraph } from '../BpmnMxGraph';
+import type { BpmnGraph } from '../BpmnGraph';
 import { mxgraph } from '../initializer';
 import type { mxStylesheet, StyleMap } from 'mxgraph';
 
@@ -99,7 +99,7 @@ export class StyleConfigurator {
     ],
   ]);
 
-  constructor(private graph: BpmnMxGraph) {}
+  constructor(private graph: BpmnGraph) {}
 
   configureStyles(): void {
     this.configureDefaultVertexStyle();

--- a/src/component/mxgraph/renderer/CoordinatesTranslator.ts
+++ b/src/component/mxgraph/renderer/CoordinatesTranslator.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { BpmnMxGraph } from '../BpmnMxGraph';
+import type { BpmnGraph } from '../BpmnGraph';
 import { mxgraph } from '../initializer';
 import type { mxCell, mxPoint } from 'mxgraph';
 
@@ -22,7 +22,7 @@ import type { mxCell, mxPoint } from 'mxgraph';
  * @internal
  */
 export default class CoordinatesTranslator {
-  constructor(readonly graph: BpmnMxGraph) {}
+  constructor(readonly graph: BpmnGraph) {}
 
   /**
    * Compute an absolute coordinate in relative coordinates in the parent cell referential.

--- a/src/component/registry/bpmn-elements-registry.ts
+++ b/src/component/registry/bpmn-elements-registry.ts
@@ -15,18 +15,18 @@
  */
 
 import { ensureIsArray } from '../helpers/array-utils';
-import type { BpmnMxGraph } from '../mxgraph/BpmnMxGraph';
+import type { BpmnGraph } from '../mxgraph/BpmnGraph';
 import { computeBpmnBaseClassName } from '../mxgraph/renderer/style-utils';
 import { CssRegistry } from './css-registry';
-import type MxGraphCellUpdater from '../mxgraph/MxGraphCellUpdater';
-import { newMxGraphCellUpdater } from '../mxgraph/MxGraphCellUpdater';
+import type GraphCellUpdater from '../mxgraph/GraphCellUpdater';
+import { newGraphCellUpdater } from '../mxgraph/GraphCellUpdater';
 import { BpmnQuerySelectors } from './query-selectors';
 import type { BpmnElement, Overlay } from './types';
 import type { BpmnModelRegistry } from './bpmn-model-registry';
 import type { BpmnElementKind } from '../../model/bpmn/internal';
 
-export function newBpmnElementsRegistry(bpmnModelRegistry: BpmnModelRegistry, graph: BpmnMxGraph): BpmnElementsRegistry {
-  return new BpmnElementsRegistry(bpmnModelRegistry, new HtmlElementRegistry(new BpmnQuerySelectors(graph.container?.id)), new CssRegistry(), newMxGraphCellUpdater(graph));
+export function newBpmnElementsRegistry(bpmnModelRegistry: BpmnModelRegistry, graph: BpmnGraph): BpmnElementsRegistry {
+  return new BpmnElementsRegistry(bpmnModelRegistry, new HtmlElementRegistry(new BpmnQuerySelectors(graph.container?.id)), new CssRegistry(), newGraphCellUpdater(graph));
 }
 
 /**
@@ -54,7 +54,7 @@ export class BpmnElementsRegistry {
     private bpmnModelRegistry: BpmnModelRegistry,
     private htmlElementRegistry: HtmlElementRegistry,
     private cssRegistry: CssRegistry,
-    private mxGraphCellUpdater: MxGraphCellUpdater,
+    private graphCellUpdater: GraphCellUpdater,
   ) {
     this.bpmnModelRegistry.registerOnLoadCallback(this.cssRegistry.clear.bind(this.cssRegistry));
   }
@@ -174,7 +174,7 @@ export class BpmnElementsRegistry {
   private updateCellIfChanged(updateCell: boolean, bpmnElementId: string): void {
     if (updateCell) {
       const allClassNames = this.cssRegistry.getClassNames(bpmnElementId);
-      this.mxGraphCellUpdater.updateAndRefreshCssClassesOfCell(bpmnElementId, allClassNames);
+      this.graphCellUpdater.updateAndRefreshCssClassesOfCell(bpmnElementId, allClassNames);
     }
   }
 
@@ -223,7 +223,7 @@ export class BpmnElementsRegistry {
    * @param overlays The overlays to add to the BPMN element
    */
   addOverlays(bpmnElementId: string, overlays: Overlay | Overlay[]): void {
-    this.mxGraphCellUpdater.addOverlays(bpmnElementId, overlays);
+    this.graphCellUpdater.addOverlays(bpmnElementId, overlays);
   }
 
   /**
@@ -240,7 +240,7 @@ export class BpmnElementsRegistry {
    * @param bpmnElementId The BPMN id of the element where to remove the overlays
    */
   removeAllOverlays(bpmnElementId: string): void {
-    this.mxGraphCellUpdater.removeAllOverlays(bpmnElementId);
+    this.graphCellUpdater.removeAllOverlays(bpmnElementId);
   }
 }
 


### PR DESCRIPTION
Remove the 'mx' prefix for clarity. They are stored in mxgraph sub-folders and their name is clear enough to understand they are related to mxGraph.