### PR TITLE
[INFRA] prod - Bump mxgraph from 4.1.0 to 4.2.2

### DIFF
--- a/docs/contributors/mxgraph-version-bump.md
+++ b/docs/contributors/mxgraph-version-bump.md
@@ -2,7 +2,7 @@
 
 ## Minimal check list
 
-- check the mxGraph changelog to see what could impact the lib: https://github.com/jgraph/mxgraph/blob/master/ChangeLog
+- check the [mxGraph changelog](https://github.com/jgraph/mxgraph/blob/master/ChangeLog) to see what could impact the lib
 - review issues list, in particular in the [BPMN Rendering Improvements milestone](https://github.com/process-analytics/bpmn-visualization-js/milestone/14) which could be impacted or fixed by the version bump
 - apply the version bump
 - review the overridden mxgraph code, generally, we redefine prototype, so search for the `prototype` string   

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "fast-xml-parser": "4.0.1",
         "lodash.debounce": "^4.0.8",
         "lodash.throttle": "^4.1.1",
-        "mxgraph": "4.1.0",
+        "mxgraph": "4.2.2",
         "strnum": "1.0.5"
       },
       "devDependencies": {
@@ -8290,8 +8290,10 @@
       "license": "MIT"
     },
     "node_modules/mxgraph": {
-      "version": "4.1.0",
-      "license": "Apache-2.0"
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/mxgraph/-/mxgraph-4.2.2.tgz",
+      "integrity": "sha512-FrJc5AxzXSqiQNF+8CyJk6VxuKO4UVPgw32FZuFZ3X9W+JqOAQBTokZhh0ZkEqGpEOyp3z778ssmBTvdrTAdqw==",
+      "deprecated": "Package no longer supported. Use at your own risk"
     },
     "node_modules/nanoid": {
       "version": "3.2.0",
@@ -17821,7 +17823,9 @@
       "dev": true
     },
     "mxgraph": {
-      "version": "4.1.0"
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/mxgraph/-/mxgraph-4.2.2.tgz",
+      "integrity": "sha512-FrJc5AxzXSqiQNF+8CyJk6VxuKO4UVPgw32FZuFZ3X9W+JqOAQBTokZhh0ZkEqGpEOyp3z778ssmBTvdrTAdqw=="
     },
     "nanoid": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "fast-xml-parser": "4.0.1",
     "lodash.debounce": "^4.0.8",
     "lodash.throttle": "^4.1.1",
-    "mxgraph": "4.1.0",
+    "mxgraph": "4.2.2",
     "strnum": "1.0.5"
   },
   "devDependencies": {

--- a/src/component/mxgraph/config/ShapeConfigurator.ts
+++ b/src/component/mxgraph/config/ShapeConfigurator.ts
@@ -135,8 +135,6 @@ export default class ShapeConfigurator {
       const canvas = new mxgraph.mxSvgCanvas2D(this.node, false);
       canvas.strokeTolerance = this.pointerEvents ? this.svgStrokeTolerance : 0;
       canvas.pointerEventsValue = this.svgPointerEvents;
-      // When bumping mxgraph to 4.1.1, remove this commented code. It has been removed in mxgraph@4.1.1
-      //((canvas as unknown) as mxgraph.mxSvgCanvas2D).blockImagePointerEvents = isFF;
       const off = this.getSvgScreenOffset();
 
       if (off != 0) {


### PR DESCRIPTION
**WIP - to much regression**

closes #321 
closes #919

Current status
- custom mxGraph extension has been migrated
- e2e snapshots have not been updated
- there are side effects 😠 see https://github.com/process-analytics/bpmn-visualization-js/pull/1784#issuecomment-1065273832