### PR TITLE
[INFRA] Disable dependabot PR auto rebase

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 2
     versioning-strategy: increase
+    rebase-strategy: "disabled"    
     commit-message:
       prefix: "[INFRA] prod -"
       prefix-development: "[INFRA] dev -"
@@ -20,6 +21,7 @@ updates:
       interval: "weekly"
       day: wednesday
     open-pull-requests-limit: 2
+    rebase-strategy: "disabled"    
     commit-message:
       prefix: "[INFRA] gha -"
     reviewers:


### PR DESCRIPTION
Automatic rebases triggered too much GH Actions run, in particular for PR that are on hold because they require manual tests or changes (on breaking changes).
They used a lot of runners so we had job in queue for PR that we wanted to merge in priority.
Now, we ask dependabot to rebase a PR just prior we want to merge it.

**Notes**
If validated, we should apply the same change to the website repository (and to other repo that make dependabot update the dependencies