### PR TITLE
[FEAT] Add new API to get version information

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ You can set the BPMN content using one of the following ways:
   * Load it from an url, like this [example](https://github.com/process-analytics/bpmn-visualization-examples/blob/master/examples/display-bpmn-diagram/load-remote-bpmn-diagrams/index.html)
   * Load from your computer, like the [demo example](https://github.com/process-analytics/bpmn-visualization-examples/tree/master/examples/display-bpmn-diagram/load-local-bpmn-diagrams/index.html)
 
-#### TypeScript Support
+#### 📜 TypeScript Support
 
 `bpmn-visualization` provides type definitions, so the integration should work out of the box in TypeScript projects.
 
@@ -133,7 +133,7 @@ In this case,
 Alternatively, you can set `skipLibCheck` to `true` in the `tsconfig.json` file, but this limits the definition checks.
 For more details, see the [skipLibCheck documentation](https://www.typescriptlang.org/tsconfig#skipLibCheck).
 
-Advanced users that want to extend the `mxGraph` integration must configure `typed-mxgraph`.
+Advanced users that want to extend the `mxGraph` integration must use `typed-mxgraph`.
 
 For more details, see the TypeScript projects in the [bpmn-visualization-examples repository](https://github.com/process-analytics/bpmn-visualization-examples/).
 

--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
     "docs:api": "typedoc --tsconfig ./tsconfig.typedoc.json src/bpmn-visualization.ts",
     "start": "rollup -c --silent --environment devMode:true",
     "watch": "rollup -cw --environment devLiveReloadMode:true",
-    "lint": "eslint \"*/**/*.{js,ts}\" NOTICE --max-warnings 0 --quiet --fix",
-    "lint-check": "eslint \"*/**/*.{js,ts}\" NOTICE --max-warnings 0",
+    "lint": "eslint \"*/**/*.{js,mjs,ts}\" NOTICE --max-warnings 0 --quiet --fix",
+    "lint-check": "eslint \"*/**/*.{js,mjs,ts}\" NOTICE --max-warnings 0",
     "test": "run-s test:unit test:integration test:e2e",
     "test:unit": "jest --runInBand --config=./test/unit/jest.config.js",
     "test:unit:coverage": "npm run test:unit -- --coverage",
@@ -152,7 +152,7 @@
     "typescript": "^4.5.5"
   },
   "lint-staged": {
-    "*.{js,ts,tsx}": [
+    "*.{js,mjs,ts}": [
       "eslint --fix"
     ],
     "NOTICE": [

--- a/scripts/manage-version-suffix.mjs
+++ b/scripts/manage-version-suffix.mjs
@@ -26,7 +26,7 @@ log('New version', newVersion);
 updateVersionInNpmFile('./package.json', newVersion);
 updateVersionInNpmFile('./package-lock.json', newVersion);
 updateVersionInSonarFile(newVersion);
-updateVersionInTypeScriptVersionFile(newVersion);
+updateVersionInSourceFile(newVersion);
 
 log('Configuration files have been updated');
 
@@ -64,7 +64,7 @@ function updateVersionInSonarFile(newVersion) {
   fs.writeFileSync(path, updatedContent);
 }
 
-function updateVersionInTypeScriptVersionFile(newVersion) {
+function updateVersionInSourceFile(newVersion) {
   const path = 'src/component/version.ts';
   const content = readFileContent(path);
   // replace the 1st occurrence, is ok as the constant appears only once in the file

--- a/scripts/manage-version-suffix.mjs
+++ b/scripts/manage-version-suffix.mjs
@@ -25,7 +25,8 @@ log('New version', newVersion);
 
 updateVersionInNpmFile('./package.json', newVersion);
 updateVersionInNpmFile('./package-lock.json', newVersion);
-updateVersionInSonarFile('./sonar-project.properties', newVersion);
+updateVersionInSonarFile(newVersion);
+updateVersionInTypeScriptVersionFile(newVersion);
 
 log('Configuration files have been updated');
 
@@ -34,8 +35,12 @@ function log(...data) {
   console.info(...data);
 }
 
+function readFileContent(path) {
+  return fs.readFileSync(path, 'utf8').toString();
+}
+
 function getCurrentVersion() {
-  const json = fs.readFileSync('./package.json', 'utf8').toString();
+  const json = readFileContent('./package.json');
   const pkg = JSON.parse(json);
   return pkg.version;
 }
@@ -45,15 +50,24 @@ function addOrRemoveVersionSuffix(version) {
 }
 
 function updateVersionInNpmFile(path, newVersion) {
-  const json = fs.readFileSync(path, 'utf8').toString();
+  const json = readFileContent(path);
   const pkg = JSON.parse(json);
   pkg.version = newVersion;
   fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + '\n');
 }
 
-function updateVersionInSonarFile(path, newVersion) {
-  const content = fs.readFileSync(path, 'utf8').toString();
+function updateVersionInSonarFile(newVersion) {
+  const path = './sonar-project.properties';
+  const content = readFileContent(path);
   // replace the 1st occurrence, is ok as a key appears only once in the file
   const updatedContent = content.replace(/sonar\.projectVersion=.*/, `sonar.projectVersion=${newVersion}`);
+  fs.writeFileSync(path, updatedContent);
+}
+
+function updateVersionInTypeScriptVersionFile(newVersion) {
+  const path = 'src/component/version.ts';
+  const content = readFileContent(path);
+  // replace the 1st occurrence, is ok as the constant appears only once in the file
+  const updatedContent = content.replace(/const libVersion =.*/, `const libVersion = '${newVersion}';`);
   fs.writeFileSync(path, updatedContent);
 }

--- a/src/bpmn-visualization.ts
+++ b/src/bpmn-visualization.ts
@@ -18,6 +18,7 @@
 export * from './component/options';
 export { BpmnVisualization } from './component/BpmnVisualization';
 export * from './component/registry';
+export type { Version } from './component/version';
 export * from './model/bpmn/internal';
 
 // not part of the public API but needed for the custom theme examples

--- a/src/component/BpmnVisualization.ts
+++ b/src/component/BpmnVisualization.ts
@@ -23,6 +23,7 @@ import type { BpmnElementsRegistry } from './registry';
 import { newBpmnElementsRegistry } from './registry/bpmn-elements-registry';
 import { BpmnModelRegistry } from './registry/bpmn-model-registry';
 import { htmlElement } from './helpers/dom-utils';
+import { version, type Version } from './version';
 
 /**
  * Let initialize `bpmn-visualization`. It requires at minimum to pass the HTMLElement in the page where the BPMN diagram is rendered.
@@ -72,5 +73,9 @@ export class BpmnVisualization {
 
   fit(options?: FitOptions): void {
     this.graph.customFit(options);
+  }
+
+  getVersion(): Version {
+    return version();
   }
 }

--- a/src/component/version.ts
+++ b/src/component/version.ts
@@ -18,7 +18,7 @@ import { mxgraph } from './mxgraph/initializer';
 
 // WARN: this constant is automatically updated at release time by the 'manage-version-suffix.mjs' script.
 // So, if you modify the name of this file or this constant, please update the script accordingly.
-const libVersion = '0.21.4-post';
+const libVersion = '0.21.5-post';
 
 /**
  * @internal

--- a/src/component/version.ts
+++ b/src/component/version.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2022 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mxgraph } from './mxgraph/initializer';
+
+// WARN: this constant is automatically updated at release time by the 'manage-version-suffix.mjs' script.
+// So, if you modify the name of this file or this constant, please update the script accordingly.
+const libVersion = '0.21.4-post';
+
+/**
+ * @internal
+ */
+export const version = (): Version => {
+  return { lib: libVersion, dependencies: new Map([['mxGraph', mxgraph.mxClient.VERSION]]) };
+};
+
+/**
+ * Version of `bpmn-visualization` and its dependencies.
+ * @category Initialization
+ */
+export interface Version {
+  /** The `bpmn-visualization` version. */
+  lib: string;
+  /** The version of the `bpmn-visualization` dependencies. This may **not** list all dependencies. */
+  dependencies: Map<string, string>;
+}

--- a/test/integration/BpmnVisualization.test.ts
+++ b/test/integration/BpmnVisualization.test.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { FitType } from '../../src/bpmn-visualization';
+import { FitType } from '../../src/component/options';
 import { readFileSync } from '../helpers/file-helper';
 import { initializeBpmnVisualizationWithHtmlElement } from './helpers/bpmn-visualization-initialization';
 
@@ -43,8 +43,32 @@ describe('BpmnVisualization', () => {
       ${FitType.Vertical}
     `('Fit with $fitType', ({ fitType }: { fitType: FitType }) => {
       bpmnVisualization.load(readFileSync('../fixtures/bpmn/simple-start-task-end.bpmn'));
-      // ensure not error
+      // ensure no error
       bpmnVisualization.fit({ type: fitType });
     });
   });
+
+  describe('Version', () => {
+    it('lib version', () => {
+      expect(bpmnVisualization.getVersion().lib).toBe(getLibVersionFromPackageJson());
+    });
+    it('mxGraph version', () => {
+      expect(bpmnVisualization.getVersion().dependencies.get('mxGraph')).toBeDefined();
+    });
+    it('not modifiable version', () => {
+      const initialVersion = bpmnVisualization.getVersion();
+      initialVersion.lib = 'set by test';
+      initialVersion.dependencies.set('extra', 'added in test');
+
+      const newVersion = bpmnVisualization.getVersion();
+      expect(newVersion.lib).not.toBe(initialVersion.lib);
+      expect(newVersion.dependencies).not.toBe(initialVersion.dependencies);
+    });
+  });
 });
+
+function getLibVersionFromPackageJson(): string {
+  const json = readFileSync('../../package.json');
+  const pkg = JSON.parse(json);
+  return pkg.version;
+}


### PR DESCRIPTION
Introduce the `getVersion` method to retrieve bpmn-visualization and mxGraph
version used at runtime. This should help debugging project that use newer
mxGraph version that currently cause issue like v4.2.2.

The bpmn-visualization version is automatically updated at release time by the
in-place script that already update the version of the package.json and sonar
files.
The lint configuration has been updated to ensure the script is part of the lint
process (all mjs files).

### Notes
About mxGraph@4.2.2, see https://github.com/process-analytics/bpmn-visualization-js/pull/1814#discussion_r806569775

I ran the following test
- version update: `node scripts/manage-version-suffix.mjs`
- types generation: `./node_modules/.bin/tsc --emitDeclarationOnly --declaration`
- API doc review

Other PR will be created later to use the new API in the demo and examples.