### PR TITLE
[INFRA] Improve the release-notes generation and documentation

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -44,6 +44,7 @@ categories:
       - chore
       - internal
   - title: 📦 Dependency updates
+    collapse-after: 5
     labels:
       - dependencies
 exclude-labels:
@@ -52,6 +53,10 @@ exclude-labels:
   - skip-changelog
   - reverted
   - wontfix
+# Exclude specific usernames from the generated $CONTRIBUTORS variable.
+# https://github.com/release-drafter/release-drafter/tree/master#exclude-contributors
+exclude-contributors:
+  - 'dependabot'
 template: |
   **TODO: add a short description about the release content - important for url preview**
   This new release focuses on .... **or something similar**
@@ -71,7 +76,7 @@ template: |
   $CHANGES
 
   **TODO: check previous and next tag in the link below**
-  
+
   **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$NEXT_PATCH_VERSION
 
 replacers:

--- a/.github/workflows/fill-gh-draft-release.yml
+++ b/.github/workflows/fill-gh-draft-release.yml
@@ -1,6 +1,7 @@
 name: Fill GitHub Draft Release
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
@@ -10,6 +11,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v5.19.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/contributors/maintainers.md
+++ b/docs/contributors/maintainers.md
@@ -29,7 +29,7 @@ are automated once the release is triggered but manual actions are required for:
 - A draft release for the version to be released should already exist:
   - [release-drafter](https://github.com/release-drafter/release-drafter) creates or updates draft release for the
   next version each time a pull request is merged to the `master` branch.
-  - create a new draft release if it is missing or rename the existing one to `In Progress`. The name is not relevant and will be later used to identify the draft release to update.
+  - Rename the existing draft release to `In Progress`. The name is not relevant and will be later used to identify the draft release to update.
 - Create a new draft release and name it `Next` (the name is not relevant and will be replaced automatically later).
   This ensures that development can continue without impacting the writing of the content of the `In Progress` release. That way,
   if a PR is merged, `release-drafter` will update the `Next` draft release keeping the `In Progress` release untouched.

--- a/docs/contributors/maintainers.md
+++ b/docs/contributors/maintainers.md
@@ -22,6 +22,19 @@ are automated once the release is triggered but manual actions are required for:
 
 ![release process automation overview](./images/release_process_part-01_release_automation.png)
 
+
+#### Prepare the GitHub Release
+
+- Open [github releases](https://github.com/process-analytics/bpmn-visualization-js/releases)
+- A draft release for the version to be released should already exist:
+  - [release-drafter](https://github.com/release-drafter/release-drafter) creates or updates draft release for the
+  next version each time a pull request is merged to the `master` branch.
+  - create a new draft release if it is missing or rename the existing one to `In Progress` (the name is not relevant and will be updated later).
+  The name will be used to identify the draft release to update later.
+- Create a new draft release and name it `Next` (the name is not relevant and will be replaced automatically later).
+  This ensures that development can continue without impacting the writing of the content of the `In Progress` release. That way,
+  if a PR is merged, `release-drafter` will update the `Next` draft release keeping the in-progress release untouched.
+
 #### Set the release version and create a git tag
 
 **Note:** This step triggers the release automation process.
@@ -59,17 +72,11 @@ A GitHub job is run at git tag creation, so the publishing should be done automa
   of the `Done` column related to the milestone
 
 
-### Prepare the GitHub Release
+### Continue filling the GitHub Release
 
 - Open [github releases](https://github.com/process-analytics/bpmn-visualization-js/releases)
-- Create a new draft release and name it `Next` (the name is not relevant and will be replaced automatically later).
-This ensures that development can continue without impacting the writing of the content of the in progress release. That way,
-if a PR is merged, `release-drafter` will update the `Next` draft release keeping the in-progress release untouched.
-- The draft release for the newly tagged version should already exist:
-  - [release-drafter](https://github.com/release-drafter/release-drafter) creates or updates draft release for the
-  next version each time a pull request is merged to the `master` branch.
-  - create a new release if it is missing or rename the existing one to match .
-- Assign the new tag as release target and save the draft (this should have already been managed by `release-drafter`)
+- Rename the existing `In Progress` draft release (updated before starting the release) to match the version that has just been tagged
+- Assign the new tag as release target and save the draft (this may have been already managed by `release-drafter`)
 - Ensure that `This is a pre-release` is unchecked (except if we are releasing alpha, beta, rc, ...)
 - In the release description (check previous releases as a source of inspiration)
   - at least add/update a link to the related milestone

--- a/docs/contributors/maintainers.md
+++ b/docs/contributors/maintainers.md
@@ -29,11 +29,10 @@ are automated once the release is triggered but manual actions are required for:
 - A draft release for the version to be released should already exist:
   - [release-drafter](https://github.com/release-drafter/release-drafter) creates or updates draft release for the
   next version each time a pull request is merged to the `master` branch.
-  - create a new draft release if it is missing or rename the existing one to `In Progress` (the name is not relevant and will be updated later).
-  The name will be used to identify the draft release to update later.
+  - create a new draft release if it is missing or rename the existing one to `In Progress`. The name is not relevant and will be later used to identify the draft release to update.
 - Create a new draft release and name it `Next` (the name is not relevant and will be replaced automatically later).
   This ensures that development can continue without impacting the writing of the content of the `In Progress` release. That way,
-  if a PR is merged, `release-drafter` will update the `Next` draft release keeping the in-progress release untouched.
+  if a PR is merged, `release-drafter` will update the `Next` draft release keeping the `In Progress` release untouched.
 
 #### Set the release version and create a git tag
 


### PR DESCRIPTION
`release-drafter` configuration
  - use a specific action version to better control updates and the use of new features. dependabot will create PR for action updates when new release-drafter releases are available
  - 'Dependencies' category: collapsed if more than 5 elements
  - exclude dependabot from the CONTRIBUTORS list. We removed it manually on every release so make it automatically
  - allow running release-drafter on demand. This is useful to fix the release notes after PR relabel

Release documentation
Update the documentation of the release procedure for the GitHub release update
It should help us to detect wrong updates by release-drafter and loosing work because it overrides our manual edits.


**Notes**
During the release of verison 0.22.0, release-drafter override manual edits we were doing. The change proposed here should avoid this in the future