### PR TITLE
[INFRA] Improve contributors list detection by release-drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -56,7 +56,9 @@ exclude-labels:
 # Exclude specific usernames from the generated $CONTRIBUTORS variable.
 # https://github.com/release-drafter/release-drafter/tree/master#exclude-contributors
 exclude-contributors:
-  - 'dependabot[bot]'
+#  - 'dependabot[bot]'
+#  - '@dependabot'
+  - '@dependabot[bot]'
 template: |
   **TODO: add a short description about the release content - important for url preview**
   This new release focuses on .... **or something similar**

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -56,7 +56,7 @@ exclude-labels:
 # Exclude specific usernames from the generated $CONTRIBUTORS variable.
 # https://github.com/release-drafter/release-drafter/tree/master#exclude-contributors
 exclude-contributors:
-  - 'dependabot'
+  - 'dependabot[bot]'
 template: |
   **TODO: add a short description about the release content - important for url preview**
   This new release focuses on .... **or something similar**
@@ -79,8 +79,8 @@ template: |
 
   **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$NEXT_PATCH_VERSION
 
-replacers:
-  - search: '@dependabot-preview'
-    replace: '@dependabot'
-  - search: '@dependabot[bot]'
-    replace: '@dependabot'
+#replacers:
+#  - search: '@dependabot-preview'
+#    replace: '@dependabot'
+#  - search: '@dependabot[bot]'
+#    replace: '@dependabot'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -60,7 +60,6 @@ exclude-contributors:
 #  - '@dependabot'
   - '@dependabot[bot]'
 template: |
-  WIP from PR
   **TODO: add a short description about the release content - important for url preview**
   This new release focuses on .... **or something similar**
 

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -60,6 +60,7 @@ exclude-contributors:
 #  - '@dependabot'
   - '@dependabot[bot]'
 template: |
+  WIP from PR
   **TODO: add a short description about the release content - important for url preview**
   This new release focuses on .... **or something similar**
 

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -56,9 +56,8 @@ exclude-labels:
 # Exclude specific usernames from the generated $CONTRIBUTORS variable.
 # https://github.com/release-drafter/release-drafter/tree/master#exclude-contributors
 exclude-contributors:
-#  - 'dependabot[bot]'
-#  - '@dependabot'
-  - '@dependabot[bot]'
+  - 'dependabot'
+  - 'dependabot[bot]'
 template: |
   **TODO: add a short description about the release content - important for url preview**
   This new release focuses on .... **or something similar**
@@ -80,9 +79,3 @@ template: |
   **TODO: check previous and next tag in the link below**
 
   **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$NEXT_PATCH_VERSION
-
-#replacers:
-#  - search: '@dependabot-preview'
-#    replace: '@dependabot'
-#  - search: '@dependabot[bot]'
-#    replace: '@dependabot'


### PR DESCRIPTION
- remove dependabot from the contributors list
- don't replace dependabot user (no impact in the dependencies list but avoid side effects in the contributors list removal)

### Notes

Tested in https://github.com/process-analytics/github-actions-playground/ (see https://github.com/process-analytics/github-actions-playground/pull/40 and https://github.com/process-analytics/github-actions-playground/pull/41 + the generated draft)

before | now
-------- | --------
![image](https://user-images.githubusercontent.com/27200110/157461667-69ea93ad-69c0-4145-be48-814833a74579.png) | ![image](https://user-images.githubusercontent.com/27200110/157497653-e80a1878-0fb4-4a85-9628-9f672bf555e9.png)

