### PR TITLE
[INFRA] Do not fail when surge teardown fails

### DIFF
--- a/.github/workflows/generate-demo-preview.yml
+++ b/.github/workflows/generate-demo-preview.yml
@@ -52,5 +52,4 @@ jobs:
           failOnError: ${{ github.event.action != 'closed' }} # Do not fail when closing PR (the PR may not create the deployment, in particular, when the PR has been created by dependabot)
           teardown: 'true'
           build: |
-            npm ci
-            npm run demo
+            do_not_exist

--- a/.github/workflows/generate-demo-preview.yml
+++ b/.github/workflows/generate-demo-preview.yml
@@ -49,7 +49,7 @@ jobs:
           surge_token: ${{ secrets.SURGE_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           dist: build/demo
-          failOnError: true
+          failOnError: ${{ github.event.action != 'closed' }} # Do not fail when closing PR (the PR may not create the deployment, in particular, when the PR has been created by dependabot)
           teardown: 'true'
           build: |
             npm ci

--- a/.github/workflows/generate-demo-preview.yml
+++ b/.github/workflows/generate-demo-preview.yml
@@ -52,4 +52,4 @@ jobs:
           failOnError: ${{ github.event.action != 'closed' }} # Do not fail when closing PR (the PR may not create the deployment, in particular, when the PR has been created by dependabot)
           teardown: 'true'
           build: |
-            do_not_exist
+            exit -1

--- a/.github/workflows/generate-demo-preview.yml
+++ b/.github/workflows/generate-demo-preview.yml
@@ -52,4 +52,5 @@ jobs:
           failOnError: ${{ github.event.action != 'closed' }} # Do not fail when closing PR (the PR may not create the deployment, in particular, when the PR has been created by dependabot)
           teardown: 'true'
           build: |
-            exit -1
+            npm ci
+            npm run demo

--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -61,7 +61,7 @@ jobs:
           dist: build/docs
           failOnError: ${{ github.event.action != 'closed' }} # Do not fail when closing PR (the PR may not create the deployment, in particular, when the PR has been created by dependabot)
           build: |
-            do_not_exist
+            exit -1
 
   generate_doc:
     if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&  github.event.ref == 'refs/heads/master'

--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -59,8 +59,7 @@ jobs:
           surge_token: ${{ secrets.SURGE_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           dist: build/docs
-          failOnError: true
-          teardown: 'true'
+          failOnError: ${{ github.event.action != 'closed' }} # Do not fail when closing PR (the PR may not create the deployment, in particular, when the PR has been created by dependabot)
           build: |
             npm ci
             npm run docs

--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -61,8 +61,7 @@ jobs:
           dist: build/docs
           failOnError: ${{ github.event.action != 'closed' }} # Do not fail when closing PR (the PR may not create the deployment, in particular, when the PR has been created by dependabot)
           build: |
-            npm ci
-            npm run docs
+            do_not_exist
 
   generate_doc:
     if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&  github.event.ref == 'refs/heads/master'

--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -61,7 +61,8 @@ jobs:
           dist: build/docs
           failOnError: ${{ github.event.action != 'closed' }} # Do not fail when closing PR (the PR may not create the deployment, in particular, when the PR has been created by dependabot)
           build: |
-            exit -1
+            npm ci
+            npm run docs
 
   generate_doc:
     if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&  github.event.ref == 'refs/heads/master'


### PR DESCRIPTION
When a Pull Request is created by dependabot or an external contributor, the
deployments are not created. But when the PR is merged or closed by a repository
collaborator, the teardown is triggered. As there is no deployment, the teardown
fails.
Previously, this mark the workflow execution in error. Now, we don't fail on
error anymore because we don't really care.
We have a scheduled task that regularly teardown old surge deployments, so we
know they will be removed later.


### Notes

Tests done with f85958a
- PR change surge deploy fails on error `failOnError: true`: [Generate Demo Preview](https://github.com/process-analytics/bpmn-visualization-js/runs/5494500422?check_suite_focus=true) and [Generate Documentation](https://github.com/process-analytics/bpmn-visualization-js/runs/5494500808?check_suite_focus=true)
- PR closed: `failOnError: false` https://github.com/process-analytics/bpmn-visualization-js/runs/5494553629?check_suite_focus=true but the workflow run is marked as failed! 😠  --> not working so closing the PR, and stop investigating