### PR TITLE
[INFRA] Declare `typed-mxgraph` in production dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,7 @@ Depending on the build system used by the TypeScript project, it may get the fol
 - error TS7016: Could not find a declaration file for module 'mxgraph'
 
 In this case, 
-- Install `@typed-mxgraph/typed-mxgraph` as devDependencies, for instance by running `npm i --save-dev @typed-mxgraph/typed-mxgraph@1.0.4`
-- Declare the `typed-mxgraph` types in the `tsconfig.json` as in the following 👇
+- Declare the `typed-mxgraph` types in the `tsconfig.json` as in the following (see the [typeRoots](https://www.typescriptlang.org/tsconfig#typeRoots) documentation for more explanations) 👇
 
 ```json
 {
@@ -133,7 +132,7 @@ In this case,
 Alternatively, you can set `skipLibCheck` to `true` in the `tsconfig.json` file, but this limits the definition checks.
 For more details, see the [skipLibCheck documentation](https://www.typescriptlang.org/tsconfig#skipLibCheck).
 
-Advanced users that want to extend the `mxGraph` integration must use `typed-mxgraph`.
+Advanced users that want to extend the `mxGraph` integration must add `typed-mxgraph` to `typeRoots`.
 
 For more details, see the TypeScript projects in the [bpmn-visualization-examples repository](https://github.com/process-analytics/bpmn-visualization-examples/).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.22.0-post",
       "license": "Apache-2.0",
       "dependencies": {
+        "@typed-mxgraph/typed-mxgraph": "^1.0.4",
         "entities": "^3.0.1",
         "fast-xml-parser": "4.0.6",
         "lodash.debounce": "^4.0.8",
@@ -19,7 +20,6 @@
       "devDependencies": {
         "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-node-resolve": "^13.1.3",
-        "@typed-mxgraph/typed-mxgraph": "^1.0.4",
         "@types/debug": "^4.1.7",
         "@types/jest": "^27.4.1",
         "@types/jest-image-snapshot": "^4.3.1",
@@ -2355,7 +2355,6 @@
     },
     "node_modules/@typed-mxgraph/typed-mxgraph": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "mxgraph": "^4.2.2"
@@ -13667,7 +13666,6 @@
     },
     "@typed-mxgraph/typed-mxgraph": {
       "version": "1.0.4",
-      "dev": true,
       "requires": {}
     },
     "@types/babel__core": {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
+    "@typed-mxgraph/typed-mxgraph": "^1.0.4",
     "entities": "^3.0.1",
     "fast-xml-parser": "4.0.6",
     "lodash.debounce": "^4.0.8",
@@ -94,7 +95,6 @@
   "devDependencies": {
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^13.1.3",
-    "@typed-mxgraph/typed-mxgraph": "^1.0.4",
     "@types/debug": "^4.1.7",
     "@types/jest": "^27.4.1",
     "@types/jest-image-snapshot": "^4.3.1",


### PR DESCRIPTION
Some exported types like `BpmnCanvas` references mxgraph types
`/// <reference types="typed-mxgraph" />`

These forced project integrating bpmn-visualization to manually declare
typed-mxgraph as dependency to not get TypeScript type errors.
Declaring it as a production dependency makes it automatically available to
project and simplify their configuration.

### Notes
This is the use case described in https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#dependencies
I also test the change with the TS vite project in the examples repository.


https://github.com/microsoft/TypeScript-Website/blob/377bb75d61ca12717c043b3c539b8f81d4c111ac/packages/documentation/copy/en/declaration-files/Publishing.md#dependencies
```json
{
  "name": "browserify-typescript-extension",
  "author": "Vandelay Industries",
  "version": "1.0.0",
  "main": "./lib/main.js",
  "types": "./lib/main.d.ts",
  "dependencies": {
    "browserify": "latest",
    "@types/browserify": "latest",
    "typescript": "next"
  }
}
```

> Here, our package depends on the `browserify` and `typescript` packages.
`browserify` does not bundle its declaration files with its npm packages, so we needed to depend on `@types/browserify` for its declarations.
`typescript`, on the other hand, packages its declaration files, so there was no need for any additional dependencies.
>
> Our package exposes declarations from each of those, so any user of our `browserify-typescript-extension` package needs to have these dependencies as well.
For that reason, we used `"dependencies"` and not `"devDependencies"`, because otherwise our consumers would have needed to manually install those packages.
If we had just written a command line application and not expected our package to be used as a library, we might have used `devDependencies`.
