### PR TITLE
[INFRA] prod - Bump typed-mxgraph from 1.0.4 to 1.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.22.0-post",
       "license": "Apache-2.0",
       "dependencies": {
-        "@typed-mxgraph/typed-mxgraph": "^1.0.4",
+        "@typed-mxgraph/typed-mxgraph": "^1.0.5",
         "entities": "^3.0.1",
         "fast-xml-parser": "4.0.6",
         "lodash.debounce": "^4.0.8",
@@ -2345,11 +2345,9 @@
       }
     },
     "node_modules/@typed-mxgraph/typed-mxgraph": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "peerDependencies": {
-        "mxgraph": "^4.2.2"
-      }
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@typed-mxgraph/typed-mxgraph/-/typed-mxgraph-1.0.5.tgz",
+      "integrity": "sha512-yJAFy5wLFmImBLAAUPtlnoN4r6JSnwM3466ubdaL5accJOmrHZ5gwGTZFNc7zAMtxfDN8sbEkNND3tZRilcRWg=="
     },
     "node_modules/@types/babel__core": {
       "version": "7.1.18",
@@ -13648,8 +13646,9 @@
       }
     },
     "@typed-mxgraph/typed-mxgraph": {
-      "version": "1.0.4",
-      "requires": {}
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@typed-mxgraph/typed-mxgraph/-/typed-mxgraph-1.0.5.tgz",
+      "integrity": "sha512-yJAFy5wLFmImBLAAUPtlnoN4r6JSnwM3466ubdaL5accJOmrHZ5gwGTZFNc7zAMtxfDN8sbEkNND3tZRilcRWg=="
     },
     "@types/babel__core": {
       "version": "7.1.18",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "@typed-mxgraph/typed-mxgraph": "^1.0.4",
+    "@typed-mxgraph/typed-mxgraph": "^1.0.5",
     "entities": "^3.0.1",
     "fast-xml-parser": "4.0.6",
     "lodash.debounce": "^4.0.8",


### PR DESCRIPTION
With this release, typed-mxgraph doesn't declare mxgraph as peerDependencies.
This should avoid side effects on project that need to directly use mxgraph, for instance for extension.

**Notes**
typed-mxgraph@1.0.5 release notes: https://github.com/typed-mxgraph/typed-mxgraph/releases/tag/v1.0.5
About the peerDependencies, see https://github.com/process-analytics/bpmn-visualization-examples/pull/297#issuecomment-1060522329
