### PR TITLE
[EXAMPLE] Better highlight conditional and default sequence flows

### DIFF
--- a/dev/public/elements-identification.html
+++ b/dev/public/elements-identification.html
@@ -59,6 +59,10 @@
       }
       /* sequence flow arrow */
       .bpmn-sequence-flow.detection > path:nth-child(3),
+      /* sequence flow arrow for conditional */
+      .bpmn-sequence-flow.detection > path:nth-child(4),
+      /* sequence flow arrow for default  */
+      .bpmn-sequence-flow.detection > path:nth-child(5),
       /* message flow start */
       .bpmn-message-flow.detection > ellipse,
       /* message flow arrow */
@@ -69,6 +73,10 @@
       .bpmn-sequence-flow.detection > path:nth-child(2),
        /* sequence flow arrow */
       .bpmn-sequence-flow.detection > path:nth-child(3),
+        /* sequence flow arrow for conditional and sequence flow default marker */
+      .bpmn-sequence-flow.detection > path:nth-child(4),
+        /* sequence flow arrow for default  */
+      .bpmn-sequence-flow.detection > path:nth-child(5),
         /* message flow start marker */
       .bpmn-message-flow.detection > ellipse,
         /* message flow line */


### PR DESCRIPTION
The following elements weren't highlighted in the past implementation of `elements-identification.html`:
  - conditional: arrow
  - default: marker and arrow

### Screenshots

With the `test/fixtures/bpmn/non-regression/flows.sequence.01.kinds.and.complex.paths.bpmn` diagram

before | now
------- | -------
 ![hightlight_01_before](https://user-images.githubusercontent.com/27200110/158408482-db53f91c-2157-4328-9952-a775d006bb09.png) | ![hightlight_02_after](https://user-images.githubusercontent.com/27200110/158408527-e29e034a-caf9-4ceb-bc2f-1a94b712e9a5.png)
 