### PR TITLE
[INFRA] Fix the release GitHub workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "test:bundles": "jest --runInBand --detectOpenHandles --config=./test/bundles/jest.config.js",
     "test:bundles:verbose": "cross-env DEBUG=bv:*,pw:browser* npm run test:bundles",
     "version-prepare": "node scripts/manage-version-in-files.mjs && git commit --no-verify -a -m \"[RELEASE] Prepare version for release\"",
-    "version": "cross-env IS_RELEASING=true node scripts/manage-version-in-files.mjs && git add .",
+    "version": "IS_RELEASING=true node scripts/manage-version-in-files.mjs && git add .",
     "postversion": "node scripts/manage-version-in-files.mjs && git commit --no-verify -a -m \"[RELEASE] Prepare version for new developments\"",
     "prepublishOnly": "pinst --disable",
     "postpublish": "pinst --enable",

--- a/scripts/manage-version-in-files.mjs
+++ b/scripts/manage-version-in-files.mjs
@@ -23,7 +23,7 @@ if (process.env.IS_RELEASING) {
 }
 
 function updateVersionInFilesOnRelease() {
-  log('Updating version in files on release');
+  log('Updating version in files for release');
   const currentVersion = getCurrentVersion();
   log('Current version', currentVersion);
   updateVersionInSourceFile(currentVersion);


### PR DESCRIPTION
Remove the call to the `cross-env `command from the custom npm `version` script as it is not available at runtime in the release GitHub workflow.
Dependencies are not available as we are not running `npm ci` prior running `npm version`.
We are now using the Linux syntax which is not an issue as we always run the npm script from the GitHub workflow (never run locally).

### Notes

Refs #1858
Tested by running `npm run version-prepare && npm version patch --no-commit-hooks --message "[RELEASE] %s"` on  Ubuntu 20.04.4 LTS

![version_update_on_release](https://user-images.githubusercontent.com/27200110/159240135-0f09f381-7edd-4cf5-b4e0-71ddb61266c5.png)

