### PR TITLE
[DOC] Improve the gateways icons of the 'BPMN Support' paragraph

### DIFF
--- a/docs/users/bpmn-support.adoc
+++ b/docs/users/bpmn-support.adoc
@@ -571,7 +571,7 @@ The event definition can be defined on the event or on the definitions.
 
 .^|Event-Based
 ^.^|icon:check-circle-o[]
-^.^|image:images/icons/gateway_event_based.svg[Event-Based icon,30]
+^.^|image:images/icons/gateway_event_based.svg[Event-Based icon,30] image:images/icons/gateway_event_based_exclusive.svg[Exclusive Event-Based icon,30] image:images/icons/gateway_event_based_parallel.svg[Parallel Event-Based icon,30]
 .^|Support the `event gateway type` (Exclusive and Parallel) and the `instantiate` status
 |===
 

--- a/docs/users/images/icons/gateway_event_based.svg
+++ b/docs/users/images/icons/gateway_event_based.svg
@@ -1,17 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   viewBox="0 0 53.657318 53.602362"
-   version="1.1"
-   id="svg192"
-   width="53.657318"
-   height="53.60236"
-   xmlns="http://www.w3.org/2000/svg">
-  <path
-     d="m 51.398658,22.472361 -24.57,-19.9599998 -24.5699997,19.9599998 9.2099997,29.18 h 30.72 l 9.21,-29.18 -24.57,-19.9599998"
-     fill="none"
-     stroke="#000000"
-     stroke-width="3.9"
-     stroke-miterlimit="10"
-     pointer-events="all"
-     id="path190" />
+<svg viewBox="0 0 158.323 158.485" width="96" height="96" xmlns="http://www.w3.org/2000/svg">
+  <g transform="translate(-54.975 -540.757)" stroke="#000" pointer-events="all">
+    <path d="M133.5 545l75 75-75 75-75-75z" fill="#fff" stroke-width="6" stroke-miterlimit="10"/>
+    <circle cx="133.5" cy="620" fill="none" stroke-width="3" r="41.25"/>
+    <circle cx="133.5" cy="620" fill="none" stroke-width="3" r="33.75"/>
+    <path d="M156 615.78l-22.5-18.28-22.5 18.28 8.44 26.72h28.12l8.44-26.72-22.5-18.28" fill="none" stroke-width="3" stroke-miterlimit="10"/>
+  </g>
 </svg>

--- a/docs/users/images/icons/gateway_event_based_exclusive.svg
+++ b/docs/users/images/icons/gateway_event_based_exclusive.svg
@@ -1,0 +1,7 @@
+<svg viewBox="0 0 158.485 158.485" width="96" height="96" xmlns="http://www.w3.org/2000/svg">
+  <g transform="translate(-354.257 -540.757)" stroke="#000" pointer-events="all">
+    <path d="M433.5 545l75 75-75 75-75-75z" fill="#fff" stroke-width="6" stroke-miterlimit="10"/>
+    <circle cx="433.5" cy="620" fill="none" stroke-width="3" r="41.25"/>
+    <path d="M456 615.78l-22.5-18.28-22.5 18.28 8.44 26.72h28.12l8.44-26.72-22.5-18.28" fill="none" stroke-width="3" stroke-miterlimit="10"/>
+  </g>
+</svg>

--- a/docs/users/images/icons/gateway_event_based_parallel.svg
+++ b/docs/users/images/icons/gateway_event_based_parallel.svg
@@ -1,0 +1,7 @@
+<svg viewBox="0 0 158.485 158.485" width="96" height="96" xmlns="http://www.w3.org/2000/svg">
+  <g transform="translate(-624.257 -540.757)" stroke="#000" pointer-events="all">
+    <path d="M703.5 545l75 75-75 75-75-75z" fill="#fff" stroke-width="6" stroke-miterlimit="10"/>
+    <circle cx="703.5" cy="620" fill="none" stroke-width="3" r="41.25"/>
+    <path d="M698.1 597.5h10.8v17.1H726v10.8h-17.1v17.1h-10.8v-17.1H681v-10.8h17.1z" fill="#fff" stroke-width="3" stroke-miterlimit="10"/>
+  </g>
+</svg>

--- a/docs/users/images/icons/gateway_exclusive.svg
+++ b/docs/users/images/icons/gateway_exclusive.svg
@@ -1,16 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   viewBox="0 0 73.227982 73.227984"
-   version="1.1"
-   id="svg3588"
-   width="73.227982"
-   height="73.227982"
-   xmlns="http://www.w3.org/2000/svg">
-  <path
-     d="M 58.619152,0.70710678 72.520871,14.608826 50.515708,36.613989 72.520871,58.619152 58.626223,72.5138 36.62106,50.508637 14.608826,72.520871 0.70710678,58.619152 22.719341,36.606918 0.71417785,14.601755 14.608826,0.70710678 36.613989,22.71227 Z"
-     fill="#000000"
-     stroke="#000000"
-     stroke-miterlimit="10"
-     pointer-events="all"
-     id="path3586" />
+<svg viewBox="0 0 158.485 158.485" width="96" height="96" xmlns="http://www.w3.org/2000/svg">
+  <path d="M79.243 4.243l75 75-75 75-75-75z" fill="#fff" stroke="#000" stroke-width="6" stroke-miterlimit="10" pointer-events="all"/>
+  <path d="M99.395 46.362l12.728 12.728-20.152 20.153 20.152 20.152-12.728 12.728-20.152-20.152-20.153 20.152-12.728-12.728 20.153-20.152L46.362 59.09 59.09 46.362l20.153 20.153z" stroke="#000" stroke-miterlimit="10" pointer-events="all"/>
 </svg>

--- a/docs/users/images/icons/gateway_inclusive.svg
+++ b/docs/users/images/icons/gateway_inclusive.svg
@@ -1,18 +1,6 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   viewBox="0 0 89.856004 89.856004"
-   version="1.1"
-   id="svg269"
-   width="89.856003"
-   height="89.856003"
-   xmlns="http://www.w3.org/2000/svg">
-  <circle
-     cx="44.928001"
-     cy="44.928001"
-     fill="none"
-     stroke="#000000"
-     stroke-width="19.5"
-     pointer-events="all"
-     id="ellipse151"
-     r="35.178001" />
+<svg viewBox="0 0 158.485 158.485" width="96" height="96" xmlns="http://www.w3.org/2000/svg">
+  <g stroke="#000" pointer-events="all" transform="translate(-54.257 -300.757)">
+    <path d="M133.5 305l75 75-75 75-75-75z" fill="#fff" stroke-width="6" stroke-miterlimit="10"/>
+    <circle cx="133.5" cy="380" fill="none" stroke-width="15" r="34.5"/>
+  </g>
 </svg>

--- a/docs/users/images/icons/gateway_parallel.svg
+++ b/docs/users/images/icons/gateway_parallel.svg
@@ -1,16 +1,6 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   viewBox="0 0 82.900002 82.900005"
-   version="1.1"
-   id="svg277"
-   width="82.900002"
-   height="82.900002"
-   xmlns="http://www.w3.org/2000/svg">
-  <path
-     d="M 31.62,0.5 H 51.28 V 31.62 H 82.4 V 51.27 H 51.28 V 82.4 H 31.62 V 51.27 H 0.5 V 31.62 h 31.12 z"
-     fill="#000000"
-     stroke="#000000"
-     stroke-miterlimit="10"
-     pointer-events="all"
-     id="path275" />
+<svg viewBox="0 0 158.485 158.485" width="96" height="96" xmlns="http://www.w3.org/2000/svg">
+  <g stroke="#000" stroke-miterlimit="10" pointer-events="all">
+    <path d="M79.243 4.243l75 75-75 75-75-75z" fill="#fff" stroke-width="6"/>
+    <path d="M70.243 41.743h18v28.5h28.5v18h-28.5v28.5h-18v-28.5h-28.5v-18h28.5z"/>
+  </g>
 </svg>


### PR DESCRIPTION
Display the gateway diamond around the marker for clarity
Add the exclusive and parallel event based gateway icons

### Screenshots

before | now
------ | -----------
![image](https://user-images.githubusercontent.com/27200110/159972658-926c9403-1aa3-44ee-b6fd-ab15509e1d06.png) | ![image](https://user-images.githubusercontent.com/27200110/159972667-1d8dcb95-8547-405d-aeeb-4cf355a00ed4.png)
