### PR TITLE
[INFRA] Remove declaration of the rollup json plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "strnum": "1.0.5"
       },
       "devDependencies": {
-        "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-node-resolve": "^13.2.1",
         "@types/debug": "^4.1.7",
         "@types/jest": "^27.4.1",
@@ -2218,17 +2217,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@rollup/plugin-json": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rollup/pluginutils": "^3.0.8"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0 || ^2.0.0"
       }
     },
     "node_modules/@rollup/plugin-node-resolve": {
@@ -13575,13 +13563,6 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
-      }
-    },
-    "@rollup/plugin-json": {
-      "version": "4.1.0",
-      "dev": true,
-      "requires": {
-        "@rollup/pluginutils": "^3.0.8"
       }
     },
     "@rollup/plugin-node-resolve": {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "strnum": "1.0.5"
   },
   "devDependencies": {
-    "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^13.2.1",
     "@types/debug": "^4.1.7",
     "@types/jest": "^27.4.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -26,7 +26,6 @@ import typescript from 'rollup-plugin-typescript2';
 import commonjs from 'rollup-plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
 import pkg from './package.json';
-import json from '@rollup/plugin-json';
 
 import parseArgs from 'minimist';
 
@@ -67,7 +66,6 @@ if (!buildBundles) {
     // the 'resolve' and 'commonjs' plugins ensure we can bundle commonjs dependencies
     resolve(),
     commonjs(),
-    json(),
     // to have sizes of dependencies listed at the end of build log
     sizes(),
   ];
@@ -93,7 +91,6 @@ if (!buildBundles) {
 
   const pluginsBundles = [
     typescriptPlugin(),
-    json(),
     // ensure we do not bundle dependencies
     autoExternal(),
     // to have sizes of dependencies listed at the end of build log
@@ -161,7 +158,7 @@ function withMinification(plugins) {
 }
 
 function pluginsForDevelopment() {
-  const plugins = [typescriptPlugin(), resolve(), commonjs(), json()];
+  const plugins = [typescriptPlugin(), resolve(), commonjs()];
 
   // Copy static resources
   if (devMode || demoMode) {

--- a/utils.rollup.config.mjs
+++ b/utils.rollup.config.mjs
@@ -16,7 +16,6 @@
 import typescript from 'rollup-plugin-typescript2';
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
-import json from '@rollup/plugin-json';
 import externals from 'rollup-plugin-node-externals';
 import ts from 'typescript';
 
@@ -30,7 +29,6 @@ const plugins = [
   }),
   resolve(),
   commonjs(),
-  json(),
 ];
 export default {
   input: 'scripts/utils/parseBpmn.ts',


### PR DESCRIPTION
We don't import json resources in the code, so this plugin is useless. Removing it from the Rollup
configuration simplify the maintenance (smaller configuration file, less development dependencies).