### PR TITLE
[POC] Test new public beta of macOS 12 for Github-hosted runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         # syntax inspired from https://github.community/t5/GitHub-Actions/Using-a-matrix-defined-input-for-a-custom-action/m-p/32032/highlight/true#M988
         os:
           - { name: ubuntu-20.04, coverage: '-- --coverage' }
-          - { name: macos-11 }
+          - { name: macos-12 }
           - { name: windows-2019 }
     steps:
       - name: Checkout with shallow clone
@@ -110,11 +110,11 @@ jobs:
       # don't cancel running jobs even if one fails
       fail-fast: false
       matrix:
-        os: [macos-11, ubuntu-20.04, windows-2019]
+        os: [macos-12, ubuntu-20.04, windows-2019]
         browser: [chromium, firefox, chrome]
         include:
           # only test WebKit on macOS
-          - os: macos-11
+          - os: macos-12
             browser: webkit
           # only test Edge on Windows
           - os: windows-2019

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -35,12 +35,12 @@ jobs:
       # we want to run the full build on all os: don't cancel running jobs even if one fails
       fail-fast: false
       matrix:
-        os: [macos-11, ubuntu-20.04, windows-2019]
+        os: [macos-12, ubuntu-20.04, windows-2019]
         # TODO activate chrome, see https://github.com/process-analytics/bpmn-visualization-js/issues/1933
         browser: [chromium, firefox]
         include:
           # only test WebKit on macOS
-          - os: macos-11
+          - os: macos-12
             browser: webkit
           # TODO activate edge, see https://github.com/process-analytics/bpmn-visualization-js/issues/1933
           # only test Edge on Windows


### PR DESCRIPTION
**WIP please do not force push, use merge instead** This PR is used to investigate #1933 

https://github.blog/changelog/2022-04-25-github-actions-public-beta-of-macos-12-for-github-hosted-runners-is-now-available