### PR TITLE
[INFRA] Simplify surge preview teardown

### DIFF
--- a/.github/workflows/generate-demo-preview.yml
+++ b/.github/workflows/generate-demo-preview.yml
@@ -39,6 +39,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
+        if: github.event.action != 'closed'
       - name: Publish Demo preview
         id: publish_demo_preview
         uses: afc163/surge-preview@v1

--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -49,6 +49,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
+        if: github.event.action != 'closed'
       - name: Publish preview
         id: publish_preview
         uses: afc163/surge-preview@v1


### PR DESCRIPTION
When closing the Pull Request, the only thing to do is to run the surge teardown. So skip other actions in this case.

### Notes

This is what is done in the [playground repository](https://github.com/process-analytics/github-actions-playground/blob/5d35937bbd5ac92a0bceda3ce313c7e698d895c3/.github/workflows/surge-preview-for-pr.yml#L28).
Also done in https://github.com/process-analytics/process-analytics.dev/pull/478