### PR TITLE
[INFRA] Temporarly disable Chrome and Edge e2e tests on CI

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -36,7 +36,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-11, ubuntu-20.04, windows-2019]
-        browser: [chromium, firefox, chrome]
+        # TODO activate chrome, see https://github.com/process-analytics/bpmn-visualization-js/issues/1933
+        browser: [chromium, firefox]
         include:
           # only test WebKit on macOS
           - os: macos-11

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -42,9 +42,10 @@ jobs:
           # only test WebKit on macOS
           - os: macos-11
             browser: webkit
+          # TODO activate edge, see https://github.com/process-analytics/bpmn-visualization-js/issues/1933
           # only test Edge on Windows
-          - os: windows-2019
-            browser: msedge
+          #- os: windows-2019
+          #  browser: msedge
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Some tests involving BPMN label are not passing anymore, without any code code nor dependencies changes.
Disable them to give us time to investigate without stopping developments.

covers #1933 