### PR TITLE
[REFACTOR] Fix remaining SonarCloud code smells

### DIFF
--- a/src/component/mxgraph/shape/text-annotation-shapes.ts
+++ b/src/component/mxgraph/shape/text-annotation-shapes.ts
@@ -22,7 +22,7 @@ import type { mxAbstractCanvas2D } from 'mxgraph';
  * @internal
  */
 export class TextAnnotationShape extends mxgraph.mxRectangleShape {
-  override paintBackground(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): void {
+  override paintBackground(c: mxAbstractCanvas2D, x: number, y: number, _w: number, h: number): void {
     // paint sort of left square bracket shape - for text annotation
     c.begin();
     c.moveTo(x + StyleDefault.TEXT_ANNOTATION_BORDER_LENGTH, y);

--- a/src/component/parser/xml/BpmnXmlParser.ts
+++ b/src/component/parser/xml/BpmnXmlParser.ts
@@ -30,7 +30,7 @@ export default class BpmnXmlParser {
     parseAttributeValue: true, // ensure numbers are parsed as number, not as string
     // entities management
     processEntities: false, // If you don't have entities in your XML document then it is recommended to disable it for better performance.
-    attributeValueProcessor: (name: string, val: string) => {
+    attributeValueProcessor: (_name: string, val: string) => {
       return decodeXML(val);
     },
   };


### PR DESCRIPTION
Fix detected 'unused function parameter' issues.
Prefix parameter name by the '_' character. This is a common practice to acknowledge the fact that some parameter is
unused (e.g. in TypeScript compiler).

Continues work started in #1932