### PR TITLE
[INFRA] Fix released demo artifact name

### DIFF
--- a/.github/workflows/upload-demo-archive-and-trigger-examples-repository-update.yml
+++ b/.github/workflows/upload-demo-archive-and-trigger-examples-repository-update.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Build Demo
         run: npm run demo
       - name: Set ARTIFACT_NAME
-        run: echo "ARTIFACT_NAME='demo-${{github.sha}}'" >> $GITHUB_ENV
+        run: echo "ARTIFACT_NAME=demo-${{github.sha}}" >> $GITHUB_ENV
       - name: Upload
         uses: actions/upload-artifact@v3
         with:
@@ -32,5 +32,5 @@ jobs:
         with:
           PA_REPOSITORY: 'bpmn-visualization-examples'
           BUILD_DEMO_WORKFLOW_ID: "upload-demo-archive-and-trigger-examples-repository-update.yml"
-          ARTIFACT_NAME: ${{ env.ARTIFACT_NAME }}
+          ARTIFACT_NAME: '${{ env.ARTIFACT_NAME }}'
           TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}


### PR DESCRIPTION
The artifact name contained extra enclosing quotes. It made the manual PR creation in the examples repository harder to do and broke the contract between the 2 repositories.

closes #1972 
Tested in the playground repository, see https://github.com/process-analytics/github-actions-playground/pull/89#issuecomment-1128928494