### PR TITLE
[INFRA] Restore Chrome and Edge e2e tests on CI

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -36,16 +36,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-11, ubuntu-20.04, windows-2019]
-        # TODO activate chrome, see https://github.com/process-analytics/bpmn-visualization-js/issues/1933
-        browser: [chromium, firefox]
+        browser: [chromium, firefox, chrome]
         include:
           # only test WebKit on macOS
           - os: macos-11
             browser: webkit
-          # TODO activate edge, see https://github.com/process-analytics/bpmn-visualization-js/issues/1933
           # only test Edge on Windows
-          #- os: windows-2019
-          #  browser: msedge
+          - os: windows-2019
+            browser: msedge
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
We recently updated playwright to version 1.22.1. The Chromium version was bump, so we changed the screenshots and thresholds.
As this Chromium version is more up to date with the latest Chrome and Edge version, the test configuration changes correctly apply to these 2 browsers.

closes #1933 
tested with #1935