### PR TITLE
[POC] Execute GitHub workflows with Ubuntu 22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       matrix:
         # syntax inspired from https://github.community/t5/GitHub-Actions/Using-a-matrix-defined-input-for-a-custom-action/m-p/32032/highlight/true#M988
         os:
-          - { name: ubuntu-20.04, coverage: '-- --coverage' }
+          - { name: ubuntu-22.04, coverage: '-- --coverage' }
           - { name: macos-11 }
           - { name: windows-2019 }
     steps:
@@ -110,7 +110,7 @@ jobs:
       # don't cancel running jobs even if one fails
       fail-fast: false
       matrix:
-        os: [macos-11, ubuntu-20.04, windows-2019]
+        os: [macos-11, ubuntu-22.04, windows-2019]
         browser: [chromium, firefox, chrome]
         include:
           # only test WebKit on macOS

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,7 +26,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/dependency-review-pr.yml
+++ b/.github/workflows/dependency-review-pr.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@v3

--- a/.github/workflows/generate-demo-preview.yml
+++ b/.github/workflows/generate-demo-preview.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   # inspired from https://github.com/process-analytics/github-actions-playground/pull/23
   check_secrets:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       is_SURGE_TOKEN_set: ${{ steps.secret_availability.outputs.is_SURGE_TOKEN_set }}
     steps:
@@ -36,7 +36,7 @@ jobs:
   demo_preview:
     needs: [check_secrets]
     if: needs.check_secrets.outputs.is_SURGE_TOKEN_set == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         if: github.event.action != 'closed'

--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -31,7 +31,7 @@ jobs:
   # inspired from https://github.com/process-analytics/github-actions-playground/pull/23
   check_secrets:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       is_SURGE_TOKEN_set: ${{ steps.secret_availability.outputs.is_SURGE_TOKEN_set }}
     steps:
@@ -46,7 +46,7 @@ jobs:
   doc_preview:
     needs: [check_secrets]
     if: github.event_name == 'pull_request' && needs.check_secrets.outputs.is_SURGE_TOKEN_set == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         if: github.event.action != 'closed'
@@ -68,7 +68,7 @@ jobs:
 
   generate_doc:
     if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&  github.event.ref == 'refs/heads/master'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Setup node
@@ -89,7 +89,7 @@ jobs:
 
   push_to_gh_pages:
     if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&  github.event.ref == 'refs/heads/master'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: generate_doc
     steps:
       - name: Download

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -35,7 +35,7 @@ jobs:
       # we want to run the full build on all os: don't cancel running jobs even if one fails
       fail-fast: false
       matrix:
-        os: [macos-11, ubuntu-20.04, windows-2019]
+        os: [macos-11, ubuntu-22.04, windows-2019]
         browser: [chromium, firefox, chrome]
         include:
           # only test WebKit on macOS


### PR DESCRIPTION
**POC not intended to be merged, as we did for #1928**

Tests if workflow runs triggered on PR work.
The Ubuntu 22 runners are in beta. Let's chek if they work in this project.
See https://github.blog/changelog/2022-05-10-github-actions-beta-of-ubuntu-22-04-for-github-hosted-runners-is-now-available/

Prerequisites
- tests involving playwright  (bunde , e2e): https://github.com/microsoft/playwright/issues/13738
- sonar cloud action: unable to connect to the docker daemon --> build not run, bundle tests not run
```bash
 /usr/bin/docker build -t 08450d:e58b3f63cbc2441a90111ec41f818308 -f "/home/runner/work/_actions/SonarSource/sonarcloud-github-action/v1.6/Dockerfile" "/home/runner/work/_actions/SonarSource/sonarcloud-github-action/v1.6"
  Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
```