### PR TITLE
[INFRA] dev - Bump @rollup/plugin-commonjs from 10.1.0 to 22.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "strnum": "1.0.5"
       },
       "devDependencies": {
+        "@rollup/plugin-commonjs": "~22.0.0",
         "@rollup/plugin-node-resolve": "~13.3.0",
         "@types/debug": "~4.1.7",
         "@types/jest": "~27.5.0",
@@ -60,7 +61,6 @@
         "rimraf": "~3.0.2",
         "rollup": "~2.74.1",
         "rollup-plugin-auto-external": "~2.0.0",
-        "rollup-plugin-commonjs": "~10.1.0",
         "rollup-plugin-copy": "~3.4.0",
         "rollup-plugin-copy-watch": "0.0.1",
         "rollup-plugin-execute": "~1.1.1",
@@ -2217,6 +2217,53 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-22.0.0.tgz",
+      "integrity": "sha512-Ktvf2j+bAO+30awhbYoCaXpBcyPmJbaEUYClQns/+6SNCYFURbvBiNbWgHITEsIgDDWCDUclWRKEuf8cwZCFoQ==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^3.1.0",
+        "commondir": "^1.0.1",
+        "estree-walker": "^2.0.1",
+        "glob": "^7.1.6",
+        "is-reference": "^1.2.1",
+        "magic-string": "^0.25.7",
+        "resolve": "^1.17.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.68.0"
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@rollup/plugin-node-resolve": {
@@ -9870,26 +9917,6 @@
         "semver": "bin/semver"
       }
     },
-    "node_modules/rollup-plugin-commonjs": {
-      "version": "10.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "estree-walker": "^0.6.1",
-        "is-reference": "^1.1.2",
-        "magic-string": "^0.25.2",
-        "resolve": "^1.11.0",
-        "rollup-pluginutils": "^2.8.1"
-      },
-      "peerDependencies": {
-        "rollup": ">=1.12.0"
-      }
-    },
-    "node_modules/rollup-plugin-commonjs/node_modules/estree-walker": {
-      "version": "0.6.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/rollup-plugin-copy": {
       "version": "3.4.0",
       "dev": true,
@@ -10202,19 +10229,6 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true
-    },
-    "node_modules/rollup-pluginutils": {
-      "version": "2.8.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "estree-walker": "^0.6.1"
-      }
-    },
-    "node_modules/rollup-pluginutils/node_modules/estree-walker": {
-      "version": "0.6.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -13193,6 +13207,43 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
+      }
+    },
+    "@rollup/plugin-commonjs": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-22.0.0.tgz",
+      "integrity": "sha512-Ktvf2j+bAO+30awhbYoCaXpBcyPmJbaEUYClQns/+6SNCYFURbvBiNbWgHITEsIgDDWCDUclWRKEuf8cwZCFoQ==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.1.0",
+        "commondir": "^1.0.1",
+        "estree-walker": "^2.0.1",
+        "glob": "^7.1.6",
+        "is-reference": "^1.2.1",
+        "magic-string": "^0.25.7",
+        "resolve": "^1.17.0"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+          "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "@rollup/plugin-node-resolve": {
@@ -18346,23 +18397,6 @@
         }
       }
     },
-    "rollup-plugin-commonjs": {
-      "version": "10.1.0",
-      "dev": true,
-      "requires": {
-        "estree-walker": "^0.6.1",
-        "is-reference": "^1.1.2",
-        "magic-string": "^0.25.2",
-        "resolve": "^1.11.0",
-        "rollup-pluginutils": "^2.8.1"
-      },
-      "dependencies": {
-        "estree-walker": {
-          "version": "0.6.1",
-          "dev": true
-        }
-      }
-    },
     "rollup-plugin-copy": {
       "version": "3.4.0",
       "dev": true,
@@ -18590,19 +18624,6 @@
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
           "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-          "dev": true
-        }
-      }
-    },
-    "rollup-pluginutils": {
-      "version": "2.8.2",
-      "dev": true,
-      "requires": {
-        "estree-walker": "^0.6.1"
-      },
-      "dependencies": {
-        "estree-walker": {
-          "version": "0.6.1",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "strnum": "1.0.5"
   },
   "devDependencies": {
+    "@rollup/plugin-commonjs": "~22.0.0",
     "@rollup/plugin-node-resolve": "~13.3.0",
     "@types/debug": "~4.1.7",
     "@types/jest": "~27.5.0",
@@ -140,7 +141,6 @@
     "rimraf": "~3.0.2",
     "rollup": "~2.74.1",
     "rollup-plugin-auto-external": "~2.0.0",
-    "rollup-plugin-commonjs": "~10.1.0",
     "rollup-plugin-copy": "~3.4.0",
     "rollup-plugin-copy-watch": "0.0.1",
     "rollup-plugin-execute": "~1.1.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,7 +23,7 @@ import autoExternal from 'rollup-plugin-auto-external';
 import execute from 'rollup-plugin-execute';
 
 import typescript from 'rollup-plugin-typescript2';
-import commonjs from 'rollup-plugin-commonjs'; // at least, needed to bundle mxGraph which is only available as a CommonJS module
+import commonjs from '@rollup/plugin-commonjs'; // at least, needed to bundle mxGraph which is only available as a CommonJS module
 import resolve from '@rollup/plugin-node-resolve';
 import pkg from './package.json';
 


### PR DESCRIPTION
The plugin was relocated from `rollup-plugin-commonjs` to `@rollup/plugin-commonjs` almost 3 years ago.
That's why we haven't received any updates for this plugin! The latest version was released on 2019-08-27.

### Notes

Also done for examples: https://github.com/process-analytics/bpmn-visualization-examples/pull/343

Impact of the new plugin on bundles: none except a minor one for IIFE
- non minified
  - now: 2 877 772. Change the way commonjs elements are named. They are now often postfixed with $x
  - 0.23.3: 2 789 037 (https://unpkg.com/bpmn-visualization@0.23.3/dist/bpmn-visualization.js?meta)
- minified
  - now: 967 091
  - 0.23.3: 967 086 (https://unpkg.com/bpmn-visualization@0.23.3/dist/bpmn-visualization.min.js?meta)




