### PR TITLE
[POC] Add hierarchy in the internal model 

### DIFF
--- a/dev/ts/main.ts
+++ b/dev/ts/main.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { BpmnElement, BpmnElementKind, FitOptions, FitType, GlobalOptions, LoadOptions, Overlay, Version, ZoomType } from '../../src/bpmn-visualization';
+import type { BpmnElement, BpmnElementKind, FitOptions, FitType, GlobalOptions, LoadOptions, ModelFilter, Overlay, Version, ZoomType } from '../../src/bpmn-visualization';
 import { fetchBpmnContent, logDownload, logErrorAndOpenAlert, logStartup, stringify } from './utils/internal-helpers';
 import { log } from './utils/shared-helpers';
 import { DropFileUserInterface } from './component/DropFileUserInterface';
@@ -196,6 +196,15 @@ function configureBpmnElementIdToCollapseFromParameters(parameters: URLSearchPar
   bpmnElementIdToCollapse = parameters.get('bpmn.element.id.collapsed');
 }
 
+function configurePoolsFilteringFromParameters(parameters: URLSearchParams): ModelFilter | undefined {
+  const poolIdToFilter = parameters.get('bpmn.pool.id.filtered');
+  if (!poolIdToFilter) {
+    return;
+  }
+  log('Configuring load options to only include pool id: ', poolIdToFilter);
+  return { includes: { pools: { ids: poolIdToFilter } } };
+}
+
 export function startBpmnVisualization(config: BpmnVisualizationDemoConfiguration): void {
   const log = logStartup;
   const container = config.globalOptions.container;
@@ -211,6 +220,7 @@ export function startBpmnVisualization(config: BpmnVisualizationDemoConfiguratio
   log('Configuring Load Options');
   loadOptions = config.loadOptions || {};
   loadOptions.fit = getFitOptionsFromParameters(config, parameters);
+  loadOptions.modelFilter = configurePoolsFilteringFromParameters(parameters);
 
   configureStyleFromParameters(parameters);
   configureBpmnElementIdToCollapseFromParameters(parameters);

--- a/src/component/BpmnVisualization.ts
+++ b/src/component/BpmnVisualization.ts
@@ -76,7 +76,7 @@ export class BpmnVisualization {
    */
   load(xml: string, options?: LoadOptions): void {
     const bpmnModel = newBpmnParser().parse(xml);
-    const renderedModel = this.bpmnModelRegistry.load(bpmnModel);
+    const renderedModel = this.bpmnModelRegistry.load(bpmnModel, options?.modelFilter);
     newBpmnRenderer(this.graph).render(renderedModel, options);
   }
 

--- a/src/component/mxgraph/BpmnRenderer.ts
+++ b/src/component/mxgraph/BpmnRenderer.ts
@@ -62,7 +62,7 @@ export class BpmnRenderer {
   }
 
   private getParent(bpmnElement: ShapeBpmnElement): mxCell {
-    const bpmnElementParent = this.getCell(bpmnElement.parentId);
+    const bpmnElementParent = this.getCell(bpmnElement.parent);
     return bpmnElementParent ?? this.graph.getDefaultParent();
   }
 

--- a/src/component/mxgraph/BpmnRenderer.ts
+++ b/src/component/mxgraph/BpmnRenderer.ts
@@ -82,8 +82,8 @@ export class BpmnRenderer {
     edges.forEach(edge => {
       const bpmnElement = edge.bpmnElement;
       const parent = this.graph.getDefaultParent();
-      const source = this.getCell(bpmnElement.sourceRefId);
-      const target = this.getCell(bpmnElement.targetRefId);
+      const source = this.getCell(bpmnElement.source?.id);
+      const target = this.getCell(bpmnElement.target?.id);
       const labelBounds = edge.label?.bounds;
       const style = this.styleComputer.computeStyle(edge, labelBounds);
       const mxEdge = this.graph.insertEdge(parent, bpmnElement.id, bpmnElement.name, source, target, style);

--- a/src/component/mxgraph/BpmnRenderer.ts
+++ b/src/component/mxgraph/BpmnRenderer.ts
@@ -62,7 +62,7 @@ export class BpmnRenderer {
   }
 
   private getParent(bpmnElement: ShapeBpmnElement): mxCell {
-    const bpmnElementParent = this.getCell(bpmnElement.parent);
+    const bpmnElementParent = this.getCell(bpmnElement.parent?.id);
     return bpmnElementParent ?? this.graph.getDefaultParent();
   }
 

--- a/src/component/options.ts
+++ b/src/component/options.ts
@@ -60,11 +60,37 @@ export interface ZoomConfiguration {
 }
 
 /**
+ * ```typescript
+ * bpmnVisualization.load({ modelFilter: {
+ *      includes: {
+ *        ids: 'Participant_1257_x151';
+ *        names: ['Customer', 'Supplier'];
+ *      }
+ *    }
+ * });
+ * ```
+ * @category Initialization
+ */
+export interface ModelFilter {
+  includes?: {
+    pools?: {
+      ids?: string | string[];
+      names?: string | string[];
+    };
+    // for the future
+    // diagrams: {
+    //   id: string;
+    // };
+  };
+}
+
+/**
  * Options when loading a BPMN Diagram.
  * @category Initialization
  */
 export interface LoadOptions {
   fit?: FitOptions;
+  modelFilter?: ModelFilter;
 }
 
 /**

--- a/src/component/parser/BpmnParser.ts
+++ b/src/component/parser/BpmnParser.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type BpmnModel from '../../model/bpmn/internal/BpmnModel';
+import type { BpmnModel } from '../../model/bpmn/internal/BpmnModel';
 import BpmnXmlParser from './xml/BpmnXmlParser';
 import type BpmnJsonParser from './json/BpmnJsonParser';
 import { newBpmnJsonParser } from './json/BpmnJsonParser';

--- a/src/component/parser/json/BpmnJsonParser.ts
+++ b/src/component/parser/json/BpmnJsonParser.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type BpmnModel from '../../../model/bpmn/internal/BpmnModel';
+import type { BpmnModel } from '../../../model/bpmn/internal/BpmnModel';
 import type { BpmnJsonModel, TDefinitions } from '../../../model/bpmn/json/BPMN20';
 import CollaborationConverter from './converter/CollaborationConverter';
 import ProcessConverter from './converter/ProcessConverter';

--- a/src/component/parser/json/BpmnJsonParser.ts
+++ b/src/component/parser/json/BpmnJsonParser.ts
@@ -42,10 +42,11 @@ export default class BpmnJsonParser {
     const definitions: TDefinitions = json.definitions;
 
     this.categoryConverter.deserialize(definitions);
-    this.collaborationConverter.deserialize(definitions.collaboration);
+    this.collaborationConverter.deserializeElementsOnWhichProcessDepends(definitions.collaboration);
     this.eventDefinitionConverter.deserialize(definitions);
     this.globalTaskConverter.deserialize(definitions);
     this.processConverter.deserialize(definitions.process);
+    this.collaborationConverter.deserializeElementsDependentOnProcess(definitions.collaboration);
     return this.diagramConverter.deserialize(definitions.BPMNDiagram);
   }
 }

--- a/src/component/parser/json/converter/CollaborationConverter.ts
+++ b/src/component/parser/json/converter/CollaborationConverter.ts
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-import { Participant } from '../../../../model/bpmn/internal/shape/ShapeBpmnElement';
 import { MessageFlow } from '../../../../model/bpmn/internal/edge/flows';
 import type { TCollaboration } from '../../../../model/bpmn/json/baseElement/rootElement/collaboration';
 import type { TParticipant } from '../../../../model/bpmn/json/baseElement/participant';
 import type { TMessageFlow } from '../../../../model/bpmn/json/baseElement/baseElement';
-import type { ConvertedElements } from './utils';
+import { type ConvertedElements, Participant } from './utils';
 import { ensureIsArray } from '../../../helpers/array-utils';
 import type { TGroup } from '../../../../model/bpmn/json/baseElement/artifact';
 

--- a/src/component/parser/json/converter/DiagramConverter.ts
+++ b/src/component/parser/json/converter/DiagramConverter.ts
@@ -109,10 +109,10 @@ export default class DiagramConverter {
     if (bpmnElement) {
       const bounds = DiagramConverter.deserializeBounds(shape);
 
-      if (bpmnElement.parentId) {
-        const participant = this.convertedElements.findParticipantByProcessRef(bpmnElement.parentId);
+      if (bpmnElement.parent) {
+        const participant = this.convertedElements.findParticipantByProcessRef(bpmnElement.parent);
         if (participant) {
-          bpmnElement.parentId = participant.id;
+          bpmnElement.parent = participant.id;
         }
       }
 

--- a/src/component/parser/json/converter/DiagramConverter.ts
+++ b/src/component/parser/json/converter/DiagramConverter.ts
@@ -109,13 +109,6 @@ export default class DiagramConverter {
     if (bpmnElement) {
       const bounds = DiagramConverter.deserializeBounds(shape);
 
-      if (bpmnElement.parent) {
-        const participant = this.convertedElements.findParticipantByProcessRef(bpmnElement.parent.id);
-        if (participant) {
-          bpmnElement.parent = participant;
-        }
-      }
-
       if (
         (bpmnElement instanceof ShapeBpmnSubProcess ||
           (bpmnElement instanceof ShapeBpmnCallActivity && bpmnElement.callActivityKind === ShapeBpmnCallActivityKind.CALLING_PROCESS)) &&

--- a/src/component/parser/json/converter/DiagramConverter.ts
+++ b/src/component/parser/json/converter/DiagramConverter.ts
@@ -110,9 +110,9 @@ export default class DiagramConverter {
       const bounds = DiagramConverter.deserializeBounds(shape);
 
       if (bpmnElement.parent) {
-        const participant = this.convertedElements.findParticipantByProcessRef(bpmnElement.parent);
+        const participant = this.convertedElements.findParticipantByProcessRef(bpmnElement.parent.id);
         if (participant) {
-          bpmnElement.parent = participant.id;
+          bpmnElement.parent = participant;
         }
       }
 

--- a/src/component/parser/json/converter/ProcessConverter.ts
+++ b/src/component/parser/json/converter/ProcessConverter.ts
@@ -86,11 +86,11 @@ export default class ProcessConverter {
 
     // containers
     this.buildLaneBpmnElements(process[ShapeBpmnElementKind.LANE], convertedProcess);
-    this.buildLaneSetBpmnElements(process['laneSet'], convertedProcess);
+    this.buildLaneSetBpmnElements(process.laneSet, convertedProcess);
 
     // flows
-    this.buildSequenceFlows(process[FlowKind.SEQUENCE_FLOW], convertedProcess);
-    this.buildAssociationFlows(process[FlowKind.ASSOCIATION_FLOW], convertedProcess);
+    this.buildSequenceFlows(process[FlowKind.SEQUENCE_FLOW]);
+    this.buildAssociationFlows(process[FlowKind.ASSOCIATION_FLOW]);
   }
 
   private buildFlowNodeBpmnElements(bpmnElements: Array<FlowNode> | FlowNode, kind: ShapeBpmnElementKind, convertedProcess: ShapeBpmnElement): void {
@@ -115,7 +115,7 @@ export default class ProcessConverter {
       } else {
         // @ts-ignore We know that the text & name fields are not on all types, but it's already tested
         const name = kind === ShapeBpmnElementKind.TEXT_ANNOTATION ? bpmnElement.text : bpmnElement.name;
-        // @ts-ignore We know that the instantiate field is not on all types, but it's already tested
+        // @ts-ignore We know that the instantiated field is not on all types, but it's already tested
         shapeBpmnElement = new ShapeBpmnElement(bpmnElement.id, name, kind, convertedProcess, bpmnElement.instantiate);
       }
 
@@ -262,19 +262,21 @@ export default class ProcessConverter {
     });
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  private buildSequenceFlows(bpmnElements: Array<TSequenceFlow> | TSequenceFlow, convertedProcess: ShapeBpmnElement): void {
+  private buildSequenceFlows(bpmnElements: Array<TSequenceFlow> | TSequenceFlow): void {
     ensureIsArray(bpmnElements).forEach(sequenceFlow => {
       const kind = this.getSequenceFlowKind(sequenceFlow);
-      this.convertedElements.registerSequenceFlow(new SequenceFlow(sequenceFlow.id, sequenceFlow.name, sequenceFlow.sourceRef, sequenceFlow.targetRef, kind));
+      const convertedSource = this.convertedElements.findFlowNode(sequenceFlow.sourceRef);
+      const convertedTarget = this.convertedElements.findFlowNode(sequenceFlow.targetRef);
+      this.convertedElements.registerSequenceFlow(new SequenceFlow(sequenceFlow.id, sequenceFlow.name, convertedSource, convertedTarget, kind));
     });
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  private buildAssociationFlows(bpmnElements: Array<TAssociation> | TAssociation, convertedProcess: ShapeBpmnElement): void {
+  private buildAssociationFlows(bpmnElements: Array<TAssociation> | TAssociation): void {
     ensureIsArray(bpmnElements).forEach(association => {
       const direction = association.associationDirection as unknown as AssociationDirectionKind;
-      this.convertedElements.registerAssociationFlow(new AssociationFlow(association.id, undefined, association.sourceRef, association.targetRef, direction));
+      const convertedSource = this.convertedElements.findFlowNode(association.sourceRef);
+      const convertedTarget = this.convertedElements.findFlowNode(association.targetRef);
+      this.convertedElements.registerAssociationFlow(new AssociationFlow(association.id, undefined, convertedSource, convertedTarget, direction));
     });
   }
 

--- a/src/component/parser/json/converter/ProcessConverter.ts
+++ b/src/component/parser/json/converter/ProcessConverter.ts
@@ -71,11 +71,11 @@ export default class ProcessConverter {
   }
 
   private parseProcess(process: TProcess): void {
-    const convertedProcess = new ShapeBpmnElement(process.id, process.name, ShapeBpmnElementKind.POOL);
-    this.convertedElements.registerProcess(convertedProcess);
+    const convertedProcess = this.convertedElements.registerProcess({ id: process.id, name: process.name });
     this.buildProcessInnerElements(process, convertedProcess);
   }
 
+  // TODO [Thomas] I would prefer we remove the 'converted' prefix in all variable/parameter names for simplicity
   private buildProcessInnerElements(process: TProcess | TSubProcess, convertedProcess: ShapeBpmnElement): void {
     // flow nodes
     ShapeUtil.flowNodeKinds()

--- a/src/component/parser/json/converter/ProcessConverter.ts
+++ b/src/component/parser/json/converter/ProcessConverter.ts
@@ -258,7 +258,7 @@ export default class ProcessConverter {
       const laneId = lane.id;
       if (shapeBpmnElement) {
         if (!ShapeUtil.isBoundaryEvent(shapeBpmnElement.kind)) {
-          shapeBpmnElement.parentId = laneId;
+          shapeBpmnElement.parent = laneId;
         }
       } else {
         this.parsingMessageCollector.warning(new LaneUnknownFlowNodeRefWarning(laneId, flowNodeRef));

--- a/src/component/parser/json/converter/ProcessConverter.ts
+++ b/src/component/parser/json/converter/ProcessConverter.ts
@@ -132,7 +132,7 @@ export default class ProcessConverter {
   }
 
   private buildShapeBpmnActivity(bpmnElement: TActivity, kind: ShapeBpmnElementKind, convertedProcess: ShapeBpmnElement): ShapeBpmnActivity {
-    const markers = ProcessConverter.buildMarkers(bpmnElement);
+    const markers = buildMarkers(bpmnElement);
 
     if (ShapeUtil.isSubProcess(kind)) {
       return this.buildShapeBpmnSubProcess(bpmnElement, markers, convertedProcess);
@@ -151,22 +151,6 @@ export default class ProcessConverter {
       return new ShapeBpmnCallActivity(bpmnElement.id, bpmnElement.name, ShapeBpmnCallActivityKind.CALLING_PROCESS, convertedProcess, markers);
     }
     return new ShapeBpmnCallActivity(bpmnElement.id, bpmnElement.name, ShapeBpmnCallActivityKind.CALLING_GLOBAL_TASK, convertedProcess, markers, globalTaskKind);
-  }
-
-  private static buildMarkers(bpmnElement: TActivity): ShapeBpmnMarkerKind[] {
-    const markers: ShapeBpmnMarkerKind[] = [];
-    // @ts-ignore We know that the standardLoopCharacteristics field is not on all types, but it's already tested
-    const standardLoopCharacteristics = bpmnElement.standardLoopCharacteristics;
-    // @ts-ignore We know that the multiInstanceLoopCharacteristics field is not on all types, but it's already tested
-    const multiInstanceLoopCharacteristics = ensureIsArray(bpmnElement.multiInstanceLoopCharacteristics, true)[0];
-    if (standardLoopCharacteristics || standardLoopCharacteristics === '') {
-      markers.push(ShapeBpmnMarkerKind.LOOP);
-    } else if (multiInstanceLoopCharacteristics && multiInstanceLoopCharacteristics.isSequential) {
-      markers.push(ShapeBpmnMarkerKind.MULTI_INSTANCE_SEQUENTIAL);
-    } else if ((multiInstanceLoopCharacteristics && !multiInstanceLoopCharacteristics.isSequential) || multiInstanceLoopCharacteristics === '') {
-      markers.push(ShapeBpmnMarkerKind.MULTI_INSTANCE_PARALLEL);
-    }
-    return markers;
   }
 
   private buildShapeBpmnEvent(bpmnElement: TCatchEvent | TThrowEvent, elementKind: BpmnEventKind, convertedProcess: ShapeBpmnElement): ShapeBpmnEvent {
@@ -296,3 +280,19 @@ export default class ProcessConverter {
     return SequenceFlowKind.NORMAL;
   }
 }
+
+const buildMarkers = (bpmnElement: TActivity): ShapeBpmnMarkerKind[] => {
+  const markers: ShapeBpmnMarkerKind[] = [];
+  // @ts-ignore We know that the standardLoopCharacteristics field is not on all types, but it's already tested
+  const standardLoopCharacteristics = bpmnElement.standardLoopCharacteristics;
+  // @ts-ignore We know that the multiInstanceLoopCharacteristics field is not on all types, but it's already tested
+  const multiInstanceLoopCharacteristics = ensureIsArray(bpmnElement.multiInstanceLoopCharacteristics, true)[0];
+  if (standardLoopCharacteristics || standardLoopCharacteristics === '') {
+    markers.push(ShapeBpmnMarkerKind.LOOP);
+  } else if (multiInstanceLoopCharacteristics && multiInstanceLoopCharacteristics.isSequential) {
+    markers.push(ShapeBpmnMarkerKind.MULTI_INSTANCE_SEQUENTIAL);
+  } else if ((multiInstanceLoopCharacteristics && !multiInstanceLoopCharacteristics.isSequential) || multiInstanceLoopCharacteristics === '') {
+    markers.push(ShapeBpmnMarkerKind.MULTI_INSTANCE_PARALLEL);
+  }
+  return markers;
+};

--- a/src/component/parser/json/converter/ProcessConverter.ts
+++ b/src/component/parser/json/converter/ProcessConverter.ts
@@ -89,8 +89,8 @@ export default class ProcessConverter {
     this.buildLaneSetBpmnElements(process.laneSet, convertedProcess);
 
     // flows
-    this.buildSequenceFlows(process[FlowKind.SEQUENCE_FLOW]);
-    this.buildAssociationFlows(process[FlowKind.ASSOCIATION_FLOW]);
+    this.buildSequenceFlows(process[FlowKind.SEQUENCE_FLOW], convertedProcess);
+    this.buildAssociationFlows(process[FlowKind.ASSOCIATION_FLOW], convertedProcess);
   }
 
   private buildFlowNodeBpmnElements(bpmnElements: Array<FlowNode> | FlowNode, kind: ShapeBpmnElementKind, convertedProcess: ShapeBpmnElement): void {
@@ -246,21 +246,21 @@ export default class ProcessConverter {
     });
   }
 
-  private buildSequenceFlows(bpmnElements: Array<TSequenceFlow> | TSequenceFlow): void {
+  private buildSequenceFlows(bpmnElements: Array<TSequenceFlow> | TSequenceFlow, convertedProcess: ShapeBpmnElement): void {
     ensureIsArray(bpmnElements).forEach(sequenceFlow => {
       const kind = this.getSequenceFlowKind(sequenceFlow);
       const convertedSource = this.convertedElements.findFlowNode(sequenceFlow.sourceRef);
       const convertedTarget = this.convertedElements.findFlowNode(sequenceFlow.targetRef);
-      this.convertedElements.registerSequenceFlow(new SequenceFlow(sequenceFlow.id, sequenceFlow.name, convertedSource, convertedTarget, kind));
+      this.convertedElements.registerSequenceFlow(new SequenceFlow(sequenceFlow.id, sequenceFlow.name, convertedSource, convertedTarget, kind, convertedProcess));
     });
   }
 
-  private buildAssociationFlows(bpmnElements: Array<TAssociation> | TAssociation): void {
+  private buildAssociationFlows(bpmnElements: Array<TAssociation> | TAssociation, convertedProcess: ShapeBpmnElement): void {
     ensureIsArray(bpmnElements).forEach(association => {
       const direction = association.associationDirection as unknown as AssociationDirectionKind;
       const convertedSource = this.convertedElements.findFlowNode(association.sourceRef);
       const convertedTarget = this.convertedElements.findFlowNode(association.targetRef);
-      this.convertedElements.registerAssociationFlow(new AssociationFlow(association.id, undefined, convertedSource, convertedTarget, direction));
+      this.convertedElements.registerAssociationFlow(new AssociationFlow(association.id, undefined, convertedSource, convertedTarget, direction, convertedProcess));
     });
   }
 

--- a/src/component/parser/json/converter/ProcessConverter.ts
+++ b/src/component/parser/json/converter/ProcessConverter.ts
@@ -115,7 +115,7 @@ export default class ProcessConverter {
       } else {
         // @ts-ignore We know that the text & name fields are not on all types, but it's already tested
         const name = kind === ShapeBpmnElementKind.TEXT_ANNOTATION ? bpmnElement.text : bpmnElement.name;
-        // @ts-ignore We know that the instantiated field is not on all types, but it's already tested
+        // @ts-ignore We know that the 'instantiate' property is not on all types, but it's already tested
         shapeBpmnElement = new ShapeBpmnElement(bpmnElement.id, name, kind, convertedProcess, bpmnElement.instantiate);
       }
 

--- a/src/component/parser/json/converter/utils.ts
+++ b/src/component/parser/json/converter/utils.ts
@@ -60,7 +60,7 @@ export class ConvertedElements {
       const process = this._findProcess(participant.processRef);
       if (process) {
         const name = participant.name || process.name;
-        return new ShapeBpmnElement(participant.id, name, process.kind, process.parentId);
+        return new ShapeBpmnElement(participant.id, name, process.kind, process.parent);
       }
       // black box pool
       return new ShapeBpmnElement(participant.id, participant.name, ShapeBpmnElementKind.POOL);

--- a/src/component/parser/json/converter/utils.ts
+++ b/src/component/parser/json/converter/utils.ts
@@ -129,7 +129,7 @@ export class ConvertedElements {
   }
 
   // Special case: create the ShapeBpmnElement instance here to avoid duplication in CollaborationConverter and ProcessConverter
-  buildShapeBpmnGroup(groupBpmnElement: TGroup, processId?: string): ShapeBpmnElement | undefined {
+  buildShapeBpmnGroup(groupBpmnElement: TGroup, processId?: ShapeBpmnElement): ShapeBpmnElement | undefined {
     const categoryValueData = this.categoryValues.get(groupBpmnElement.categoryValueRef);
     if (categoryValueData) {
       return new ShapeBpmnElement(groupBpmnElement.id, categoryValueData.value, ShapeBpmnElementKind.GROUP, processId);

--- a/src/component/registry/bpmn-model-registry.ts
+++ b/src/component/registry/bpmn-model-registry.ts
@@ -66,7 +66,7 @@ function toRenderedModel(bpmnModel: BpmnModel): RenderedModel {
       subprocesses.push(shape);
     } else if (ShapeUtil.isBoundaryEvent(kind)) {
       boundaryEvents.push(shape);
-    } else if (!collapsedSubProcessIds.includes(shape.bpmnElement.parent)) {
+    } else if (!collapsedSubProcessIds.includes(shape.bpmnElement.parent?.id)) {
       otherFlowNodes.push(shape);
     }
   });

--- a/src/component/registry/bpmn-model-registry.ts
+++ b/src/component/registry/bpmn-model-registry.ts
@@ -66,7 +66,7 @@ function toRenderedModel(bpmnModel: BpmnModel): RenderedModel {
       subprocesses.push(shape);
     } else if (ShapeUtil.isBoundaryEvent(kind)) {
       boundaryEvents.push(shape);
-    } else if (!collapsedSubProcessIds.includes(shape.bpmnElement.parentId)) {
+    } else if (!collapsedSubProcessIds.includes(shape.bpmnElement.parent)) {
       otherFlowNodes.push(shape);
     }
   });

--- a/src/component/registry/bpmn-model-registry.ts
+++ b/src/component/registry/bpmn-model-registry.ts
@@ -130,29 +130,36 @@ class ModelFiltering {
 
     // lookup pools
     const pools = bpmnModel.pools;
-    logModelFiltering('pools: ' + pools);
+    logModelFiltering('pools: ', pools);
     // TODO ensure it is an array
     // const filterPoolBpmnIds = <Array<string>>poolIdsFilter;
     const filterPoolBpmnIds = ensureIsArray(poolIdsFilter);
     // TODO choose filterPoolBpmnIds by id if defined, otherwise filterPoolBpmnIds by name
     const filteredPools = pools.filter(pool => filterPoolBpmnIds.includes(pool.bpmnElement.id));
-    logModelFiltering('filtered pools: ' + filteredPools);
+    logModelFiltering('filtered pools: ', filteredPools);
     if (filteredPools.length == 0) {
       throw new Error('no existing pool with ids ' + filterPoolBpmnIds);
     }
 
     // prepare parent
+    const filteredPoolBpmnElements = filteredPools.map(pool => pool.bpmnElement);
+
     // lanes
-    const filteredLanes = bpmnModel.lanes.filter(flowNode => filterPoolBpmnIds.includes(flowNode.bpmnElement.parent.id));
-    const filteredLaneBpmnElementIds = filteredLanes.map(lane => lane.bpmnElement.id);
-    logModelFiltering('filtered lanes: ' + filteredLaneBpmnElementIds);
+    logModelFiltering('lanes: ', bpmnModel.lanes);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const filteredLanes = bpmnModel.lanes.filter(lane => filteredPoolBpmnElements.includes(lane.bpmnElement.parent));
+    logModelFiltering('filtered lanes: ', filteredLanes);
 
     // TODO subprocesses / call activity
 
     // TODO group - they are currently not associated to participant. How do we handle it?
 
-    filterPoolBpmnIds.push(...filteredLaneBpmnElementIds);
-    const filteredFlowNodes = bpmnModel.flowNodes.filter(flowNode => filterPoolBpmnIds.includes(flowNode.bpmnElement.parent.id));
+    const filteredFlowNodes = bpmnModel.flowNodes.filter(
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      flowNode => filteredPools.map(pool => pool.bpmnElement).includes(flowNode.bpmnElement.parent) || filteredLanes.includes(flowNode.bpmnElement.parent),
+    );
 
     const flowNodes: Shape[] = filteredFlowNodes; //[];
     // const flowNodes: Shape[] = bpmnModel.flowNodes; //[];

--- a/src/model/bpmn/internal/BpmnModel.ts
+++ b/src/model/bpmn/internal/BpmnModel.ts
@@ -13,22 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-import type Shape from './shape/Shape';
+import Shape from './shape/Shape';
 import type { Edge } from './edge/edge';
 
 /**
  * @internal
  */
-export default interface BpmnModel extends Shapes {
-  edges: Edge[];
-}
+export type BpmnModel = Array<Shape | Edge>;
+export type FlatBpmnModel = Array<Shape | Edge>;
 
-/**
- * @internal
- */
-export interface Shapes {
-  flowNodes: Shape[];
-  lanes: Shape[];
-  pools: Shape[];
-}
+export const flat = (bpmnModel: BpmnModel): FlatBpmnModel => {
+  if (!bpmnModel || bpmnModel.length === 0) {
+    return [];
+  }
+
+  const flatChildren = flat(
+    bpmnModel
+      .filter(element => element instanceof Shape)
+      .map(element => (element as Shape).children)
+      .flat(),
+  );
+  return [...bpmnModel, ...flatChildren];
+};

--- a/src/model/bpmn/internal/edge/edge.ts
+++ b/src/model/bpmn/internal/edge/edge.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type Shape from '../shape/Shape';
 import type Label from '../Label';
 import type { Flow } from './flows';
 import { MessageVisibleKind } from './kinds';
@@ -28,7 +29,15 @@ export class Edge {
     readonly waypoints?: Waypoint[],
     readonly label?: Label,
     readonly messageVisibleKind: MessageVisibleKind = MessageVisibleKind.NONE,
-  ) {}
+    public parent?: Shape,
+  ) {
+    parent?.addChild(this);
+  }
+
+  addParent(parent: Shape): void {
+    this.parent = parent;
+    parent?.addChild(this);
+  }
 }
 
 /**

--- a/src/model/bpmn/internal/edge/flows.ts
+++ b/src/model/bpmn/internal/edge/flows.ts
@@ -14,21 +14,22 @@
  * limitations under the License.
  */
 
+import type ShapeBpmnElement from '../shape/ShapeBpmnElement';
 import { AssociationDirectionKind, FlowKind, SequenceFlowKind } from './kinds';
 
 /**
  * @internal
  */
 export abstract class Flow {
-  protected constructor(readonly id: string, readonly name: string, readonly kind: FlowKind, readonly sourceRefId?: string, readonly targetRefId?: string) {}
+  protected constructor(readonly id: string, readonly name: string, readonly kind: FlowKind, readonly source?: ShapeBpmnElement, readonly target?: ShapeBpmnElement) {}
 }
 
 /**
  * @internal
  */
 export class SequenceFlow extends Flow {
-  constructor(id: string, name: string, sourceRefId?: string, targetRefId?: string, readonly sequenceFlowKind = SequenceFlowKind.NORMAL) {
-    super(id, name, FlowKind.SEQUENCE_FLOW, sourceRefId, targetRefId);
+  constructor(id: string, name: string, source?: ShapeBpmnElement, target?: ShapeBpmnElement, readonly sequenceFlowKind = SequenceFlowKind.NORMAL) {
+    super(id, name, FlowKind.SEQUENCE_FLOW, source, target);
   }
 }
 
@@ -36,8 +37,8 @@ export class SequenceFlow extends Flow {
  * @internal
  */
 export class MessageFlow extends Flow {
-  constructor(id: string, name: string, sourceRefId?: string, targetRefId?: string) {
-    super(id, name, FlowKind.MESSAGE_FLOW, sourceRefId, targetRefId);
+  constructor(id: string, name: string, source?: ShapeBpmnElement, target?: ShapeBpmnElement) {
+    super(id, name, FlowKind.MESSAGE_FLOW, source, target);
   }
 }
 
@@ -45,7 +46,7 @@ export class MessageFlow extends Flow {
  * @internal
  */
 export class AssociationFlow extends Flow {
-  constructor(id: string, name: string, sourceRefId?: string, targetRefId?: string, readonly associationDirectionKind = AssociationDirectionKind.NONE) {
-    super(id, name, FlowKind.ASSOCIATION_FLOW, sourceRefId, targetRefId);
+  constructor(id: string, name: string, source?: ShapeBpmnElement, target?: ShapeBpmnElement, readonly associationDirectionKind = AssociationDirectionKind.NONE) {
+    super(id, name, FlowKind.ASSOCIATION_FLOW, source, target);
   }
 }

--- a/src/model/bpmn/internal/edge/flows.ts
+++ b/src/model/bpmn/internal/edge/flows.ts
@@ -21,15 +21,24 @@ import { AssociationDirectionKind, FlowKind, SequenceFlowKind } from './kinds';
  * @internal
  */
 export abstract class Flow {
-  protected constructor(readonly id: string, readonly name: string, readonly kind: FlowKind, readonly source?: ShapeBpmnElement, readonly target?: ShapeBpmnElement) {}
+  protected constructor(
+    readonly id: string,
+    readonly name: string,
+    readonly kind: FlowKind,
+    readonly source?: ShapeBpmnElement,
+    readonly target?: ShapeBpmnElement,
+    public parent?: ShapeBpmnElement,
+  ) {
+    parent?.addChild(this);
+  }
 }
 
 /**
  * @internal
  */
 export class SequenceFlow extends Flow {
-  constructor(id: string, name: string, source?: ShapeBpmnElement, target?: ShapeBpmnElement, readonly sequenceFlowKind = SequenceFlowKind.NORMAL) {
-    super(id, name, FlowKind.SEQUENCE_FLOW, source, target);
+  constructor(id: string, name: string, source?: ShapeBpmnElement, target?: ShapeBpmnElement, readonly sequenceFlowKind = SequenceFlowKind.NORMAL, parent?: ShapeBpmnElement) {
+    super(id, name, FlowKind.SEQUENCE_FLOW, source, target, parent);
   }
 }
 
@@ -46,7 +55,14 @@ export class MessageFlow extends Flow {
  * @internal
  */
 export class AssociationFlow extends Flow {
-  constructor(id: string, name: string, source?: ShapeBpmnElement, target?: ShapeBpmnElement, readonly associationDirectionKind = AssociationDirectionKind.NONE) {
-    super(id, name, FlowKind.ASSOCIATION_FLOW, source, target);
+  constructor(
+    id: string,
+    name: string,
+    source?: ShapeBpmnElement,
+    target?: ShapeBpmnElement,
+    readonly associationDirectionKind = AssociationDirectionKind.NONE,
+    parent?: ShapeBpmnElement,
+  ) {
+    super(id, name, FlowKind.ASSOCIATION_FLOW, source, target, parent);
   }
 }

--- a/src/model/bpmn/internal/shape/Shape.ts
+++ b/src/model/bpmn/internal/shape/Shape.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { Edge } from '../edge/edge';
 import type ShapeBpmnElement from './ShapeBpmnElement';
 import type Bounds from '../Bounds';
 import type Label from '../Label';
@@ -22,5 +23,24 @@ import type Label from '../Label';
  * @internal
  */
 export default class Shape {
-  constructor(readonly id: string, readonly bpmnElement: ShapeBpmnElement, readonly bounds?: Bounds, readonly label?: Label, readonly isHorizontal?: boolean) {}
+  constructor(
+    readonly id: string,
+    readonly bpmnElement: ShapeBpmnElement,
+    readonly bounds?: Bounds,
+    readonly label?: Label,
+    readonly isHorizontal?: boolean,
+    public parent?: Shape,
+    readonly children: Array<Shape | Edge> = [],
+  ) {
+    parent?.addChild(this);
+  }
+
+  addChild(child: Shape | Edge): void {
+    this.children.push(child);
+  }
+
+  addParent(parent: Shape): void {
+    this.parent = parent;
+    parent?.addChild(this);
+  }
 }

--- a/src/model/bpmn/internal/shape/ShapeBpmnElement.ts
+++ b/src/model/bpmn/internal/shape/ShapeBpmnElement.ts
@@ -21,14 +21,20 @@ import { ShapeBpmnElementKind, ShapeBpmnEventBasedGatewayKind } from './kinds';
  * @internal
  */
 export default class ShapeBpmnElement {
-  constructor(readonly id: string, readonly name: string, readonly kind: ShapeBpmnElementKind, public parent?: string, readonly instantiate: boolean = false) {}
+  constructor(
+    readonly id: string,
+    readonly name: string,
+    readonly kind: ShapeBpmnElementKind,
+    public parent?: ShapeBpmnElement | Participant,
+    readonly instantiate: boolean = false,
+  ) {}
 }
 
 /**
  * @internal
  */
 export class ShapeBpmnActivity extends ShapeBpmnElement {
-  constructor(id: string, name: string, kind: ShapeBpmnElementKind, parent: string, instantiate?: boolean, readonly markers: ShapeBpmnMarkerKind[] = []) {
+  constructor(id: string, name: string, kind: ShapeBpmnElementKind, parent: ShapeBpmnElement, instantiate?: boolean, readonly markers: ShapeBpmnMarkerKind[] = []) {
     super(id, name, kind, parent, instantiate);
   }
 }
@@ -41,7 +47,7 @@ export class ShapeBpmnCallActivity extends ShapeBpmnActivity {
     id: string,
     name: string,
     readonly callActivityKind: ShapeBpmnCallActivityKind,
-    parent: string,
+    parent: ShapeBpmnElement,
     markers?: ShapeBpmnMarkerKind[],
     readonly globalTaskKind?: GlobalTaskKind,
   ) {
@@ -53,7 +59,7 @@ export class ShapeBpmnCallActivity extends ShapeBpmnActivity {
  * @internal
  */
 export class ShapeBpmnSubProcess extends ShapeBpmnActivity {
-  constructor(id: string, name: string, readonly subProcessKind: ShapeBpmnSubProcessKind, parent: string, markers?: ShapeBpmnMarkerKind[]) {
+  constructor(id: string, name: string, readonly subProcessKind: ShapeBpmnSubProcessKind, parent: ShapeBpmnElement, markers?: ShapeBpmnMarkerKind[]) {
     super(id, name, ShapeBpmnElementKind.SUB_PROCESS, parent, undefined, markers);
   }
 }
@@ -62,8 +68,8 @@ export class ShapeBpmnSubProcess extends ShapeBpmnActivity {
  * @internal
  */
 export class ShapeBpmnEvent extends ShapeBpmnElement {
-  constructor(id: string, name: string, elementKind: BpmnEventKind, readonly eventDefinitionKind: ShapeBpmnEventDefinitionKind, parentId: string) {
-    super(id, name, elementKind, parentId);
+  constructor(id: string, name: string, elementKind: BpmnEventKind, readonly eventDefinitionKind: ShapeBpmnEventDefinitionKind, parent: ShapeBpmnElement) {
+    super(id, name, elementKind, parent);
   }
 }
 
@@ -71,7 +77,7 @@ export class ShapeBpmnEvent extends ShapeBpmnElement {
  * @internal
  */
 export class ShapeBpmnStartEvent extends ShapeBpmnEvent {
-  constructor(id: string, name: string, eventDefinitionKind: ShapeBpmnEventDefinitionKind, parent: string, readonly isInterrupting?: boolean) {
+  constructor(id: string, name: string, eventDefinitionKind: ShapeBpmnEventDefinitionKind, parent: ShapeBpmnElement, readonly isInterrupting?: boolean) {
     super(id, name, ShapeBpmnElementKind.EVENT_START, eventDefinitionKind, parent);
   }
 }
@@ -80,7 +86,7 @@ export class ShapeBpmnStartEvent extends ShapeBpmnEvent {
  * @internal
  */
 export class ShapeBpmnBoundaryEvent extends ShapeBpmnEvent {
-  constructor(id: string, name: string, eventDefinitionKind: ShapeBpmnEventDefinitionKind, parent: string, readonly isInterrupting: boolean = true) {
+  constructor(id: string, name: string, eventDefinitionKind: ShapeBpmnEventDefinitionKind, parent: ShapeBpmnElement, readonly isInterrupting: boolean = true) {
     super(id, name, ShapeBpmnElementKind.EVENT_BOUNDARY, eventDefinitionKind, parent);
   }
 }
@@ -89,7 +95,7 @@ export class ShapeBpmnBoundaryEvent extends ShapeBpmnEvent {
  * @internal
  */
 export class ShapeBpmnEventBasedGateway extends ShapeBpmnElement {
-  constructor(id: string, name: string, parent: string, instantiate?: boolean, readonly gatewayKind = ShapeBpmnEventBasedGatewayKind.None) {
+  constructor(id: string, name: string, parent: ShapeBpmnElement, instantiate?: boolean, readonly gatewayKind = ShapeBpmnEventBasedGatewayKind.None) {
     super(id, name, ShapeBpmnElementKind.GATEWAY_EVENT_BASED, parent, instantiate);
   }
 }

--- a/src/model/bpmn/internal/shape/ShapeBpmnElement.ts
+++ b/src/model/bpmn/internal/shape/ShapeBpmnElement.ts
@@ -21,15 +21,15 @@ import { ShapeBpmnElementKind, ShapeBpmnEventBasedGatewayKind } from './kinds';
  * @internal
  */
 export default class ShapeBpmnElement {
-  constructor(readonly id: string, readonly name: string, readonly kind: ShapeBpmnElementKind, public parentId?: string, readonly instantiate: boolean = false) {}
+  constructor(readonly id: string, readonly name: string, readonly kind: ShapeBpmnElementKind, public parent?: string, readonly instantiate: boolean = false) {}
 }
 
 /**
  * @internal
  */
 export class ShapeBpmnActivity extends ShapeBpmnElement {
-  constructor(id: string, name: string, kind: ShapeBpmnElementKind, parentId: string, instantiate?: boolean, readonly markers: ShapeBpmnMarkerKind[] = []) {
-    super(id, name, kind, parentId, instantiate);
+  constructor(id: string, name: string, kind: ShapeBpmnElementKind, parent: string, instantiate?: boolean, readonly markers: ShapeBpmnMarkerKind[] = []) {
+    super(id, name, kind, parent, instantiate);
   }
 }
 
@@ -41,11 +41,11 @@ export class ShapeBpmnCallActivity extends ShapeBpmnActivity {
     id: string,
     name: string,
     readonly callActivityKind: ShapeBpmnCallActivityKind,
-    parentId: string,
+    parent: string,
     markers?: ShapeBpmnMarkerKind[],
     readonly globalTaskKind?: GlobalTaskKind,
   ) {
-    super(id, name, ShapeBpmnElementKind.CALL_ACTIVITY, parentId, undefined, markers);
+    super(id, name, ShapeBpmnElementKind.CALL_ACTIVITY, parent, undefined, markers);
   }
 }
 
@@ -53,8 +53,8 @@ export class ShapeBpmnCallActivity extends ShapeBpmnActivity {
  * @internal
  */
 export class ShapeBpmnSubProcess extends ShapeBpmnActivity {
-  constructor(id: string, name: string, readonly subProcessKind: ShapeBpmnSubProcessKind, parentId: string, markers?: ShapeBpmnMarkerKind[]) {
-    super(id, name, ShapeBpmnElementKind.SUB_PROCESS, parentId, undefined, markers);
+  constructor(id: string, name: string, readonly subProcessKind: ShapeBpmnSubProcessKind, parent: string, markers?: ShapeBpmnMarkerKind[]) {
+    super(id, name, ShapeBpmnElementKind.SUB_PROCESS, parent, undefined, markers);
   }
 }
 
@@ -71,8 +71,8 @@ export class ShapeBpmnEvent extends ShapeBpmnElement {
  * @internal
  */
 export class ShapeBpmnStartEvent extends ShapeBpmnEvent {
-  constructor(id: string, name: string, eventDefinitionKind: ShapeBpmnEventDefinitionKind, parentId: string, readonly isInterrupting?: boolean) {
-    super(id, name, ShapeBpmnElementKind.EVENT_START, eventDefinitionKind, parentId);
+  constructor(id: string, name: string, eventDefinitionKind: ShapeBpmnEventDefinitionKind, parent: string, readonly isInterrupting?: boolean) {
+    super(id, name, ShapeBpmnElementKind.EVENT_START, eventDefinitionKind, parent);
   }
 }
 
@@ -80,8 +80,8 @@ export class ShapeBpmnStartEvent extends ShapeBpmnEvent {
  * @internal
  */
 export class ShapeBpmnBoundaryEvent extends ShapeBpmnEvent {
-  constructor(id: string, name: string, eventDefinitionKind: ShapeBpmnEventDefinitionKind, parentId: string, readonly isInterrupting: boolean = true) {
-    super(id, name, ShapeBpmnElementKind.EVENT_BOUNDARY, eventDefinitionKind, parentId);
+  constructor(id: string, name: string, eventDefinitionKind: ShapeBpmnEventDefinitionKind, parent: string, readonly isInterrupting: boolean = true) {
+    super(id, name, ShapeBpmnElementKind.EVENT_BOUNDARY, eventDefinitionKind, parent);
   }
 }
 
@@ -89,8 +89,8 @@ export class ShapeBpmnBoundaryEvent extends ShapeBpmnEvent {
  * @internal
  */
 export class ShapeBpmnEventBasedGateway extends ShapeBpmnElement {
-  constructor(id: string, name: string, parentId: string, instantiate?: boolean, readonly gatewayKind = ShapeBpmnEventBasedGatewayKind.None) {
-    super(id, name, ShapeBpmnElementKind.GATEWAY_EVENT_BASED, parentId, instantiate);
+  constructor(id: string, name: string, parent: string, instantiate?: boolean, readonly gatewayKind = ShapeBpmnEventBasedGatewayKind.None) {
+    super(id, name, ShapeBpmnElementKind.GATEWAY_EVENT_BASED, parent, instantiate);
   }
 }
 

--- a/src/model/bpmn/internal/shape/ShapeBpmnElement.ts
+++ b/src/model/bpmn/internal/shape/ShapeBpmnElement.ts
@@ -28,7 +28,7 @@ export default class ShapeBpmnElement {
     readonly id: string,
     readonly name: string,
     readonly kind: ShapeBpmnElementKind,
-    public parent?: ShapeBpmnElement | Participant,
+    public parent?: ShapeBpmnElement,
     readonly instantiate: boolean = false,
     readonly children: ShapeBpmnElementChildren[] = [],
   ) {
@@ -123,16 +123,5 @@ export class ShapeBpmnBoundaryEvent extends ShapeBpmnEvent {
 export class ShapeBpmnEventBasedGateway extends ShapeBpmnElement {
   constructor(id: string, name: string, parent: ShapeBpmnElement, instantiate?: boolean, readonly gatewayKind = ShapeBpmnEventBasedGatewayKind.None) {
     super(id, name, ShapeBpmnElementKind.GATEWAY_EVENT_BASED, parent, instantiate);
-  }
-}
-
-/**
- * @internal
- */
-export class Participant {
-  constructor(readonly id: string, readonly name?: string, public processRef?: string, readonly children: ShapeBpmnElementChildren[] = []) {}
-
-  addChild(child: ShapeBpmnElementChildren): void {
-    this.children.push(child);
   }
 }

--- a/test/integration/mxGraph.model.bpmn.elements.test.ts
+++ b/test/integration/mxGraph.model.bpmn.elements.test.ts
@@ -1462,4 +1462,49 @@ describe('mxGraph model - BPMN elements', () => {
       });
     });
   });
+
+  // TODO we should have a single test here, the detailed tests should be done directly on the Filtering class instead
+  // eslint-disable-next-line jest/no-focused-tests
+  describe.only('Filter pools in the mxGraph model', () => {
+    it('Filter one pool by id - non existing pool id', () => {
+      // load BPMN
+      bpmnVisualization.load(readFileSync('../fixtures/bpmn/model-complete-semantic.bpmn'), {
+        modelFilter: {
+          includes: {
+            pools: {
+              ids: 'i_do_not_exist',
+            },
+          },
+        },
+      });
+    });
+
+    // TODO manage participant and process ref
+    // eslint-disable-next-line jest/no-focused-tests
+    it.only('Filter one pool by id - existing pool id', () => {
+      // load BPMN
+      bpmnVisualization.load(readFileSync('../fixtures/bpmn/model-complete-semantic.bpmn'), {
+        modelFilter: {
+          includes: {
+            pools: {
+              ids: 'participant_1_id',
+            },
+          },
+        },
+      });
+    });
+
+    it('Filter several pool by id - non existing pool id', () => {
+      // load BPMN
+      bpmnVisualization.load(readFileSync('../fixtures/bpmn/model-complete-semantic.bpmn'), {
+        modelFilter: {
+          includes: {
+            pools: {
+              ids: ['i_do_not_exist-1', 'i_do_not_exist-2'],
+            },
+          },
+        },
+      });
+    });
+  });
 });

--- a/test/unit/component/parser/BpmnParser.test.ts
+++ b/test/unit/component/parser/BpmnParser.test.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { expectLanePoolEdgeFlowNode, splitModel } from './json/JsonTestUtils';
 import { newBpmnParser } from '../../../../src/component/parser/BpmnParser';
 import { readFileSync } from '../../../helpers/file-helper';
 
@@ -20,10 +21,8 @@ describe('parse xml to model', () => {
   it('Single process with no participant', () => {
     const model = newBpmnParser().parse(readFileSync('../fixtures/bpmn/xml-parsing/miwg-A.1.0.bpmn'));
 
-    expect(model.flowNodes).toHaveLength(5);
-    expect(model.edges).toHaveLength(4);
-    expect(model.lanes).toHaveLength(0);
-    expect(model.pools).toHaveLength(0);
+    const splitedParseResult = splitModel(model);
+    expectLanePoolEdgeFlowNode(splitedParseResult, 0, 0, 4, 5);
   });
 
   describe('error management', () => {
@@ -36,9 +35,11 @@ describe('parse xml to model', () => {
     it('Parse a truncated diagram file', () => {
       // we don't have xml validation so the parsing is done. The parser tries to extract the most it can from the xml.
       const model = newBpmnParser().parse(readFileSync('../fixtures/bpmn/xml-parsing/special/simple-start-task-end_truncated.bpmn'));
-      expect(model.flowNodes).toHaveLength(2);
+
+      const splitedParseResult = splitModel(model);
+      expect(splitedParseResult.flowNodes).toHaveLength(2);
       // This element is truncated in the source xml file
-      const activities = model.flowNodes.filter(shape => shape.id == 'BPMNShape_Activity_1');
+      const activities = splitedParseResult.flowNodes.filter(shape => shape.id == 'BPMNShape_Activity_1');
       expect(activities[0].bpmnElement.id).toBe('Activity_1');
     });
 

--- a/test/unit/component/parser/json/BpmnJsonParser.association.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.association.test.ts
@@ -24,6 +24,7 @@ describe('parse bpmn as json for association', () => {
       sourceRef: 'Activity_01',
       targetRef: 'Annotation_01',
     },
+    task: [{ id: 'Activity_01' }, { id: 'Annotation_01' }],
   };
 
   it.each([
@@ -63,6 +64,7 @@ describe('parse bpmn as json for association', () => {
       definitions: {
         targetNamespace: '',
         process: {
+          task: [{ id: 'Activity_01' }, { id: 'Annotation_01' }, { id: 'Activity_02' }, { id: 'Annotation_02' }],
           association: [
             {
               id: 'association_id_0',

--- a/test/unit/component/parser/json/BpmnJsonParser.event.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.event.test.ts
@@ -74,9 +74,8 @@ function testMustConvertOneShape({
   const json = buildDefinitionsAndProcessWithTask(process);
   addEvent(json, bpmnKind, buildEventDefinitionParameter, buildEventParameter);
 
-  const model = parseJsonAndExpectEvent(json, expectedEventDefinitionKind, 1);
-
-  const shapes = getEventShapes(model);
+  const splitedParseResult = parseJsonAndExpectEvent(json, expectedEventDefinitionKind, 1);
+  const shapes = getEventShapes(splitedParseResult);
   verifyEventShape(shapes[0], buildEventParameter, expectedShapeBpmnElementKind);
 }
 

--- a/test/unit/component/parser/json/BpmnJsonParser.lane.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.lane.test.ts
@@ -101,7 +101,7 @@ describe('parse bpmn as json for lane', () => {
     });
 
     expect(model.flowNodes).toHaveLength(1);
-    expect(model.flowNodes[0].bpmnElement.parentId).toBe('Lane_12u5n6x');
+    expect(model.flowNodes[0].bpmnElement.parent).toBe('Lane_12u5n6x');
   });
 
   it('json containing one process with a single lane with flowNodeRef as object & flowNode not parsed', () => {
@@ -191,7 +191,7 @@ describe('parse bpmn as json for lane', () => {
     });
 
     expect(model.flowNodes).toHaveLength(1);
-    expect(model.flowNodes[0].bpmnElement.parentId).toBe('Lane_12u5n6x');
+    expect(model.flowNodes[0].bpmnElement.parent).toBe('Lane_12u5n6x');
   });
 
   it('json containing one process declared as array with a laneSet', () => {

--- a/test/unit/component/parser/json/BpmnJsonParser.lane.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.lane.test.ts
@@ -86,7 +86,8 @@ describe('parse bpmn as json for lane', () => {
     const model = parseJson(json);
 
     expect(model.lanes).toHaveLength(1);
-    verifyShape(model.lanes[0], {
+    const lane = model.lanes[0];
+    verifyShape(lane, {
       shapeId: 'Lane_1h5yeu4_di',
       bpmnElementId: 'Lane_12u5n6x',
       bpmnElementName: undefined,
@@ -101,7 +102,7 @@ describe('parse bpmn as json for lane', () => {
     });
 
     expect(model.flowNodes).toHaveLength(1);
-    expect(model.flowNodes[0].bpmnElement.parent.id).toBe('Lane_12u5n6x');
+    expect(model.flowNodes[0].bpmnElement.parent).toBe(lane.bpmnElement);
   });
 
   it('json containing one process with a single lane with flowNodeRef as object & flowNode not parsed', () => {
@@ -176,7 +177,8 @@ describe('parse bpmn as json for lane', () => {
     const model = parseJson(json);
 
     expect(model.lanes).toHaveLength(1);
-    verifyShape(model.lanes[0], {
+    const lane = model.lanes[0];
+    verifyShape(lane, {
       shapeId: 'Lane_1h5yeu4_di',
       bpmnElementId: 'Lane_12u5n6x',
       bpmnElementName: undefined,
@@ -191,7 +193,7 @@ describe('parse bpmn as json for lane', () => {
     });
 
     expect(model.flowNodes).toHaveLength(1);
-    expect(model.flowNodes[0].bpmnElement.parent.id).toBe('Lane_12u5n6x');
+    expect(model.flowNodes[0].bpmnElement.parent).toBe(lane.bpmnElement);
   });
 
   it('json containing one process declared as array with a laneSet', () => {

--- a/test/unit/component/parser/json/BpmnJsonParser.lane.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.lane.test.ts
@@ -101,7 +101,7 @@ describe('parse bpmn as json for lane', () => {
     });
 
     expect(model.flowNodes).toHaveLength(1);
-    expect(model.flowNodes[0].bpmnElement.parent).toBe('Lane_12u5n6x');
+    expect(model.flowNodes[0].bpmnElement.parent.id).toBe('Lane_12u5n6x');
   });
 
   it('json containing one process with a single lane with flowNodeRef as object & flowNode not parsed', () => {
@@ -191,7 +191,7 @@ describe('parse bpmn as json for lane', () => {
     });
 
     expect(model.flowNodes).toHaveLength(1);
-    expect(model.flowNodes[0].bpmnElement.parent).toBe('Lane_12u5n6x');
+    expect(model.flowNodes[0].bpmnElement.parent.id).toBe('Lane_12u5n6x');
   });
 
   it('json containing one process declared as array with a laneSet', () => {

--- a/test/unit/component/parser/json/BpmnJsonParser.process.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.process.test.ts
@@ -514,7 +514,7 @@ describe('parse bpmn as json for process/pool', () => {
       bpmnElementId: 'event_id_0',
       bpmnElementName: undefined,
       bpmnElementKind: ShapeBpmnElementKind.EVENT_START,
-      parentId: 'Participant_1',
+      parent: pool.bpmnElement,
       bounds: {
         x: 362,
         y: 232,
@@ -792,6 +792,11 @@ describe('parse bpmn as json for process/pool', () => {
 
     const model = parseJsonAndExpect(json, 0, 0, 5, 4);
 
-    model.flowNodes.map(flowNode => flowNode.bpmnElement).forEach(bpmnElement => expect(bpmnElement.parent.id).toBe('WFP-6-'));
+    model.flowNodes
+      .map(flowNode => flowNode.bpmnElement)
+      .forEach(bpmnElement => {
+        // TODO here we have a pool bpmn element without shape!
+        expect(bpmnElement.parent.id).toBe('WFP-6-');
+      });
   });
 });

--- a/test/unit/component/parser/json/BpmnJsonParser.process.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.process.test.ts
@@ -773,6 +773,6 @@ describe('parse bpmn as json for process/pool', () => {
 
     const model = parseJsonAndExpect(json, 0, 0, 5, 4);
 
-    model.flowNodes.map(flowNode => flowNode.bpmnElement).forEach(bpmnElement => expect(bpmnElement.parent).toBe('WFP-6-'));
+    model.flowNodes.map(flowNode => flowNode.bpmnElement).forEach(bpmnElement => expect(bpmnElement.parent.id).toBe('WFP-6-'));
   });
 });

--- a/test/unit/component/parser/json/BpmnJsonParser.process.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.process.test.ts
@@ -386,14 +386,14 @@ describe('parse bpmn as json for process/pool', () => {
     });
   });
 
-  it('participant without processRef are not considered as pool', () => {
+  it('json containing participants with and without processRef', () => {
     const json = {
       definitions: {
         targetNamespace: '',
         collaboration: {
           participant: [
             { id: 'Participant_1', name: 'Pool 1', processRef: 'Process_1' },
-            { id: 'Participant_2', name: 'Not a process' },
+            { id: 'Participant_2', name: 'Pool 2 without processRef' },
           ],
         },
         process: {
@@ -410,16 +410,21 @@ describe('parse bpmn as json for process/pool', () => {
                 isHorizontal: true,
                 Bounds: { x: 158, y: 50, width: 1620, height: 430 },
               },
+              {
+                id: 'shape_Participant_2',
+                bpmnElement: 'Participant_2',
+                isHorizontal: true,
+                Bounds: { x: 10158, y: 50, width: 1620, height: 430 },
+              },
             ],
           },
         },
       },
     };
 
-    const model = parseJsonAndExpectOnlyPools(json, 1);
+    const model = parseJsonAndExpectOnlyPools(json, 2);
 
-    const pool = model.pools[0];
-    verifyShape(pool, {
+    verifyShape(model.pools[0], {
       shapeId: 'shape_Participant_1',
       bpmnElementId: 'Participant_1',
       bpmnElementName: 'Pool 1',
@@ -428,6 +433,20 @@ describe('parse bpmn as json for process/pool', () => {
       isHorizontal: true,
       bounds: {
         x: 158,
+        y: 50,
+        width: 1620,
+        height: 430,
+      },
+    });
+    verifyShape(model.pools[1], {
+      shapeId: 'shape_Participant_2',
+      bpmnElementId: 'Participant_2',
+      bpmnElementName: 'Pool 2 without processRef',
+      bpmnElementKind: ShapeBpmnElementKind.POOL,
+      parentId: undefined,
+      isHorizontal: true,
+      bounds: {
+        x: 10158,
         y: 50,
         width: 1620,
         height: 430,
@@ -442,7 +461,7 @@ describe('parse bpmn as json for process/pool', () => {
         collaboration: {
           participant: [
             { id: 'Participant_1', name: 'Pool 1', processRef: 'Process_1' },
-            { id: 'Participant_2', name: 'Not a process' },
+            { id: 'Participant_2', name: 'Missing shape so not in present in the BpmnModel' },
           ],
         },
         process: {

--- a/test/unit/component/parser/json/BpmnJsonParser.process.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.process.test.ts
@@ -773,6 +773,6 @@ describe('parse bpmn as json for process/pool', () => {
 
     const model = parseJsonAndExpect(json, 0, 0, 5, 4);
 
-    model.flowNodes.map(flowNode => flowNode.bpmnElement).forEach(bpmnElement => expect(bpmnElement.parentId).toBe('WFP-6-'));
+    model.flowNodes.map(flowNode => flowNode.bpmnElement).forEach(bpmnElement => expect(bpmnElement.parent).toBe('WFP-6-'));
   });
 });

--- a/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.conditional.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.conditional.test.ts
@@ -71,7 +71,7 @@ describe('parse bpmn as json for conditional sequence flow', () => {
         },
       };
       const process = json.definitions.process as TProcess;
-      process[`${sourceKind}`] = { id: 'source_id_0' };
+      process[`${sourceKind}`] = [{ id: 'source_id_0' }, { id: 'targetRef_RLk' }];
       (process.sequenceFlow as TSequenceFlow).conditionExpression['#text'] = '&quot;Contract to be written&quot;.equals(loanRequested.status)';
 
       const model = parseJsonAndExpectOnlyEdgesAndFlowNodes(json, 1, 1);
@@ -95,6 +95,7 @@ describe('parse bpmn as json for conditional sequence flow', () => {
         process: {
           id: 'Process_1',
           parallelGateway: { id: 'gateway_id_0' },
+          task: [{ id: 'targetRef_RLk' }],
           sequenceFlow: {
             id: 'sequenceFlow_id_0',
             sourceRef: 'gateway_id_0',

--- a/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.default.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.default.test.ts
@@ -64,7 +64,7 @@ describe('parse bpmn as json for default sequence flow', () => {
         },
       },
     };
-    (json.definitions.process as TProcess)[`${sourceKind}`] = { id: 'source_id_0', default: 'sequenceFlow_id_0' };
+    (json.definitions.process as TProcess)[`${sourceKind}`] = [{ id: 'source_id_0', default: 'sequenceFlow_id_0' }, { id: 'targetRef_RLk' }];
 
     const model = parseJsonAndExpectOnlyEdgesAndFlowNodes(json, 1, 1);
 
@@ -86,6 +86,7 @@ describe('parse bpmn as json for default sequence flow', () => {
         process: {
           id: 'Process_1',
           parallelGateway: { id: 'gateway_id_0', default: 'sequenceFlow_id_0' },
+          task: { id: 'targetRef_RLk' },
           sequenceFlow: {
             id: 'sequenceFlow_id_0',
             sourceRef: 'gateway_id_0',

--- a/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.normal.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.normal.test.ts
@@ -25,6 +25,7 @@ describe('parse bpmn as json for sequence flow', () => {
       sourceRef: 'sourceRef_id_xsdas',
       targetRef: 'targetRef_RLk',
     },
+    task: [{ id: 'sourceRef_id_xsdas' }, { id: 'targetRef_RLk' }],
   } as TProcess;
 
   it.each([
@@ -79,6 +80,7 @@ describe('parse bpmn as json for sequence flow', () => {
               targetRef: 'targetRef_1',
             },
           ],
+          task: [{ id: 'sourceRef_id_xsdas' }, { id: 'targetRef_RLk' }, { id: 'sequenceFlow_id_1' }, { id: 'targetRef_1' }],
         },
         BPMNDiagram: {
           id: 'BpmnDiagram_1',
@@ -139,6 +141,7 @@ describe('parse bpmn as json for sequence flow', () => {
               targetRef: 'targetRef_1',
             },
           ],
+          task: [{ id: 'sourceRef_id_xsdas' }, { id: 'targetRef_RLk' }, { id: 'sequenceFlow_id_1' }, { id: 'targetRef_1' }],
         },
         BPMNDiagram: {
           id: 'BpmnDiagram_1',

--- a/test/unit/component/parser/json/BpmnJsonParser.sub.process.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.sub.process.test.ts
@@ -13,21 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { ExpectedShape } from './JsonTestUtils';
+import type { ExpectedShape, SplitedParseResult } from './JsonTestUtils';
 import { parseJson, parseJsonAndExpectOnlySubProcess, verifyEdge, verifyShape, verifySubProcess } from './JsonTestUtils';
 import type { TProcess } from '../../../../../src/model/bpmn/json/baseElement/rootElement/rootElement';
-import type BpmnModel from '../../../../../src/model/bpmn/internal/BpmnModel';
 import { ShapeBpmnElementKind, ShapeBpmnEventDefinitionKind, ShapeBpmnMarkerKind, ShapeBpmnSubProcessKind } from '../../../../../src/model/bpmn/internal';
 import type { ShapeBpmnEvent } from '../../../../../src/model/bpmn/internal/shape/ShapeBpmnElement';
 import type Shape from '../../../../../src/model/bpmn/internal/shape/Shape';
 import { getEventShapes } from './TestUtils';
 
-function expectNoPoolLane(model: BpmnModel): void {
+function expectNoPoolLane(model: SplitedParseResult): void {
   expect(model.lanes).toHaveLength(0);
   expect(model.pools).toHaveLength(0);
 }
 
-function expectNoEdgePoolLane(model: BpmnModel): void {
+function expectNoEdgePoolLane(model: SplitedParseResult): void {
   expectNoPoolLane(model);
   expect(model.edges).toHaveLength(0);
 }

--- a/test/unit/component/parser/json/JsonTestUtils.ts
+++ b/test/unit/component/parser/json/JsonTestUtils.ts
@@ -166,7 +166,7 @@ export function verifyShape(shape: Shape, expectedShape: ExpectedShape | Expecte
   expect(bpmnElement.id).toEqual(expectedShape.bpmnElementId);
   expect(bpmnElement.name).toEqual(expectedShape.bpmnElementName);
   expect(bpmnElement.kind).toEqual(expectedShape.bpmnElementKind);
-  expect(bpmnElement.parentId).toEqual(expectedShape.parentId);
+  expect(bpmnElement.parent).toEqual(expectedShape.parentId);
 
   if (bpmnElement instanceof ShapeBpmnActivity) {
     const expectedActivityShape = expectedShape as ExpectedActivityShape;

--- a/test/unit/component/parser/json/JsonTestUtils.ts
+++ b/test/unit/component/parser/json/JsonTestUtils.ts
@@ -166,7 +166,7 @@ export function verifyShape(shape: Shape, expectedShape: ExpectedShape | Expecte
   expect(bpmnElement.id).toEqual(expectedShape.bpmnElementId);
   expect(bpmnElement.name).toEqual(expectedShape.bpmnElementName);
   expect(bpmnElement.kind).toEqual(expectedShape.bpmnElementKind);
-  expect(bpmnElement.parent).toEqual(expectedShape.parentId);
+  expect(bpmnElement.parent?.id).toEqual(expectedShape.parentId);
 
   if (bpmnElement instanceof ShapeBpmnActivity) {
     const expectedActivityShape = expectedShape as ExpectedActivityShape;

--- a/test/unit/component/parser/json/JsonTestUtils.ts
+++ b/test/unit/component/parser/json/JsonTestUtils.ts
@@ -100,7 +100,7 @@ class ParsingMessageCollectorTester extends ParsingMessageCollector {
 
 export const parsingMessageCollector = new ParsingMessageCollectorTester();
 
-function checkParsingWarnings(numberOfWarnings: number): void {
+export function checkParsingWarnings(numberOfWarnings: number): void {
   expect(parsingMessageCollector.getWarnings()).toHaveLength(numberOfWarnings);
 }
 
@@ -203,8 +203,8 @@ export function verifyEdge(edge: Edge, expectedValue: ExpectedEdge | ExpectedSeq
   const bpmnElement = edge.bpmnElement;
   expect(bpmnElement.id).toEqual(expectedValue.bpmnElementId);
   expect(bpmnElement.name).toEqual(expectedValue.bpmnElementName);
-  expect(bpmnElement.sourceRefId).toEqual(expectedValue.bpmnElementSourceRefId);
-  expect(bpmnElement.targetRefId).toEqual(expectedValue.bpmnElementTargetRefId);
+  expect(bpmnElement.source?.id).toEqual(expectedValue.bpmnElementSourceRefId);
+  expect(bpmnElement.target?.id).toEqual(expectedValue.bpmnElementTargetRefId);
 
   if (bpmnElement instanceof SequenceFlow) {
     expect(edge.bpmnElement.kind).toEqual(FlowKind.SEQUENCE_FLOW);

--- a/test/unit/component/parser/json/JsonTestUtils.ts
+++ b/test/unit/component/parser/json/JsonTestUtils.ts
@@ -26,6 +26,7 @@ import type Shape from '../../../../../src/model/bpmn/internal/shape/Shape';
 import { newBpmnJsonParser } from '../../../../../src/component/parser/json/BpmnJsonParser';
 import type { Edge, Waypoint } from '../../../../../src/model/bpmn/internal/edge/edge';
 import type BpmnModel from '../../../../../src/model/bpmn/internal/BpmnModel';
+import type ShapeBpmnElement from '../../../../../src/model/bpmn/internal/shape/ShapeBpmnElement';
 import { ShapeBpmnActivity, ShapeBpmnCallActivity, ShapeBpmnEvent, ShapeBpmnSubProcess } from '../../../../../src/model/bpmn/internal/shape/ShapeBpmnElement';
 import type Label from '../../../../../src/model/bpmn/internal/Label';
 import { SequenceFlow } from '../../../../../src/model/bpmn/internal/edge/flows';
@@ -38,6 +39,8 @@ export interface ExpectedShape {
   bpmnElementId: string;
   bpmnElementName: string;
   bpmnElementKind: ShapeBpmnElementKind;
+  parent?: ShapeBpmnElement;
+  /** Not used if the `parent` property is set. */
   parentId?: string;
   bounds?: ExpectedBounds;
   isHorizontal?: boolean;
@@ -166,7 +169,14 @@ export function verifyShape(shape: Shape, expectedShape: ExpectedShape | Expecte
   expect(bpmnElement.id).toEqual(expectedShape.bpmnElementId);
   expect(bpmnElement.name).toEqual(expectedShape.bpmnElementName);
   expect(bpmnElement.kind).toEqual(expectedShape.bpmnElementKind);
-  expect(bpmnElement.parent?.id).toEqual(expectedShape.parentId);
+  if (expectedShape.parent) {
+    // do strict equality on purpose, check the instance of the parent is the right one, generally by passing an instance retrieved from the model
+    expect(bpmnElement.parent).toBe(expectedShape.parent);
+  }
+  // only check parent id
+  else {
+    expect(bpmnElement.parent?.id).toEqual(expectedShape.parentId);
+  }
 
   if (bpmnElement instanceof ShapeBpmnActivity) {
     const expectedActivityShape = expectedShape as ExpectedActivityShape;

--- a/test/unit/component/parser/json/TestUtils.ts
+++ b/test/unit/component/parser/json/TestUtils.ts
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import type { SplitedParseResult } from './JsonTestUtils';
 import { ShapeBpmnElementKind, ShapeUtil } from '../../../../../src/model/bpmn/internal';
-import type BpmnModel from '../../../../../src/model/bpmn/internal/BpmnModel';
 import type Shape from '../../../../../src/model/bpmn/internal/shape/Shape';
 
 export const shapeBpmnElementKindForLabelTests = Object.values(ShapeBpmnElementKind)
@@ -25,6 +25,6 @@ export const shapeBpmnElementKindForLabelTests = Object.values(ShapeBpmnElementK
   .filter(kind => ![ShapeBpmnElementKind.EVENT_BOUNDARY, ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH].includes(kind))
   .map(kind => [kind]);
 
-export function getEventShapes(model: BpmnModel): Shape[] {
-  return model.flowNodes.filter(shape => ShapeUtil.isEvent(shape.bpmnElement.kind));
+export function getEventShapes(parseResult: SplitedParseResult): Shape[] {
+  return parseResult.flowNodes.filter(shape => ShapeUtil.isEvent(shape.bpmnElement.kind));
 }

--- a/test/unit/component/registry/bpmn-model-registry.test.ts
+++ b/test/unit/component/registry/bpmn-model-registry.test.ts
@@ -41,8 +41,10 @@ function sequenceFlowInModel(id: string, name: string): BpmnModel {
 }
 
 function startEventInModel(id: string, name: string): BpmnModel {
+  const parent = new ShapeBpmnElement('parentId', 'parentName', ShapeBpmnElementKind.POOL);
+
   const bpmnModel = newBpmnModel();
-  bpmnModel.flowNodes.push(new Shape(`Shape_${id}`, new ShapeBpmnStartEvent(id, name, ShapeBpmnEventDefinitionKind.TIMER, 'parentId')));
+  bpmnModel.flowNodes.push(new Shape(`Shape_${id}`, new ShapeBpmnStartEvent(id, name, ShapeBpmnEventDefinitionKind.TIMER, parent)));
   return bpmnModel;
 }
 

--- a/test/unit/component/registry/bpmn-model-registry.test.ts
+++ b/test/unit/component/registry/bpmn-model-registry.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { BpmnModelRegistry } from '../../../../src/component/registry/bpmn-model-registry';
-import type BpmnModel from '../../../../src/model/bpmn/internal/BpmnModel';
+import type { BpmnModel } from '../../../../src/model/bpmn/internal/BpmnModel';
 import { Edge } from '../../../../src/model/bpmn/internal/edge/edge';
 import { SequenceFlow } from '../../../../src/model/bpmn/internal/edge/flows';
 import Shape from '../../../../src/model/bpmn/internal/shape/Shape';
@@ -26,17 +26,12 @@ import { expectLane, expectPool, expectSequenceFlow, expectStartEvent } from '..
 const bpmnModelRegistry = new BpmnModelRegistry();
 
 function newBpmnModel(): BpmnModel {
-  return {
-    edges: [],
-    flowNodes: [],
-    lanes: [],
-    pools: [],
-  };
+  return [];
 }
 
 function sequenceFlowInModel(id: string, name: string): BpmnModel {
   const bpmnModel = newBpmnModel();
-  bpmnModel.edges.push(new Edge(`Edge_${id}`, new SequenceFlow(id, name)));
+  bpmnModel.push(new Edge(`Edge_${id}`, new SequenceFlow(id, name)));
   return bpmnModel;
 }
 
@@ -44,19 +39,19 @@ function startEventInModel(id: string, name: string): BpmnModel {
   const parent = new ShapeBpmnElement('parentId', 'parentName', ShapeBpmnElementKind.POOL);
 
   const bpmnModel = newBpmnModel();
-  bpmnModel.flowNodes.push(new Shape(`Shape_${id}`, new ShapeBpmnStartEvent(id, name, ShapeBpmnEventDefinitionKind.TIMER, parent)));
+  bpmnModel.push(new Shape(`Shape_${id}`, new ShapeBpmnStartEvent(id, name, ShapeBpmnEventDefinitionKind.TIMER, parent)));
   return bpmnModel;
 }
 
 function laneInModel(id: string, name: string): BpmnModel {
   const bpmnModel = newBpmnModel();
-  bpmnModel.lanes.push(new Shape(`Shape_${id}`, new ShapeBpmnElement(id, name, ShapeBpmnElementKind.LANE)));
+  bpmnModel.push(new Shape(`Shape_${id}`, new ShapeBpmnElement(id, name, ShapeBpmnElementKind.LANE)));
   return bpmnModel;
 }
 
 function poolInModel(id: string, name: string): BpmnModel {
   const bpmnModel = newBpmnModel();
-  bpmnModel.pools.push(new Shape(`Shape_${id}`, new ShapeBpmnElement(id, name, ShapeBpmnElementKind.POOL)));
+  bpmnModel.push(new Shape(`Shape_${id}`, new ShapeBpmnElement(id, name, ShapeBpmnElementKind.POOL)));
   return bpmnModel;
 }
 

--- a/test/unit/model/bpmn/internal/shape/BpmnModel.test.ts
+++ b/test/unit/model/bpmn/internal/shape/BpmnModel.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Copyright 2022 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { AssociationFlow, MessageFlow, SequenceFlow } from '../../../../../../src/model/bpmn/internal/edge/flows';
+import { ShapeBpmnElementKind } from '../../../../../../src/model/bpmn/internal';
+import ShapeBpmnElement from '../../../../../../src/model/bpmn/internal/shape/ShapeBpmnElement';
+import Shape from '../../../../../../src/model/bpmn/internal/shape/Shape';
+import { flat } from '../../../../../../src/model/bpmn/internal/BpmnModel';
+import { Edge } from '../../../../../../src/model/bpmn/internal/edge/edge';
+
+describe('BpmnModel', () => {
+  it('flat empty array', () => {
+    const result = flat([]);
+
+    expect(result).toBeEmpty();
+  });
+
+  it('flat array with shapes and no children', () => {
+    const bpmnModel = [
+      new Shape('shape1', new ShapeBpmnElement('id1', 'name1', ShapeBpmnElementKind.EVENT_END)),
+      new Shape('shape2', new ShapeBpmnElement('id2', 'name2', ShapeBpmnElementKind.CALL_ACTIVITY)),
+    ];
+    const result = flat(bpmnModel);
+
+    expect(result).toHaveLength(2);
+    expect(result).toStrictEqual(bpmnModel);
+  });
+
+  it('flat array with shapes and shape as children', () => {
+    const bpmnModel = [
+      new Shape('shape1', new ShapeBpmnElement('id1', 'name1', ShapeBpmnElementKind.EVENT_END)),
+      new Shape('shape2', new ShapeBpmnElement('id2', 'name2', ShapeBpmnElementKind.CALL_ACTIVITY)),
+    ];
+    const child1 = new Shape('shape3', new ShapeBpmnElement('id3', 'name3', ShapeBpmnElementKind.CALL_ACTIVITY));
+    const child2 = new Shape('shape4', new ShapeBpmnElement('id4', 'name4', ShapeBpmnElementKind.CALL_ACTIVITY));
+    bpmnModel[0].addChild(child1);
+    bpmnModel[0].addChild(child2);
+
+    const result = flat(bpmnModel);
+
+    expect(result).toHaveLength(4);
+    expect(result).toStrictEqual([...bpmnModel, child1, child2]);
+  });
+
+  it('flat array with shapes and edge as children', () => {
+    const bpmnModel = [
+      new Shape('shape1', new ShapeBpmnElement('id1', 'name1', ShapeBpmnElementKind.EVENT_END)),
+      new Shape('shape2', new ShapeBpmnElement('id2', 'name2', ShapeBpmnElementKind.CALL_ACTIVITY)),
+    ];
+    const child1 = new Edge('edge1', new SequenceFlow('id3', 'name3'));
+    const child2 = new Edge('edge2', new AssociationFlow('id4', 'name4'));
+    bpmnModel[0].addChild(child1);
+    bpmnModel[0].addChild(child2);
+
+    const result = flat(bpmnModel);
+
+    expect(result).toHaveLength(4);
+    expect(result).toStrictEqual([...bpmnModel, child1, child2]);
+  });
+
+  it('flat array with shapes and shape/edge as children', () => {
+    const bpmnModel = [
+      new Shape('shape1', new ShapeBpmnElement('id1', 'name1', ShapeBpmnElementKind.EVENT_END)),
+      new Shape('shape2', new ShapeBpmnElement('id2', 'name2', ShapeBpmnElementKind.CALL_ACTIVITY)),
+    ];
+    const child1 = new Shape('shape3', new ShapeBpmnElement('id3', 'name3', ShapeBpmnElementKind.CALL_ACTIVITY));
+    const child2 = new Shape('shape4', new ShapeBpmnElement('id4', 'name4', ShapeBpmnElementKind.CALL_ACTIVITY));
+    const child3 = new Edge('edge1', new SequenceFlow('id5', 'name5'));
+    const child4 = new Edge('edge2', new AssociationFlow('id6', 'name6'));
+    bpmnModel[1].addChild(child1);
+    bpmnModel[1].addChild(child2);
+    bpmnModel[1].addChild(child3);
+    bpmnModel[1].addChild(child4);
+
+    const result = flat(bpmnModel);
+
+    expect(result).toHaveLength(6);
+    expect(result).toStrictEqual([...bpmnModel, child1, child2, child3, child4]);
+  });
+
+  it('flat array with edges and no children', () => {
+    const bpmnModel = [new Edge('edge1', new SequenceFlow('id1', 'name1')), new Edge('edge2', new AssociationFlow('id2', 'name2'))];
+    const result = flat(bpmnModel);
+
+    expect(result).toHaveLength(2);
+    expect(result).toStrictEqual(bpmnModel);
+  });
+
+  it('flat array with shapes and edges', () => {
+    const bpmnModel = [
+      new Shape('shape1', new ShapeBpmnElement('id1', 'name1', ShapeBpmnElementKind.EVENT_END)),
+      new Shape('shape2', new ShapeBpmnElement('id2', 'name2', ShapeBpmnElementKind.CALL_ACTIVITY)),
+      new Edge('edge1', new SequenceFlow('id3', 'name3')),
+      new Edge('edge2', new AssociationFlow('id4', 'name4')),
+    ];
+
+    const result = flat(bpmnModel);
+
+    expect(result).toHaveLength(4);
+    expect(result).toStrictEqual(bpmnModel);
+  });
+
+  it('flat array with shapes and edges and shape/edge as children', () => {
+    const child1 = new Shape('shape3', new ShapeBpmnElement('id5', 'name5', ShapeBpmnElementKind.CALL_ACTIVITY));
+    const child2 = new Shape('shape4', new ShapeBpmnElement('id6', 'name6', ShapeBpmnElementKind.CALL_ACTIVITY));
+    const child3 = new Edge('edge3', new SequenceFlow('id7', 'name7'));
+    const child4 = new Edge('edge4', new AssociationFlow('id8', 'name8'));
+
+    const shape1 = new Shape('shape1', new ShapeBpmnElement('id1', 'name1', ShapeBpmnElementKind.EVENT_END));
+    shape1.addChild(child1);
+    shape1.addChild(child3);
+
+    const shape2 = new Shape('shape2', new ShapeBpmnElement('id2', 'name2', ShapeBpmnElementKind.CALL_ACTIVITY));
+    shape2.addChild(child2);
+    shape2.addChild(child4);
+
+    const edge1 = new Edge('edge1', new SequenceFlow('id3', 'name3'));
+    const edge2 = new Edge('edge2', new AssociationFlow('id4', 'name4'));
+
+    const result = flat([shape1, shape2, edge1, edge2]);
+
+    expect(result).toHaveLength(8);
+    expect(result).toStrictEqual([shape1, shape2, edge1, edge2, child1, child3, child2, child4]);
+  });
+
+  it('flat array with shapes and edges and shape/edge as children and shape/edge as sub-children', () => {
+    const subChild1 = new Shape('shape5', new ShapeBpmnElement('id9', 'name9', ShapeBpmnElementKind.SUB_PROCESS));
+    const subChild2 = new Shape('shape6', new ShapeBpmnElement('id10', 'name10', ShapeBpmnElementKind.EVENT_END));
+    const subChild3 = new Edge('edge5', new SequenceFlow('id11', 'name11'));
+    const subChild4 = new Edge('edge6', new AssociationFlow('id12', 'name12'));
+
+    const child1 = new Shape('shape3', new ShapeBpmnElement('id5', 'name5', ShapeBpmnElementKind.CALL_ACTIVITY));
+    child1.addChild(subChild1);
+    child1.addChild(subChild3);
+
+    const child2 = new Shape('shape4', new ShapeBpmnElement('id6', 'name6', ShapeBpmnElementKind.CALL_ACTIVITY));
+    child2.addChild(subChild2);
+    child2.addChild(subChild4);
+
+    const child3 = new Edge('edge3', new SequenceFlow('id7', 'name7'));
+    const child4 = new Edge('edge4', new AssociationFlow('id8', 'name8'));
+
+    const shape1 = new Shape('shape1', new ShapeBpmnElement('id1', 'name1', ShapeBpmnElementKind.EVENT_END));
+    shape1.addChild(child1);
+    shape1.addChild(child3);
+
+    const shape2 = new Shape('shape2', new ShapeBpmnElement('id2', 'name2', ShapeBpmnElementKind.CALL_ACTIVITY));
+    shape2.addChild(child2);
+    shape2.addChild(child4);
+
+    const edge1 = new Edge('edge1', new MessageFlow('id3', 'name3'));
+    const edge2 = new Edge('edge2', new AssociationFlow('id4', 'name4'));
+
+    const result = flat([shape1, shape2, edge1, edge2]);
+
+    expect(result).toHaveLength(12);
+    expect(result).toStrictEqual([shape1, shape2, edge1, edge2, child1, child3, child2, child4, subChild1, subChild3, subChild2, subChild4]);
+  });
+});


### PR DESCRIPTION
covers #592 

Based on #2025

### url to test the filtering with the demo and test pages

- http://localhost:10001/dev/public/index.html?url=/test/fixtures/bpmn/model-complete-semantic.bpmn&bpmn.pool.id.filtered=participant_4_id0
- B.1.0: bpmn.pool.id.filtered=_cde15ee4-b395-43a3-9f5e-9028446f8a52
- http://localhost:10001/dev/public/index.html?url=/test/fixtures/bpmn/performance/B.2.0.bpmn&bpmn.pool.id.filtered=_55bb31e8-9e62-48ea-8f0e-1a748c04bbf6

----
### POC result, at the commit 075f1c8358ec0c11ab5d89bb24daef1b9dbbd23d

- [ ] 🐛 In the case where a Call Activity calls a Process, the process and its elements are not linked to this Call Activity.
- [ ] To keep: The new combination of unit tests for the Message Flows https://github.com/process-analytics/bpmn-visualization-js/pull/2020/files#diff-89b5eb500f682ed39624c42dd091bec5d28c4cd195fa73efb88a678b2c8b7a5fR325
- [ ] To improve: The refactoring to avoid false Pool and simplify Participant conversion to Pool 
- https://github.com/process-analytics/bpmn-visualization-js/pull/2020/files#diff-f847968ed95a9cd2f9921dc82c5c64bc8504e4ec39baf0e0a76d4af12331184fR51
- https://github.com/process-analytics/bpmn-visualization-js/pull/2020/files#diff-a3f4d22ee90476febc6e7329a9d846e235d02b8e5e49b9c3fdc9fe92c1937b38R74
- https://github.com/process-analytics/bpmn-visualization-js/pull/2020/files#diff-c4380fe1ce053f0b54b90710afdded58060a0400cbc0c9646c979cd6c8a1563aL112
- [ ] To keep: Some refactoring on the `ProcessConverter`
- https://github.com/process-analytics/bpmn-visualization-js/pull/2020/files#diff-a3f4d22ee90476febc6e7329a9d846e235d02b8e5e49b9c3fdc9fe92c1937b38R212-R218
- https://github.com/process-analytics/bpmn-visualization-js/pull/2020/files#diff-a3f4d22ee90476febc6e7329a9d846e235d02b8e5e49b9c3fdc9fe92c1937b38R284-R298
- [ ] To move or not ? https://github.com/process-analytics/bpmn-visualization-js/pull/2020/files#diff-f847968ed95a9cd2f9921dc82c5c64bc8504e4ec39baf0e0a76d4af12331184fL132-R160
- [ ] Change the test titles & the `Participant`/`Process` names: test/unit/component/parser/json/BpmnJsonParser.process.test.ts
- [ ] The expected result should be undefined: https://github.com/process-analytics/bpmn-visualization-js/pull/2020/files#diff-c69ba0c6d73c0c841b28502862435ddb243b08c64a2fedfc200b56bfc66be277L776
- [ ] See what we keep & add unit tests on new behavior: test/unit/component/parser/json/JsonBuilder.ts
- [ ] To keep: https://github.com/process-analytics/bpmn-visualization-js/pull/2020/files#diff-a55edd723b34eab5eb7b051dbe6e7ca26736cc3bd941d4df1ff3ba74e8c63b68R124-R139
- [ ] Simplify the ModelFilter: https://github.com/process-analytics/bpmn-visualization-js/pull/2020/files#diff-50ae702bef362f7c48654927768587f8d08aac5b4382ac6a51fbe69a2d486ae5R74-R86
```
export interface ModelFilter {
    pools?: {
      ids?: string | string[];
      names?: string | string[];
    };
  };
}
```