### PR TITLE
[INFRA] Use ViteJS for development and the demo build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,3 @@
 
 # npm build
 *.tgz
-# tailwind css generated for demo
-/dev/public/static/css/tailwind.css

--- a/dev/public/diagram-navigation.html
+++ b/dev/public/diagram-navigation.html
@@ -8,7 +8,6 @@
   <title>BPMN Visualization - Diagram Navigation</title>
   <link rel="icon" href="static/img/favicon.png">
   <link rel="stylesheet" href="static/css/test-page.css">
-
   <style>
     .fit {
       background-color: #f9dfe8;
@@ -19,9 +18,7 @@
       width: 35px;
     }
   </style>
-
-  <!-- load app -->
-  <script src="static/js/diagram-navigation.js" type="module"></script>
+  <script src="/dev/public/static/js/diagram-navigation.js" type="module"></script>
 </head>
 <body>
 <div class="flex-container">

--- a/dev/public/elements-identification.html
+++ b/dev/public/elements-identification.html
@@ -120,9 +120,7 @@
         color: var(--color-flow) !important;
       }
     </style>
-
-    <!-- load app -->
-    <script src="static/js/elements-identification.js" type="module"></script>
+    <script src="/dev/public/static/js/elements-identification.js" type="module"></script>
 </head>
 <body>
     <div id="controls">

--- a/dev/public/index.html
+++ b/dev/public/index.html
@@ -5,10 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>BPMN Visualization Demo</title>
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v6.1.1/css/all.css">
-    <link href="static/css/tailwind.css" rel="stylesheet">
+    <link href="/dev/public/static/css/styles.css" rel="stylesheet">
     <link rel="icon" href="static/img/favicon.png">
-    <!-- load demo -->
-    <script src="static/js/index.js" type="module"></script>
+    <script src="/dev/public/static/js/index.js" type="module"></script>
 </head>
 <body class="bg-gray-800 font-sans leading-normal tracking-normal flex flex-col h-screen">
     <!--Nav-->

--- a/dev/public/lib-integration.html
+++ b/dev/public/lib-integration.html
@@ -4,8 +4,7 @@
   <meta charset="UTF-8">
   <title>BPMN Visualization Lib Integration</title>
   <link rel="icon" href="static/img/favicon.png">
-  <!-- load app -->
-  <script src="static/js/lib-integration.js" type="module"></script>
+  <script src="/dev/public/static/js/lib-integration.js" type="module"></script>
 </head>
 <body>
   <div id="bpmn-container-custom"></div>

--- a/dev/public/non-regression.html
+++ b/dev/public/non-regression.html
@@ -18,8 +18,7 @@
         font-weight: bold;
       }
     </style>
-    <!-- load app -->
-    <script src="static/js/non-regression.js" type="module"></script>
+    <script src="/dev/public/static/js/non-regression.js" type="module"></script>
 </head>
 <body>
     <div id="fetch-status"></div>

--- a/dev/public/overlays.html
+++ b/dev/public/overlays.html
@@ -8,14 +8,12 @@
   <title>BPMN Visualization - Overlays</title>
   <link rel="icon" href="static/img/favicon.png">
   <link rel="stylesheet" href="static/css/test-page.css">
-
   <style>
     .overlay {
       background-color: MintCream;
     }
   </style>
-  <!-- load app -->
-  <script src="static/js/overlays.js" type="module"></script>
+  <script src="/dev/public/static/js/overlays.js" type="module"></script>
 </head>
 <body>
 <div class="flex-container">

--- a/dev/public/static/js/diagram-navigation.js
+++ b/dev/public/static/js/diagram-navigation.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { documentReady, startBpmnVisualization, fit, FitType, zoom, ZoomType } from '../../index.es.js';
+import { documentReady, startBpmnVisualization, fit, FitType, zoom, ZoomType } from '/dev/ts/internal-dev-bundle-index.ts';
 import { configureControlsPanel, configureMousePointer } from './helpers/controls.js';
 
 function configureFitAndZoomButtons() {

--- a/dev/public/static/js/elements-identification.js
+++ b/dev/public/static/js/elements-identification.js
@@ -27,7 +27,7 @@ import {
   ShapeUtil,
   addOverlays,
   removeAllOverlays,
-} from '../../index.es.js';
+} from '/dev/ts/internal-dev-bundle-index.ts';
 
 let lastIdentifiedBpmnIds = [];
 const cssClassName = 'detection';

--- a/dev/public/static/js/index.js
+++ b/dev/public/static/js/index.js
@@ -13,7 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { documentReady, handleFileSelect, startBpmnVisualization, fit, log, updateLoadOptions, getCurrentLoadOptions, getVersion, zoom, ZoomType } from '/dev/ts/internal-dev-bundle-index.ts';
+import {
+  documentReady,
+  handleFileSelect,
+  startBpmnVisualization,
+  fit,
+  log,
+  updateLoadOptions,
+  getCurrentLoadOptions,
+  getVersion,
+  zoom,
+  ZoomType,
+} from '/dev/ts/internal-dev-bundle-index.ts';
 
 let fitOnLoad = true;
 let fitOptions = {};

--- a/dev/public/static/js/index.js
+++ b/dev/public/static/js/index.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { documentReady, handleFileSelect, startBpmnVisualization, fit, log, updateLoadOptions, getCurrentLoadOptions, getVersion, zoom, ZoomType } from '../../index.es.js';
+import { documentReady, handleFileSelect, startBpmnVisualization, fit, log, updateLoadOptions, getCurrentLoadOptions, getVersion, zoom, ZoomType } from '/dev/ts/internal-dev-bundle-index.ts';
 
 let fitOnLoad = true;
 let fitOptions = {};

--- a/dev/public/static/js/lib-integration.js
+++ b/dev/public/static/js/lib-integration.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { BpmnVisualization } from '../../index.es.js';
+import { BpmnVisualization } from '/src/bpmn-visualization.ts';
 
 const bpmnVisualizationIntegration = new BpmnVisualization({ container: 'bpmn-container-custom' });
 bpmnVisualizationIntegration.load(bpmnDefaultContent());

--- a/dev/public/static/js/non-regression.js
+++ b/dev/public/static/js/non-regression.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { documentReady, startBpmnVisualization } from '../../index.es.js';
+import { documentReady, startBpmnVisualization } from '/dev/ts/internal-dev-bundle-index.ts';
 
 function statusFetchKO(errorMsg) {
   const statusElt = document.getElementById('fetch-status');

--- a/dev/public/static/js/overlays.js
+++ b/dev/public/static/js/overlays.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { documentReady, startBpmnVisualization, addOverlays, removeAllOverlays, getElementsByIds } from '../../index.es.js';
+import { documentReady, startBpmnVisualization, addOverlays, removeAllOverlays, getElementsByIds } from '/dev/ts/internal-dev-bundle-index.ts';
 import { configureControlsPanel, configureMousePointer } from './helpers/controls.js';
 
 function addOverlay(overlay) {

--- a/docs/contributors/demo-page-css.md
+++ b/docs/contributors/demo-page-css.md
@@ -1,11 +1,10 @@
 ## CSS for Demo
-The project demo page uses [tailwindcss](https://tailwindcss.com/docs).
 
-To process the CSS rules and get an output `tailwind.css` file, which is used in demo page:
-run: `npm run demo`
+The project demo page (`index.html`) uses [tailwindcss](https://tailwindcss.com/docs).
 
-The `demo:css` npm script does the trick, it uses postcss. Feel free to preview config files:
+Vite automatically processes the CSS rules using `postcss`.
+
+Feel free to preview config files:
 - [postcss.config.js](postcss.config.js)
 - [tailwind.config.js](tailwind.config.js)
 
-The Rollup build handles the livereload and the html/css resources watch.

--- a/docs/contributors/development.md
+++ b/docs/contributors/development.md
@@ -13,8 +13,8 @@
 ## Build
 
 - `npm install`           *Install the dependencies in the local node_modules folder*
-- `npm run watch`         *Watch files in bundle and rebuild on changes* <br>
-                          You can now access the project on http://localhost:10001
+- `npm run dev`           *Start the development server and rebuild on changes* <br>
+                          You can now access the project on http://localhost:10001/dev/public/index.html
 
 ## Tests
 

--- a/docs/contributors/testing.md
+++ b/docs/contributors/testing.md
@@ -159,12 +159,12 @@ All configurations described here can be done in `bpmn.rendering.test.ts`.
 <a name="image-diff-threshold"></a>
 ##### Image diff threshold
 
-The ideal scenario generates SVG that does not involve font: SVG is supposed to be rendered in the same way on all OS, so
-in that case, the actual rendering exactly matches the reference image.
+The ideal scenario generates SVG that does not involve font: SVG is supposed to be rendered in the same way on all OS and
+web browsers, so in that case, the actual rendering exactly matches the reference image.
 
-As font rendering differs depending on the OS, BPMN diagram containing label won't be rendered exactly as the reference
-image on all OS. In that case, a diff threshold image must be configured: the test will fail if the diff is above the
-threshold.
+As font rendering differs depending on the OS and the web browsers, BPMN diagram containing label won't be rendered exactly
+as the reference image on all OS. In that case, a diff threshold image must be configured: the test will fail if the diff
+is above the threshold.
 
 To be able to detect most of the unwanted changes, this threshold must be set as small as possible but large enough to
 manage small variations and not produce false positive errors.
@@ -180,8 +180,13 @@ The diagrams used by tests are located in the `test/fixtures/bpmn` folder and su
 by tests are in charge of loading the BPMN diagrams.
 
 To load a diagram, just pass a relative path to the diagram as query parameter. The page is able to fetch the diagram content
-as the diagrams are served by the dev server.
-Convenient methods exist to only pass the name of the diagram without having to manage the folder tree to the file.
+as the diagrams are served by the dev server. The parameter name is `url` and the value is the path from the project root like
+`/test/fixtures/bpmn/simple-start-task-end.bpmn`. This works with all test pages of the project.
+
+Example: 
+> http://localhost:10001/dev/public/index.html?url=/test/fixtures/bpmn/non-regression/associations.and.annotations.01.general.bpmn
+
+In tests, convenient methods exist to only pass the name of the diagram without having to manage the folder tree to the file.
 
 
 ### Performance tests

--- a/index.html
+++ b/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta http-equiv="refresh" content="0; url='/dev/public/'" />
+  <title>Redirect to the actual dev page</title>
+</head>
+<body>
+<p>Please follow <a href="/dev/public/">this link</a> to see the index.html development page.</p>
+</body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,8 @@
         "tailwindcss": "~3.0.24",
         "ts-jest": "~27.1.4",
         "typedoc": "~0.22.17",
-        "typescript": "~4.7.3"
+        "typescript": "~4.7.3",
+        "vite": "~2.9.10"
       }
     },
     "node_modules/@asciidoctor/cli": {
@@ -4327,6 +4328,361 @@
       "version": "4.1.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.42.tgz",
+      "integrity": "sha512-V0uPZotCEHokJdNqyozH6qsaQXqmZEOiZWrXnds/zaH/0SyrIayRXWRB98CENO73MIZ9T3HBIOsmds5twWtmgw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "esbuild-android-64": "0.14.42",
+        "esbuild-android-arm64": "0.14.42",
+        "esbuild-darwin-64": "0.14.42",
+        "esbuild-darwin-arm64": "0.14.42",
+        "esbuild-freebsd-64": "0.14.42",
+        "esbuild-freebsd-arm64": "0.14.42",
+        "esbuild-linux-32": "0.14.42",
+        "esbuild-linux-64": "0.14.42",
+        "esbuild-linux-arm": "0.14.42",
+        "esbuild-linux-arm64": "0.14.42",
+        "esbuild-linux-mips64le": "0.14.42",
+        "esbuild-linux-ppc64le": "0.14.42",
+        "esbuild-linux-riscv64": "0.14.42",
+        "esbuild-linux-s390x": "0.14.42",
+        "esbuild-netbsd-64": "0.14.42",
+        "esbuild-openbsd-64": "0.14.42",
+        "esbuild-sunos-64": "0.14.42",
+        "esbuild-windows-32": "0.14.42",
+        "esbuild-windows-64": "0.14.42",
+        "esbuild-windows-arm64": "0.14.42"
+      }
+    },
+    "node_modules/esbuild-android-64": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.42.tgz",
+      "integrity": "sha512-P4Y36VUtRhK/zivqGVMqhptSrFILAGlYp0Z8r9UQqHJ3iWztRCNWnlBzD9HRx0DbueXikzOiwyOri+ojAFfW6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-android-arm64": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.42.tgz",
+      "integrity": "sha512-0cOqCubq+RWScPqvtQdjXG3Czb3AWI2CaKw3HeXry2eoA2rrPr85HF7IpdU26UWdBXgPYtlTN1LUiuXbboROhg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-darwin-64": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.42.tgz",
+      "integrity": "sha512-ipiBdCA3ZjYgRfRLdQwP82rTiv/YVMtW36hTvAN5ZKAIfxBOyPXY7Cejp3bMXWgzKD8B6O+zoMzh01GZsCuEIA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-darwin-arm64": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.42.tgz",
+      "integrity": "sha512-bU2tHRqTPOaoH/4m0zYHbFWpiYDmaA0gt90/3BMEFaM0PqVK/a6MA2V/ypV5PO0v8QxN6gH5hBPY4YJ2lopXgA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-freebsd-64": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.42.tgz",
+      "integrity": "sha512-75h1+22Ivy07+QvxHyhVqOdekupiTZVLN1PMwCDonAqyXd8TVNJfIRFrdL8QmSJrOJJ5h8H1I9ETyl2L8LQDaw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-freebsd-arm64": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.42.tgz",
+      "integrity": "sha512-W6Jebeu5TTDQMJUJVarEzRU9LlKpNkPBbjqSu+GUPTHDCly5zZEQq9uHkmHHl7OKm+mQ2zFySN83nmfCeZCyNA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-32": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.42.tgz",
+      "integrity": "sha512-Ooy/Bj+mJ1z4jlWcK5Dl6SlPlCgQB9zg1UrTCeY8XagvuWZ4qGPyYEWGkT94HUsRi2hKsXvcs6ThTOjBaJSMfg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-64": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.42.tgz",
+      "integrity": "sha512-2L0HbzQfbTuemUWfVqNIjOfaTRt9zsvjnme6lnr7/MO9toz/MJ5tZhjqrG6uDWDxhsaHI2/nsDgrv8uEEN2eoA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-arm": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.42.tgz",
+      "integrity": "sha512-STq69yzCMhdRaWnh29UYrLSr/qaWMm/KqwaRF1pMEK7kDiagaXhSL1zQGXbYv94GuGY/zAwzK98+6idCMUOOCg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-arm64": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.42.tgz",
+      "integrity": "sha512-c3Ug3e9JpVr8jAcfbhirtpBauLxzYPpycjWulD71CF6ZSY26tvzmXMJYooQ2YKqDY4e/fPu5K8bm7MiXMnyxuA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-mips64le": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.42.tgz",
+      "integrity": "sha512-QuvpHGbYlkyXWf2cGm51LBCHx6eUakjaSrRpUqhPwjh/uvNUYvLmz2LgPTTPwCqaKt0iwL+OGVL0tXA5aDbAbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-ppc64le": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.42.tgz",
+      "integrity": "sha512-8ohIVIWDbDT+i7lCx44YCyIRrOW1MYlks9fxTo0ME2LS/fxxdoJBwHWzaDYhjvf8kNpA+MInZvyOEAGoVDrMHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-riscv64": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.42.tgz",
+      "integrity": "sha512-DzDqK3TuoXktPyG1Lwx7vhaF49Onv3eR61KwQyxYo4y5UKTpL3NmuarHSIaSVlTFDDpcIajCDwz5/uwKLLgKiQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-s390x": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.42.tgz",
+      "integrity": "sha512-YFRhPCxl8nb//Wn6SiS5pmtplBi4z9yC2gLrYoYI/tvwuB1jldir9r7JwAGy1Ck4D7sE7wBN9GFtUUX/DLdcEQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-netbsd-64": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.42.tgz",
+      "integrity": "sha512-QYSD2k+oT9dqB/4eEM9c+7KyNYsIPgzYOSrmfNGDIyJrbT1d+CFVKvnKahDKNJLfOYj8N4MgyFaU9/Ytc6w5Vw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-openbsd-64": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.42.tgz",
+      "integrity": "sha512-M2meNVIKWsm2HMY7+TU9AxM7ZVwI9havdsw6m/6EzdXysyCFFSoaTQ/Jg03izjCsK17FsVRHqRe26Llj6x0MNA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-sunos-64": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.42.tgz",
+      "integrity": "sha512-uXV8TAZEw36DkgW8Ak3MpSJs1ofBb3Smkc/6pZ29sCAN1KzCAQzsje4sUwugf+FVicrHvlamCOlFZIXgct+iqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-32": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.42.tgz",
+      "integrity": "sha512-4iw/8qWmRICWi9ZOnJJf9sYt6wmtp3hsN4TdI5NqgjfOkBVMxNdM9Vt3626G1Rda9ya2Q0hjQRD9W1o+m6Lz6g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-64": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.42.tgz",
+      "integrity": "sha512-j3cdK+Y3+a5H0wHKmLGTJcq0+/2mMBHPWkItR3vytp/aUGD/ua/t2BLdfBIzbNN9nLCRL9sywCRpOpFMx3CxzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-arm64": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.42.tgz",
+      "integrity": "sha512-+lRAARnF+hf8J0mN27ujO+VbhPbDqJ8rCcJKye4y7YZLV6C4n3pTRThAb388k/zqF5uM0lS5O201u0OqoWSicw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -11311,6 +11667,43 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "node_modules/vite": {
+      "version": "2.9.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.10.tgz",
+      "integrity": "sha512-TwZRuSMYjpTurLqXspct+HZE7ONiW9d+wSWgvADGxhDPPyoIcNywY+RX4ng+QpK30DCa1l/oZgi2PLZDibhzbQ==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.14.27",
+        "postcss": "^8.4.13",
+        "resolve": "^1.22.0",
+        "rollup": "^2.59.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": ">=12.2.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "less": "*",
+        "sass": "*",
+        "stylus": "*"
+      },
+      "peerDependenciesMeta": {
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vscode-oniguruma": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
@@ -14592,6 +14985,174 @@
     "es6-error": {
       "version": "4.1.1",
       "dev": true
+    },
+    "esbuild": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.42.tgz",
+      "integrity": "sha512-V0uPZotCEHokJdNqyozH6qsaQXqmZEOiZWrXnds/zaH/0SyrIayRXWRB98CENO73MIZ9T3HBIOsmds5twWtmgw==",
+      "dev": true,
+      "requires": {
+        "esbuild-android-64": "0.14.42",
+        "esbuild-android-arm64": "0.14.42",
+        "esbuild-darwin-64": "0.14.42",
+        "esbuild-darwin-arm64": "0.14.42",
+        "esbuild-freebsd-64": "0.14.42",
+        "esbuild-freebsd-arm64": "0.14.42",
+        "esbuild-linux-32": "0.14.42",
+        "esbuild-linux-64": "0.14.42",
+        "esbuild-linux-arm": "0.14.42",
+        "esbuild-linux-arm64": "0.14.42",
+        "esbuild-linux-mips64le": "0.14.42",
+        "esbuild-linux-ppc64le": "0.14.42",
+        "esbuild-linux-riscv64": "0.14.42",
+        "esbuild-linux-s390x": "0.14.42",
+        "esbuild-netbsd-64": "0.14.42",
+        "esbuild-openbsd-64": "0.14.42",
+        "esbuild-sunos-64": "0.14.42",
+        "esbuild-windows-32": "0.14.42",
+        "esbuild-windows-64": "0.14.42",
+        "esbuild-windows-arm64": "0.14.42"
+      }
+    },
+    "esbuild-android-64": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.42.tgz",
+      "integrity": "sha512-P4Y36VUtRhK/zivqGVMqhptSrFILAGlYp0Z8r9UQqHJ3iWztRCNWnlBzD9HRx0DbueXikzOiwyOri+ojAFfW6A==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-android-arm64": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.42.tgz",
+      "integrity": "sha512-0cOqCubq+RWScPqvtQdjXG3Czb3AWI2CaKw3HeXry2eoA2rrPr85HF7IpdU26UWdBXgPYtlTN1LUiuXbboROhg==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-darwin-64": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.42.tgz",
+      "integrity": "sha512-ipiBdCA3ZjYgRfRLdQwP82rTiv/YVMtW36hTvAN5ZKAIfxBOyPXY7Cejp3bMXWgzKD8B6O+zoMzh01GZsCuEIA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-darwin-arm64": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.42.tgz",
+      "integrity": "sha512-bU2tHRqTPOaoH/4m0zYHbFWpiYDmaA0gt90/3BMEFaM0PqVK/a6MA2V/ypV5PO0v8QxN6gH5hBPY4YJ2lopXgA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-freebsd-64": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.42.tgz",
+      "integrity": "sha512-75h1+22Ivy07+QvxHyhVqOdekupiTZVLN1PMwCDonAqyXd8TVNJfIRFrdL8QmSJrOJJ5h8H1I9ETyl2L8LQDaw==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-freebsd-arm64": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.42.tgz",
+      "integrity": "sha512-W6Jebeu5TTDQMJUJVarEzRU9LlKpNkPBbjqSu+GUPTHDCly5zZEQq9uHkmHHl7OKm+mQ2zFySN83nmfCeZCyNA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-32": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.42.tgz",
+      "integrity": "sha512-Ooy/Bj+mJ1z4jlWcK5Dl6SlPlCgQB9zg1UrTCeY8XagvuWZ4qGPyYEWGkT94HUsRi2hKsXvcs6ThTOjBaJSMfg==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-64": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.42.tgz",
+      "integrity": "sha512-2L0HbzQfbTuemUWfVqNIjOfaTRt9zsvjnme6lnr7/MO9toz/MJ5tZhjqrG6uDWDxhsaHI2/nsDgrv8uEEN2eoA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-arm": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.42.tgz",
+      "integrity": "sha512-STq69yzCMhdRaWnh29UYrLSr/qaWMm/KqwaRF1pMEK7kDiagaXhSL1zQGXbYv94GuGY/zAwzK98+6idCMUOOCg==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-arm64": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.42.tgz",
+      "integrity": "sha512-c3Ug3e9JpVr8jAcfbhirtpBauLxzYPpycjWulD71CF6ZSY26tvzmXMJYooQ2YKqDY4e/fPu5K8bm7MiXMnyxuA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-mips64le": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.42.tgz",
+      "integrity": "sha512-QuvpHGbYlkyXWf2cGm51LBCHx6eUakjaSrRpUqhPwjh/uvNUYvLmz2LgPTTPwCqaKt0iwL+OGVL0tXA5aDbAbg==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-ppc64le": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.42.tgz",
+      "integrity": "sha512-8ohIVIWDbDT+i7lCx44YCyIRrOW1MYlks9fxTo0ME2LS/fxxdoJBwHWzaDYhjvf8kNpA+MInZvyOEAGoVDrMHg==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-riscv64": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.42.tgz",
+      "integrity": "sha512-DzDqK3TuoXktPyG1Lwx7vhaF49Onv3eR61KwQyxYo4y5UKTpL3NmuarHSIaSVlTFDDpcIajCDwz5/uwKLLgKiQ==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-s390x": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.42.tgz",
+      "integrity": "sha512-YFRhPCxl8nb//Wn6SiS5pmtplBi4z9yC2gLrYoYI/tvwuB1jldir9r7JwAGy1Ck4D7sE7wBN9GFtUUX/DLdcEQ==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-netbsd-64": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.42.tgz",
+      "integrity": "sha512-QYSD2k+oT9dqB/4eEM9c+7KyNYsIPgzYOSrmfNGDIyJrbT1d+CFVKvnKahDKNJLfOYj8N4MgyFaU9/Ytc6w5Vw==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-openbsd-64": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.42.tgz",
+      "integrity": "sha512-M2meNVIKWsm2HMY7+TU9AxM7ZVwI9havdsw6m/6EzdXysyCFFSoaTQ/Jg03izjCsK17FsVRHqRe26Llj6x0MNA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-sunos-64": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.42.tgz",
+      "integrity": "sha512-uXV8TAZEw36DkgW8Ak3MpSJs1ofBb3Smkc/6pZ29sCAN1KzCAQzsje4sUwugf+FVicrHvlamCOlFZIXgct+iqQ==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-windows-32": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.42.tgz",
+      "integrity": "sha512-4iw/8qWmRICWi9ZOnJJf9sYt6wmtp3hsN4TdI5NqgjfOkBVMxNdM9Vt3626G1Rda9ya2Q0hjQRD9W1o+m6Lz6g==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-windows-64": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.42.tgz",
+      "integrity": "sha512-j3cdK+Y3+a5H0wHKmLGTJcq0+/2mMBHPWkItR3vytp/aUGD/ua/t2BLdfBIzbNN9nLCRL9sywCRpOpFMx3CxzA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-windows-arm64": {
+      "version": "0.14.42",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.42.tgz",
+      "integrity": "sha512-+lRAARnF+hf8J0mN27ujO+VbhPbDqJ8rCcJKye4y7YZLV6C4n3pTRThAb388k/zqF5uM0lS5O201u0OqoWSicw==",
+      "dev": true,
+      "optional": true
     },
     "escalade": {
       "version": "3.1.1",
@@ -19289,6 +19850,19 @@
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "vite": {
+      "version": "2.9.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.10.tgz",
+      "integrity": "sha512-TwZRuSMYjpTurLqXspct+HZE7ONiW9d+wSWgvADGxhDPPyoIcNywY+RX4ng+QpK30DCa1l/oZgi2PLZDibhzbQ==",
+      "dev": true,
+      "requires": {
+        "esbuild": "^0.14.27",
+        "fsevents": "~2.3.2",
+        "postcss": "^8.4.13",
+        "resolve": "^1.22.0",
+        "rollup": "^2.59.0"
       }
     },
     "vscode-oniguruma": {

--- a/package.json
+++ b/package.json
@@ -47,20 +47,19 @@
     "NOTICE"
   ],
   "scripts": {
+    "dev": "vite",
     "all": "run-s clean lint lint-check build test",
     "clean": "rimraf build dist",
-    "build": "rollup -c",
-    "build-bundles": "rollup -c --config-build-bundles true",
+    "build": "tsc --noEmit",
+    "build-bundles": "rollup -c",
     "prepack": "run-s clean build-bundles",
     "demo": "run-s demo:*",
-    "demo:clean": "rimraf build/demo",
-    "demo:css": "postcss dev/public/static/css/styles.css -o dev/public/static/css/tailwind.css",
-    "demo:build": "rollup -c --silent --environment demoMode:true",
+    "demo:build": "tsc --noEmit && vite build",
+    "demo:prepare": "node scripts/prepare-demo-for-publish.mjs",
+    "demo-preview": "vite preview",
     "docs": "run-s docs:*",
     "docs:user": "node scripts/docs.js",
     "docs:api": "typedoc --tsconfig ./tsconfig.typedoc.json src/bpmn-visualization.ts",
-    "start": "rollup -c --silent --environment devMode:true",
-    "watch": "rollup -cw --environment devLiveReloadMode:true",
     "lint": "eslint \"*/**/*.{js,mjs,ts}\" NOTICE --max-warnings 0 --quiet --fix",
     "lint-check": "eslint \"*/**/*.{js,mjs,ts}\" NOTICE --max-warnings 0",
     "test": "run-s test:unit test:integration test:e2e",
@@ -153,7 +152,8 @@
     "tailwindcss": "~3.0.24",
     "ts-jest": "~27.1.4",
     "typedoc": "~0.22.17",
-    "typescript": "~4.7.3"
+    "typescript": "~4.7.3",
+    "vite": "~2.9.10"
   },
   "lint-staged": {
     "*.{js,mjs,ts}": [

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -13,17 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 const defaultPlugins = {
   tailwindcss: {},
   autoprefixer: {},
 };
 
-const plugins = process.env.devLiveReloadMode
-  ? defaultPlugins
-  : {
-      ...defaultPlugins,
-      cssnano: {
-        preset: 'default',
-      },
-    };
+const plugins =
+  process.env.NODE_ENV === 'development'
+    ? defaultPlugins
+    : {
+        ...defaultPlugins,
+        cssnano: {
+          preset: 'default',
+        },
+      };
 module.exports = { plugins };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,125 +13,85 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import serve from 'rollup-plugin-serve';
-import livereload from 'rollup-plugin-livereload';
-import copy from 'rollup-plugin-copy';
-import copyWatch from 'rollup-plugin-copy-watch';
+
+import autoExternal from 'rollup-plugin-auto-external';
 import { terser } from 'rollup-plugin-terser';
 import sizes from 'rollup-plugin-sizes';
-import autoExternal from 'rollup-plugin-auto-external';
-import execute from 'rollup-plugin-execute';
 
 import typescript from 'rollup-plugin-typescript2';
 import commonjs from '@rollup/plugin-commonjs'; // at least, needed to bundle mxGraph which is only available as a CommonJS module
 import resolve from '@rollup/plugin-node-resolve';
 import pkg from './package.json';
 
-import parseArgs from 'minimist';
+const libInput = 'src/bpmn-visualization.ts';
+const pluginsBundleIIFE = [
+  typescriptPlugin(),
+  // the 'resolve' and 'commonjs' plugins ensure we can bundle commonjs dependencies
+  resolve(),
+  commonjs(),
+  // to have sizes of dependencies listed at the end of build log
+  sizes(),
+];
+const outputIIFE = {
+  file: pkg.browser.replace('.min.js', '.js'),
+  name: 'bpmnvisu',
+  format: 'iife',
+};
 
-const devLiveReloadMode = process.env.devLiveReloadMode;
-const devMode = devLiveReloadMode ? true : process.env.devMode;
-const demoMode = process.env.demoMode;
+const configIIFE = {
+  input: libInput,
+  output: outputIIFE,
+  plugins: pluginsBundleIIFE,
+};
+const configIIFEMinified = {
+  input: libInput,
+  output: {
+    ...outputIIFE,
+    file: pkg.browser,
+  },
+  plugins: withMinification(pluginsBundleIIFE),
+};
 
-// parse command line arguments
-const argv = parseArgs(process.argv.slice(2)); // start with 'node rollup' so drop them
-// for the 'config-xxx' syntax, see https://github.com/rollup/rollup/issues/1662#issuecomment-395382741
-const serverPort = process.env.SERVER_PORT || argv['config-server-port'] || 10001;
-const buildBundles = argv['config-build-bundles'] || false;
+const pluginsBundles = [
+  typescriptPlugin(),
+  // ensure we do not bundle dependencies
+  autoExternal(),
+  // to have sizes of dependencies listed at the end of build log
+  sizes(),
+];
 
-const outputDir = demoMode ? 'build/demo' : 'build/public';
-let rollupConfigs;
-
-// internal lib development
-if (!buildBundles) {
-  const sourceMap = !demoMode;
-  rollupConfigs = [
+const configBundlesMinified = {
+  input: libInput,
+  output: [
     {
-      input: 'dev/ts/internal-dev-bundle-index.ts',
-      output: [
-        {
-          file: `${outputDir}/index.es.js`,
-          format: 'es',
-          sourcemap: sourceMap,
-        },
-      ],
-      external: [...Object.keys(pkg.peerDependencies || {})],
-      plugins: pluginsForDevelopment(),
+      file: pkg.module.replace('.js', '.min.js'),
+      format: 'es',
     },
-  ];
-} else {
-  const libInput = 'src/bpmn-visualization.ts';
-  const pluginsBundleIIFE = [
-    typescriptPlugin(),
-    // the 'resolve' and 'commonjs' plugins ensure we can bundle commonjs dependencies
-    resolve(),
-    commonjs(),
-    // to have sizes of dependencies listed at the end of build log
-    sizes(),
-  ];
-  const outputIIFE = {
-    file: pkg.browser.replace('.min.js', '.js'),
-    name: 'bpmnvisu',
-    format: 'iife',
-  };
-
-  const configIIFE = {
-    input: libInput,
-    output: outputIIFE,
-    plugins: pluginsBundleIIFE,
-  };
-  const configIIFEMinified = {
-    input: libInput,
-    output: {
-      ...outputIIFE,
-      file: pkg.browser,
+    {
+      file: pkg.main.replace('.js', '.min.js'),
+      format: 'cjs',
     },
-    plugins: withMinification(pluginsBundleIIFE),
-  };
+  ],
 
-  const pluginsBundles = [
-    typescriptPlugin(),
-    // ensure we do not bundle dependencies
-    autoExternal(),
-    // to have sizes of dependencies listed at the end of build log
-    sizes(),
-  ];
+  plugins: withMinification(pluginsBundles),
+};
+const configBundles = {
+  ...configBundlesMinified,
+  plugins: pluginsBundles,
+  output: [
+    { file: pkg.module, format: 'es' },
+    { file: pkg.main, format: 'cjs' },
+  ],
+};
 
-  const configBundlesMinified = {
-    input: libInput,
-    output: [
-      {
-        file: pkg.module.replace('.js', '.min.js'),
-        format: 'es',
-      },
-      {
-        file: pkg.main.replace('.js', '.min.js'),
-        format: 'cjs',
-      },
-    ],
-    plugins: withMinification(pluginsBundles),
-  };
-  const configBundles = {
-    ...configBundlesMinified,
-    plugins: pluginsBundles,
-    output: [
-      { file: pkg.module, format: 'es' },
-      { file: pkg.main, format: 'cjs' },
-    ],
-  };
-  rollupConfigs = [configIIFE, configIIFEMinified, configBundles, configBundlesMinified];
-}
-
-export default rollupConfigs;
+export default [configIIFE, configIIFEMinified, configBundles, configBundlesMinified];
 
 // =====================================================================================================================
 // helpers
 // =====================================================================================================================
 
 function typescriptPlugin() {
-  const tsDeclarationFiles = !demoMode || buildBundles;
-  const tsSourceMap = !demoMode && !buildBundles; // TODO logic duplicated with build selection
-  const tsconfigOverride = { compilerOptions: { sourceMap: tsSourceMap, declaration: tsDeclarationFiles } };
+  const tsconfigOverride = { compilerOptions: { sourceMap: false, declaration: true } };
 
   const options = {
     typescript: require('typescript'),
@@ -139,9 +99,7 @@ function typescriptPlugin() {
   };
 
   // Ensure we only bundle production sources
-  if (!devMode) {
-    options.tsconfig = './tsconfig.bundle.json';
-  }
+  options.tsconfig = './tsconfig.bundle.json';
 
   return typescript(options);
 }
@@ -153,51 +111,4 @@ function withMinification(plugins) {
       ecma: 6,
     }),
   ];
-}
-
-function pluginsForDevelopment() {
-  const plugins = [typescriptPlugin(), resolve(), commonjs()];
-
-  // Copy static resources
-  if (devMode || demoMode) {
-    plugins.push(execute('npm run demo:css', true)); // sync to ensure the execution is linked to the main rollup process
-    if (devLiveReloadMode) {
-      plugins.push(execute('npm run demo:css -- --watch --verbose'));
-    }
-
-    const copyTargets = [];
-    copyTargets.push({ src: 'dev/public/*.html', dest: `${outputDir}/` });
-    copyTargets.push({ src: 'dev/public/static', dest: outputDir });
-    let copyPlugin;
-    if (devLiveReloadMode) {
-      copyPlugin = copyWatch({
-        watch: ['dev/public/static/**', 'dev/public/*.html'],
-        targets: copyTargets,
-      });
-    } else {
-      copyPlugin = copy({
-        targets: copyTargets,
-      });
-    }
-    plugins.push(copyPlugin);
-
-    // to have sizes of dependencies listed at the end of build log
-    plugins.push(sizes());
-  }
-
-  if (devMode) {
-    // Create a server for dev mode
-    plugins.push(serve({ contentBase: outputDir, port: serverPort }));
-
-    if (devLiveReloadMode) {
-      // Allow to livereload on any update
-      plugins.push(livereload({ watch: outputDir, verbose: true }));
-    }
-  }
-
-  if (demoMode) {
-    return withMinification(plugins);
-  }
-
-  return plugins;
 }

--- a/scripts/prepare-demo-for-publish.mjs
+++ b/scripts/prepare-demo-for-publish.mjs
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Bonitasoft S.A.
+ * Copyright 2022 Bonitasoft S.A.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { copySync } from 'fs-extra';
 
-copySync(`${__dirname}/../fixtures/bpmn`, `${__dirname}/../../build/public/static/bpmn/`, { overwrite: true, recursive: true });
+import * as fs from 'fs';
+import { join } from 'path';
+
+const demoRootDirectory = './build/demo';
+
+const relPathToHtmlPages = 'dev/public';
+const pages = fs.readdirSync(join(demoRootDirectory, relPathToHtmlPages));
+pages.forEach(page => {
+  // eslint-disable-next-line no-console
+  console.info('Managing', page);
+  // move page out of the public/dev directory
+  fs.renameSync(join(demoRootDirectory, relPathToHtmlPages, page), join(demoRootDirectory, page));
+});
+
+fs.rmSync(join(demoRootDirectory, 'dev'), { recursive: true });

--- a/test/config/jest-playwright.js
+++ b/test/config/jest-playwright.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const { isRunningOnCISlowOS } = require('../helpers/environment-utils');
+const { isRunningOnCISlowOS, isRunningOnCi } = require('../helpers/environment-utils');
 
 const log = require('debug')('bv:test:config:pw');
 
@@ -86,14 +86,19 @@ const computeConfigurationForDevServerUsage = defaultBrowsers => {
   log('Computing configuration for dev server usage');
   /** @type {import('jest-playwright-preset/types/global').ServerOptions} */
   const serverOptions = {
-    command: `npm run start -- --config-server-port 10002`,
-    port: 10002,
+    command: `npm run dev`,
+    port: 10001,
+    basePath: '/dev/public/index.html',
     // if default or tcp, the test starts right await whereas the dev server is not available on http
     // for more details, see https://github.com/process-analytics/bpmn-visualization-js/pull/1056
     protocol: 'http',
-    launchTimeout: 60_000, // high value mainly for GitHub Workflows running on macOS (slow machines) and to build the bundle before start
+    // high value mainly for GitHub Workflows running on macOS (slow machines) and to build the bundle before start
+    launchTimeout: isRunningOnCi() ? 60_000 : 10_000,
     debug: true,
     usedPortAction: 'ignore', // your tests are executed, we assume that the server is already started
+    waitOnScheme: {
+      verbose: false,
+    },
   };
   return {
     ...computeBaseConfiguration(defaultBrowsers),

--- a/test/e2e/helpers/visu/bpmn-page-utils.ts
+++ b/test/e2e/helpers/visu/bpmn-page-utils.ts
@@ -13,6 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// in the future, we should find a solution to avoid using the reference everywhere in tests
+// see https://github.com/jest-community/jest-extended/issues/367
+/// <reference types="jest-extended" />
+
 import 'expect-playwright';
 import type { PageWaitForSelectorOptions } from 'expect-playwright';
 import type { ElementHandle, Page } from 'playwright';
@@ -105,7 +110,7 @@ export class PageTester {
    */
   constructor(protected targetedPageConfiguration: TargetedPageConfiguration, protected page: Page) {
     const showMousePointer = targetedPageConfiguration.showMousePointer ?? false;
-    this.baseUrl = `http://localhost:10002/${targetedPageConfiguration.pageFileName}.html?showMousePointer=${showMousePointer}`;
+    this.baseUrl = `http://localhost:10001/dev/public/${targetedPageConfiguration.pageFileName}.html?showMousePointer=${showMousePointer}`;
     this.bpmnContainerId = targetedPageConfiguration.bpmnContainerId ?? 'bpmn-container';
     this.diagramSubfolder = targetedPageConfiguration.diagramSubfolder;
     this.bpmnPage = new BpmnPage(this.bpmnContainerId, this.page);
@@ -124,8 +129,9 @@ export class PageTester {
   protected async doGotoPageAndLoadBpmnDiagram(url: string, checkResponseStatus = true): Promise<void> {
     const response = await this.page.goto(url);
     if (checkResponseStatus) {
+      // the Vite server can return http 304 for optimization
       // eslint-disable-next-line jest/no-standalone-expect
-      expect(response.status()).toBe(200);
+      expect(response.status()).toBeOneOf([200, 304]);
     }
 
     await this.bpmnPage.expectPageTitle(this.targetedPageConfiguration.expectedPageTitle);
@@ -143,7 +149,7 @@ export class PageTester {
    */
   private computePageUrl(bpmnDiagramName: string, loadOptions: LoadOptions, styleOptions?: StyleOptions, bpmndElementIdToCollapse?: string | undefined): string {
     let url = this.baseUrl;
-    url += `&url=./static/bpmn/${this.diagramSubfolder}/${bpmnDiagramName}.bpmn`;
+    url += `&url=/test/fixtures/bpmn/${this.diagramSubfolder}/${bpmnDiagramName}.bpmn`;
 
     // load query parameters
     loadOptions.fit?.type && (url += `&fitTypeOnLoad=${loadOptions.fit.type}`);

--- a/test/e2e/jest.config.js
+++ b/test/e2e/jest.config.js
@@ -34,8 +34,8 @@ module.exports = {
   coveragePathIgnorePatterns: ['/src/model'],
   coverageReporters: ['lcov', 'text-summary'],
   coverageDirectory: 'build/test-report/e2e',
-  setupFiles: ['./test/config/copy.bpmn.diagram.ts'],
   setupFilesAfterEnv: [
+    'jest-extended/all',
     'expect-playwright',
     './test/config/jest.retries.ts',
     // jest-image-snapshot configuration doesn't work with setupFiles, fix with setupFilesAfterEnv: see https://github.com/testing-library/jest-dom/issues/122#issuecomment-650520461

--- a/test/performance/jest.config.js
+++ b/test/performance/jest.config.js
@@ -30,6 +30,6 @@ module.exports = {
       tsconfig: './tsconfig.json',
     },
   },
-  setupFiles: ['./test/config/copy.bpmn.diagram.ts', './test/config/jest.retries.ts'],
+  setupFiles: ['./test/config/jest.retries.ts'],
   setupFilesAfterEnv: ['expect-playwright'],
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,9 @@
     ],
     "stripInternal": true,
     "noImplicitOverride": true,
+    // Vitejs requirements https://vitejs.dev/guide/features.html#typescript-compiler-options
+    "isolatedModules": true, // https://esbuild.github.io/content-types/#isolated-modules
+    "useDefineForClassFields": true,
   },
   "include": [
     "src/**/*",

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2022 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { resolve } from 'path';
+import { defineConfig } from 'vite';
+
+export default defineConfig(({ mode }) => {
+  // create the environment variable for configuration in the postcss config
+  process.env['NODE_ENV'] = mode;
+
+  return {
+    base: './', // Base public path when served in development or production. https://vitejs.dev/config/#base
+    server: {
+      port: 10001,
+    },
+
+    // Configuration to build the demo
+    build: {
+      outDir: 'build/demo',
+      rollupOptions: {
+        input: {
+          index: resolve(__dirname, 'dev/public/index.html'),
+          'elements-identification': resolve(__dirname, 'dev/public/elements-identification.html'),
+        },
+        // No hash in asset names. We make the demo publicly available via the examples repository and served by statically.io
+        // New versions are accessed using tags. The master branch is cachecd by statically.io and updated once a day.
+        // see https://github.com/vitejs/vite/issues/378#issuecomment-768816653
+        output: {
+          entryFileNames: `assets/[name].js`,
+          chunkFileNames: `assets/[name].js`,
+          assetFileNames: `assets/[name].[ext]`,
+        },
+      },
+    },
+    preview: {
+      port: 10002,
+    },
+  };
+});


### PR DESCRIPTION
We benefit from the ViteJS 'unbundled' way of working: the dev server starts and updates in 200-300 ms instead of 13-18
seconds.
We also have a much better integration for tailwindcss than with the custom hack we previously used.

Rollup configuration simplification
  - Remove the former Rollup configuration used to build the demo and run the development server.
  - Only keep the bundles build configuration.
  - Remove some dev dependencies that are no longer needed

Improvements in e2e tests
  - No need to copy the diagrams, the dev server exposes the diagrams source folders
  - Use the same dev server instance in tests and development and reduce the launchTimeout locally as it starts very
  fast

Demo: only keep 2 pages, others are for test only


based on #1416
closes #596