### PR TITLE
[INFRA] Configure GH workflow for default `read contents` GITHUB_TOKEN

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,10 @@ jobs:
           - { name: ubuntu-20.04, coverage: '-- --coverage' }
           - { name: macos-11 }
           - { name: windows-2019 }
+    permissions:
+      # SonarCloud: checks and pull-requests
+      checks: write
+      pull-requests: write
     steps:
       - name: Checkout with shallow clone
         uses: actions/checkout@v3

--- a/.github/workflows/fill-gh-draft-release.yml
+++ b/.github/workflows/fill-gh-draft-release.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   update_release_draft:
     runs-on: ubuntu-20.04
+    permissions:
+      # To create or update releases
+      contents: write
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5.20.0

--- a/.github/workflows/generate-demo-preview.yml
+++ b/.github/workflows/generate-demo-preview.yml
@@ -37,6 +37,9 @@ jobs:
     needs: [check_secrets]
     if: needs.check_secrets.outputs.is_SURGE_TOKEN_set == 'true'
     runs-on: ubuntu-20.04
+    permissions:
+      # surge-preview: PR comments
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
         if: github.event.action != 'closed'

--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -47,6 +47,9 @@ jobs:
     needs: [check_secrets]
     if: github.event_name == 'pull_request' && needs.check_secrets.outputs.is_SURGE_TOKEN_set == 'true'
     runs-on: ubuntu-20.04
+    permissions:
+      # surge-preview: PR comments
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
         if: github.event.action != 'closed'
@@ -91,6 +94,9 @@ jobs:
     if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&  github.event.ref == 'refs/heads/master'
     runs-on: ubuntu-20.04
     needs: generate_doc
+    permissions:
+      # Push to gh-pages
+      contents: write
     steps:
       - name: Download
         uses: actions/download-artifact@v3


### PR DESCRIPTION
Set GITHUB_TOKEN permissions to ensure the workflows still work when the default permissions are set to `read contents` only in the repository.

closes #2012

### Notes

As the repository has just been configured for default read-only token, workflows will fail until this Pull Request is merged.
