### PR TITLE
[DEMO] Simplify imports and asset loading in sources

### DIFF
--- a/dev/public/diagram-navigation.html
+++ b/dev/public/diagram-navigation.html
@@ -6,8 +6,8 @@
 <head>
   <meta charset="UTF-8">
   <title>BPMN Visualization - Diagram Navigation</title>
-  <link rel="icon" href="static/img/favicon.png">
-  <link rel="stylesheet" href="static/css/test-page.css">
+  <link rel="icon" href="./static/img/favicon.png">
+  <link rel="stylesheet" href="./static/css/test-page.css">
   <style>
     .fit {
       background-color: #f9dfe8;
@@ -18,7 +18,7 @@
       width: 35px;
     }
   </style>
-  <script src="/dev/public/static/js/diagram-navigation.js" type="module"></script>
+  <script src="./static/js/diagram-navigation.js" type="module"></script>
 </head>
 <body>
 <div class="flex-container">

--- a/dev/public/elements-identification.html
+++ b/dev/public/elements-identification.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>BPMN Visualization - Elements Identification</title>
-    <link rel="icon" href="static/img/favicon.png">
+    <link rel="icon" href="./static/img/favicon.png">
     <style>
       #main-container {
         top: 140px;
@@ -120,7 +120,7 @@
         color: var(--color-flow) !important;
       }
     </style>
-    <script src="/dev/public/static/js/elements-identification.js" type="module"></script>
+    <script src="./static/js/elements-identification.js" type="module"></script>
 </head>
 <body>
     <div id="controls">

--- a/dev/public/index.html
+++ b/dev/public/index.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>BPMN Visualization Demo</title>
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v6.1.1/css/all.css">
-    <link href="/dev/public/static/css/styles.css" rel="stylesheet">
-    <link rel="icon" href="static/img/favicon.png">
-    <script src="/dev/public/static/js/index.js" type="module"></script>
+    <link href="./static/css/styles.css" rel="stylesheet">
+    <link rel="icon" href="./static/img/favicon.png">
+    <script src="./static/js/index.js" type="module"></script>
 </head>
 <body class="bg-gray-800 font-sans leading-normal tracking-normal flex flex-col h-screen">
     <!--Nav-->

--- a/dev/public/lib-integration.html
+++ b/dev/public/lib-integration.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <title>BPMN Visualization Lib Integration</title>
-  <link rel="icon" href="static/img/favicon.png">
-  <script src="/dev/public/static/js/lib-integration.js" type="module"></script>
+  <link rel="icon" href="./static/img/favicon.png">
+  <script src="./static/js/lib-integration.js" type="module"></script>
 </head>
 <body>
   <div id="bpmn-container-custom"></div>

--- a/dev/public/non-regression.html
+++ b/dev/public/non-regression.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>BPMN Visualization Non Regression</title>
-    <link rel="icon" href="static/img/favicon.png">
+    <link rel="icon" href="./static/img/favicon.png">
     <style>
       #bpmn-container {
         top: 10px;
@@ -18,7 +18,7 @@
         font-weight: bold;
       }
     </style>
-    <script src="/dev/public/static/js/non-regression.js" type="module"></script>
+    <script src="./static/js/non-regression.js" type="module"></script>
 </head>
 <body>
     <div id="fetch-status"></div>

--- a/dev/public/overlays.html
+++ b/dev/public/overlays.html
@@ -6,14 +6,14 @@
 <head>
   <meta charset="UTF-8">
   <title>BPMN Visualization - Overlays</title>
-  <link rel="icon" href="static/img/favicon.png">
-  <link rel="stylesheet" href="static/css/test-page.css">
+  <link rel="icon" href="./static/img/favicon.png">
+  <link rel="stylesheet" href="./static/css/test-page.css">
   <style>
     .overlay {
       background-color: MintCream;
     }
   </style>
-  <script src="/dev/public/static/js/overlays.js" type="module"></script>
+  <script src="./static/js/overlays.js" type="module"></script>
 </head>
 <body>
 <div class="flex-container">

--- a/dev/public/static/js/diagram-navigation.js
+++ b/dev/public/static/js/diagram-navigation.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { documentReady, startBpmnVisualization, fit, FitType, zoom, ZoomType } from '/dev/ts/internal-dev-bundle-index.ts';
+import { documentReady, startBpmnVisualization, fit, FitType, zoom, ZoomType } from '../../../ts/dev-bundle-index';
 import { configureControlsPanel, configureMousePointer } from './helpers/controls.js';
 
 function configureFitAndZoomButtons() {

--- a/dev/public/static/js/elements-identification.js
+++ b/dev/public/static/js/elements-identification.js
@@ -27,7 +27,7 @@ import {
   ShapeUtil,
   addOverlays,
   removeAllOverlays,
-} from '/dev/ts/internal-dev-bundle-index.ts';
+} from '../../../ts/dev-bundle-index';
 
 let lastIdentifiedBpmnIds = [];
 const cssClassName = 'detection';

--- a/dev/public/static/js/index.js
+++ b/dev/public/static/js/index.js
@@ -24,7 +24,7 @@ import {
   getVersion,
   zoom,
   ZoomType,
-} from '/dev/ts/internal-dev-bundle-index.ts';
+} from '../../../ts/dev-bundle-index';
 
 let fitOnLoad = true;
 let fitOptions = {};

--- a/dev/public/static/js/lib-integration.js
+++ b/dev/public/static/js/lib-integration.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { BpmnVisualization } from '/src/bpmn-visualization.ts';
+import { BpmnVisualization } from '../../../../src/bpmn-visualization';
 
 const bpmnVisualizationIntegration = new BpmnVisualization({ container: 'bpmn-container-custom' });
 bpmnVisualizationIntegration.load(bpmnDefaultContent());

--- a/dev/public/static/js/overlays.js
+++ b/dev/public/static/js/overlays.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { documentReady, startBpmnVisualization, addOverlays, removeAllOverlays, getElementsByIds } from '/dev/ts/internal-dev-bundle-index.ts';
+import { documentReady, startBpmnVisualization, addOverlays, removeAllOverlays, getElementsByIds } from '../../../ts/dev-bundle-index';
 import { configureControlsPanel, configureMousePointer } from './helpers/controls.js';
 
 function addOverlay(overlay) {

--- a/dev/ts/component/DropFileUserInterface.ts
+++ b/dev/ts/component/DropFileUserInterface.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { logErrorAndOpenAlert } from '../helper';
+import { logErrorAndOpenAlert } from '../utils/internal-helpers';
 
 export class DropFileUserInterface {
   private document: Document;

--- a/dev/ts/component/ThemedBpmnVisualization.ts
+++ b/dev/ts/component/ThemedBpmnVisualization.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { BpmnVisualization, FlowKind, ShapeBpmnElementKind, ShapeUtil } from '../../../src/bpmn-visualization';
-import { logStartup } from '../helper';
+import { logStartup } from '../utils/internal-helpers';
 import { mxgraph } from '../../../src/component/mxgraph/initializer';
 
 interface Theme {

--- a/dev/ts/component/download.ts
+++ b/dev/ts/component/download.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { logDownload } from '../helper';
+import { logDownload } from '../utils/internal-helpers';
 
 // inspired from https://ourcodeworld.com/articles/read/189/how-to-create-a-file-and-generate-a-download-with-javascript-in-the-browser-without-a-server
 function download(filename: string, contentType: string, text: string): void {

--- a/dev/ts/dev-bundle-index.ts
+++ b/dev/ts/dev-bundle-index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Bonitasoft S.A.
+ * Copyright 2021 Bonitasoft S.A.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,12 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { documentReady, startBpmnVisualization } from '../../../ts/dev-bundle-index';
-
-function statusFetchKO(errorMsg) {
-  const statusElt = document.getElementById('fetch-status');
-  statusElt.innerText = errorMsg;
-  statusElt.className = 'status-ko';
-}
-
-documentReady(() => startBpmnVisualization({ globalOptions: { container: 'bpmn-container' }, statusFetchKoNotifier: statusFetchKO }));
+export * from './main';
+export * from './utils/shared-helpers';
+export * from '../../src/bpmn-visualization';

--- a/dev/ts/main.ts
+++ b/dev/ts/main.ts
@@ -15,13 +15,12 @@
  */
 
 import type { BpmnElement, BpmnElementKind, FitOptions, FitType, GlobalOptions, LoadOptions, Overlay, Version, ZoomType } from '../../src/bpmn-visualization';
-import { log, logDownload, logErrorAndOpenAlert, logStartup } from './helper';
+import { fetchBpmnContent, logDownload, logErrorAndOpenAlert, logStartup, stringify } from './utils/internal-helpers';
+import { log } from './utils/shared-helpers';
 import { DropFileUserInterface } from './component/DropFileUserInterface';
 import { SvgExporter } from './component/SvgExporter';
 import { downloadAsPng, downloadAsSvg } from './component/download';
 import { ThemedBpmnVisualization } from './component/ThemedBpmnVisualization';
-
-export * from './helper';
 
 let bpmnVisualization: ThemedBpmnVisualization;
 let loadOptions: LoadOptions = {};
@@ -35,10 +34,6 @@ export function updateLoadOptions(fitOptions: FitOptions): void {
 
 export function getCurrentLoadOptions(): LoadOptions {
   return { ...loadOptions };
-}
-
-function stringify(value: unknown): string {
-  return JSON.stringify(value, undefined, 2);
 }
 
 function loadBpmn(bpmn: string): void {
@@ -128,16 +123,6 @@ function readAndLoadFile(f: File): void {
 export function handleFileSelect(evt: any): void {
   const f = evt.target.files[0];
   readAndLoadFile(f);
-}
-
-function fetchBpmnContent(url: string): Promise<string> {
-  log(`Fetching BPMN content from url ${url}`);
-  return fetch(url).then(response => {
-    if (!response.ok) {
-      throw Error(String(response.status));
-    }
-    return response.text();
-  });
 }
 
 function loadBpmnFromUrl(url: string, statusFetchKoNotifier: (errorMsg: string) => void): void {

--- a/dev/ts/utils/internal-helpers.ts
+++ b/dev/ts/utils/internal-helpers.ts
@@ -14,27 +14,19 @@
  * limitations under the License.
  */
 
-export function documentReady(callbackFunction: () => void): void {
-  // see if DOM is already available
-  if (document.readyState === 'complete' || document.readyState === 'interactive') {
-    // call on next available tick
-    setTimeout(callbackFunction, 1);
-  } else {
-    document.addEventListener('DOMContentLoaded', callbackFunction);
-  }
+import { log } from './shared-helpers';
+
+export function stringify(value: unknown): string {
+  return JSON.stringify(value, undefined, 2);
 }
 
-function _log(header: string, message: unknown, ...optionalParams: unknown[]): void {
+export function _log(header: string, message: unknown, ...optionalParams: unknown[]): void {
   // eslint-disable-next-line no-console
   console.info(header + ' ' + message, ...optionalParams);
 }
 
 export function logStartup(message?: string, ...optionalParams: unknown[]): void {
   _log('[DEMO STARTUP]', message, ...optionalParams);
-}
-
-export function log(message?: string, ...optionalParams: unknown[]): void {
-  _log('[DEMO]', message, ...optionalParams);
 }
 
 export function logErrorAndOpenAlert(error: unknown, alertMsg?: string): void {
@@ -44,4 +36,14 @@ export function logErrorAndOpenAlert(error: unknown, alertMsg?: string): void {
 
 export function logDownload(message?: unknown, ...optionalParams: unknown[]): void {
   _log('[DEMO DOWNLOAD]', message, ...optionalParams);
+}
+
+export function fetchBpmnContent(url: string): Promise<string> {
+  log(`Fetching BPMN content from url ${url}`);
+  return fetch(url).then(response => {
+    if (!response.ok) {
+      throw Error(String(response.status));
+    }
+    return response.text();
+  });
 }

--- a/dev/ts/utils/shared-helpers.ts
+++ b/dev/ts/utils/shared-helpers.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Bonitasoft S.A.
+ * Copyright 2022 Bonitasoft S.A.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,5 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './demo';
-export * from '../../src/bpmn-visualization';
+
+import { _log } from './internal-helpers';
+
+export function documentReady(callbackFunction: () => void): void {
+  // see if DOM is already available
+  if (document.readyState === 'complete' || document.readyState === 'interactive') {
+    // call on next available tick
+    setTimeout(callbackFunction, 1);
+  } else {
+    document.addEventListener('DOMContentLoaded', callbackFunction);
+  }
+}
+
+export function log(message?: string, ...optionalParams: unknown[]): void {
+  _log('[DEMO]', message, ...optionalParams);
+}


### PR DESCRIPTION
Simplify how TS code is imported in static JS file and how assets are loaded in page
The previous syntax work for the Vite dev server and demo bundling, but was not understood by IDE. We now use relative
paths that make code navigation possible.

Reorganize code to clarify what is internal and what is shared by example and test code
  - rename TS entry point for demo and test pages
  - move utils code in dedicated files