### PR TITLE
[INFRA] Remove build setup duplication in GitHub workflows

### DIFF
--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -7,9 +7,16 @@ runs:
       uses: actions/setup-node@v3
       with:
         node-version-file: '.nvmrc'
-        cache: 'npm'
+        # cache: 'npm'
+    - name: Cache dependencies
+      id: cache
+      uses: actions/cache@v3
+      with:
+        path: ./node_modules
+        key: modules-${{ hashFiles('package-lock.json') }}
     - name: Install dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
       env:
-        # https://playwright.dev/docs/browsers#installing-browsers
+        # Do not install browsers https://playwright.dev/docs/browsers#installing-browsers
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-      run: npm ci
+      run: npm ci --ignore-scripts

--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -7,16 +7,10 @@ runs:
       uses: actions/setup-node@v3
       with:
         node-version-file: '.nvmrc'
-        # cache: 'npm'
-    - name: Cache dependencies
-      id: cache
-      uses: actions/cache@v3
-      with:
-        path: ./node_modules
-        key: modules-${{ hashFiles('package-lock.json') }}
     - name: Install dependencies
-      if: steps.cache.outputs.cache-hit != 'true'
+      uses: bahmutov/npm-install@v1
       env:
         # Do not install browsers https://playwright.dev/docs/browsers#installing-browsers
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-      run: npm ci --ignore-scripts
+      with:
+        install-command: npm ci --ignore-scripts --prefer-offline --no-audit

--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -1,7 +1,12 @@
 name: 'Build Setup'
-description: 'Setup node'
+description: 'Setup node and install dependencies'
+inputs:
+  install-dependencies:
+    description: 'Install dependencies with npm'
+    required: false
+    default: true
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - name: Setup node
       uses: actions/setup-node@v3
@@ -9,6 +14,7 @@ runs:
         node-version-file: '.nvmrc'
     - name: Install dependencies
       uses: bahmutov/npm-install@v1
+      if: inputs.install-dependencies == 'true'
       env:
         # Do not install browsers https://playwright.dev/docs/browsers#installing-browsers
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1

--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -4,7 +4,7 @@ inputs:
   install-dependencies:
     description: 'Install dependencies with npm.'
     required: false
-    default: true
+    default: 'true'
   registry-url:
     description: 'Optional registry to set up for auth.'
     required: false
@@ -21,6 +21,6 @@ runs:
       if: inputs.install-dependencies == 'true'
       env:
         # Do not install browsers https://playwright.dev/docs/browsers#installing-browsers
-        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
       with:
         install-command: npm ci --ignore-scripts --prefer-offline --audit false

--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -13,4 +13,4 @@ runs:
         # Do not install browsers https://playwright.dev/docs/browsers#installing-browsers
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
       with:
-        install-command: npm ci --ignore-scripts --prefer-offline --no-audit
+        install-command: npm ci --ignore-scripts --prefer-offline --audit false

--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -2,9 +2,12 @@ name: 'Build Setup'
 description: 'Setup node and install dependencies'
 inputs:
   install-dependencies:
-    description: 'Install dependencies with npm'
+    description: 'Install dependencies with npm.'
     required: false
     default: true
+  registry-url:
+    description: 'Optional registry to set up for auth.'
+    required: false
 runs:
   using: 'composite'
   steps:
@@ -12,6 +15,7 @@ runs:
       uses: actions/setup-node@v3
       with:
         node-version-file: '.nvmrc'
+        registry-url: ${{ inputs.registry-url }}
     - name: Install dependencies
       uses: bahmutov/npm-install@v1
       if: inputs.install-dependencies == 'true'

--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -1,0 +1,15 @@
+name: 'Build Setup'
+description: 'Setup node'
+runs:
+  using: "composite"
+  steps:
+    - name: Setup node
+      uses: actions/setup-node@v3
+      with:
+        node-version-file: '.nvmrc'
+        cache: 'npm'
+    - name: Install dependencies
+      env:
+        # https://playwright.dev/docs/browsers#installing-browsers
+        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      run: npm ci

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
     paths:
+      - '.github/actions/build-setup/**/*'
       - '.github/workflows/build.yml'
       - 'config/**/*'
       - 'scripts/**/*'
@@ -20,6 +21,7 @@ on:
     branches:
       - master
     paths:
+      - '.github/actions/build-setup/**/*'
       - '.github/workflows/build.yml'
       - 'config/**/*'
       - 'scripts/**/*'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,17 +58,8 @@ jobs:
         with:
           # Disabling shallow clone is recommended for improving relevancy of SonarCloud reporting
           fetch-depth: 0
-      - name: Setup node
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-      # playwright browsers are needed for the bundle tests, so no special configuration as in other workflows
-      - name: Install dependencies
-        env:
-          # https://playwright.dev/docs/browsers#installing-browsers
-          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-        run: npm ci
+      - name: Build Setup
+        uses: ./.github/actions/build-setup
       - name: Lint check
         run: npm run lint-check
       - name: Build Application
@@ -126,16 +117,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Setup node
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-      - name: Install dependencies
-        env:
-          # https://playwright.dev/docs/browsers#installing-browsers
-          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-        run: npm ci
+      - name: Build Setup
+        uses: ./.github/actions/build-setup
       # Ensure we can build working bundles
       - name: Build bundles
         run: npm run build-bundles

--- a/.github/workflows/generate-demo-preview.yml
+++ b/.github/workflows/generate-demo-preview.yml
@@ -43,12 +43,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         if: github.event.action != 'closed'
+      - name: Build Setup
+        uses: ./.github/actions/build-setup
+        if: github.event.action != 'closed'
       - name: Publish Demo preview
         id: publish_demo_preview
         uses: afc163/surge-preview@v1
-        env:
-          # https://playwright.dev/docs/browsers#installing-browsers
-          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
         with:
           surge_token: ${{ secrets.SURGE_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -56,5 +56,4 @@ jobs:
           failOnError: true
           teardown: 'true'
           build: |
-            npm ci
             npm run demo

--- a/.github/workflows/generate-demo-preview.yml
+++ b/.github/workflows/generate-demo-preview.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - master
     paths:
+      - '.github/actions/build-setup/**/*'
       - '.github/workflows/generate-demo-preview.yml'
       - 'config/**/*'
       - 'dev/**/*'

--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - master
     paths:
+      - '.github/actions/build-setup/**/*'
       - '.github/workflows/generate-documentation.yml'
       - 'docs/users/**'
       - 'scripts/docs.js'
@@ -19,6 +20,7 @@ on:
     branches:
       - master
     paths:
+      - '.github/actions/build-setup/**/*'
       - '.github/workflows/generate-documentation.yml'
       - 'docs/users/**'
       - 'scripts/docs.js'

--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -53,12 +53,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         if: github.event.action != 'closed'
+      - name: Build Setup
+        uses: ./.github/actions/build-setup
+        if: github.event.action != 'closed'
       - name: Publish preview
         id: publish_preview
         uses: afc163/surge-preview@v1
-        env:
-          # https://playwright.dev/docs/browsers#installing-browsers
-          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
         with:
           surge_token: ${{ secrets.SURGE_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -66,7 +66,6 @@ jobs:
           failOnError: true
           teardown: 'true'
           build: |
-            npm ci
             npm run docs
 
   generate_doc:
@@ -74,14 +73,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - name: Setup node
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-      - name: Install dependencies
-        # https://playwright.dev/docs/browsers#installing-browsers
-        run: PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm ci
+      - name: Build Setup
+        uses: ./.github/actions/build-setup
       - name: Build docs
         run: npm run docs
       - name: Upload

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
+# TODO check if we can use 'actions/build-setup' here
       # Setup .npmrc file to publish to npm
       - name: Setup node
         uses: actions/setup-node@v3

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -8,17 +8,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-# TODO check if we can use 'actions/build-setup' here
-      # Setup .npmrc file to publish to npm
-      - name: Setup node
-        uses: actions/setup-node@v3
+      - name: Build Setup
+        uses: ./.github/actions/build-setup
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
-      - name: Install dependencies
-        # https://playwright.dev/docs/browsers#installing-browsers
-        run: PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm ci
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_RELEASE_TOKEN }}
+# TODO here we don't need npm ci, so probably we won't use 'actions/build-setup'
       - name: Setup node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,12 +26,10 @@ jobs:
         with:
           # Use a PAT to ensure workflow run are triggered after git push
           token: ${{ secrets.GH_RELEASE_TOKEN }}
-      # TODO here we don't need npm ci, so probably we won't use 'actions/build-setup'
-      - name: Setup node
-        uses: actions/setup-node@v3
+      - name: Build Setup
+        uses: ./.github/actions/build-setup
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
+          install-dependencies: false
       - name: Config git
         run: |
           git config --local user.email "62586190+process-analytics-bot@users.noreply.github.com"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,9 @@ jobs:
       - name: Setup checkout
         uses: actions/checkout@v3
         with:
+          # Use a PAT to ensure workflow run are triggered after git push
           token: ${{ secrets.GH_RELEASE_TOKEN }}
-# TODO here we don't need npm ci, so probably we won't use 'actions/build-setup'
+      # TODO here we don't need npm ci, so probably we won't use 'actions/build-setup'
       - name: Setup node
         uses: actions/setup-node@v3
         with:
@@ -45,7 +46,7 @@ jobs:
 
       - name: Branch Protection Bot - Reenable "include administrators" branch protection
         uses: benjefferies/branch-protection-bot@1.0.7
-        if: always()  # Force to always run this step to ensure "include administrators" is always turned back on
+        if: always() # Force to always run this step to ensure "include administrators" is always turned back on
         with:
           access_token: ${{ secrets.GH_RELEASE_TOKEN }}
           enforce_admins: true

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -47,16 +47,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Setup node
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-      - name: Install dependencies
-        env:
-          # https://playwright.dev/docs/browsers#installing-browsers
-          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-        run: npm ci
+      - name: Build Setup
+        uses: ./.github/actions/build-setup
       # install OS dependencies required by browsers on the GitHub runner
       # to be sure that the browser is correctly installed: https://github.com/microsoft/playwright/issues/5801
       - name: Install ${{matrix.browser}} and its dependencies only

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
     paths:
+      - '.github/actions/build-setup/**/*'
       - '.github/workflows/test-e2e.yml'
       - 'src/**/*'
       - 'test/**/*'
@@ -18,6 +19,7 @@ on:
     branches:
       - master
     paths:
+      - '.github/actions/build-setup/**/*'
       - '.github/workflows/test-e2e.yml'
       - 'src/**/*'
       - 'test/**/*'

--- a/.github/workflows/upload-demo-archive-and-trigger-examples-repository-update.yml
+++ b/.github/workflows/upload-demo-archive-and-trigger-examples-repository-update.yml
@@ -10,14 +10,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - name: Setup node
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-      - name: Install dependencies
-        # https://playwright.dev/docs/browsers#installing-browsers
-        run: PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm ci
+      - name: Build Setup
+        uses: ./.github/actions/build-setup
       - name: Build Demo
         run: npm run demo
       - name: Set ARTIFACT_NAME

--- a/scripts/manage-version-in-files.mjs
+++ b/scripts/manage-version-in-files.mjs
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+// IMPORTANT: this script is run by npm when calling 'npm version'
+// We are not installing node dependencies when running the GitHub workflow '.github/workflows/release.yml'
+// So please do not import code that is not provided by the node runtime. Otherwise, update the GitHub workflow definition
 import * as fs from 'fs';
 
 if (process.env.IS_RELEASING) {


### PR DESCRIPTION
Introduce a local `GitHub Action` to configure node and perform `npm ci` with the right configuration (disable
playwright browser download).
The npm dependencies cache and dependencies installation are now managed with the `bahmutov/npm-install` actions which has sensible good defaults

Pass options to npm ci to
  - improve the cache usage (--prefer-offline)
  - skip post-install scripts (--ignore-scripts). We don't need them to run on CI and this will block malicious script that try to steal  tokens (on npm publish for instance)

### Tests

- ✔️  no more `npm audit`
- ✔️ still no browsers download on `npm ci`

<details>
<summary>build workflow run on ubuntu - npm-install GitHub Action</summary>
<pre>
Run bahmutov/npm-install@v1
running npm-install GitHub Action
trying to restore cached NPM modules
Received 12582912 of 62427705 (20.2%), 12.0 MBs/sec
Received 62427705 of 62427705 (100.0%), 41.1 MBs/sec
Cache Size: ~60 MB (62427705 B)
/usr/bin/tar --use-compress-program zstd -d -xf /home/runner/work/_temp/13cd8632-a47a-43c1-b24f-35897dbccd77/cache.tzst -P -C /home/runner/work/bpmn-visualization-js/bpmn-visualization-js
Cache restored successfully
npm cache hit npm-linux-x64-f60cf6f070d3b3c9f9e250bdc5c95bfe188822a9c8506aafa3c53eb223f5d1ee6f0867b8178fcd786112d54d0714dd365bdcf58a42a9173b6b1b484ecc23d674
/opt/hostedtoolcache/node/16.15.1/x64/bin/npm ci --ignore-scripts --prefer-offline --audit false
npm WARN deprecated mxgraph@4.2.2: Package no longer supported. Use at your own risk
added 972 packages in 15s
138 packages are looking for funding
  run `npm fund` for details
all done, exiting
</pre>

</details>

### Resources

https://github.com/bahmutov/npm-install
npm ci options now used
- https://docs.npmjs.com/cli/v8/using-npm/config#prefer-offline
- https://docs.npmjs.com/cli/v8/using-npm/config#audit
- https://docs.npmjs.com/cli/v8/using-npm/config#ignore-scripts and https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#use-private-packages

Refs https://github.com/process-analytics/process-analytics.dev/issues/546