### PR TITLE
[REFACTOR] Use the 'node' protocol in imports

### DIFF
--- a/scripts/manage-version-in-files.mjs
+++ b/scripts/manage-version-in-files.mjs
@@ -17,7 +17,7 @@
 // IMPORTANT: this script is run by npm when calling 'npm version'
 // We are not installing node dependencies when running the GitHub workflow '.github/workflows/release.yml'
 // So please do not import code that is not provided by the node runtime. Otherwise, update the GitHub workflow definition
-import * as fs from 'fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 
 if (process.env.IS_RELEASING) {
   updateVersionInFilesOnRelease();
@@ -55,7 +55,7 @@ function log(...data) {
 }
 
 function readFileContent(path) {
-  return fs.readFileSync(path, 'utf8').toString();
+  return readFileSync(path, 'utf8').toString();
 }
 
 function getCurrentVersion() {
@@ -72,7 +72,7 @@ function updateVersionInNpmFile(path, newVersion) {
   const json = readFileContent(path);
   const pkg = JSON.parse(json);
   pkg.version = newVersion;
-  fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + '\n');
+  writeFileSync(path, JSON.stringify(pkg, null, 2) + '\n');
 }
 
 function updateVersionInSonarFile(newVersion) {
@@ -80,7 +80,7 @@ function updateVersionInSonarFile(newVersion) {
   const content = readFileContent(path);
   // replace the 1st occurrence, is ok as a key appears only once in the file
   const updatedContent = content.replace(/sonar\.projectVersion=.*/, `sonar.projectVersion=${newVersion}`);
-  fs.writeFileSync(path, updatedContent);
+  writeFileSync(path, updatedContent);
 }
 
 function updateVersionInSourceFile(newVersion) {
@@ -88,5 +88,5 @@ function updateVersionInSourceFile(newVersion) {
   const content = readFileContent(path);
   // replace the 1st occurrence, is ok as the constant appears only once in the file
   const updatedContent = content.replace(/const libVersion =.*/, `const libVersion = '${newVersion}';`);
-  fs.writeFileSync(path, updatedContent);
+  writeFileSync(path, updatedContent);
 }

--- a/scripts/prepare-demo-for-publish.mjs
+++ b/scripts/prepare-demo-for-publish.mjs
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import { join } from 'path';
+import { readdirSync, renameSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
 
 const demoRootDirectory = './build/demo';
 
 const relPathToHtmlPages = 'dev/public';
-const pages = fs.readdirSync(join(demoRootDirectory, relPathToHtmlPages));
+const pages = readdirSync(join(demoRootDirectory, relPathToHtmlPages));
 pages.forEach(page => {
   // eslint-disable-next-line no-console
   console.info('Managing', page);
   // move page out of the public/dev directory
-  fs.renameSync(join(demoRootDirectory, relPathToHtmlPages, page), join(demoRootDirectory, page));
+  renameSync(join(demoRootDirectory, relPathToHtmlPages, page), join(demoRootDirectory, page));
 });
 
-fs.rmSync(join(demoRootDirectory, 'dev'), { recursive: true });
+rmSync(join(demoRootDirectory, 'dev'), { recursive: true });

--- a/scripts/utils/parseBpmn.ts
+++ b/scripts/utils/parseBpmn.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as path from 'path';
+import { resolve as resolvePath } from 'node:path';
 import clipboardy from 'clipboardy';
 import parseArgs from 'minimist';
 import type BpmnModel from '../../src/model/bpmn/internal/BpmnModel';
@@ -23,7 +23,7 @@ import { newBpmnJsonParser } from '../../src/component/parser/json/BpmnJsonParse
 import { ParsingMessageCollector } from '../../src/component/parser/parsing-messages';
 import { readFileSync } from '../../test/helpers/file-helper';
 
-const __dirname = path.resolve();
+const __dirname = resolvePath();
 const argv = parseArgs(process.argv.slice(2));
 const bpmnFilePath = argv._[0];
 const outputType = argv['output'] || 'json';

--- a/test/bundles/bundles.test.ts
+++ b/test/bundles/bundles.test.ts
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { existsSync } from 'fs';
+import { existsSync } from 'node:fs';
 import 'jest-playwright-preset';
-import { resolve } from 'path';
+import { resolve } from 'node:path';
 import type { Page } from 'playwright';
 import type { TargetedPageConfiguration } from '../e2e/helpers/visu/bpmn-page-utils';
 import { BpmnPageSvgTester } from '../e2e/helpers/visu/bpmn-page-utils';

--- a/test/config/jest.image.ts
+++ b/test/config/jest.image.ts
@@ -15,7 +15,7 @@
  */
 import type { MatchImageSnapshotOptions } from 'jest-image-snapshot';
 import { toMatchImageSnapshot } from 'jest-image-snapshot';
-import { copyFileSync } from 'fs';
+import { copyFileSync } from 'node:fs';
 import { addAttach } from 'jest-html-reporters/helper';
 import MatcherContext = jest.MatcherContext;
 import CustomMatcherResult = jest.CustomMatcherResult;

--- a/test/e2e/diagram.navigation.fit.test.ts
+++ b/test/e2e/diagram.navigation.fit.test.ts
@@ -15,7 +15,7 @@
  */
 import type { MatchImageSnapshotOptions } from 'jest-image-snapshot';
 import 'jest-playwright-preset';
-import { join } from 'path';
+import { join } from 'node:path';
 import type { Page } from 'playwright';
 import { FitType } from '../../src/component/options';
 import { getBpmnDiagramNames } from './helpers/test-utils';

--- a/test/e2e/diagram.navigation.zoom.pan.test.ts
+++ b/test/e2e/diagram.navigation.zoom.pan.test.ts
@@ -15,7 +15,7 @@
  */
 
 import 'jest-playwright-preset';
-import { join } from 'path';
+import { join } from 'node:path';
 import type { Page } from 'playwright';
 import type { Point } from './helpers/visu/bpmn-page-utils';
 import { AvailableTestPages, PageTester } from './helpers/visu/bpmn-page-utils';

--- a/test/e2e/helpers/test-utils.ts
+++ b/test/e2e/helpers/test-utils.ts
@@ -15,7 +15,7 @@
  */
 import debugLogger from 'debug';
 import 'jest-playwright-preset';
-import { join } from 'path';
+import { join } from 'node:path';
 import { findFiles } from '../../helpers/file-helper';
 
 export const configLog = debugLogger('bv:test:config');

--- a/test/e2e/helpers/visu/image-snapshot-config.ts
+++ b/test/e2e/helpers/visu/image-snapshot-config.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { dirname, join } from 'path';
+import { dirname, join } from 'node:path';
 import type { MatchImageSnapshotOptions as MatchImageSnapshotOptionsOrig } from 'jest-image-snapshot';
 import { configLog, getSimplePlatformName, getTestedBrowserFamily } from '../test-utils';
 

--- a/test/e2e/overlays.rendering.test.ts
+++ b/test/e2e/overlays.rendering.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import 'jest-playwright-preset';
-import { join } from 'path';
+import { join } from 'node:path';
 import type { Page } from 'playwright';
 import { ensureIsArray } from '../../src/component/helpers/array-utils';
 import type { OverlayEdgePosition, OverlayPosition, OverlayShapePosition } from '../../src/component/registry';

--- a/test/helpers/file-helper.ts
+++ b/test/helpers/file-helper.ts
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { readdirSync, readFileSync as fsReadFileSync } from 'fs';
-import { join } from 'path';
+import { readdirSync, readFileSync as fsReadFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 export function readFileSync(relPathToSourceFile: string, encoding: BufferEncoding = 'utf-8', dirName = __dirname): string {
   return fsReadFileSync(join(dirName, relPathToSourceFile), { encoding });

--- a/test/performance/bpmn.load.performance.test.ts
+++ b/test/performance/bpmn.load.performance.test.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 import type { Page } from 'playwright';
 import { getSimplePlatformName } from '../e2e/helpers/test-utils';
 import { AvailableTestPages, PageTester } from '../e2e/helpers/visu/bpmn-page-utils';

--- a/test/performance/bpmn.navigation.performance.test.ts
+++ b/test/performance/bpmn.navigation.performance.test.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 import type { Page } from 'playwright';
 import { delay, getSimplePlatformName } from '../e2e/helpers/test-utils';
 import type { Point } from '../e2e/helpers/visu/bpmn-page-utils';

--- a/vite.config.js
+++ b/vite.config.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { resolve } from 'path';
+import { resolve } from 'node:path';
 import { defineConfig } from 'vite';
 
 export default defineConfig(({ mode }) => {


### PR DESCRIPTION
The location of the imported modules are more explicit.

### Resources

- https://nodejs.org/api/esm.html#esm_node_imports