### PR TITLE
[TEST] Simplify imports of expected model elements

### DIFF
--- a/test/unit/component/mxgraph/renderer/StyleComputer.test.ts
+++ b/test/unit/component/mxgraph/renderer/StyleComputer.test.ts
@@ -41,10 +41,10 @@ import {
   ShapeBpmnSubProcessKind,
 } from '../../../../../src/bpmn-visualization';
 import Label, { Font } from '../../../../../src/model/bpmn/internal/Label';
-import type { ExpectedFont } from '../../parser/json/JsonTestUtils';
 import { Edge } from '../../../../../src/model/bpmn/internal/edge/edge';
 import { AssociationFlow, MessageFlow, SequenceFlow } from '../../../../../src/model/bpmn/internal/edge/flows';
 import Bounds from '../../../../../src/model/bpmn/internal/Bounds';
+import type { ExpectedFont } from '../../../helpers/bpmn-model-expect';
 
 function toFont(font: ExpectedFont): Font {
   return new Font(font.name, font.size, font.isBold, font.isItalic, font.isUnderline, font.isStrikeThrough);

--- a/test/unit/component/parser/json/BpmnJsonParser.association.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.association.test.ts
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { parseJsonAndExpectOnlyEdges, verifyEdge } from './JsonTestUtils';
+
+import { parseJsonAndExpectOnlyEdges } from './JsonTestUtils';
+import { verifyEdge } from '../../../helpers/bpmn-model-expect';
 import { Waypoint } from '../../../../../src/model/bpmn/internal/edge/edge';
 import type { TProcess } from '../../../../../src/model/bpmn/json/baseElement/rootElement/rootElement';
 

--- a/test/unit/component/parser/json/BpmnJsonParser.callActivity.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.callActivity.test.ts
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { parseJsonAndExpectOnlyFlowNodes, verifyShape } from './JsonTestUtils';
+
+import { parseJsonAndExpectOnlyFlowNodes } from './JsonTestUtils';
+import { verifyShape } from '../../../helpers/bpmn-model-expect';
 import type { TCallActivity } from '../../../../../src/model/bpmn/json/baseElement/flowNode/activity/activity';
 import type { GlobalTaskKind } from '../../../../../src/model/bpmn/internal';
 import { ShapeBpmnCallActivityKind, ShapeBpmnElementKind, ShapeBpmnMarkerKind } from '../../../../../src/model/bpmn/internal';

--- a/test/unit/component/parser/json/BpmnJsonParser.diagram.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.diagram.test.ts
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { parseJsonAndExpectOnlyFlowNodes, verifyShape } from './JsonTestUtils';
+
+import { parseJsonAndExpectOnlyFlowNodes } from './JsonTestUtils';
+import { verifyShape } from '../../../helpers/bpmn-model-expect';
 import { ShapeBpmnElementKind } from '../../../../../src/model/bpmn/internal';
 import type { BpmnJsonModel } from '../../../../../src/model/bpmn/json/BPMN20';
 

--- a/test/unit/component/parser/json/BpmnJsonParser.event.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.event.test.ts
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { expectAsWarning, parseJsonAndExpectEvent, parseJsonAndExpectOnlyFlowNodes, parsingMessageCollector, verifyShape } from './JsonTestUtils';
+
+import { expectAsWarning, parseJsonAndExpectEvent, parseJsonAndExpectOnlyFlowNodes, parsingMessageCollector } from './JsonTestUtils';
+import { verifyShape } from '../../../helpers/bpmn-model-expect';
 import type { TProcess } from '../../../../../src/model/bpmn/json/baseElement/rootElement/rootElement';
 import type { TEventDefinition } from '../../../../../src/model/bpmn/json/baseElement/rootElement/eventDefinition';
 import type { TCatchEvent, TThrowEvent } from '../../../../../src/model/bpmn/json/baseElement/flowNode/event';

--- a/test/unit/component/parser/json/BpmnJsonParser.flowNode.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.flowNode.test.ts
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { parseJsonAndExpectOnlyFlowNodes, verifyShape } from './JsonTestUtils';
+
+import { parseJsonAndExpectOnlyFlowNodes } from './JsonTestUtils';
+import { verifyShape } from '../../../helpers/bpmn-model-expect';
 import type { TProcess } from '../../../../../src/model/bpmn/json/baseElement/rootElement/rootElement';
 import { ShapeBpmnElementKind, ShapeBpmnEventBasedGatewayKind } from '../../../../../src/model/bpmn/internal';
 import type { ShapeBpmnEventBasedGateway } from '../../../../../src/model/bpmn/internal/shape/ShapeBpmnElement';

--- a/test/unit/component/parser/json/BpmnJsonParser.group.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.group.test.ts
@@ -21,8 +21,8 @@ import {
   parseJsonAndExpectOnlyPoolsAndFlowNodes,
   parseJsonAndExpectOnlyWarnings,
   parsingMessageCollector,
-  verifyShape,
 } from './JsonTestUtils';
+import { verifyShape } from '../../../helpers/bpmn-model-expect';
 import { ShapeBpmnElementKind } from '../../../../../src/model/bpmn/internal';
 import { GroupUnknownCategoryValueWarning, ShapeUnknownBpmnElementWarning } from '../../../../../src/component/parser/json/warnings';
 

--- a/test/unit/component/parser/json/BpmnJsonParser.lane.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.lane.test.ts
@@ -13,8 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import { expectAsWarning, parseJson, parseJsonAndExpectOnlyLanes, parsingMessageCollector } from './JsonTestUtils';
+import { verifyShape } from '../../../helpers/bpmn-model-expect';
 import { ShapeBpmnElementKind } from '../../../../../src/model/bpmn/internal';
-import { expectAsWarning, parseJson, parseJsonAndExpectOnlyLanes, parsingMessageCollector, verifyShape } from './JsonTestUtils';
 import { LaneUnknownFlowNodeRefWarning } from '../../../../../src/component/parser/json/warnings';
 
 describe('parse bpmn as json for lane', () => {

--- a/test/unit/component/parser/json/BpmnJsonParser.marker.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.marker.test.ts
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { parseJsonAndExpectOnlyFlowNodes, verifyShape } from './JsonTestUtils';
+
+import { parseJsonAndExpectOnlyFlowNodes } from './JsonTestUtils';
+import { verifyShape } from '../../../helpers/bpmn-model-expect';
 import type { TProcess } from '../../../../../src/model/bpmn/json/baseElement/rootElement/rootElement';
 import type { TMultiInstanceLoopCharacteristics, TStandardLoopCharacteristics } from '../../../../../src/model/bpmn/json/baseElement/loopCharacteristics';
 import { ShapeBpmnCallActivityKind, ShapeBpmnElementKind, ShapeBpmnMarkerKind } from '../../../../../src/model/bpmn/internal';

--- a/test/unit/component/parser/json/BpmnJsonParser.messageFlow.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.messageFlow.test.ts
@@ -13,9 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { parseJsonAndExpectOnlyEdges, verifyEdge } from './JsonTestUtils';
+
+import { parseJsonAndExpectOnlyEdges } from './JsonTestUtils';
+import { verifyEdge } from '../../../helpers/bpmn-model-expect';
 import { Waypoint } from '../../../../../src/model/bpmn/internal/edge/edge';
-import { MessageVisibleKind } from '../../../../../src/model/bpmn/internal/edge/kinds';
+import { MessageVisibleKind } from '../../../../../src/model/bpmn/internal';
 import * as bpmndi from '../../../../../src/model/bpmn/json/BPMNDI';
 
 describe('parse bpmn as json for message flow', () => {

--- a/test/unit/component/parser/json/BpmnJsonParser.process.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.process.test.ts
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { parseJsonAndExpect, parseJsonAndExpectOnlyPools, parseJsonAndExpectOnlyPoolsAndFlowNodes, parseJsonAndExpectOnlyPoolsAndLanes, verifyShape } from './JsonTestUtils';
+
+import { parseJsonAndExpect, parseJsonAndExpectOnlyPools, parseJsonAndExpectOnlyPoolsAndFlowNodes, parseJsonAndExpectOnlyPoolsAndLanes } from './JsonTestUtils';
+import { verifyShape } from '../../../helpers/bpmn-model-expect';
 import { ShapeBpmnElementKind } from '../../../../../src/model/bpmn/internal';
 import type { BpmnJsonModel } from '../../../../../src/model/bpmn/json/BPMN20';
 

--- a/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.conditional.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.conditional.test.ts
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { parseJsonAndExpectOnlyEdgesAndFlowNodes, verifyEdge } from './JsonTestUtils';
+
+import { parseJsonAndExpectOnlyEdgesAndFlowNodes } from './JsonTestUtils';
+import { verifyEdge } from '../../../helpers/bpmn-model-expect';
 import { SequenceFlowKind } from '../../../../../src/model/bpmn/internal';
 import type { TProcess } from '../../../../../src/model/bpmn/json/baseElement/rootElement/rootElement';
 import type { TSequenceFlow } from '../../../../../src/model/bpmn/json/baseElement/flowElement';

--- a/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.default.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.default.test.ts
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { parseJsonAndExpectOnlyEdgesAndFlowNodes, verifyEdge } from './JsonTestUtils';
+
+import { parseJsonAndExpectOnlyEdgesAndFlowNodes } from './JsonTestUtils';
+import { verifyEdge } from '../../../helpers/bpmn-model-expect';
 import { SequenceFlowKind } from '../../../../../src/model/bpmn/internal';
 import { Waypoint } from '../../../../../src/model/bpmn/internal/edge/edge';
 import type { TProcess } from '../../../../../src/model/bpmn/json/baseElement/rootElement/rootElement';

--- a/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.normal.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.normal.test.ts
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { parseJsonAndExpectOnlyEdges, verifyEdge } from './JsonTestUtils';
+
+import { parseJsonAndExpectOnlyEdges } from './JsonTestUtils';
+import { verifyEdge } from '../../../helpers/bpmn-model-expect';
 import { Waypoint } from '../../../../../src/model/bpmn/internal/edge/edge';
 import type { TProcess } from '../../../../../src/model/bpmn/json/baseElement/rootElement/rootElement';
 

--- a/test/unit/component/parser/json/BpmnJsonParser.sub.process.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.sub.process.test.ts
@@ -13,14 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { ExpectedShape } from './JsonTestUtils';
-import { parseJson, parseJsonAndExpectOnlySubProcess, verifyEdge, verifyShape, verifySubProcess } from './JsonTestUtils';
+
+import { parseJson, parseJsonAndExpectOnlySubProcess, verifySubProcess } from './JsonTestUtils';
+import { getEventShapes } from './TestUtils';
+import type { ExpectedShape } from '../../../helpers/bpmn-model-expect';
+import { verifyEdge, verifyShape } from '../../../helpers/bpmn-model-expect';
 import type { TProcess } from '../../../../../src/model/bpmn/json/baseElement/rootElement/rootElement';
 import type BpmnModel from '../../../../../src/model/bpmn/internal/BpmnModel';
 import { ShapeBpmnElementKind, ShapeBpmnEventDefinitionKind, ShapeBpmnMarkerKind, ShapeBpmnSubProcessKind } from '../../../../../src/model/bpmn/internal';
 import type { ShapeBpmnEvent } from '../../../../../src/model/bpmn/internal/shape/ShapeBpmnElement';
 import type Shape from '../../../../../src/model/bpmn/internal/shape/Shape';
-import { getEventShapes } from './TestUtils';
 
 function expectNoPoolLane(model: BpmnModel): void {
   expect(model.lanes).toHaveLength(0);

--- a/test/unit/component/parser/json/BpmnJsonParser.text.annotation.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.text.annotation.test.ts
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { parseJsonAndExpectOnlyFlowNodes, verifyShape } from './JsonTestUtils';
+
+import { parseJsonAndExpectOnlyFlowNodes } from './JsonTestUtils';
+import { verifyShape } from '../../../helpers/bpmn-model-expect';
 import { ShapeBpmnElementKind } from '../../../../../src/model/bpmn/internal';
 import type { TProcess } from '../../../../../src/model/bpmn/json/baseElement/rootElement/rootElement';
 

--- a/test/unit/component/parser/json/JsonTestUtils.ts
+++ b/test/unit/component/parser/json/JsonTestUtils.ts
@@ -24,10 +24,6 @@ import type { JsonParsingWarning } from '../../../../../src/component/parser/par
 import { ParsingMessageCollector } from '../../../../../src/component/parser/parsing-messages';
 import type { ExpectedBounds, ExpectedFont } from '../../../helpers/bpmn-model-expect';
 
-// This is a temporary solution after the verifyShape and verifyEdge functions moved to the 'bpmn-model-expect' file.
-// It left the json parser tests imports untouched. The imports will be changed later.
-export * from '../../../helpers/bpmn-model-expect';
-
 class ParsingMessageCollectorTester extends ParsingMessageCollector {
   private warnings: Array<JsonParsingWarning> = [];
 


### PR DESCRIPTION
`JsonTestUtils` re-exported all exports of `helpers/bpmn-model-expect`.
This was a temporary solution after the `verifyShape` and `verifyEdge` functions were moved to the `bpmn-model-expect` file.
The re-export is now removed.