### PR TITLE
[TEST] Improve integration tests of the load API

### DIFF
--- a/src/component/BpmnVisualization.ts
+++ b/src/component/BpmnVisualization.ts
@@ -77,7 +77,7 @@ export class BpmnVisualization {
   load(xml: string, options?: LoadOptions): void {
     const bpmnModel = newBpmnParser().parse(xml);
     const renderedModel = this.bpmnModelRegistry.load(bpmnModel, options?.modelFilter);
-    newBpmnRenderer(this.graph).render(renderedModel, options);
+    newBpmnRenderer(this.graph).render(renderedModel, options?.fit);
   }
 
   /**

--- a/src/component/mxgraph/BpmnRenderer.ts
+++ b/src/component/mxgraph/BpmnRenderer.ts
@@ -23,7 +23,7 @@ import { MessageVisibleKind, ShapeUtil } from '../../model/bpmn/internal';
 import CoordinatesTranslator from './renderer/CoordinatesTranslator';
 import StyleComputer from './renderer/StyleComputer';
 import type { BpmnGraph } from './BpmnGraph';
-import type { LoadOptions } from '../options';
+import type { FitOptions } from '../options';
 import type { RenderedModel } from '../registry/bpmn-model-registry';
 import { mxgraph } from './initializer';
 import type { mxCell } from 'mxgraph';
@@ -34,9 +34,9 @@ import type { mxCell } from 'mxgraph';
 export class BpmnRenderer {
   constructor(readonly graph: BpmnGraph, readonly coordinatesTranslator: CoordinatesTranslator, readonly styleComputer: StyleComputer) {}
 
-  render(renderedModel: RenderedModel, loadOptions?: LoadOptions): void {
+  render(renderedModel: RenderedModel, fitOptions?: FitOptions): void {
     this.insertShapesAndEdges(renderedModel);
-    this.graph.customFit(loadOptions?.fit);
+    this.graph.customFit(fitOptions);
   }
 
   private insertShapesAndEdges({ pools, lanes, subprocesses, otherFlowNodes, boundaryEvents, edges }: RenderedModel): void {

--- a/test/integration/BpmnVisualization.test.ts
+++ b/test/integration/BpmnVisualization.test.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
+import { initializeBpmnVisualization, initializeBpmnVisualizationWithHtmlElement, type GlobalOptionsWithoutContainer } from './helpers/bpmn-visualization-initialization';
 import { readFileSync } from '../helpers/file-helper';
-import type { GlobalOptionsWithoutContainer } from './helpers/bpmn-visualization-initialization';
-import { initializeBpmnVisualization, initializeBpmnVisualizationWithHtmlElement } from './helpers/bpmn-visualization-initialization';
+import { allTestedFitTypes } from './helpers/fit-utils';
+import type { FitType } from '../../src/component/options';
 
 describe('BpmnVisualization initialization', () => {
   it.each`
@@ -34,11 +35,16 @@ describe('BpmnVisualization API', () => {
   const bpmnVisualization = initializeBpmnVisualizationWithHtmlElement('bpmn-container', true);
 
   describe('Load', () => {
+    it.each(allTestedFitTypes)('Fit type: %s', (fitType: string) => {
+      bpmnVisualization.load(readFileSync('../fixtures/bpmn/simple-start-task-end.bpmn'), { fit: { type: <FitType>fitType } });
+    });
+
     it('Load invalid diagram (text file)', async () => {
       expect(() => bpmnVisualization.load(readFileSync('../fixtures/bpmn/xml-parsing/special/text-only.txt'))).toThrow(
         `XML parsing failed. Unable to retrieve 'definitions' from the BPMN source.`,
       );
     });
+
     it('Load and filter pools by id - non existing pool id', () => {
       expect(() =>
         bpmnVisualization.load(readFileSync('../fixtures/bpmn/filter/pools.bpmn'), {

--- a/test/integration/diagram.navigation.test.ts
+++ b/test/integration/diagram.navigation.test.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import { FitType, ZoomType } from '../../src/component/options';
-import { readFileSync } from '../helpers/file-helper';
 import { initializeBpmnVisualizationWithHtmlElement } from './helpers/bpmn-visualization-initialization';
+import { readFileSync } from '../helpers/file-helper';
+import { allTestedFitTypes } from './helpers/fit-utils';
+import { type FitType, ZoomType } from '../../src/component/options';
 
 const bpmnVisualization = initializeBpmnVisualizationWithHtmlElement('bpmn-container', true);
 
@@ -25,25 +26,15 @@ describe('diagram navigation', () => {
     bpmnVisualization.load(readFileSync('../fixtures/bpmn/simple-start-task-end.bpmn'));
   });
 
+  // The following tests ensure there is no error when calling the fit method
   describe('Fit', () => {
     it('Fit no options', async () => {
       // use the deprecated method on purpose, switch to `navigation.fit` when removing the deprecated one.
       bpmnVisualization.fit();
     });
 
-    it.each`
-      fitType
-      ${undefined}
-      ${null}
-      ${FitType.Center}
-      ${FitType.Horizontal}
-      ${FitType.HorizontalVertical}
-      ${FitType.None}
-      ${FitType.Vertical}
-      ${'invalid'}
-    `('Fit with $fitType', ({ fitType }: { fitType: FitType }) => {
-      // ensure no error
-      bpmnVisualization.navigation.fit({ type: fitType });
+    it.each(allTestedFitTypes)('Fit with %s', (fitType: string) => {
+      bpmnVisualization.navigation.fit({ type: <FitType>fitType });
     });
   });
 

--- a/test/integration/helpers/fit-utils.ts
+++ b/test/integration/helpers/fit-utils.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2022 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FitType } from '../../../src/component/options';
+
+export const allTestedFitTypes = [undefined, null, 'invalid', ...Object.values(FitType)];


### PR DESCRIPTION
Add missing tests for 'load with fit' and reorganize the 'fit' tests.
Also simplify the signature of the `BpmnRenderer.render` method. There is no need to pass the whole `LoadOptions` as it only
use the `FitOptions`.