### PR TITLE
[INFRA] Improve surge preview workflows

### DIFF
--- a/.github/actions/custom-surge-preview/action.yml
+++ b/.github/actions/custom-surge-preview/action.yml
@@ -1,0 +1,38 @@
+name: 'Custom surge preview'
+description: 'Simplify usage of surge-preview'
+inputs:
+  build-preview-command:
+    description: 'The command to build the preview'
+    required: true
+  build-preview-dist:
+    description: 'The dist folder deployed to surge.sh'
+    required: true
+  github-token:
+    description: 'A token with `pull-requests: write` to let the surge-preview action create comments on pull requests'
+    required: true
+  surge-token:
+    description: 'A surge token to manage the deployment'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: bonitasoft/actions/packages/surge-preview-tools@v1.2.0
+      id: surge-preview-tools
+      with:
+        surge-token: ${{ inputs.surge-token }}
+    - uses: actions/checkout@v3
+      if: github.event.action != 'closed'
+    - name: Build Setup
+      uses: ./.github/actions/build-setup
+      if: github.event.action != 'closed'
+    - name: Manage surge preview
+      if: steps.surge-preview-tools.outputs.can-run-surge-command == 'true'
+      uses: afc163/surge-preview@v1
+      with:
+        surge_token: ${{ inputs.surge-token }}
+        github_token: ${{ inputs.github-token }}
+        dist: ${{ inputs.build-preview-dist }}
+        failOnError: true
+        teardown: 'true'
+        build: ${{ inputs.build-preview-command }}

--- a/.github/workflows/generate-demo-preview.yml
+++ b/.github/workflows/generate-demo-preview.yml
@@ -26,23 +26,10 @@ jobs:
       # surge-preview: PR comments
       pull-requests: write
     steps:
-      - uses: bonitasoft/actions/packages/surge-preview-tools@v1.2.0
-        id: surge-preview-tools
+      - name: surge preview
+        uses: ./.github/actions/custom-surge-preview
         with:
+          build-preview-command: npm run demo
+          build-preview-dist: build/demo
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           surge-token: ${{ secrets.SURGE_TOKEN }}
-      - uses: actions/checkout@v3
-        if: github.event.action != 'closed'
-      - name: Build Setup
-        uses: ./.github/actions/build-setup
-        if: github.event.action != 'closed'
-      - name: Publish preview
-        if: steps.surge-preview-tools.outputs.can-run-surge-command == 'true'
-        uses: afc163/surge-preview@v1
-        with:
-          surge_token: ${{ secrets.SURGE_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          dist: build/demo
-          failOnError: true
-          teardown: 'true'
-          build: |
-            npm run demo

--- a/.github/workflows/generate-demo-preview.yml
+++ b/.github/workflows/generate-demo-preview.yml
@@ -26,6 +26,7 @@ jobs:
       # surge-preview: PR comments
       pull-requests: write
     steps:
+      - uses: actions/checkout@v3 # access to the local action
       - name: surge preview
         uses: ./.github/actions/custom-surge-preview
         with:

--- a/.github/workflows/generate-demo-preview.yml
+++ b/.github/workflows/generate-demo-preview.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Build Setup
         uses: ./.github/actions/build-setup
         if: github.event.action != 'closed'
-      - name: Publish Demo preview
+      - name: Publish preview
         if: steps.surge-preview-tools.outputs.can-run-surge-command == 'true'
         uses: afc163/surge-preview@v1
         with:

--- a/.github/workflows/generate-demo-preview.yml
+++ b/.github/workflows/generate-demo-preview.yml
@@ -20,34 +20,23 @@ on:
       - 'tsconfig.json'
 
 jobs:
-  # inspired from https://github.com/process-analytics/github-actions-playground/pull/23
-  check_secrets:
-    runs-on: ubuntu-20.04
-    outputs:
-      is_SURGE_TOKEN_set: ${{ steps.secret_availability.outputs.is_SURGE_TOKEN_set }}
-    steps:
-      - name: Compute secrets availability
-        id: secret_availability
-        env:
-          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
-        run: |
-          echo "is_SURGE_TOKEN_set: ${{ env.SURGE_TOKEN != '' }}"
-          echo "::set-output name=is_SURGE_TOKEN_set::${{ env.SURGE_TOKEN != '' }}"
-
-  demo_preview:
-    needs: [check_secrets]
-    if: needs.check_secrets.outputs.is_SURGE_TOKEN_set == 'true'
+  demo_preview: # the id is used by surge to generate the surge url
     runs-on: ubuntu-20.04
     permissions:
       # surge-preview: PR comments
       pull-requests: write
     steps:
+      - uses: bonitasoft/actions/packages/surge-preview-tools@v1.2.0
+        id: surge-preview-tools
+        with:
+          surge-token: ${{ secrets.SURGE_TOKEN }}
       - uses: actions/checkout@v3
         if: github.event.action != 'closed'
       - name: Build Setup
         uses: ./.github/actions/build-setup
         if: github.event.action != 'closed'
       - name: Publish Demo preview
+        if: steps.surge-preview-tools.outputs.can-run-surge-command == 'true'
         id: publish_demo_preview
         uses: afc163/surge-preview@v1
         with:

--- a/.github/workflows/generate-demo-preview.yml
+++ b/.github/workflows/generate-demo-preview.yml
@@ -20,7 +20,7 @@ on:
       - 'tsconfig.json'
 
 jobs:
-  demo_preview: # the id is used by surge to generate the surge url
+  demo_preview: # keep unique across jobs using surge preview (preview url and PR comment id)
     runs-on: ubuntu-20.04
     permissions:
       # surge-preview: PR comments
@@ -37,7 +37,6 @@ jobs:
         if: github.event.action != 'closed'
       - name: Publish Demo preview
         if: steps.surge-preview-tools.outputs.can-run-surge-command == 'true'
-        id: publish_demo_preview
         uses: afc163/surge-preview@v1
         with:
           surge_token: ${{ secrets.SURGE_TOKEN }}

--- a/.github/workflows/generate-demo-preview.yml
+++ b/.github/workflows/generate-demo-preview.yml
@@ -23,8 +23,7 @@ jobs:
   demo_preview: # keep unique across jobs using surge preview (preview url and PR comment id)
     runs-on: ubuntu-20.04
     permissions:
-      # surge-preview: PR comments
-      pull-requests: write
+      pull-requests: write # surge-preview: PR comments
     steps:
       - uses: actions/checkout@v3 # access to the local action
       - name: surge preview

--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -37,6 +37,7 @@ jobs:
       # surge-preview: PR comments
       pull-requests: write
     steps:
+      - uses: actions/checkout@v3 # access to the local action
       - name: surge preview
         uses: ./.github/actions/custom-surge-preview
         with:

--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -34,8 +34,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-20.04
     permissions:
-      # surge-preview: PR comments
-      pull-requests: write
+      pull-requests: write # surge-preview: PR comments
     steps:
       - uses: actions/checkout@v3 # access to the local action
       - name: surge preview
@@ -66,8 +65,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs: generate_doc
     permissions:
-      # Push to gh-pages
-      contents: write
+      contents: write # Push to gh-pages
     steps:
       - name: Download
         uses: actions/download-artifact@v3

--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -37,26 +37,13 @@ jobs:
       # surge-preview: PR comments
       pull-requests: write
     steps:
-      - uses: bonitasoft/actions/packages/surge-preview-tools@v1.2.0
-        id: surge-preview-tools
+      - name: surge preview
+        uses: ./.github/actions/custom-surge-preview
         with:
+          build-preview-command: npm run docs
+          build-preview-dist: build/docs
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           surge-token: ${{ secrets.SURGE_TOKEN }}
-      - uses: actions/checkout@v3
-        if: github.event.action != 'closed'
-      - name: Build Setup
-        uses: ./.github/actions/build-setup
-        if: github.event.action != 'closed'
-      - name: Publish preview
-        if: steps.surge-preview-tools.outputs.can-run-surge-command == 'true'
-        uses: afc163/surge-preview@v1
-        with:
-          surge_token: ${{ secrets.SURGE_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          dist: build/docs
-          failOnError: true
-          teardown: 'true'
-          build: |
-            npm run docs
 
   generate_doc:
     if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&  github.event.ref == 'refs/heads/master'

--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -31,7 +31,7 @@ on:
 
 jobs:
   doc_preview: # keep unique across jobs using surge preview (preview url and PR comment id)
-    if: github.event_name == 'pull_request' && needs.check_secrets.outputs.is_SURGE_TOKEN_set == 'true'
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-20.04
     permissions:
       # surge-preview: PR comments

--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -30,7 +30,7 @@ on:
       - 'typedoc.json'
 
 jobs:
-  doc_preview: # the id is used by surge to generate the surge url
+  doc_preview: # keep unique across jobs using surge preview (preview url and PR comment id)
     if: github.event_name == 'pull_request' && needs.check_secrets.outputs.is_SURGE_TOKEN_set == 'true'
     runs-on: ubuntu-20.04
     permissions:
@@ -48,7 +48,6 @@ jobs:
         if: github.event.action != 'closed'
       - name: Publish preview
         if: steps.surge-preview-tools.outputs.can-run-surge-command == 'true'
-        id: publish_preview
         uses: afc163/surge-preview@v1
         with:
           surge_token: ${{ secrets.SURGE_TOKEN }}

--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -30,35 +30,24 @@ on:
       - 'typedoc.json'
 
 jobs:
-  # inspired from https://github.com/process-analytics/github-actions-playground/pull/23
-  check_secrets:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-20.04
-    outputs:
-      is_SURGE_TOKEN_set: ${{ steps.secret_availability.outputs.is_SURGE_TOKEN_set }}
-    steps:
-      - name: Compute secrets availability
-        id: secret_availability
-        env:
-          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
-        run: |
-          echo "is_SURGE_TOKEN_set: ${{ env.SURGE_TOKEN != '' }}"
-          echo "::set-output name=is_SURGE_TOKEN_set::${{ env.SURGE_TOKEN != '' }}"
-
-  doc_preview:
-    needs: [check_secrets]
+  doc_preview: # the id is used by surge to generate the surge url
     if: github.event_name == 'pull_request' && needs.check_secrets.outputs.is_SURGE_TOKEN_set == 'true'
     runs-on: ubuntu-20.04
     permissions:
       # surge-preview: PR comments
       pull-requests: write
     steps:
+      - uses: bonitasoft/actions/packages/surge-preview-tools@v1.2.0
+        id: surge-preview-tools
+        with:
+          surge-token: ${{ secrets.SURGE_TOKEN }}
       - uses: actions/checkout@v3
         if: github.event.action != 'closed'
       - name: Build Setup
         uses: ./.github/actions/build-setup
         if: github.event.action != 'closed'
       - name: Publish preview
+        if: steps.surge-preview-tools.outputs.can-run-surge-command == 'true'
         id: publish_preview
         uses: afc163/surge-preview@v1
         with:


### PR DESCRIPTION
Remove duplication by introducing a custom action. We now run a single job instead of 2 jobs with cryptic secret checks.
Delegate most of the work to the https://github.com/bonitasoft/actions `surge-preview-tools` action to better manage PR created from fork repositories or by Dependabot.
We shouldn't have error on PR close when it was created by dependabot: most of the time the preview doesn't exist. We previously had errors because we always tried to teardown the surge domain even when it didn't exist. This is now fixed.

Previously valided with https://github.com/process-analytics/github-actions-playground/pull/103