### PR TITLE
[DOC] Improve the doc of API marked as experimental in the HTML docs

### DIFF
--- a/src/component/BpmnVisualization.ts
+++ b/src/component/BpmnVisualization.ts
@@ -39,20 +39,29 @@ export class BpmnVisualization {
   /**
    * Direct access to the `mxGraph` instance that powers `bpmn-visualization`.
    * It is for **advanced users**, so please use the lib API first and access to the `mxGraph` instance only when there is no alternative.
-   * @experimental subject to change, could be removed or made available in another way.
+   *
+   * **WARN**: subject to change, could be removed or made available in another way.
+   *
+   * @experimental
    */
   readonly graph: BpmnGraph;
 
   /**
    * Perform BPMN diagram navigation.
-   * @experimental subject to change, feedback welcome.
+   *
+   * **WARN**: subject to change, feedback welcome.
+   *
+   * @experimental
    * @since 0.24.0
    */
   readonly navigation: Navigation;
 
   /**
    * Interact with BPMN diagram elements rendered in the page.
-   * @experimental subject to change, feedback welcome.
+   *
+   * **WARN**: subject to change, feedback welcome.
+   *
+   * @experimental
    */
   readonly bpmnElementsRegistry: BpmnElementsRegistry;
 


### PR DESCRIPTION
Typedoc 0.23 changed the way it renders 'experimental' tags. Previously, we could have a message explaining why it was
experimental. Typedoc did display the message close to the tag. Now, it put the tag close to the class/property name and
the message is display anywhere in the description, which makes the doc hard to understand.
Some API documentation were already updated as part of the Typedoc version dump, but some remains unchanged. This is now
fixed.

See #2079


### Screenshots

before | now
----- | -----
![image](https://user-images.githubusercontent.com/27200110/177613281-59073376-2c4e-4b0b-ae1a-5e5672b5a43d.png) | ![image](https://user-images.githubusercontent.com/27200110/177613347-f8a9c6c1-aa33-4e87-b33b-7e872f26b516.png)
