### PR TITLE
[TEST] Customize Task in generated json by JsonBuilder 

### DIFF
--- a/test/unit/component/parser/json/BpmnJsonParser.event.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.event.test.ts
@@ -43,7 +43,7 @@ function testMustConvertOneShape({ bpmnKind, buildEventDefinitionParameter, buil
   const json = buildDefinitions({
     process: {
       events: [{ bpmnKind, eventDefinitionParameter: buildEventDefinitionParameter, eventParameter: buildEventParameter }],
-      withTask: true,
+      task: {},
     },
   });
 
@@ -105,7 +105,7 @@ function executeEventCommonTests(
             { bpmnKind, eventDefinitionParameter: buildEventDefinitionParameter, eventParameter: specificBuildEventParameter },
             { bpmnKind, eventDefinitionParameter: buildEventDefinitionParameter, eventParameter: { ...specificBuildEventParameter, index: 1 } },
           ],
-          withTask: true,
+          task: {},
         };
         const json = buildDefinitions(title === 'object' ? { process } : { process: [process] });
 
@@ -175,7 +175,7 @@ function executeEventCommonTests(
           process: {
             eventDefinitionKind,
             events: [{ bpmnKind, eventDefinitionParameter: { ...buildEventDefinitionParameter, withDifferentDefinition: true }, eventParameter: specificBuildEventParameter }],
-            withTask: true,
+            task: {},
           },
         });
 
@@ -186,7 +186,7 @@ function executeEventCommonTests(
         const json = buildDefinitions({
           process: {
             events: [{ bpmnKind, eventDefinitionParameter: { ...buildEventDefinitionParameter, withMultipleDefinitions: true }, eventParameter: specificBuildEventParameter }],
-            withTask: true,
+            task: {},
           },
         });
 
@@ -197,7 +197,7 @@ function executeEventCommonTests(
         const json = buildDefinitions({
           process: {
             events: [{ bpmnKind, eventDefinitionParameter: { eventDefinitionKind, eventDefinitionOn: EventDefinitionOn.BOTH }, eventParameter: specificBuildEventParameter }],
-            withTask: true,
+            task: {},
           },
         });
 
@@ -226,7 +226,7 @@ function executeEventCommonTests(
                     eventParameter: { ...specificBuildEventParameter, isInterrupting: undefined },
                   },
                 ],
-                withTask: true,
+                task: {},
               },
             });
 
@@ -278,7 +278,6 @@ function executeEventCommonTests(
               ],
             },
           });
-
           parseAndExpectNoBoundaryEvents(json, 0);
         });
       }

--- a/test/unit/helpers/JsonBuilder.test.ts
+++ b/test/unit/helpers/JsonBuilder.test.ts
@@ -44,7 +44,7 @@ describe('build json', () => {
       process: [
         {
           id: 'participant_0',
-          withTask: false,
+          task: {},
           events: [
             {
               bpmnKind: 'startEvent',
@@ -74,7 +74,7 @@ describe('build json', () => {
         },
         {
           id: 'participant_1',
-          withTask: true,
+          task: { id: 'task_id_1' },
           events: [
             {
               bpmnKind: 'startEvent',
@@ -93,7 +93,6 @@ describe('build json', () => {
         },
         {
           id: 'participant_2',
-          withTask: false,
           events: [
             {
               bpmnKind: 'intermediateCatchEvent',
@@ -132,6 +131,10 @@ describe('build json', () => {
         process: [
           {
             id: 'process_participant_0',
+            task: {
+              id: 'task_id_0_0',
+              name: 'task name',
+            },
             endEvent: {
               cancelActivity: true,
               eventDefinitionRef: 'event_definition_id',
@@ -157,7 +160,7 @@ describe('build json', () => {
               name: 'startEvent',
             },
             task: {
-              id: 'task_id_1_0',
+              id: 'task_id_1',
               name: 'task name',
             },
           },
@@ -182,6 +185,11 @@ describe('build json', () => {
                 Bounds: { x: 567, y: 345, width: 36, height: 45 },
               },
               {
+                bpmnElement: 'task_id_0_0',
+                id: 'shape_task_id_0_0',
+                Bounds: { x: 362, y: 232, height: 45, width: 36 },
+              },
+              {
                 bpmnElement: 'event_id_0_0',
                 id: 'shape_event_id_0_0',
                 Bounds: { x: 362, y: 232, height: 45, width: 36 },
@@ -197,8 +205,8 @@ describe('build json', () => {
                 Bounds: { x: 567, y: 345, width: 36, height: 45 },
               },
               {
-                bpmnElement: 'task_id_1_0',
-                id: 'shape_task_id_1_0',
+                bpmnElement: 'task_id_1',
+                id: 'shape_task_id_1',
                 Bounds: { x: 362, y: 232, height: 45, width: 36 },
               },
               {
@@ -355,7 +363,7 @@ describe('build json', () => {
                 },
               },
             ],
-            withTask: true,
+            task: {},
           },
         });
 
@@ -424,7 +432,7 @@ describe('build json', () => {
                 },
               },
             ],
-            withTask: true,
+            task: {},
           },
         });
 
@@ -492,7 +500,7 @@ describe('build json', () => {
                 },
               },
             ],
-            withTask: true,
+            task: {},
           },
         });
 
@@ -566,7 +574,7 @@ describe('build json', () => {
                 },
               },
             ],
-            withTask: true,
+            task: {},
           },
         });
 
@@ -633,7 +641,7 @@ describe('build json', () => {
                 },
               },
             ],
-            withTask: true,
+            task: {},
           },
         });
 
@@ -702,7 +710,7 @@ describe('build json', () => {
                 },
               },
             ],
-            withTask: true,
+            task: {},
           },
         });
 
@@ -771,7 +779,7 @@ describe('build json', () => {
                 },
               },
             ],
-            withTask: true,
+            task: {},
           },
         });
 
@@ -1577,10 +1585,49 @@ describe('build json', () => {
   });
 
   describe('build json with task', () => {
-    it('build json of definitions containing one process with task', () => {
+    it('build json of definitions containing one process with task (with id)', () => {
       const json = buildDefinitions({
         process: {
-          withTask: true,
+          task: { id: '0' },
+        },
+      });
+
+      expect(json).toEqual({
+        definitions: {
+          targetNamespace: '',
+          collaboration: {
+            id: 'collaboration_id_0',
+          },
+          process: {
+            id: '0',
+            task: {
+              id: '0',
+              name: 'task name',
+            },
+          },
+          BPMNDiagram: {
+            name: 'process 0',
+            BPMNPlane: {
+              BPMNShape: {
+                id: 'shape_0',
+                bpmnElement: '0',
+                Bounds: {
+                  x: 362,
+                  y: 232,
+                  width: 36,
+                  height: 45,
+                },
+              },
+            },
+          },
+        },
+      });
+    });
+
+    it('build json of definitions containing one process with task (without id)', () => {
+      const json = buildDefinitions({
+        process: {
+          task: {},
         },
       });
 
@@ -1616,9 +1663,9 @@ describe('build json', () => {
       });
     });
 
-    it('build json of definitions containing 2 processes with task', () => {
+    it('build json of definitions containing 2 processes with task (without id)', () => {
       const json = buildDefinitions({
-        process: [{ withTask: true }, { withTask: true }],
+        process: [{ task: {} }, { task: {} }],
       });
 
       expect(json).toEqual({

--- a/test/unit/helpers/JsonBuilder.ts
+++ b/test/unit/helpers/JsonBuilder.ts
@@ -48,12 +48,16 @@ export interface BuildEventDefinitionParameter {
   withMultipleDefinitions?: boolean;
 }
 
+export interface BuildTaskParameter {
+  id?: string;
+}
+
 export interface BuildExclusiveGatewayParameter {
   id?: string;
 }
 
 export interface BuildProcessParameter {
-  withTask?: boolean;
+  task?: BuildTaskParameter | BuildTaskParameter[];
   eventDefinitionKind?: string;
   events?: {
     bpmnKind: string;
@@ -180,8 +184,8 @@ function addParticipant(id: string, jsonModel: BpmnJsonModel): void {
 }
 
 function addElementsOnProcess(processParameter: BuildProcessParameter, json: BpmnJsonModel, processIndex: number): void {
-  if (processParameter.withTask) {
-    addTask(json, processIndex);
+  if (processParameter.task) {
+    (Array.isArray(processParameter.task) ? processParameter.task : [processParameter.task]).forEach((taskParameter, index) => addTask(json, taskParameter, index, processIndex));
   }
   if (processParameter.exclusiveGateway) {
     addExclusiveGateway(json, processParameter.exclusiveGateway, processIndex);
@@ -219,9 +223,9 @@ function addShape(jsonModel: BpmnJsonModel, taskShape: BPMNShape): void {
   updateBpmnElement(bpmnPlane.BPMNShape, taskShape, (value: BPMNShape | BPMNShape[]) => (bpmnPlane.BPMNShape = value));
 }
 
-function addTask(jsonModel: BpmnJsonModel, processIndex: number): void {
+function addTask(jsonModel: BpmnJsonModel, taskParameter: BuildTaskParameter, index: number, processIndex: number): void {
   const task = {
-    id: `task_id_${processIndex}_0`,
+    id: taskParameter.id ? taskParameter.id : `task_id_${processIndex}_${index}`,
     name: 'task name',
   };
   addFlownode(jsonModel, 'task', task, processIndex);


### PR DESCRIPTION
Modify JsonBuilder:

- Introduce BuildTaskParameter interface
- Modify the option to add task in order to customize it and add several
- Add unit tests

It's the 3rd step to simplify the unit tests of the JsonParser. To see the final result, see https://github.com/process-analytics/bpmn-visualization-js/pull/2098.