### PR TITLE
[TEST] Add several Exclusive Gateway in generated json by JsonBuilder

### DIFF
--- a/test/unit/helpers/JsonBuilder.test.ts
+++ b/test/unit/helpers/JsonBuilder.test.ts
@@ -1781,16 +1781,14 @@ describe('build json', () => {
       });
     });
 
-    it('build json of definitions containing 2 processes with exclusive gateway', () => {
+    it('build json of definitions containing 2 processes with exclusive gateway (without id)', () => {
       const json = buildDefinitions({
         process: [
           {
-            exclusiveGateway: { id: 'exclusive_gateway_id_4' },
+            exclusiveGateway: {},
           },
           {
-            exclusiveGateway: {
-              id: 'exclusive_gateway_id_67',
-            },
+            exclusiveGateway: {},
           },
         ],
       });
@@ -1802,21 +1800,21 @@ describe('build json', () => {
             id: 'collaboration_id_0',
           },
           process: [
-            { id: '0', exclusiveGateway: { id: 'exclusive_gateway_id_4', name: 'exclusiveGateway name' } },
-            { id: '1', exclusiveGateway: { id: 'exclusive_gateway_id_67', name: 'exclusiveGateway name' } },
+            { id: '0', exclusiveGateway: { id: 'exclusiveGateway_id_0_0', name: 'exclusiveGateway name' } },
+            { id: '1', exclusiveGateway: { id: 'exclusiveGateway_id_1_0', name: 'exclusiveGateway name' } },
           ],
           BPMNDiagram: {
             name: 'process 0',
             BPMNPlane: {
               BPMNShape: [
                 {
-                  id: 'shape_exclusive_gateway_id_4',
-                  bpmnElement: 'exclusive_gateway_id_4',
+                  id: 'shape_exclusiveGateway_id_0_0',
+                  bpmnElement: 'exclusiveGateway_id_0_0',
                   Bounds: { x: 567, y: 345, width: 25, height: 25 },
                 },
                 {
-                  id: 'shape_exclusive_gateway_id_67',
-                  bpmnElement: 'exclusive_gateway_id_67',
+                  id: 'shape_exclusiveGateway_id_1_0',
+                  bpmnElement: 'exclusiveGateway_id_1_0',
                   Bounds: { x: 567, y: 345, width: 25, height: 25 },
                 },
               ],

--- a/test/unit/helpers/JsonBuilder.ts
+++ b/test/unit/helpers/JsonBuilder.ts
@@ -64,7 +64,7 @@ export interface BuildProcessParameter {
     eventDefinitionParameter: BuildEventDefinitionParameter;
     eventParameter?: BuildEventParameter;
   }[];
-  exclusiveGateway?: BuildExclusiveGatewayParameter;
+  exclusiveGateway?: BuildExclusiveGatewayParameter | BuildExclusiveGatewayParameter[];
 
   /**
    * - If `withParticipant` of `BuildDefinitionParameter` is false, it's corresponding to the id of the process.
@@ -188,7 +188,9 @@ function addElementsOnProcess(processParameter: BuildProcessParameter, json: Bpm
     (Array.isArray(processParameter.task) ? processParameter.task : [processParameter.task]).forEach((taskParameter, index) => addTask(json, taskParameter, index, processIndex));
   }
   if (processParameter.exclusiveGateway) {
-    addExclusiveGateway(json, processParameter.exclusiveGateway, processIndex);
+    (Array.isArray(processParameter.exclusiveGateway) ? processParameter.exclusiveGateway : [processParameter.exclusiveGateway]).forEach((exclusiveGatewayParameter, index) =>
+      addExclusiveGateway(json, exclusiveGatewayParameter, index, processIndex),
+    );
   }
   processParameter.events?.forEach(event => addEvent(json, event, processIndex));
 }
@@ -238,9 +240,9 @@ function addTask(jsonModel: BpmnJsonModel, taskParameter: BuildTaskParameter, in
   addShape(jsonModel, taskShape);
 }
 
-function addExclusiveGateway(jsonModel: BpmnJsonModel, exclusiveGatewayParameter: BuildExclusiveGatewayParameter, processIndex: number): void {
+function addExclusiveGateway(jsonModel: BpmnJsonModel, exclusiveGatewayParameter: BuildExclusiveGatewayParameter, index: number, processIndex: number): void {
   const exclusiveGateway = {
-    id: exclusiveGatewayParameter.id ? exclusiveGatewayParameter.id : `exclusiveGateway_id_${processIndex}_0`,
+    id: exclusiveGatewayParameter.id ? exclusiveGatewayParameter.id : `exclusiveGateway_id_${processIndex}_${index}`,
     name: 'exclusiveGateway name',
   };
   addFlownode(jsonModel, 'exclusiveGateway', exclusiveGateway, processIndex);


### PR DESCRIPTION
Modify the option in JsonBuilder to add several exclusiveGateway.

Depends on https://github.com/process-analytics/bpmn-visualization-js/pull/2101

It's the 4th step to simplify the unit tests of the JsonParser. To see the final result, see https://github.com/process-analytics/bpmn-visualization-js/pull/2098.