### PR TITLE
[TEST] Add several Call Activity in generated json by JsonBuilder

### DIFF
--- a/test/unit/helpers/JsonBuilder.test.ts
+++ b/test/unit/helpers/JsonBuilder.test.ts
@@ -107,6 +107,7 @@ describe('build json', () => {
               },
             },
           ],
+          callActivity: {},
         },
       ],
     });
@@ -173,6 +174,10 @@ describe('build json', () => {
               name: 'intermediateCatchEvent',
               timerEventDefinition: '',
             },
+            callActivity: {
+              id: 'callActivity_id_2_0',
+              name: 'callActivity name',
+            },
           },
         ],
         BPMNDiagram: {
@@ -223,6 +228,11 @@ describe('build json', () => {
                 id: `shape_participant_2`,
                 bpmnElement: `participant_2`,
                 Bounds: { x: 567, y: 345, width: 36, height: 45 },
+              },
+              {
+                bpmnElement: 'callActivity_id_2_0',
+                id: 'shape_callActivity_id_2_0',
+                Bounds: { x: 346, y: 856, height: 56, width: 45 },
               },
               {
                 bpmnElement: 'event_id_2_2',
@@ -1783,14 +1793,7 @@ describe('build json', () => {
 
     it('build json of definitions containing 2 processes with exclusive gateway (without id)', () => {
       const json = buildDefinitions({
-        process: [
-          {
-            exclusiveGateway: {},
-          },
-          {
-            exclusiveGateway: {},
-          },
-        ],
+        process: [{ exclusiveGateway: {} }, { exclusiveGateway: {} }],
       });
 
       expect(json).toEqual({
@@ -1816,6 +1819,124 @@ describe('build json', () => {
                   id: 'shape_exclusiveGateway_id_1_0',
                   bpmnElement: 'exclusiveGateway_id_1_0',
                   Bounds: { x: 567, y: 345, width: 25, height: 25 },
+                },
+              ],
+            },
+          },
+        },
+      });
+    });
+  });
+
+  describe('build json with call activity', () => {
+    it('build json of definitions containing one process with call activity (with id)', () => {
+      const json = buildDefinitions({
+        process: {
+          callActivity: { id: '0' },
+        },
+      });
+
+      expect(json).toEqual({
+        definitions: {
+          targetNamespace: '',
+          collaboration: {
+            id: 'collaboration_id_0',
+          },
+          process: {
+            id: '0',
+            callActivity: {
+              id: '0',
+              name: 'callActivity name',
+            },
+          },
+          BPMNDiagram: {
+            name: 'process 0',
+            BPMNPlane: {
+              BPMNShape: {
+                id: 'shape_0',
+                bpmnElement: '0',
+                Bounds: { x: 346, y: 856, width: 45, height: 56 },
+              },
+            },
+          },
+        },
+      });
+    });
+
+    it('build json of definitions containing one process with call activity (without id)', () => {
+      const json = buildDefinitions({
+        process: {
+          callActivity: {},
+        },
+      });
+
+      expect(json).toEqual({
+        definitions: {
+          targetNamespace: '',
+          collaboration: {
+            id: 'collaboration_id_0',
+          },
+          process: {
+            id: '0',
+            callActivity: {
+              id: 'callActivity_id_0_0',
+              name: 'callActivity name',
+            },
+          },
+          BPMNDiagram: {
+            name: 'process 0',
+            BPMNPlane: {
+              BPMNShape: {
+                id: 'shape_callActivity_id_0_0',
+                bpmnElement: 'callActivity_id_0_0',
+                Bounds: { x: 346, y: 856, width: 45, height: 56 },
+              },
+            },
+          },
+        },
+      });
+    });
+
+    it('build json of definitions containing 2 processes with call activity (without id)', () => {
+      const json = buildDefinitions({
+        process: [{ callActivity: {} }, { callActivity: {} }],
+      });
+
+      expect(json).toEqual({
+        definitions: {
+          targetNamespace: '',
+          collaboration: {
+            id: 'collaboration_id_0',
+          },
+          process: [
+            {
+              id: '0',
+              callActivity: {
+                id: 'callActivity_id_0_0',
+                name: 'callActivity name',
+              },
+            },
+            {
+              id: '1',
+              callActivity: {
+                id: 'callActivity_id_1_0',
+                name: 'callActivity name',
+              },
+            },
+          ],
+          BPMNDiagram: {
+            name: 'process 0',
+            BPMNPlane: {
+              BPMNShape: [
+                {
+                  id: 'shape_callActivity_id_0_0',
+                  bpmnElement: 'callActivity_id_0_0',
+                  Bounds: { x: 346, y: 856, width: 45, height: 56 },
+                },
+                {
+                  id: 'shape_callActivity_id_1_0',
+                  bpmnElement: 'callActivity_id_1_0',
+                  Bounds: { x: 346, y: 856, width: 45, height: 56 },
                 },
               ],
             },

--- a/test/unit/helpers/JsonBuilder.ts
+++ b/test/unit/helpers/JsonBuilder.ts
@@ -52,6 +52,10 @@ export interface BuildTaskParameter {
   id?: string;
 }
 
+export interface BuildCallActivityParameter {
+  id?: string;
+}
+
 export interface BuildExclusiveGatewayParameter {
   id?: string;
 }
@@ -65,6 +69,7 @@ export interface BuildProcessParameter {
     eventParameter?: BuildEventParameter;
   }[];
   exclusiveGateway?: BuildExclusiveGatewayParameter | BuildExclusiveGatewayParameter[];
+  callActivity?: BuildCallActivityParameter | BuildCallActivityParameter[];
 
   /**
    * - If `withParticipant` of `BuildDefinitionParameter` is false, it's corresponding to the id of the process.
@@ -192,6 +197,11 @@ function addElementsOnProcess(processParameter: BuildProcessParameter, json: Bpm
       addExclusiveGateway(json, exclusiveGatewayParameter, index, processIndex),
     );
   }
+  if (processParameter.callActivity) {
+    (Array.isArray(processParameter.callActivity) ? processParameter.callActivity : [processParameter.callActivity]).forEach((callActivityParameter, index) =>
+      addCallActivity(json, callActivityParameter, index, processIndex),
+    );
+  }
   processParameter.events?.forEach(event => addEvent(json, event, processIndex));
 }
 
@@ -251,6 +261,21 @@ function addExclusiveGateway(jsonModel: BpmnJsonModel, exclusiveGatewayParameter
     id: `shape_${exclusiveGateway.id}`,
     bpmnElement: exclusiveGateway.id,
     Bounds: { x: 567, y: 345, width: 25, height: 25 },
+  };
+  addShape(jsonModel, shape);
+}
+
+function addCallActivity(jsonModel: BpmnJsonModel, callActivityParameter: BuildCallActivityParameter, index: number, processIndex: number): void {
+  const callActivity = {
+    id: callActivityParameter.id ? callActivityParameter.id : `callActivity_id_${processIndex}_${index}`,
+    name: 'callActivity name',
+  };
+  addFlownode(jsonModel, 'callActivity', callActivity, processIndex);
+
+  const shape = {
+    id: `shape_${callActivity.id}`,
+    bpmnElement: callActivity.id,
+    Bounds: { x: 346, y: 856, width: 45, height: 56 },
   };
   addShape(jsonModel, shape);
 }


### PR DESCRIPTION
Modify JsonBuilder:

- Introduce BuildCallActivityParameter interface
- Add option to add several callActivity in the generated json
- Add unit tests

Depends on https://github.com/process-analytics/bpmn-visualization-js/pull/2102

It's the 5th step to simplify the unit tests of the JsonParser. To see the final result, see https://github.com/process-analytics/bpmn-visualization-js/pull/2098.