### PR TITLE
[TEST] To be able to override the generic id of the generated event with JsonBuilder

### DIFF
--- a/test/unit/component/parser/json/BpmnJsonParser.messageFlow.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.messageFlow.test.ts
@@ -359,12 +359,14 @@ describe('parse bpmn as json for message flow', () => {
       const isBoundaryEvent = kind === ShapeBpmnElementKind.EVENT_BOUNDARY;
       const eventParameter: BuildEventParameter = isBoundaryEvent
         ? {
+            id,
             bpmnKind: kind,
             isInterrupting: true,
             attachedToRef: 'task_id_0',
             eventDefinitionParameter: { eventDefinitionKind: 'message', eventDefinitionOn: EventDefinitionOn.EVENT },
           }
         : {
+            id,
             bpmnKind: kind,
             eventDefinitionParameter: { eventDefinitionKind: 'message', eventDefinitionOn: EventDefinitionOn.EVENT },
           };

--- a/test/unit/helpers/JsonBuilder.test.ts
+++ b/test/unit/helpers/JsonBuilder.test.ts
@@ -369,7 +369,7 @@ describe('build json', () => {
 
   describe('build json with boundary event', () => {
     describe('build json with interrupting boundary event', () => {
-      it('build json of definitions containing one process with task and interrupting boundary event (with attachedToRef & empty messageEventDefinition)', () => {
+      it('build json of definitions containing one process with task and interrupting boundary event (with attachedToRef, empty messageEventDefinition, name & id)', () => {
         const json = buildDefinitions({
           process: {
             event: [
@@ -377,6 +377,8 @@ describe('build json', () => {
                 bpmnKind: 'boundaryEvent',
                 isInterrupting: true,
                 attachedToRef: 'task_id_0_0',
+                name: 'name',
+                id: 'another_id',
                 eventDefinitionParameter: { eventDefinitionKind: 'message', eventDefinitionOn: EventDefinitionOn.EVENT },
               },
             ],
@@ -397,11 +399,11 @@ describe('build json', () => {
                 name: 'task name',
               },
               boundaryEvent: {
-                id: 'event_id_0_0',
+                id: 'another_id',
                 cancelActivity: true,
                 attachedToRef: 'task_id_0_0',
                 messageEventDefinition: '',
-                name: undefined,
+                name: 'name',
               },
             },
             BPMNDiagram: {
@@ -419,8 +421,8 @@ describe('build json', () => {
                     },
                   },
                   {
-                    id: 'shape_event_id_0_0',
-                    bpmnElement: 'event_id_0_0',
+                    id: 'shape_another_id',
+                    bpmnElement: 'another_id',
                     Bounds: {
                       x: 362,
                       y: 232,
@@ -1187,7 +1189,7 @@ describe('build json', () => {
     });
 
     describe('build json with non-interrupting boundary event', () => {
-      it('build json of definitions containing one process with task and non-interrupting boundary event (with attachedToRef, empty messageEventDefinition and name, without cancelActivity)', () => {
+      it('build json of definitions containing one process with task and non-interrupting boundary event (with attachedToRef, empty messageEventDefinition, name & id, without cancelActivity)', () => {
         const json = buildDefinitions({
           process: {
             event: [
@@ -1195,6 +1197,7 @@ describe('build json', () => {
                 bpmnKind: 'boundaryEvent',
                 attachedToRef: 'task_id_0_0',
                 name: 'name',
+                id: 'another_id',
                 eventDefinitionParameter: { eventDefinitionKind: 'message', eventDefinitionOn: EventDefinitionOn.EVENT },
               },
             ],
@@ -1215,7 +1218,7 @@ describe('build json', () => {
                 name: 'task name',
               },
               boundaryEvent: {
-                id: 'event_id_0_0',
+                id: 'another_id',
                 attachedToRef: 'task_id_0_0',
                 messageEventDefinition: '',
                 name: 'name',
@@ -1236,8 +1239,8 @@ describe('build json', () => {
                     },
                   },
                   {
-                    id: 'shape_event_id_0_0',
-                    bpmnElement: 'event_id_0_0',
+                    id: 'shape_another_id',
+                    bpmnElement: 'another_id',
                     Bounds: {
                       x: 362,
                       y: 232,
@@ -2070,7 +2073,7 @@ describe('build json', () => {
   });
 
   describe.each(['startEvent', 'endEvent', 'intermediateCatchEvent', 'intermediateThrowEvent'])('build json with %s event', (bpmnKind: string) => {
-    it('build json of definitions containing one process with ${bpmnKind} (without eventDefinition)', () => {
+    it('build json of definitions containing one process with ${bpmnKind} (without eventDefinition & id)', () => {
       const json = buildDefinitions({
         process: {
           event: [
@@ -2115,13 +2118,14 @@ describe('build json', () => {
       });
     });
 
-    it('build json of definitions containing one process with ${bpmnKind} (with one messageEventDefinition & name)', () => {
+    it('build json of definitions containing one process with ${bpmnKind} (with one messageEventDefinition & name & id)', () => {
       const json = buildDefinitions({
         process: {
           event: [
             {
               bpmnKind,
               name: 'name',
+              id: 'another_id',
               eventDefinitionParameter: { eventDefinitionKind: 'message', eventDefinitionOn: EventDefinitionOn.EVENT },
             },
           ],
@@ -2137,7 +2141,7 @@ describe('build json', () => {
           process: {
             id: '0',
             [bpmnKind]: {
-              id: 'event_id_0_0',
+              id: 'another_id',
               messageEventDefinition: '',
               name: 'name',
             },
@@ -2146,8 +2150,8 @@ describe('build json', () => {
             name: 'process 0',
             BPMNPlane: {
               BPMNShape: {
-                id: 'shape_event_id_0_0',
-                bpmnElement: 'event_id_0_0',
+                id: 'shape_another_id',
+                bpmnElement: 'another_id',
                 Bounds: {
                   x: 362,
                   y: 232,

--- a/test/unit/helpers/JsonBuilder.ts
+++ b/test/unit/helpers/JsonBuilder.ts
@@ -36,7 +36,8 @@ export enum EventDefinitionOn {
 
 export interface BuildEventParameter {
   /**
-   * `event_id_${processIndex}_${index}`
+   * If it sets, the default id is override.
+   * Otherwise, the id has the format: `event_id_${processIndex}_${index}`
    */
   id?: string;
   bpmnKind: string;
@@ -56,21 +57,24 @@ export interface BuildEventDefinitionParameter {
 
 export interface BuildTaskParameter {
   /**
-   * `task_id_${processIndex}_${index}`
+   * If it sets, the default id is override.
+   * Otherwise, the id has the format: `task_id_${processIndex}_${index}`
    */
   id?: string;
 }
 
 export interface BuildCallActivityParameter {
   /**
-   * `callActivity_id_${processIndex}_${index}`
+   * If it sets, the default id is override.
+   * Otherwise, the id has the format: `callActivity_id_${processIndex}_${index}`
    */
   id?: string;
 }
 
 export interface BuildExclusiveGatewayParameter {
   /**
-   * `exclusiveGateway_id_${processIndex}_${index}`
+   * If it sets, the default id is override.
+   * Otherwise, the id has the format: `exclusiveGateway_id_${processIndex}_${index}`
    */
   id?: string;
 }

--- a/test/unit/helpers/JsonBuilder.ts
+++ b/test/unit/helpers/JsonBuilder.ts
@@ -35,6 +35,10 @@ export enum EventDefinitionOn {
 }
 
 export interface BuildEventParameter {
+  /**
+   * `event_id_${processIndex}_${index}`
+   */
+  id?: string;
   bpmnKind: string;
   name?: string;
   isInterrupting?: boolean;
@@ -51,14 +55,23 @@ export interface BuildEventDefinitionParameter {
 }
 
 export interface BuildTaskParameter {
+  /**
+   * `task_id_${processIndex}_${index}`
+   */
   id?: string;
 }
 
 export interface BuildCallActivityParameter {
+  /**
+   * `callActivity_id_${processIndex}_${index}`
+   */
   id?: string;
 }
 
 export interface BuildExclusiveGatewayParameter {
+  /**
+   * `exclusiveGateway_id_${processIndex}_${index}`
+   */
   id?: string;
 }
 
@@ -365,9 +378,9 @@ function addEventDefinitionsOnEvent(event: TCatchEvent | TThrowEvent | TBoundary
   }
 }
 
-function buildEvent(index: number, processIndex: number, name?: string, isInterrupting?: boolean, attachedToRef?: string): BPMNTEvent {
+function buildEvent(index: number, processIndex: number, name: string, isInterrupting: boolean, attachedToRef: string, id: string): BPMNTEvent {
   const event: BPMNTEvent = {
-    id: `event_id_${processIndex}_${index}`,
+    id: id ? id : `event_id_${processIndex}_${index}`,
     name: name,
   };
 
@@ -382,11 +395,11 @@ function buildEvent(index: number, processIndex: number, name?: string, isInterr
 
 function addEvent(
   jsonModel: BpmnJsonModel,
-  { bpmnKind, eventDefinitionParameter, name, isInterrupting, attachedToRef }: BuildEventParameter,
+  { id, bpmnKind, eventDefinitionParameter, name, isInterrupting, attachedToRef }: BuildEventParameter,
   index: number,
   processIndex: number,
 ): void {
-  const event = buildEvent(index, processIndex, name, isInterrupting, attachedToRef);
+  const event = buildEvent(index, processIndex, name, isInterrupting, attachedToRef, id);
   switch (eventDefinitionParameter.eventDefinitionOn) {
     case EventDefinitionOn.BOTH:
       addEventDefinitionsOnEvent(event, eventDefinitionParameter);


### PR DESCRIPTION
Closes #2041  

- Add an option on `JsonBuilder` to override the default id of the generated event
- New unit tests
- Fix unit tests for `message flow` with source/target as `Event`