### PR TITLE
 [INFRA] Improve full changelog visibility in release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -69,13 +69,14 @@ template: |
   **TODO: add milestone id when publishing**
   See [milestone $NEXT_PATCH_VERSION](https://github.com/process-analytics/bpmn-visualization-js/milestone/x?closed=1) to get the list of issues covered by this release.
 
+  **TODO: check previous and next tag in the "full changelog" link in the "What's changed section"**
+
   # Highlights
 
   **TODO: add screenshots and user oriented info**
 
   # What's Changed
-  $CHANGES
-
-  **TODO: check previous and next tag in the link below**
 
   **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$NEXT_PATCH_VERSION
+
+  $CHANGES


### PR DESCRIPTION
Avoid forgetting to delete the reminder comments and not updating the full changelog link.

### Notes

This is what we have done manually in https://github.com/process-analytics/bpmn-visualization-js/releases/tag/v0.26.0

To be first tested with https://github.com/process-analytics/github-actions-playground/pull/123