### PR TITLE
[POC] Experiment BPMN diagram navigation with CSS Transforms

### DIFF
--- a/src/component/mxgraph/BpmnGraph.ts
+++ b/src/component/mxgraph/BpmnGraph.ts
@@ -175,6 +175,7 @@ export class BpmnGraph extends mxgraph.mxGraph {
     } else {
       // TODO implementation
       console.warn('@@@@@registerMouseWheelZoomListeners detected useCssTransforms - no mouse Zoom for now!!!!!!!');
+      mxgraph.mxEvent.addMouseWheelListener(this.createMouseWheelZoomListenerForCssTransforms(), this.container);
     }
   }
 
@@ -189,6 +190,35 @@ export class BpmnGraph extends mxgraph.mxGraph {
       this.view.scaleAndTranslate(newScale, this.view.translate.x + dx, this.view.translate.y + dy);
       mxgraph.mxEvent.consume(evt);
     }
+  }
+  // TODO duplication with createMouseWheelZoomListener
+  private createMouseWheelZoomListenerForCssTransforms() {
+    return (event: Event, up: boolean) => {
+      if (mxgraph.mxEvent.isConsumed(event)) {
+        return;
+      }
+      const evt = event as MouseEvent;
+      // only the ctrl key
+      const isZoomWheelEvent = evt.ctrlKey && !evt.altKey && !evt.shiftKey && !evt.metaKey;
+      if (isZoomWheelEvent) {
+        this.manageMouseWheelZoomEventForCssTransforms(up, evt);
+      }
+    };
+  }
+
+  private manageMouseWheelZoomEventForCssTransforms(up: boolean, evt: MouseEvent): void {
+    const factor = up ? zoomFactorIn : zoomFactorOut;
+    console.warn('==========manageMouseWheelZoomEventForCssTransforms - factor', factor);
+
+    // or view.scale?
+    const newScale = this.currentScale * factor;
+
+    const [offsetX, offsetY] = this.getEventRelativeCoordinates(evt);
+    // const [newScale, dx, dy] = this.getScaleAndTranslationDeltas(offsetX, offsetY);
+    const [dx, dy] = this.calculateTranslationDeltas(factor, newScale, offsetX * 2, offsetY * 2);
+
+    this.view.scaleAndTranslate(newScale, this.view.translate.x + dx, this.view.translate.y + dy);
+    mxgraph.mxEvent.consume(evt);
   }
 
   private createMouseWheelZoomListener(performScaling: boolean) {

--- a/src/component/mxgraph/BpmnGraph.ts
+++ b/src/component/mxgraph/BpmnGraph.ts
@@ -205,6 +205,8 @@ export class BpmnGraph extends mxgraph.mxGraph {
   }
 
   private getEventRelativeCoordinates(evt: MouseEvent): [number, number] {
+    // TODO EXTRA mouse zoom impl probably better with call of mxUtils.convertPoint
+    // mxgraph.mxUtils.convertPoint(this.container, mxgraph.mxEvent.getClientX(evt), mxgraph.mxEvent.getClientY(evt));
     const rect = this.container.getBoundingClientRect();
     const x = evt.clientX - rect.left;
     const y = evt.clientY - rect.top;

--- a/src/component/mxgraph/BpmnGraph.ts
+++ b/src/component/mxgraph/BpmnGraph.ts
@@ -24,8 +24,8 @@ import type { mxCellState, mxGraphView, mxPoint } from 'mxgraph';
 import type { mxCell } from 'mxgraph';
 import type { mxRectangle } from 'mxgraph';
 
-// TODO change value when using CSS transform (was 1.25) (we should have different values depending on the useCssTransforms value
-const zoomFactorIn = 1.05;
+// TODO change value when using CSS transform (we should have different values depending on the useCssTransforms value
+const zoomFactorIn = 1.25;
 const zoomFactorOut = 1 / zoomFactorIn;
 
 export class BpmnGraph extends mxgraph.mxGraph {

--- a/src/component/mxgraph/BpmnGraph.ts
+++ b/src/component/mxgraph/BpmnGraph.ts
@@ -24,7 +24,8 @@ import type { mxCellState, mxGraphView, mxPoint } from 'mxgraph';
 import type { mxCell } from 'mxgraph';
 import type { mxRectangle } from 'mxgraph';
 
-const zoomFactorIn = 1.25;
+// TODO change value when using CSS transform (was 1.25) (we should have different values depending on the useCssTransforms value
+const zoomFactorIn = 1.05;
 const zoomFactorOut = 1 / zoomFactorIn;
 
 export class BpmnGraph extends mxgraph.mxGraph {
@@ -36,7 +37,7 @@ export class BpmnGraph extends mxgraph.mxGraph {
   /**
    * Uses CSS transforms for scale and translate.
    */
-  // TODO test with true
+  // TODO make this configurable
   useCssTransforms = true;
 
   /**

--- a/src/component/mxgraph/BpmnGraph.ts
+++ b/src/component/mxgraph/BpmnGraph.ts
@@ -302,14 +302,12 @@ export class BpmnGraph extends mxgraph.mxGraph {
    */
   // eslint-disable-next-line @typescript-eslint/ban-types -- Function is type is required by typed-mxgraph
   override getCellAt(x: number, y: number, parent?: mxCell, vertices?: boolean, edges?: boolean, ignoreFn?: Function): mxCell {
-    // getCellAt = function(x, y, parent, vertices, edges, ignoreFn)
     if (this.useCssTransforms) {
       x = x / this.currentScale - this.currentTranslate.x;
       y = y / this.currentScale - this.currentTranslate.y;
     }
 
     return this.getScaledCellAt(x, y, parent, vertices, edges, ignoreFn);
-    // return null;
   }
 
   /**
@@ -365,12 +363,12 @@ export class BpmnGraph extends mxgraph.mxGraph {
    * Check the following test case on page 1 before enabling this in production:
    * https://devhost.jgraph.com/git/drawio/etc/embed/sf-math-fo-clipping.html?dev=1
    */
-  // TODO test if Safari still fails
-  isCssTransformsSupported(): boolean {
-    // this.updateCssTransform
-    return this.dialect == mxgraph.mxConstants.DIALECT_SVG && !mxgraph.mxClient.NO_FO && !mxgraph.mxClient.IS_SF;
-    // return this.dialect == mxgraph.mxConstants.DIALECT_SVG && !mxgraph.mxClient.NO_FO && (!this.lightbox || !mxgraph.mxClient.IS_SF);
-  }
+  // we test no Safari latest and it works
+  // isCssTransformsSupported(): boolean {
+  //   // this.updateCssTransform
+  //   return this.dialect == mxgraph.mxConstants.DIALECT_SVG && !mxgraph.mxClient.NO_FO && !mxgraph.mxClient.IS_SF;
+  //   // return this.dialect == mxgraph.mxConstants.DIALECT_SVG && !mxgraph.mxClient.NO_FO && (!this.lightbox || !mxgraph.mxClient.IS_SF);
+  // }
 
   /**
    * Zooms out of the graph by <zoomFactor>.


### PR DESCRIPTION
**DISCLAIMER: This is a POC it is not intended to be merged. Tests can fail, SonarCloud complains and force-push can occur at any time**

_**TODO description in progress**_

### Rationale

By default, mxGraph manages pan and zoom/fit by recomputing and rendering the graph again (this involves DOM manipulation). This has bad performances and decreases the User Experience. 
See https://github.com/maxGraph/maxGraph/issues/2#issuecomment-1068750484, https://github.com/jgraph/mxgraph/issues/204 or https://github.com/jgraph/mxgraph/issues/265
Notice that if the container used to display the graph has scrollbars, the pan is managed by default by using the scroll bars, which is cheap.

As part of the support of the "zoom with the mouse wheel" in  `bpmn-visualization`, we have been forced to do `throttle/debounce `to limit lags, but lags can occur when using the zoom API (currently, there is no throttle/debounce on it). Others like draw.io, the mxGraph graphEditor example used the same technique with features called _fastZoomEnabled_ or _lazyZoomEnabled_.
However, if this solution avoids lags, the zoom experience isn't smooth. There is a delay between mouse wheel scroll and the actual application of the new scale, especially because of the denounce.


In addition, if updates are done on the DOM elements related to the diagrams prior navigation, they are removed after navigation. This limits a lot the customization that can be done outside `bpmn-visualization`.
We introduced the CSS API not only to help people applying CSS classes (we hide selectors) but also to ensure the classes remained applied when mxGraph redo rendering.
However, this doesn't cover all use cases. For instance
- if the CSS class defines an animation that is supposed to run only when the class is applied, it is replayed on zoom/pan because of the new rendering.
- if custom code modify SVG to update the aspect of a cell directly in JS code, it is dropped after the new rendering

I also recently see warnings in the DevTools console with Chrome 104.0.5112.101 (Official build) (64 bits) or Brave 1.42.97 Chromium: 104.0.5112.102 (Official build) (64 bits)
With reference file B.2.0, at load time (whatever the fit type is), when zooming, doing fit or panning
- at load time
```
[Violation] 'load' handler took 436ms main.js:52 
[Violation] Forced reflow while executing JavaScript took 129ms
```
- other cases
```
[Violation] 'click' handler took 349ms index.js:1 
[Violation] 'pointerup' handler took 288ms mxgraph.js:3
```

### Solution experimented here

Instead of doing new rendering, the zoom/fit and move should rely on the transform attribute to manage the scaling and the translation of the graph. This delegates all navigation operations to the browser as this is generally done in diagramming and rendering solutions.


In draw.io and in the mxGraph graphEditor examples, there is a `useCssTransforms` property in the `Graph` prototype (which inherits from the `mxGraph` prototype).

https://github.com/jgraph/mxgraph/blob/v4.2.2/javascript/examples/grapheditor/www/js/Graph.js#L1647-L1660

<-- I thought that a code snippet will be displayed with a specific commit but it doesn't work
https://github.com/jgraph/mxgraph/blob/273779f744f4ff9012847a423bbb620839da58bb/javascript/examples/grapheditor/www/js/Graph.js#L1647-L1660
-->

There are also a bunch of code (function prototype redefinition mainly in `mxGraph` and `mxGraphView`) to change the xxx. **to continue....**


### Implementation done here

I have integrated the draw.io@20.2.6 and mxGraph@4.2.2 code related to `useCssTransforms`.
Then
- add custom implementation to make the pan work. The draw.io/mxgraph code only works with a container with scrollbar
- update the implementation of the zoom for mouse wheel when using CSS transforms

The code can still managed the zoom and pan as curently done in the bpmn-visualization release.
It could be possible to make the usage of CSS transforms an option for evaluation.

### 1st results

With B.2.0,
- very smooth zoom
- Fit Center operation: 10 to 30 ms instead of 250-350 ms in v0.26.0. Check with console logs of the demo, this is not a performance test, but it gives direction. Visually, this is faster
- the violation warnings only occur at load time

### Possible next steps

Run performance tests to have more insights
The e2e tests for the BPMN rendering fail: the differences seem coming for the scaling computation (may be a rounding issue)
Investigate what is happening when adding overlays (see xxxx)
Review the value of the zoomFactor that may not be accurate for CSS transforms. We may need to make it configurable at initialization and/or at runtime.