### PR TITLE
[DOC] Do not add dev dependencies to release notes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,14 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 2
     versioning-strategy: increase
-    rebase-strategy: "disabled"    
+    rebase-strategy: "disabled"
     commit-message:
-      prefix: "[INFRA] prod -"
+      prefix: "[INFRA] deps -"
       prefix-development: "[INFRA] dev -"
+    labels:
+      - dependencies
+      - javascript
+      - skip-changelog
     reviewers:
       - process-analytics/pa-collaborators
 
@@ -21,8 +25,12 @@ updates:
       interval: "weekly"
       day: wednesday
     open-pull-requests-limit: 2
-    rebase-strategy: "disabled"    
+    rebase-strategy: "disabled"
     commit-message:
       prefix: "[INFRA] gha -"
+    labels:
+      - dependencies
+      - github_actions
+      - skip-changelog
     reviewers:
       - process-analytics/pa-collaborators

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -36,38 +36,31 @@ categories:
     label: documentation
   - title: 🎮 Demo and Examples
     label: example
-  - title: 👻 Maintenance
-    labels:
-      - infra:build
-      - infra:refactoring
-      - infra:repo
-      - chore
-      - internal
   - title: 📦 Dependency updates
-    collapse-after: 5
     labels:
       - dependencies
+  - title: 👻 Maintenance
+    labels:
+      - chore
+      - refactoring
 exclude-labels:
-  - invalid
-  - no-changelog
   - skip-changelog
-  - reverted
-  - wontfix
 # Exclude specific usernames from the generated $CONTRIBUTORS variable.
 # https://github.com/release-drafter/release-drafter/tree/master#exclude-contributors
 exclude-contributors:
   - 'dependabot'
   - 'dependabot[bot]'
+  - 'process-analytics-bot'
 template: |
   **TODO: add a short description about the release content - important for url preview**
   This new release focuses on .... **or something similar**
-
+  This new version brings improvements to ...
 
   **TODO: review the contributors list (remove ALL bots and avoid duplicates)**
   Thanks to all the contributors of this release 🌈: $CONTRIBUTORS
 
-  **TODO: add milestone id when publishing**
-  See [milestone $NEXT_PATCH_VERSION](https://github.com/process-analytics/bpmn-visualization-js/milestone/x?closed=1) to get the list of issues covered by this release.
+  **TODO: use the right milestone id and ensure the version is the right one**
+  See [milestone $NEXT_PATCH_VERSION](https://github.com/$OWNER/$REPOSITORY/milestone/x?closed=1) to get the list of issues covered by this release.
 
   **TODO: check previous and next tag in the "full changelog" link in the "What's changed section"**
 


### PR DESCRIPTION
Dependabot now creates Pull Requests that are not present in the release notes.
As there is only runtime dependencies in the release notes, the dependency updates list isn't collapsed to ensure all
changes are visible.
The `Dependencies update` section is now above the `Maintenance` section as dependencies update are more important for
users than what we did internally to improve the library.

Other release notes improvements:
  - exclude process-analytics-bot. The project bot is excluded from the $CONTRIBUTORS variable to avoid manual edits of
  the release notes.
  - update after label changes in the GitHub repository
    - infra:refactoring --> refactoring
    - infra:build --> chore
    - infra:repo: removed

closes #2208

### Notes

The updated dependabot configuration has already been tested: 
- configuration: https://github.com/process-analytics/github-actions-playground/pull/130
- PR created by dependabot with the new configuration: https://github.com/process-analytics/github-actions-playground/pull/131

The release-drafter configuration changes are already tested in the R package repository: https://github.com/process-analytics/bpmn-visualization-R/pull/105

I have manually added the `skip-changelog` label to the PR about the dev dependencies update for the development version (16 Pull Requests have been updated).