### PR TITLE
[FIX] Do not export ModelFiltering in types

### DIFF
--- a/src/component/registry/bpmn-model-filters.ts
+++ b/src/component/registry/bpmn-model-filters.ts
@@ -20,6 +20,9 @@ import type BpmnModel from '../../model/bpmn/internal/BpmnModel';
 import type { ModelFilter } from '../options';
 import { ensureIsArray } from '../helpers/array-utils';
 
+/**
+ * @internal
+ */
 export class ModelFiltering {
   filter(bpmnModel: BpmnModel, modelFilter?: ModelFilter): BpmnModel {
     const poolIdsFilter: string[] = [];


### PR DESCRIPTION
This is an internal implementation which references the `BpmnModel` type. As `BpmnModel` is internal as well and is not exported, it cannot be resolved which generates type errors.

### Notes

The issue can be seen in https://unpkg.com/browse/bpmn-visualization@0.26.1/dist/component/registry/bpmn-model-filters.d.ts
Notice that the API doc doesn't include the `ModelFiltering` class. Implementing #2231 will probably fix any future issue of that kind.

Tested by running `tsc --emitDeclarationOnly --declaration --project ./tsconfig.bundle.json`
For reviews: check the content of the npm package generated by the related Checks on this PR.

