### PR TITLE
[DOC] Add a changelog file that refs GH releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 See release notes on [the GitHub Releases page](https://github.com/process-analytics/bpmn-visualization-js/releases).
 
 It provides user-centric information, including screenshots and videos illustrating fixes and new features.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+See release notes on [the GitHub Releases page](https://github.com/process-analytics/bpmn-visualization-js/releases).
+
+It provides user-centric information, including screenshots and videos illustrating fixes and new features.


### PR DESCRIPTION
This allows people who are used to reading changelog files to know where to find the `bpmn-visualization` release notes.

### Notes

Inspiration
- https://github.com/ezolenko/rollup-plugin-typescript2/blob/0.34.0/CHANGELOG.md
- https://github.com/agilgur5/react-signature-canvas/blob/v1.0.6/CHANGELOG.md