### PR TITLE
[DOC] Simplify the introduction of the user documentation

### DIFF
--- a/docs/users/intro.adoc
+++ b/docs/users/intro.adoc
@@ -1,2 +1,2 @@
 `bpmn-visualization` is a TypeScript library for visualizing process execution data on https://www.omg.org/spec/BPMN/2.0.2/[BPMN]
-diagrams. It is in early development stages and is subject to change prior to the `1.0.0` release.
+diagrams.


### PR DESCRIPTION
We removed reference to the " early development stage" in the README. Do the same in the user documentation.

### Notes

This change was first proposed in #2184 
Change in README: #1869
