### PR TITLE
[FIX] Fix the browser field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "type": "git",
     "url": "git+https://github.com/process-analytics/bpmn-visualization-js.git"
   },
-  "browser": "dist/bpmn-visualization.min.js",
+  "browser": "dist/bpmn-visualization.esm.js",
   "main": "dist/bpmn-visualization.cjs.js",
   "module": "dist/bpmn-visualization.esm.js",
   "types": "dist/bpmn-visualization.d.ts",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -32,8 +32,9 @@ const pluginsBundleIIFE = [
   // to have sizes of dependencies listed at the end of build log
   sizes(),
 ];
+const iifeBundleFile = 'dist/bpmn-visualization.min.js';
 const outputIIFE = {
-  file: pkg.browser.replace('.min.js', '.js'),
+  file: iifeBundleFile.replace('.min.js', '.js'),
   name: 'bpmnvisu',
   format: 'iife',
 };
@@ -47,7 +48,7 @@ const configIIFEMinified = {
   input: libInput,
   output: {
     ...outputIIFE,
-    file: pkg.browser,
+    file: iifeBundleFile,
   },
   plugins: withMinification(pluginsBundleIIFE),
 };


### PR DESCRIPTION
The browser field is meant to declare module that are used client-side.
We previously set its value to the IIFE bundle which cannot be used for
such purpose.

closes #2228