### PR TITLE
[DOC] README indicates the lowest supported TypeScript version

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,8 @@ You can set the BPMN content using one of the following ways:
 
 #### 📜 TypeScript Support
 
-`bpmn-visualization` provides type definitions, so the integration should work out of the box in TypeScript projects.
+`bpmn-visualization` provides type definitions, so the integration works out of the box in TypeScript projects.
+`bpmn-visualization` requires TypeScript 4.5 or greater.
 
 Depending on the build system used by the TypeScript project, it may get the following type errors:
 - error TS2688: Cannot find type definition file for 'typed-mxgraph'

--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ You can set the BPMN content using one of the following ways:
 #### 📜 TypeScript Support
 
 `bpmn-visualization` provides type definitions, so the integration works out of the box in TypeScript projects.
-`bpmn-visualization` requires TypeScript 4.5 or greater.
+
+`bpmn-visualization` requires **TypeScript 4.5** or greater.
 
 Depending on the build system used by the TypeScript project, it may get the following type errors:
 - error TS2688: Cannot find type definition file for 'typed-mxgraph'

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ You can set the BPMN content using one of the following ways:
 
 `bpmn-visualization` requires **TypeScript 4.5** or greater.
 
-Depending on the build system used by the TypeScript project, it may get the following type errors:
+Depending on the TypeScript configuration of the project, the following errors can occur:
 - error TS2688: Cannot find type definition file for 'typed-mxgraph'
 - error TS7016: Could not find a declaration file for module 'mxgraph'
 


### PR DESCRIPTION
Put the information in the README. This is a first step of larger changes that will be implemented later.
Making it explicit in the README is just a minimum.

refs #2246