### PR TITLE
[FIX] Allow BPMN container HTML element without id

### DIFF
--- a/dev/public/elements-identification.html
+++ b/dev/public/elements-identification.html
@@ -12,7 +12,7 @@
         right: 10px;
         position: absolute;
       }
-      #bpmn-container {
+      .bpmn-container {
         top: 0;
         bottom: 0;
         left: 0;
@@ -153,7 +153,7 @@
     </div>
 
     <div id="main-container">
-      <div id="bpmn-container"></div>
+      <div class="bpmn-container"></div>
     </div>
 </body>
 </html>

--- a/dev/public/static/js/elements-identification.js
+++ b/dev/public/static/js/elements-identification.js
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 import {
+  addCssClasses,
+  addOverlays,
   documentReady,
   downloadPng,
   downloadSvg,
   FitType,
   getElementsByKinds,
-  addCssClasses,
-  removeCssClasses,
   log,
+  removeAllOverlays,
+  removeCssClasses,
+  ShapeUtil,
   startBpmnVisualization,
   updateLoadOptions,
-  ShapeUtil,
-  addOverlays,
-  removeAllOverlays,
 } from '../../../ts/dev-bundle-index';
 
 let lastIdentifiedBpmnIds = [];
@@ -144,7 +144,8 @@ function configureDownloadButtons() {
 documentReady(() => {
   startBpmnVisualization({
     globalOptions: {
-      container: 'bpmn-container',
+      // Use a DOM element without id to test the fix for https://github.com/process-analytics/bpmn-visualization-js/issues/2270
+      container: document.querySelector('.bpmn-container'),
       navigation: {
         enabled: true,
       },

--- a/dev/ts/component/DropFileUserInterface.ts
+++ b/dev/ts/component/DropFileUserInterface.ts
@@ -20,7 +20,7 @@ export class DropFileUserInterface {
   private head: Element;
   private body: Element;
 
-  constructor(private window: Window, private outerContainerId: string, private containerToFadeId: string, private dropCallback: (file: File) => void) {
+  constructor(private window: Window, private outerContainerId: string, private containerToFade: HTMLElement, private dropCallback: (file: File) => void) {
     this.document = window.document;
     this.head = document.head;
     this.body = document.body;
@@ -28,8 +28,9 @@ export class DropFileUserInterface {
   }
 
   private initializeDragAndDrop(): void {
-    const containerToBeFaded = document.getElementById(this.containerToFadeId);
-    this.addDomElements(containerToBeFaded);
+    // Add a special CSS class to the container to identify it. It doesn't always have an id, so we cannot use CSS selector involving its id
+    this.containerToFade.classList.add('faded-container');
+    this.addDomElements(this.containerToFade);
     this.addStyle();
 
     const dropContainer = document.getElementById(this.outerContainerId);
@@ -37,8 +38,8 @@ export class DropFileUserInterface {
     this.preventDefaultsOnEvents(['dragover', 'drop'], this.window);
     this.preventDefaultsOnEvents(['dragover', 'dragleave', 'drop'], dropContainer);
 
-    this.addEventsOnDropContainer(dropContainer, containerToBeFaded);
-    this.addEventsOnDocument(this.outerContainerId, containerToBeFaded);
+    this.addEventsOnDropContainer(dropContainer, this.containerToFade);
+    this.addEventsOnDocument(this.outerContainerId, this.containerToFade);
   }
 
   private preventDefaults(e: Event): void {
@@ -65,10 +66,10 @@ export class DropFileUserInterface {
   private addStyle(): void {
     // region CSS
     const css = `
-#${this.containerToFadeId} {
+.faded-container {
     opacity: 1;
 }
-#${this.containerToFadeId}.faded {
+.faded-container.faded {
     opacity: 0.1;
 }
 #${this.outerContainerId} {

--- a/dev/ts/main.ts
+++ b/dev/ts/main.ts
@@ -239,12 +239,10 @@ function configurePoolsFilteringFromParameters(parameters: URLSearchParams): Mod
 
 export function startBpmnVisualization(config: BpmnVisualizationDemoConfiguration): void {
   const log = logStartup;
-  const container = config.globalOptions.container;
-
-  log(`Initializing BpmnVisualization with container '${container}'...`);
+  log(`Initializing BpmnVisualization with container '${config.globalOptions.container}'...`);
   bpmnVisualization = new ThemedBpmnVisualization(config.globalOptions);
   log('Initialization completed');
-  new DropFileUserInterface(window, 'drop-container', container as string, readAndLoadFile);
+  new DropFileUserInterface(window, 'drop-container', bpmnVisualization.graph.container, readAndLoadFile);
   log('Drag&Drop support initialized');
 
   const parameters = new URLSearchParams(window.location.search);

--- a/src/component/registry/bpmn-elements-registry.ts
+++ b/src/component/registry/bpmn-elements-registry.ts
@@ -29,7 +29,7 @@ import type { BpmnElementKind } from '../../model/bpmn/internal';
  * @internal
  */
 export function newBpmnElementsRegistry(bpmnModelRegistry: BpmnModelRegistry, graph: BpmnGraph): BpmnElementsRegistry {
-  return new BpmnElementsRegistry(bpmnModelRegistry, new HtmlElementRegistry(new BpmnQuerySelectors(graph.container?.id)), new CssRegistry(), newGraphCellUpdater(graph));
+  return new BpmnElementsRegistry(bpmnModelRegistry, new HtmlElementRegistry(graph.container, new BpmnQuerySelectors()), new CssRegistry(), newGraphCellUpdater(graph));
 }
 
 /**
@@ -266,18 +266,18 @@ export class BpmnElementsRegistry {
 }
 
 class HtmlElementRegistry {
-  constructor(private querySelectors: BpmnQuerySelectors) {}
+  constructor(private container: HTMLElement, private querySelectors: BpmnQuerySelectors) {}
 
   /**
    * Returns `null` if no element is found.
    * @param bpmnElementId the id of the BPMN element represented by the searched Html Element.
    */
   getBpmnHtmlElement(bpmnElementId: string): HTMLElement | null {
-    return document.querySelector<HTMLElement>(this.querySelectors.element(bpmnElementId));
+    return this.container.querySelector<HTMLElement>(this.querySelectors.element(bpmnElementId));
   }
 
   getBpmnHtmlElements(bpmnElementKind: BpmnElementKind): HTMLElement[] {
     const selectors = this.querySelectors.elementsOfKind(computeBpmnBaseClassName(bpmnElementKind));
-    return [...document.querySelectorAll<HTMLElement>(selectors)];
+    return [...this.container.querySelectorAll<HTMLElement>(selectors)];
   }
 }

--- a/src/component/registry/query-selectors.ts
+++ b/src/component/registry/query-selectors.ts
@@ -55,13 +55,11 @@
  * @internal
  */
 export class BpmnQuerySelectors {
-  constructor(protected containerId: string) {}
-
   element(bpmnElementId: string): string {
-    return `#${this.containerId} > svg > g > g > g[data-bpmn-id="${bpmnElementId}"]`;
+    return `svg > g > g > g[data-bpmn-id="${bpmnElementId}"]`;
   }
 
   elementsOfKind(bpmnKindCssClassname: string): string {
-    return `#${this.containerId} > svg > g > g > g.${bpmnKindCssClassname}:not(.bpmn-label)`;
+    return `svg > g > g > g.${bpmnKindCssClassname}:not(.bpmn-label)`;
   }
 }

--- a/test/e2e/helpers/visu/bpmn-page-utils.ts
+++ b/test/e2e/helpers/visu/bpmn-page-utils.ts
@@ -32,7 +32,7 @@ class BpmnPage {
   private bpmnQuerySelectors: BpmnQuerySelectorsForTests;
 
   constructor(private bpmnContainerId: string, private page: Page) {
-    this.bpmnQuerySelectors = new BpmnQuerySelectorsForTests(this.bpmnContainerId);
+    this.bpmnQuerySelectors = new BpmnQuerySelectorsForTests();
   }
 
   async expectAvailableBpmnContainer(options?: PageWaitForSelectorOptions): Promise<void> {
@@ -240,7 +240,7 @@ export class BpmnPageSvgTester extends PageTester {
   constructor(targetedPage: TargetedPageConfiguration, page: Page) {
     super(targetedPage, page);
     // TODO duplicated with BpmnPage
-    this.bpmnQuerySelectors = new BpmnQuerySelectorsForTests(this.bpmnContainerId);
+    this.bpmnQuerySelectors = new BpmnQuerySelectorsForTests();
   }
 
   override async gotoPageAndLoadBpmnDiagram(bpmnDiagramName?: string): Promise<void> {

--- a/test/helpers/query-selectors.ts
+++ b/test/helpers/query-selectors.ts
@@ -20,7 +20,7 @@ export class BpmnQuerySelectorsForTests extends BpmnQuerySelectors {
    * This targets a SVG Group
    */
   existingElement(): string {
-    return `#${this.containerId} > svg > g > g > g[data-bpmn-id]`;
+    return `svg > g > g > g[data-bpmn-id]`;
   }
 
   labelLastDiv(bpmnElementId: string): string {
@@ -28,13 +28,13 @@ export class BpmnQuerySelectorsForTests extends BpmnQuerySelectors {
   }
 
   labelSvgGroup(bpmnElementId: string): string {
-    return `#${this.containerId} > svg > g > g > g[data-bpmn-id="${bpmnElementId}"].bpmn-label`;
+    return `svg > g > g > g[data-bpmn-id="${bpmnElementId}"].bpmn-label`;
   }
 
   /**
    * This targets a SVG Group
    */
   overlays(bpmnElementId: string): string {
-    return `#${this.containerId} > svg > g > g:nth-child(3) > g[data-bpmn-id="${bpmnElementId}"]`;
+    return `svg > g > g:nth-child(3) > g[data-bpmn-id="${bpmnElementId}"]`;
   }
 }

--- a/test/integration/BpmnVisualization.test.ts
+++ b/test/integration/BpmnVisualization.test.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { initializeBpmnVisualization, initializeBpmnVisualizationWithHtmlElement, type GlobalOptionsWithoutContainer } from './helpers/bpmn-visualization-initialization';
+import {
+  initializeBpmnVisualizationWithContainerId,
+  initializeBpmnVisualizationWithHtmlElement,
+  type GlobalOptionsWithoutContainer,
+} from './helpers/bpmn-visualization-initialization';
 import { readFileSync } from '../helpers/file-helper';
 import { allTestedFitTypes } from './helpers/fit-utils';
 import type { FitType } from '../../src/component/options';
@@ -27,7 +31,7 @@ describe('BpmnVisualization initialization', () => {
     ${'navigation without zoom config'} | ${{ navigation: { enabled: true } }}
     ${'navigation with zoom config'}    | ${{ navigation: { enabled: true, zoom: { throttleDelay: 20 } } }}
   `(`Verify correct initialization with '$configName' configuration`, ({ configName, config }: { configName: string; config: GlobalOptionsWithoutContainer }) => {
-    initializeBpmnVisualization(`bpmn-visualization-init-check-with-config-${configName}`, config);
+    initializeBpmnVisualizationWithContainerId(`bpmn-visualization-init-check-with-config-${configName}`, config);
   });
 });
 

--- a/test/integration/dom.bpmn.elements.test.ts
+++ b/test/integration/dom.bpmn.elements.test.ts
@@ -22,11 +22,11 @@ import {
   expectStartEventBpmnElement,
   expectTaskBpmnElement,
 } from './helpers/semantic-with-svg-utils';
-import { initializeBpmnVisualization } from './helpers/bpmn-visualization-initialization';
+import { initializeBpmnVisualizationWithContainerId } from './helpers/bpmn-visualization-initialization';
 import { readFileSync } from '../helpers/file-helper';
 
 describe('Bpmn Elements registry - retrieve BPMN elements', () => {
-  const bpmnVisualization = initializeBpmnVisualization();
+  const bpmnVisualization = initializeBpmnVisualizationWithContainerId();
 
   describe('Get by ids', () => {
     it('Pass several existing ids', async () => {

--- a/test/integration/dom.bpmn.elements.test.ts
+++ b/test/integration/dom.bpmn.elements.test.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import type { BpmnVisualization } from '../../src/bpmn-visualization';
 import { FlowKind, ShapeBpmnElementKind } from '../../src/bpmn-visualization';
 import {
   expectEndEventBpmnElement,
@@ -22,77 +23,90 @@ import {
   expectStartEventBpmnElement,
   expectTaskBpmnElement,
 } from './helpers/semantic-with-svg-utils';
-import { initializeBpmnVisualizationWithContainerId } from './helpers/bpmn-visualization-initialization';
+import {
+  initializeBpmnVisualization,
+  initializeBpmnVisualizationWithContainerId,
+  initializeBpmnVisualizationWithHtmlElement,
+  initializeBpmnVisualizationWithoutId,
+} from './helpers/bpmn-visualization-initialization';
 import { readFileSync } from '../helpers/file-helper';
 
 describe('Bpmn Elements registry - retrieve BPMN elements', () => {
-  const bpmnVisualization = initializeBpmnVisualizationWithContainerId();
+  describe.each`
+    bpmnVisualization                               | type
+    ${initializeBpmnVisualizationWithContainerId()} | ${'html id'}
+    ${initializeBpmnVisualizationWithHtmlElement()} | ${'html element'}
+    ${initializeBpmnVisualizationWithoutId()}       | ${'html element without id'}
+    ${initializeBpmnVisualization('')}              | ${'html element with id set to empty string'}
+    ${initializeBpmnVisualization(null)}            | ${'html element with id set to null'}
+    ${initializeBpmnVisualization(undefined)}       | ${'html element with id set to undefined'}
+  `('container set with "$type"', ({ bpmnVisualization }: { bpmnVisualization: BpmnVisualization }) => {
+    describe('Get by ids', () => {
+      it('Pass several existing ids', async () => {
+        bpmnVisualization.load(readFileSync('../fixtures/bpmn/simple-start-task-end.bpmn'));
 
-  describe('Get by ids', () => {
-    it('Pass several existing ids', async () => {
-      bpmnVisualization.load(readFileSync('../fixtures/bpmn/simple-start-task-end.bpmn'));
+        const bpmnElements = bpmnVisualization.bpmnElementsRegistry.getElementsByIds(['StartEvent_1', 'Flow_2']);
+        expect(bpmnElements).toHaveLength(2);
 
-      const bpmnElements = bpmnVisualization.bpmnElementsRegistry.getElementsByIds(['StartEvent_1', 'Flow_2']);
-      expect(bpmnElements).toHaveLength(2);
+        expectStartEventBpmnElement(bpmnElements[0], { id: 'StartEvent_1', name: 'Start Event 1' });
+        expectSequenceFlowBpmnElement(bpmnElements[1], { id: 'Flow_2' });
+      });
 
-      expectStartEventBpmnElement(bpmnElements[0], { id: 'StartEvent_1', name: 'Start Event 1' });
-      expectSequenceFlowBpmnElement(bpmnElements[1], { id: 'Flow_2' });
+      it('Pass a single non existing id', async () => {
+        bpmnVisualization.load(readFileSync('../fixtures/bpmn/simple-start-task-end.bpmn'));
+        const bpmnElements = bpmnVisualization.bpmnElementsRegistry.getElementsByIds('unknown');
+        expect(bpmnElements).toHaveLength(0);
+      });
+
+      it('Pass existing and non existing ids', async () => {
+        bpmnVisualization.load(readFileSync('../fixtures/bpmn/simple-start-task-end.bpmn'));
+        const bpmnElements = bpmnVisualization.bpmnElementsRegistry.getElementsByIds(['StartEvent_1', 'unknown', 'Flow_1', 'another_unknown']);
+        expect(bpmnElements).toHaveLength(2);
+      });
     });
 
-    it('Pass a single non existing id', async () => {
-      bpmnVisualization.load(readFileSync('../fixtures/bpmn/simple-start-task-end.bpmn'));
-      const bpmnElements = bpmnVisualization.bpmnElementsRegistry.getElementsByIds('unknown');
-      expect(bpmnElements).toHaveLength(0);
-    });
+    describe('Get by kinds', () => {
+      it('Pass a single kind related to a single existing element', async () => {
+        bpmnVisualization.load(readFileSync('../fixtures/bpmn/simple-start-task-end.bpmn'));
+        const bpmnElements = bpmnVisualization.bpmnElementsRegistry.getElementsByKinds(ShapeBpmnElementKind.TASK);
+        expect(bpmnElements).toHaveLength(1);
 
-    it('Pass existing and non existing ids', async () => {
-      bpmnVisualization.load(readFileSync('../fixtures/bpmn/simple-start-task-end.bpmn'));
-      const bpmnElements = bpmnVisualization.bpmnElementsRegistry.getElementsByIds(['StartEvent_1', 'unknown', 'Flow_1', 'another_unknown']);
-      expect(bpmnElements).toHaveLength(2);
-    });
-  });
+        expectTaskBpmnElement(bpmnElements[0], { id: 'Activity_1', name: 'Task 1' });
+      });
 
-  describe('Get by kinds', () => {
-    it('Pass a single kind related to a single existing element', async () => {
-      bpmnVisualization.load(readFileSync('../fixtures/bpmn/simple-start-task-end.bpmn'));
-      const bpmnElements = bpmnVisualization.bpmnElementsRegistry.getElementsByKinds(ShapeBpmnElementKind.TASK);
-      expect(bpmnElements).toHaveLength(1);
+      it('Pass a single kind related to several existing elements', async () => {
+        bpmnVisualization.load(readFileSync('../fixtures/bpmn/simple-start-task-end.bpmn'));
+        const bpmnElements = bpmnVisualization.bpmnElementsRegistry.getElementsByKinds(FlowKind.SEQUENCE_FLOW);
+        expect(bpmnElements).toHaveLength(2);
 
-      expectTaskBpmnElement(bpmnElements[0], { id: 'Activity_1', name: 'Task 1' });
-    });
+        expectSequenceFlowBpmnElement(bpmnElements[0], { id: 'Flow_1', name: 'Sequence Flow 1' });
+        expectSequenceFlowBpmnElement(bpmnElements[1], { id: 'Flow_2' });
+      });
 
-    it('Pass a single kind related to several existing elements', async () => {
-      bpmnVisualization.load(readFileSync('../fixtures/bpmn/simple-start-task-end.bpmn'));
-      const bpmnElements = bpmnVisualization.bpmnElementsRegistry.getElementsByKinds(FlowKind.SEQUENCE_FLOW);
-      expect(bpmnElements).toHaveLength(2);
+      it('No elements for this kind', async () => {
+        bpmnVisualization.load(readFileSync('../fixtures/bpmn/simple-start-task-end.bpmn'));
+        const bpmnElements = bpmnVisualization.bpmnElementsRegistry.getElementsByKinds(ShapeBpmnElementKind.SUB_PROCESS);
+        expect(bpmnElements).toHaveLength(0);
+      });
 
-      expectSequenceFlowBpmnElement(bpmnElements[0], { id: 'Flow_1', name: 'Sequence Flow 1' });
-      expectSequenceFlowBpmnElement(bpmnElements[1], { id: 'Flow_2' });
-    });
+      it('Pass a several kinds that all match existing elements', async () => {
+        bpmnVisualization.load(readFileSync('../fixtures/bpmn/registry/1-pool-3-lanes-message-start-end-intermediate-events.bpmn'));
+        const bpmnElements = bpmnVisualization.bpmnElementsRegistry.getElementsByKinds([ShapeBpmnElementKind.EVENT_END, ShapeBpmnElementKind.POOL]);
+        expect(bpmnElements).toHaveLength(3);
 
-    it('No elements for this kind', async () => {
-      bpmnVisualization.load(readFileSync('../fixtures/bpmn/simple-start-task-end.bpmn'));
-      const bpmnElements = bpmnVisualization.bpmnElementsRegistry.getElementsByKinds(ShapeBpmnElementKind.SUB_PROCESS);
-      expect(bpmnElements).toHaveLength(0);
-    });
+        expectEndEventBpmnElement(bpmnElements[0], { id: 'endEvent_terminate_1', name: 'terminate end 1' });
+        expectEndEventBpmnElement(bpmnElements[1], { id: 'endEvent_message_1', name: 'message end 2' });
+        expectPoolBpmnElement(bpmnElements[2], { id: 'Participant_1', name: 'Pool 1' });
+      });
 
-    it('Pass a several kinds that all match existing elements', async () => {
-      bpmnVisualization.load(readFileSync('../fixtures/bpmn/registry/1-pool-3-lanes-message-start-end-intermediate-events.bpmn'));
-      const bpmnElements = bpmnVisualization.bpmnElementsRegistry.getElementsByKinds([ShapeBpmnElementKind.EVENT_END, ShapeBpmnElementKind.POOL]);
-      expect(bpmnElements).toHaveLength(3);
+      it('Pass a several kinds that match existing and non-existing elements', async () => {
+        bpmnVisualization.load(readFileSync('../fixtures/bpmn/registry/1-pool-3-lanes-message-start-end-intermediate-events.bpmn'));
+        const bpmnElements = bpmnVisualization.bpmnElementsRegistry.getElementsByKinds([ShapeBpmnElementKind.CALL_ACTIVITY, ShapeBpmnElementKind.TASK_SERVICE]);
+        expect(bpmnElements).toHaveLength(2);
 
-      expectEndEventBpmnElement(bpmnElements[0], { id: 'endEvent_terminate_1', name: 'terminate end 1' });
-      expectEndEventBpmnElement(bpmnElements[1], { id: 'endEvent_message_1', name: 'message end 2' });
-      expectPoolBpmnElement(bpmnElements[2], { id: 'Participant_1', name: 'Pool 1' });
-    });
-
-    it('Pass a several kinds that match existing and non-existing elements', async () => {
-      bpmnVisualization.load(readFileSync('../fixtures/bpmn/registry/1-pool-3-lanes-message-start-end-intermediate-events.bpmn'));
-      const bpmnElements = bpmnVisualization.bpmnElementsRegistry.getElementsByKinds([ShapeBpmnElementKind.CALL_ACTIVITY, ShapeBpmnElementKind.TASK_SERVICE]);
-      expect(bpmnElements).toHaveLength(2);
-
-      expectServiceTaskBpmnElement(bpmnElements[0], { id: 'serviceTask_1_2', name: 'Service Task 1.2' });
-      expectServiceTaskBpmnElement(bpmnElements[1], { id: 'serviceTask_2_1', name: 'Service Task 2.1' });
+        expectServiceTaskBpmnElement(bpmnElements[0], { id: 'serviceTask_1_2', name: 'Service Task 1.2' });
+        expectServiceTaskBpmnElement(bpmnElements[1], { id: 'serviceTask_2_1', name: 'Service Task 2.1' });
+      });
     });
   });
 });

--- a/test/integration/dom.container.div.test.ts
+++ b/test/integration/dom.container.div.test.ts
@@ -15,18 +15,19 @@
  */
 import type { BpmnVisualization } from '../../src/bpmn-visualization';
 import { ShapeBpmnEventDefinitionKind } from '../../src/bpmn-visualization';
-import { initializeBpmnVisualizationWithContainerId, initializeBpmnVisualizationWithHtmlElement, initializeBpmnVisualization } from './helpers/bpmn-visualization-initialization';
+import {
+  initializeBpmnVisualizationWithContainerId,
+  initializeBpmnVisualizationWithHtmlElement,
+  initializeBpmnVisualizationWithoutId,
+} from './helpers/bpmn-visualization-initialization';
 import { HtmlElementLookup } from './helpers/html-utils';
 import { readFileSync } from '../helpers/file-helper';
 
-/*    div has no id
-    div has an id set to an empty string
-    div has an id set to null or undefined*/
 describe.each`
   bpmnVisualization                               | type
   ${initializeBpmnVisualizationWithContainerId()} | ${'html id'}
   ${initializeBpmnVisualizationWithHtmlElement()} | ${'html element'}
-  ${initializeBpmnVisualization()}                | ${'html element without id'}
+  ${initializeBpmnVisualizationWithoutId()}       | ${'html element without id'}
 `('Resulting DOM after diagram load - container set with "$type"', ({ bpmnVisualization }: { bpmnVisualization: BpmnVisualization }) => {
   const htmlElementLookup = new HtmlElementLookup(bpmnVisualization);
 

--- a/test/integration/dom.container.div.test.ts
+++ b/test/integration/dom.container.div.test.ts
@@ -15,13 +15,20 @@
  */
 import type { BpmnVisualization } from '../../src/bpmn-visualization';
 import { ShapeBpmnEventDefinitionKind } from '../../src/bpmn-visualization';
-import { initializeBpmnVisualization, initializeBpmnVisualizationWithHtmlElement, initializeBpmnVisualizationWithNoContainerId } from './helpers/bpmn-visualization-initialization';
+import {
+  initializeBpmnVisualizationWithContainerId,
+  initializeBpmnVisualizationWithHtmlElement,
+  initializeBpmnVisualizationWithNoContainerId,
+} from './helpers/bpmn-visualization-initialization';
 import { HtmlElementLookup } from './helpers/html-utils';
 import { readFileSync } from '../helpers/file-helper';
 
+/*    div has no id
+    div has an id set to an empty string
+    div has an id set to null or undefined*/
 describe.each`
   bpmnVisualization                                 | type
-  ${initializeBpmnVisualization()}                  | ${'html id'}
+  ${initializeBpmnVisualizationWithContainerId()}   | ${'html id'}
   ${initializeBpmnVisualizationWithHtmlElement()}   | ${'html element'}
   ${initializeBpmnVisualizationWithNoContainerId()} | ${'html element without id'}
 `('Resulting DOM after diagram load - container set with "$type"', ({ bpmnVisualization }: { bpmnVisualization: BpmnVisualization }) => {

--- a/test/integration/dom.container.div.test.ts
+++ b/test/integration/dom.container.div.test.ts
@@ -15,11 +15,7 @@
  */
 import type { BpmnVisualization } from '../../src/bpmn-visualization';
 import { ShapeBpmnEventDefinitionKind } from '../../src/bpmn-visualization';
-import {
-  initializeBpmnVisualizationWithContainerId,
-  initializeBpmnVisualizationWithHtmlElement,
-  initializeBpmnVisualizationWithNoContainerId,
-} from './helpers/bpmn-visualization-initialization';
+import { initializeBpmnVisualizationWithContainerId, initializeBpmnVisualizationWithHtmlElement, initializeBpmnVisualization } from './helpers/bpmn-visualization-initialization';
 import { HtmlElementLookup } from './helpers/html-utils';
 import { readFileSync } from '../helpers/file-helper';
 
@@ -27,10 +23,10 @@ import { readFileSync } from '../helpers/file-helper';
     div has an id set to an empty string
     div has an id set to null or undefined*/
 describe.each`
-  bpmnVisualization                                 | type
-  ${initializeBpmnVisualizationWithContainerId()}   | ${'html id'}
-  ${initializeBpmnVisualizationWithHtmlElement()}   | ${'html element'}
-  ${initializeBpmnVisualizationWithNoContainerId()} | ${'html element without id'}
+  bpmnVisualization                               | type
+  ${initializeBpmnVisualizationWithContainerId()} | ${'html id'}
+  ${initializeBpmnVisualizationWithHtmlElement()} | ${'html element'}
+  ${initializeBpmnVisualization()}                | ${'html element without id'}
 `('Resulting DOM after diagram load - container set with "$type"', ({ bpmnVisualization }: { bpmnVisualization: BpmnVisualization }) => {
   const htmlElementLookup = new HtmlElementLookup(bpmnVisualization);
 

--- a/test/integration/dom.container.div.test.ts
+++ b/test/integration/dom.container.div.test.ts
@@ -23,7 +23,7 @@ describe.each`
   bpmnVisualization                                 | type
   ${initializeBpmnVisualization()}                  | ${'html id'}
   ${initializeBpmnVisualizationWithHtmlElement()}   | ${'html element'}
-  ${initializeBpmnVisualizationWithNoContainerId()} | ${'no html id'}
+  ${initializeBpmnVisualizationWithNoContainerId()} | ${'html element without id'}
 `('Resulting DOM after diagram load - container set with "$type"', ({ bpmnVisualization }: { bpmnVisualization: BpmnVisualization }) => {
   const htmlElementLookup = new HtmlElementLookup(bpmnVisualization);
 

--- a/test/integration/dom.container.div.test.ts
+++ b/test/integration/dom.container.div.test.ts
@@ -15,14 +15,15 @@
  */
 import type { BpmnVisualization } from '../../src/bpmn-visualization';
 import { ShapeBpmnEventDefinitionKind } from '../../src/bpmn-visualization';
-import { initializeBpmnVisualization, initializeBpmnVisualizationWithHtmlElement } from './helpers/bpmn-visualization-initialization';
+import { initializeBpmnVisualization, initializeBpmnVisualizationWithHtmlElement, initializeBpmnVisualizationWithNoContainerId } from './helpers/bpmn-visualization-initialization';
 import { HtmlElementLookup } from './helpers/html-utils';
 import { readFileSync } from '../helpers/file-helper';
 
 describe.each`
-  bpmnVisualization                               | type
-  ${initializeBpmnVisualization()}                | ${'html id'}
-  ${initializeBpmnVisualizationWithHtmlElement()} | ${'html element'}
+  bpmnVisualization                                 | type
+  ${initializeBpmnVisualization()}                  | ${'html id'}
+  ${initializeBpmnVisualizationWithHtmlElement()}   | ${'html element'}
+  ${initializeBpmnVisualizationWithNoContainerId()} | ${'no html id'}
 `('Resulting DOM after diagram load - container set with "$type"', ({ bpmnVisualization }: { bpmnVisualization: BpmnVisualization }) => {
   const htmlElementLookup = new HtmlElementLookup(bpmnVisualization);
 

--- a/test/integration/dom.css.classes.test.ts
+++ b/test/integration/dom.css.classes.test.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 import { readFileSync } from '../helpers/file-helper';
-import { initializeBpmnVisualization } from './helpers/bpmn-visualization-initialization';
+import { initializeBpmnVisualizationWithContainerId } from './helpers/bpmn-visualization-initialization';
 import { HtmlElementLookup } from './helpers/html-utils';
 import { ShapeBpmnEventDefinitionKind } from '../../src/model/bpmn/internal';
 
 describe('Bpmn Elements registry - CSS class management', () => {
-  const bpmnVisualization = initializeBpmnVisualization();
+  const bpmnVisualization = initializeBpmnVisualizationWithContainerId();
   const htmlElementLookup = new HtmlElementLookup(bpmnVisualization);
 
   describe('Add classes', () => {
@@ -59,7 +59,7 @@ describe('Bpmn Elements registry - CSS class management', () => {
     });
 
     it('Css classes are cleaned between 2 diagram loads', () => {
-      const bpmnVisualizationMultipleLoads = initializeBpmnVisualization('bpmn-container-multiple-loads');
+      const bpmnVisualizationMultipleLoads = initializeBpmnVisualizationWithContainerId('bpmn-container-multiple-loads');
       const htmlElementLookup = new HtmlElementLookup(bpmnVisualizationMultipleLoads);
 
       const bpmnDiagramContent = readFileSync('../fixtures/bpmn/simple-start-task-end.bpmn');

--- a/test/integration/dom.overlays.test.ts
+++ b/test/integration/dom.overlays.test.ts
@@ -17,11 +17,11 @@
 import type { OverlayEdgePosition, OverlayShapePosition } from '../../src/bpmn-visualization';
 import { readFileSync } from '../helpers/file-helper';
 import { overlayEdgePositionValues, overlayShapePositionValues } from '../helpers/overlays';
-import { initializeBpmnVisualization } from './helpers/bpmn-visualization-initialization';
+import { initializeBpmnVisualizationWithContainerId } from './helpers/bpmn-visualization-initialization';
 import { HtmlElementLookup } from './helpers/html-utils';
 
 describe('Bpmn Elements registry - Overlay management', () => {
-  const bpmnVisualization = initializeBpmnVisualization();
+  const bpmnVisualization = initializeBpmnVisualizationWithContainerId();
   const htmlElementLookup = new HtmlElementLookup(bpmnVisualization);
 
   describe('BPMN Shape', () => {

--- a/test/integration/helpers/bpmn-visualization-initialization.ts
+++ b/test/integration/helpers/bpmn-visualization-initialization.ts
@@ -19,7 +19,7 @@ import { insertBpmnContainer } from './dom-utils';
 
 export type GlobalOptionsWithoutContainer = Omit<GlobalOptions, 'container'>;
 
-export const initializeBpmnVisualization = (bpmnContainerId = 'bpmn-visualization-container', options?: GlobalOptionsWithoutContainer): BpmnVisualization => {
+export const initializeBpmnVisualizationWithContainerId = (bpmnContainerId = 'bpmn-visualization-container', options?: GlobalOptionsWithoutContainer): BpmnVisualization => {
   insertBpmnContainer(bpmnContainerId);
   return new BpmnVisualization({ container: bpmnContainerId, ...options });
 };

--- a/test/integration/helpers/bpmn-visualization-initialization.ts
+++ b/test/integration/helpers/bpmn-visualization-initialization.ts
@@ -19,14 +19,17 @@ import { insertBpmnContainer } from './dom-utils';
 
 export type GlobalOptionsWithoutContainer = Omit<GlobalOptions, 'container'>;
 
-export const initializeBpmnVisualization = (containerId?: string, options?: GlobalOptionsWithoutContainer): BpmnVisualization => {
-  const bpmnContainerId = containerId ?? 'bpmn-visualization-container';
+export const initializeBpmnVisualization = (bpmnContainerId = 'bpmn-visualization-container', options?: GlobalOptionsWithoutContainer): BpmnVisualization => {
   insertBpmnContainer(bpmnContainerId);
   return new BpmnVisualization({ container: bpmnContainerId, ...options });
 };
 
-export const initializeBpmnVisualizationWithHtmlElement = (containerId?: string, withNavigation = false): BpmnVisualization => {
-  const bpmnContainerId = containerId ?? 'bpmn-visualization-container-alternative';
+export const initializeBpmnVisualizationWithHtmlElement = (bpmnContainerId = 'bpmn-visualization-container-alternative', withNavigation = false): BpmnVisualization => {
   const options = { container: insertBpmnContainer(bpmnContainerId), navigation: { enabled: withNavigation } };
   return new BpmnVisualization(options);
+};
+
+export const initializeBpmnVisualizationWithNoContainerId = (options?: GlobalOptionsWithoutContainer): BpmnVisualization => {
+  const container = insertBpmnContainer('');
+  return new BpmnVisualization({ container, ...options });
 };

--- a/test/integration/helpers/bpmn-visualization-initialization.ts
+++ b/test/integration/helpers/bpmn-visualization-initialization.ts
@@ -15,7 +15,7 @@
  */
 
 import { BpmnVisualization, type GlobalOptions } from '../../../src/bpmn-visualization';
-import { insertBpmnContainer } from './dom-utils';
+import { insertBpmnContainer, insertBpmnContainerWithoutId } from './dom-utils';
 
 export type GlobalOptionsWithoutContainer = Omit<GlobalOptions, 'container'>;
 
@@ -24,11 +24,15 @@ export const initializeBpmnVisualizationWithContainerId = (bpmnContainerId = 'bp
 };
 
 export const initializeBpmnVisualizationWithHtmlElement = (bpmnContainerId = 'bpmn-visualization-container-alternative', withNavigation = false): BpmnVisualization => {
-  const options = { container: insertBpmnContainer(bpmnContainerId), navigation: { enabled: withNavigation } };
-  return new BpmnVisualization(options);
+  return initializeBpmnVisualization(bpmnContainerId, { navigation: { enabled: withNavigation } });
 };
 
 export const initializeBpmnVisualization = (bpmnContainerId?: string, globalOptions?: GlobalOptionsWithoutContainer): BpmnVisualization => {
   const options = { container: insertBpmnContainer(bpmnContainerId), ...globalOptions };
+  return new BpmnVisualization(options);
+};
+
+export const initializeBpmnVisualizationWithoutId = (globalOptions?: GlobalOptionsWithoutContainer): BpmnVisualization => {
+  const options = { container: insertBpmnContainerWithoutId(), ...globalOptions };
   return new BpmnVisualization(options);
 };

--- a/test/integration/helpers/bpmn-visualization-initialization.ts
+++ b/test/integration/helpers/bpmn-visualization-initialization.ts
@@ -19,9 +19,8 @@ import { insertBpmnContainer } from './dom-utils';
 
 export type GlobalOptionsWithoutContainer = Omit<GlobalOptions, 'container'>;
 
-export const initializeBpmnVisualizationWithContainerId = (bpmnContainerId = 'bpmn-visualization-container', options?: GlobalOptionsWithoutContainer): BpmnVisualization => {
-  insertBpmnContainer(bpmnContainerId);
-  return new BpmnVisualization({ container: bpmnContainerId, ...options });
+export const initializeBpmnVisualizationWithContainerId = (bpmnContainerId = 'bpmn-visualization-container', globalOptions?: GlobalOptionsWithoutContainer): BpmnVisualization => {
+  return initializeBpmnVisualization(bpmnContainerId, globalOptions);
 };
 
 export const initializeBpmnVisualizationWithHtmlElement = (bpmnContainerId = 'bpmn-visualization-container-alternative', withNavigation = false): BpmnVisualization => {
@@ -29,7 +28,7 @@ export const initializeBpmnVisualizationWithHtmlElement = (bpmnContainerId = 'bp
   return new BpmnVisualization(options);
 };
 
-export const initializeBpmnVisualizationWithNoContainerId = (globalOptions?: GlobalOptionsWithoutContainer): BpmnVisualization => {
-  const options = { container: insertBpmnContainer(''), ...globalOptions };
+export const initializeBpmnVisualization = (bpmnContainerId?: string, globalOptions?: GlobalOptionsWithoutContainer): BpmnVisualization => {
+  const options = { container: insertBpmnContainer(bpmnContainerId), ...globalOptions };
   return new BpmnVisualization(options);
 };

--- a/test/integration/helpers/bpmn-visualization-initialization.ts
+++ b/test/integration/helpers/bpmn-visualization-initialization.ts
@@ -29,7 +29,7 @@ export const initializeBpmnVisualizationWithHtmlElement = (bpmnContainerId = 'bp
   return new BpmnVisualization(options);
 };
 
-export const initializeBpmnVisualizationWithNoContainerId = (options?: GlobalOptionsWithoutContainer): BpmnVisualization => {
-  const container = insertBpmnContainer('');
-  return new BpmnVisualization({ container, ...options });
+export const initializeBpmnVisualizationWithNoContainerId = (globalOptions?: GlobalOptionsWithoutContainer): BpmnVisualization => {
+  const options = { container: insertBpmnContainer(''), ...globalOptions };
+  return new BpmnVisualization(options);
 };

--- a/test/integration/helpers/dom-utils.ts
+++ b/test/integration/helpers/dom-utils.ts
@@ -24,3 +24,9 @@ export function insertBpmnContainer(bpmnContainerId: string): HTMLDivElement {
   document.body.insertBefore(divElement, document.body.firstChild);
   return divElement;
 }
+
+export function insertBpmnContainerWithoutId(): HTMLDivElement {
+  const divElement = document.createElement('div');
+  document.body.insertBefore(divElement, document.body.firstChild);
+  return divElement;
+}

--- a/test/integration/helpers/html-utils.ts
+++ b/test/integration/helpers/html-utils.ts
@@ -33,7 +33,7 @@ export class HtmlElementLookup {
   private bpmnQuerySelectors: BpmnQuerySelectorsForTests;
 
   constructor(private bpmnVisualization: BpmnVisualization) {
-    this.bpmnQuerySelectors = new BpmnQuerySelectorsForTests(bpmnVisualization.graph.container.id);
+    this.bpmnQuerySelectors = new BpmnQuerySelectorsForTests();
   }
 
   expectNoElement(bpmnId: string): void {


### PR DESCRIPTION
Previously, calling `BpmnElementsRegistry.getElementsByIds` generated error when the HTML BPMN container has no id.
When using framework like Svelte or Angular, the container doesn't have such id, so it prevented to use the API out of the box.

The CSS selector that retrieves the HTML elements has been simplified to not use the id. 

The "elements-identification" demo has been updated to use a BPMN container without id.
Prior, the fix, it reproduced the issue when calling the registry API
```
ERROR DOMException: Document.querySelector: '# > svg > g > g > g[data-bpmn-id="Activity_1potg3p"]' is not a valid selector
```
The drag'n drop code was only able to manage container with id. It has been updated to support container without id as well.

Closes #2270 

### Notes

The bug is reproduced with the first commit (new integration test): df2c5d6
Additional tests were added to reproduce the issue with the BpmnElementsRegistry API: 53a42bd
The elements-identification.html demo was updated to also reproduce the problem: 8946525
