### PR TITLE
[INFRA] Run some GH workflows less often

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,11 +11,10 @@ on:
       - 'scripts/**/*'
       - 'src/**/*'
       - 'test/**/*'
+      - '.eslintrc.js'
+      - '.prettierrc.js'
       - 'package.json'
       - 'package-lock.json'
-      - 'postcss.config.js'
-      - 'rollup.config.js'
-      - 'tailwind.config.js'
       - 'tsconfig.json'
   pull_request:
     branches:
@@ -27,11 +26,10 @@ on:
       - 'scripts/**/*'
       - 'src/**/*'
       - 'test/**/*'
+      - '.eslintrc.js'
+      - '.prettierrc.js'
       - 'package.json'
       - 'package-lock.json'
-      - 'postcss.config.js'
-      - 'rollup.config.js'
-      - 'tailwind.config.js'
       - 'tsconfig.json'
 
 jobs:
@@ -98,46 +96,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
-
-  test_bundles:
-    needs: build
-    runs-on: ${{ matrix.os }}
-    strategy:
-      # don't cancel running jobs even if one fails
-      fail-fast: false
-      matrix:
-        os: [macos-12, ubuntu-20.04, windows-2019]
-        browser: [chromium, firefox, chrome]
-        include:
-          # only test WebKit on macOS
-          - os: macos-12
-            browser: webkit
-          # only test Edge on Windows
-          - os: windows-2019
-            browser: msedge
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Build Setup
-        uses: ./.github/actions/build-setup
-      # Ensure we can build working bundles
-      - name: Build bundles
-        run: npm pack
-      # install OS dependencies required by browsers on the GitHub runner
-      # to be sure that the browser is correctly installed: https://github.com/microsoft/playwright/issues/5801
-      - name: Install ${{matrix.browser}} and its dependencies only
-        run: |
-          npx playwright install ${{matrix.browser}}
-          npx playwright install-deps ${{matrix.browser}}
-      - name: Test bundles
-        id: 'test_bundles'
-        env:
-          BROWSERS: ${{matrix.browser}}
-        run: npm run test:bundles:verbose
-      - name: Upload bundles test results
-        if: ${{ failure() && steps.test_bundles.outcome == 'failure' }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: bundles-${{matrix.browser}}-test-results-${{matrix.os}}-${{github.sha}}
-          path: build/test-report/bundles

--- a/.github/workflows/generate-demo-preview.yml
+++ b/.github/workflows/generate-demo-preview.yml
@@ -17,9 +17,9 @@ on:
       - 'package.json'
       - 'package-lock.json'
       - 'postcss.config.js'
-      - 'rollup.config.js'
       - 'tailwind.config.js'
       - 'tsconfig.json'
+      - 'vite.config.js'
 
 jobs:
   demo_preview: # keep unique across jobs using surge preview (preview url and PR comment id)

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -12,9 +12,9 @@ on:
       - 'package.json'
       - 'package-lock.json'
       - 'postcss.config.js'
-      - 'rollup.config.js'
       - 'tailwind.config.js'
       - 'tsconfig.json'
+      - 'vite.config.js'
   pull_request:
     branches:
       - master
@@ -26,9 +26,9 @@ on:
       - 'package.json'
       - 'package-lock.json'
       - 'postcss.config.js'
-      - 'rollup.config.js'
       - 'tailwind.config.js'
       - 'tsconfig.json'
+      - 'vite.config.js'
 
 jobs:
   test_e2e:

--- a/.github/workflows/upload-npm-package.yml
+++ b/.github/workflows/upload-npm-package.yml
@@ -31,6 +31,8 @@ on:
 jobs:
   upload:
     runs-on: ubuntu-20.04
+    env:
+      test-bundles-browser: chromium
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -43,6 +45,24 @@ jobs:
         with:
           name: bpmn-visualization-npm-package-${{github.sha}}
           path: bpmn-visualization-*.tgz
+      # install OS dependencies required by browsers on the GitHub runner
+      # to be sure that the browser is correctly installed: https://github.com/microsoft/playwright/issues/5801
+      - name: Install ${{env.test-bundles-browser}} and its dependencies only
+        run: |
+          npx playwright install ${{env.test-bundles-browser}}
+          npx playwright install-deps ${{env.test-bundles-browser}}
+      - name: Test bundles
+        id: 'test_bundles'
+        env:
+          BROWSERS: ${{env.test-bundles-browser}}
+        run: npm run test:bundles:verbose
+      - name: Upload bundles test results
+        if: ${{ failure() && steps.test_bundles.outcome == 'failure' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: bundles-test-results-${{github.sha}}
+          path: build/test-report/bundles
+      # Check the minimal TS version required to use bpmn-visualization
       - name: Setup typescript-support test
         working-directory: 'test/typescript-support'
         run: npm install --ignore-scripts --prefer-offline --audit false


### PR DESCRIPTION
Currently, across the whole GitHub organization, we can run at most 20 jobs simultaneously and no more than 5 in parallel on macOS. To reduce the load, let's reduce the amount of jobs that are run when pushing in the bpmn-visualization repostiory.

The main change here is to stop running bundle tests on all OS with all browsers. This drops 11 jobs for each PR that runs the 'build' workflow! The bundle tests are now run in the workflow that build and upload the npm package.

Other configurations of workflows have been updated to not run when some files not involved in the workflow run are modified.

covers #2172 