### PR TITLE
[DOC] Simplify the content of the NOTICE file

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,15 +1,13 @@
-/**
- * Copyright 2022 Bonitasoft S.A.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+Copyright 2020 Bonitasoft S.A.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/package.json
+++ b/package.json
@@ -63,8 +63,8 @@
     "docs": "run-s docs:*",
     "docs:user": "node scripts/docs.js",
     "docs:api": "typedoc --tsconfig ./tsconfig.typedoc.json src/bpmn-visualization.ts",
-    "lint": "eslint \"*/**/*.{js,mjs,ts}\" NOTICE --max-warnings 0 --quiet --fix",
-    "lint-check": "eslint \"*/**/*.{js,mjs,ts}\" NOTICE --max-warnings 0",
+    "lint": "eslint \"*/**/*.{js,mjs,ts}\" --max-warnings 0 --quiet --fix",
+    "lint-check": "eslint \"*/**/*.{js,mjs,ts}\" --max-warnings 0",
     "test": "run-s test:unit test:integration test:e2e",
     "test:unit": "jest --runInBand --config=./test/unit/jest.config.js",
     "test:unit:coverage": "npm run test:unit -- --coverage",
@@ -155,9 +155,6 @@
   },
   "lint-staged": {
     "*.{js,mjs,ts}": [
-      "eslint --fix"
-    ],
-    "NOTICE": [
       "eslint --fix"
     ]
   }


### PR DESCRIPTION
Remove extra TSDoc syntax, only keep plain text.
The NOTICE file has been excluded from the eslint processing: this file doesn't change, is related to the documentation, and does not follow the JS/TS header file format. So there is no reason to lint it.

Restore the Copyright date to `2020`. This is the start date of the project.

### Notes

This PR is based on the work done for the website: https://github.com/process-analytics/process-analytics.dev/pull/706
The NOTICE file initially mention year 2020. #1957 changed it to 2022. We now restore it to its initial value 😸 
