### PR TITLE
[FEAT] Downlevel the minimum supported TS version from 4.5 to 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,9 @@ You can set the BPMN content using one of the following ways:
 #### 📜 TypeScript Support
 
 The `bpmn-visualization` npm package includes type definitions, so the integration works out of the box in TypeScript projects.
-`bpmn-visualization` requires **TypeScript 4.5** or greater.
+`bpmn-visualization` requires **TypeScript 4.0** or greater. Past versions had the following requirements:
+  * 0.21.0 to 0.27.1: TypeScript 4.5
+  * 0.17.1 to 0.20.1: TypeScript 4.3
 
 ℹ️ If you are looking for examples of projects integrating `bpmn-visualization` with TypeScript, see the [bpmn-visualization-examples repository](https://github.com/process-analytics/bpmn-visualization-examples/#bpmn-visualization-usage-in-projects).
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "module": "dist/bpmn-visualization.esm.js",
   "types": "dist/not-supported-ts-versions.d.ts",
   "typesVersions": {
-    ">=4.5.0": {
+    ">=4.0.2": {
       "*": [
         "dist/bpmn-visualization.d.ts"
       ]

--- a/scripts/generate-types-for-not-supported-ts-versions.mjs
+++ b/scripts/generate-types-for-not-supported-ts-versions.mjs
@@ -34,7 +34,13 @@ const destinationDirectoryPath = getDirectorOfPath(notSupportedTSVersionsFilePat
 if (!fs.existsSync(destinationDirectoryPath)) {
   fs.mkdirSync(destinationDirectoryPath);
 }
-fs.writeFileSync(notSupportedTSVersionsFilePath, `"Package 'bpmn-visualization' support only TS versions that are ${supportedTSVersions[0]}".`);
+fs.writeFileSync(
+  notSupportedTSVersionsFilePath,
+  `// When using an unsupported version of TypeScript, this file is used and it generates a more explicit error message than what TypeScript provides out of the box.
+// error TS1003: Identifier expected.
+// "Package 'bpmn-visualization' supports only TypeScript versions that are >=x.y.z"
+"Package 'bpmn-visualization' supports only TypeScript versions that are ${supportedTSVersions[0]}".`,
+);
 
 function getDirectorOfPath(path) {
   const delimiter = '/';

--- a/test/typescript-support/package.json
+++ b/test/typescript-support/package.json
@@ -9,6 +9,6 @@
     "bpmn-visualization": "../../"
   },
   "devDependencies": {
-    "typescript": "~4.5"
+    "typescript": "4.0.2"
   }
 }


### PR DESCRIPTION
Explicitly support version greater or equal to 4.0.2 (first GA version of the 4.0 line). The README now explains what was the version supported for older releases of `bpmn-visualization`. It shows the progress and will help people using old versions to not be misguided when looking the documentation directly from the GitHub Web UI or the README of the `master` branch.

In addition, update the types file included in the npm package and used when the TypeScript version is not supported. It now contains a comment explaining what this file does.

closes #2221
closes #2252

### Notes

Based on POC done for #2230
The information about the TS version supported by v0.17.1 is taken from #1415

Tested locally and with https://github.com/process-analytics/bpmn-visualization-examples/pull/418