### PR TITLE
[INFRA] gha - bump surge-preview-tools from v1 to v2

### DIFF
--- a/.github/actions/custom-surge-preview/action.yml
+++ b/.github/actions/custom-surge-preview/action.yml
@@ -20,7 +20,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: bonitasoft/actions/packages/surge-preview-tools@v1
+    - uses: bonitasoft/actions/packages/surge-preview-tools@v2
       id: surge-preview-tools
       with:
         surge-token: ${{ inputs.surge-token }}


### PR DESCRIPTION
The new release removes warnings.

### Resources

https://github.com/bonitasoft/actions/releases/tag/v2.0.0