### PR TITLE
[INFRA] Use chrome/edge installed in GitHub runners

### DIFF
--- a/.github/actions/install-playwright-browser/action.yml
+++ b/.github/actions/install-playwright-browser/action.yml
@@ -1,0 +1,19 @@
+name: Install Playwright Browsers
+description: 'Setup node and install dependencies'
+inputs:
+  browser:
+    description: 'The browser to install'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Install ${{inputs.browser}}
+      # Only installed browsers not available in the GH runner, or that need a special version modified for playwright
+      if: inputs.browser == 'chromium' || inputs.browser == 'firefox' || inputs.browser == 'webkit'
+      shell: bash
+      run: npx playwright install ${{inputs.browser}}
+    # install OS dependencies required by browsers on the GitHub runner
+    # to be sure that the browser is correctly installed: https://github.com/microsoft/playwright/issues/5801
+    - name: Install ${{inputs.browser}} dependencies
+      shell: bash
+      run: npx playwright install-deps ${{inputs.browser}}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -55,6 +55,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Build Setup
         uses: ./.github/actions/build-setup
+# TODO if it works; create an action to avoid duplications in 3 workflows
       - name: Install ${{matrix.browser}}
         if: matrix.browser != 'chrome' || matrix.browser != 'msedge'
         run: |

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -40,11 +40,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-12, ubuntu-20.04, windows-2019]
-        browser: [chromium, firefox, chrome]
+#        TODO restore all browsers after tests
+        browser: [chromium, chrome]
+#        browser: [chromium, firefox, chrome]
         include:
           # only test WebKit on macOS
-          - os: macos-12
-            browser: webkit
+#          - os: macos-12
+#            browser: webkit
           # only test Edge on Windows
           - os: windows-2019
             browser: msedge

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -42,13 +42,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-12, ubuntu-20.04, windows-2019]
-#        TODO restore all browsers after tests
-        browser: [chromium, chrome]
-#        browser: [chromium, firefox, chrome]
+        browser: [chromium, firefox, chrome]
         include:
           # only test WebKit on macOS
-#          - os: macos-12
-#            browser: webkit
+          - os: macos-12
+            browser: webkit
           # only test Edge on Windows
           - os: windows-2019
             browser: msedge

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - '.github/actions/build-setup/**/*'
+      - '.github/actions/install-playwright-browser/**/*'
       - '.github/workflows/test-e2e.yml'
       - 'src/**/*'
       - 'test/**/*'
@@ -21,6 +22,7 @@ on:
       - master
     paths:
       - '.github/actions/build-setup/**/*'
+      - '.github/actions/install-playwright-browser/**/*'
       - '.github/workflows/test-e2e.yml'
       - 'src/**/*'
       - 'test/**/*'
@@ -55,17 +57,10 @@ jobs:
         uses: actions/checkout@v3
       - name: Build Setup
         uses: ./.github/actions/build-setup
-# TODO if it works; create an action to avoid duplications in 3 workflows
       - name: Install ${{matrix.browser}}
-        # Only installed browsers not available in the GH runner, or that need a special version modified for playwright
-        if: matrix.browser == 'chromium' || matrix.browser == 'firefox' || matrix.browser == 'webkit'
-        run: |
-          npx playwright install ${{matrix.browser}}
-      # install OS dependencies required by browsers on the GitHub runner
-      # to be sure that the browser is correctly installed: https://github.com/microsoft/playwright/issues/5801
-      - name: Install ${{matrix.browser}} dependencies
-        run: |
-          npx playwright install-deps ${{matrix.browser}}
+        uses: ./.github/actions/install-playwright-browser
+        with:
+          browser: ${{matrix.browser}}
       - name: Test Application End to End
         id: 'test_e2e'
         env:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -53,11 +53,14 @@ jobs:
         uses: actions/checkout@v3
       - name: Build Setup
         uses: ./.github/actions/build-setup
-      # install OS dependencies required by browsers on the GitHub runner
-      # to be sure that the browser is correctly installed: https://github.com/microsoft/playwright/issues/5801
-      - name: Install ${{matrix.browser}} and its dependencies only
+      - name: Install ${{matrix.browser}}
+        if: matrix.browser != 'chrome' || matrix.browser != 'msedge'
         run: |
           npx playwright install ${{matrix.browser}}
+      # install OS dependencies required by browsers on the GitHub runner
+      # to be sure that the browser is correctly installed: https://github.com/microsoft/playwright/issues/5801
+      - name: Install ${{matrix.browser}} dependencies
+        run: |
           npx playwright install-deps ${{matrix.browser}}
       - name: Test Application End to End
         id: 'test_e2e'

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -57,7 +57,8 @@ jobs:
         uses: ./.github/actions/build-setup
 # TODO if it works; create an action to avoid duplications in 3 workflows
       - name: Install ${{matrix.browser}}
-        if: matrix.browser != 'chrome' || matrix.browser != 'msedge'
+        # Only installed browsers not available in the GH runner, or that need a special version modified for playwright
+        if: matrix.browser == 'chromium' || matrix.browser == 'firefox' || matrix.browser == 'webkit'
         run: |
           npx playwright install ${{matrix.browser}}
       # install OS dependencies required by browsers on the GitHub runner

--- a/.github/workflows/test-performance.yml
+++ b/.github/workflows/test-performance.yml
@@ -10,6 +10,7 @@ on:
       - master
     paths:
       - '.github/actions/build-setup/**/*'
+      - '.github/actions/install-playwright-browser/**/*'
       - '.github/workflows/test-performance.yml'
       - 'test/performance/**/*'
       - '.nvmrc'
@@ -35,12 +36,10 @@ jobs:
         uses: actions/checkout@v3
       - name: Build Setup
         uses: ./.github/actions/build-setup
-      # install OS dependencies required by browsers on the GitHub runner
-      # to be sure that the browser is correctly installed: https://github.com/microsoft/playwright/issues/5801
-      - name: Install ${{env.browser}} and its dependencies only
-        run: |
-          npx playwright install ${{env.browser}}
-          npx playwright install-deps ${{env.browser}}
+      - name: Install ${{env.browser}}
+        uses: ./.github/actions/install-playwright-browser
+        with:
+          browser: ${{env.browser}}
       - name: Run performance tests
         id: 'run_perf_tests'
         run: npm run test:perf

--- a/.github/workflows/upload-npm-package.yml
+++ b/.github/workflows/upload-npm-package.yml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - '.github/actions/build-setup/**/*'
+      - '.github/actions/install-playwright-browser/**/*'
       - '.github/workflows/upload-npm-package.yml'
       - 'scripts/**/*'
       - 'src/**/*'
@@ -20,6 +21,7 @@ on:
       - master
     paths:
       - '.github/actions/build-setup/**/*'
+      - '.github/actions/install-playwright-browser/**/*'
       - '.github/workflows/upload-npm-package.yml'
       - 'scripts/**/*'
       - 'src/**/*'
@@ -47,12 +49,10 @@ jobs:
         with:
           name: bpmn-visualization-npm-package-${{github.sha}}
           path: bpmn-visualization-*.tgz
-      # install OS dependencies required by browsers on the GitHub runner
-      # to be sure that the browser is correctly installed: https://github.com/microsoft/playwright/issues/5801
-      - name: Install ${{env.test-bundles-browser}} and its dependencies only
-        run: |
-          npx playwright install ${{env.test-bundles-browser}}
-          npx playwright install-deps ${{env.test-bundles-browser}}
+      - name: Install ${{env.test-bundles-browser}}
+        uses: ./.github/actions/install-playwright-browser
+        with:
+          browser: ${{env.test-bundles-browser}}
       - name: Test bundles
         id: 'test_bundles'
         env:

--- a/src/component/mxgraph/renderer/StyleComputer.ts
+++ b/src/component/mxgraph/renderer/StyleComputer.ts
@@ -138,7 +138,7 @@ export default class StyleComputer {
 
       if (bpmnCell instanceof Shape) {
         // arbitrarily increase width to relax too small bounds (for instance for reference diagrams from miwg-test-suite)
-        styleValues.set(mxgraph.mxConstants.STYLE_LABEL_WIDTH, labelBounds.width + 120); // TODO TMP introduce label positioning error for testing
+        styleValues.set(mxgraph.mxConstants.STYLE_LABEL_WIDTH, labelBounds.width + 1);
         // align settings
         styleValues.set(mxgraph.mxConstants.STYLE_LABEL_POSITION, mxgraph.mxConstants.ALIGN_TOP);
         styleValues.set(mxgraph.mxConstants.STYLE_VERTICAL_LABEL_POSITION, mxgraph.mxConstants.ALIGN_LEFT);

--- a/src/component/mxgraph/renderer/StyleComputer.ts
+++ b/src/component/mxgraph/renderer/StyleComputer.ts
@@ -138,7 +138,7 @@ export default class StyleComputer {
 
       if (bpmnCell instanceof Shape) {
         // arbitrarily increase width to relax too small bounds (for instance for reference diagrams from miwg-test-suite)
-        styleValues.set(mxgraph.mxConstants.STYLE_LABEL_WIDTH, labelBounds.width + 1);
+        styleValues.set(mxgraph.mxConstants.STYLE_LABEL_WIDTH, labelBounds.width + 120); // TODO TMP introduce label positioning error for testing
         // align settings
         styleValues.set(mxgraph.mxConstants.STYLE_LABEL_POSITION, mxgraph.mxConstants.ALIGN_TOP);
         styleValues.set(mxgraph.mxConstants.STYLE_VERTICAL_LABEL_POSITION, mxgraph.mxConstants.ALIGN_LEFT);


### PR DESCRIPTION
Previously, we installed Chrome and MSEdge prior running the tests whereas the browsers are already installed in the GitHub runners.
This increases build time and limit build reproducibility (the available version for download can change without notice).

Introduce an action to manage browser download logic, in particular, to decide whether to download the browser. This will help in the future if we want to cache browsers downloaded by playwright itself.

closes #2355
covers #2356

### Tests

✔️ e2e reports are correctly generated in case of error. See 2cf18f1
✔️ all tests pass


### Remaining tasks

- [x] Remove duplication about browser download steps in workflow. The duplication increases in July, see https://github.com/process-analytics/bpmn-visualization-js/pull/2092#pullrequestreview-1030253559. Testing in f1accc0b prior applying to all workflows. Finalize in 9e4fa5a9
