### PR TITLE
[TEST] Visual diff images now only include the diff part on visual errors

### DIFF
--- a/test/e2e/helpers/visu/image-snapshot-config.ts
+++ b/test/e2e/helpers/visu/image-snapshot-config.ts
@@ -25,7 +25,7 @@ export interface ImageSnapshotThresholdConfig {
 }
 
 const defaultImageSnapshotConfig: MatchImageSnapshotOptions = {
-  diffDirection: 'vertical',
+  onlyDiff: true,
   // locally and on CI, see diff images folder directly
   dumpDiffToConsole: false,
   // use SSIM to limit false positive


### PR DESCRIPTION
`jest-image-snapshot` previously generated an image with both expected, received and diff elements. Such diff images are not very easy to detect the issue.
We already store the expected and received images in dedicated files. So generate a "diff only" images to more easily detect changes thanks the new option provided by `jest-image-snapshot@6.1.0`.