### PR TITLE
[INFRA] Revert "use organization variables for runners"

### DIFF
--- a/.github/workflows/announce-new-release.yml
+++ b/.github/workflows/announce-new-release.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   publish_tweet:
-    runs-on: ${{ vars.RUNNER_UBUNTU }}
+    runs-on: ubuntu-22.04
     steps:
       - name: Publish a tweet
         uses: snow-actions/tweet@v1.4.0
@@ -32,7 +32,7 @@ jobs:
           ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
 
   publish_discord_post:
-    runs-on: ${{ vars.RUNNER_UBUNTU }}
+    runs-on: ubuntu-22.04
     steps:
       - name: Publish a message on Discord
         uses: sarisia/actions-status-discord@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,8 +42,10 @@ jobs:
       fail-fast: false
       matrix:
         # syntax inspired from https://github.community/t5/GitHub-Actions/Using-a-matrix-defined-input-for-a-custom-action/m-p/32032/highlight/true#M988
-        # os: ${{ fromJSON('[{"name":"ubuntu-22.04", "coverage":"-- --coverage"}, {"name":"macos-12"}, {"name":"windows-2019"}]') }}
-        os: ${{ fromJSON(format('[{{"name":"{0}", "coverage":"-- --coverage"}}, {{"name":"{1}"}}, {{"name":"{2}"}}]', vars.RUNNER_UBUNTU, vars.RUNNER_MACOS, vars.RUNNER_WINDOWS)) }}
+        os:
+          - { name: ubuntu-20.04, coverage: '-- --coverage' }
+          - { name: macos-12 }
+          - { name: windows-2019 }
     permissions:
       # SonarCloud: checks and pull-requests
       checks: write

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,7 +26,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ${{ vars.RUNNER_UBUNTU }}
+    runs-on: ubuntu-20.04
     permissions:
       # required for all workflows by github/codeql-action
       security-events: write

--- a/.github/workflows/dependency-review-pr.yml
+++ b/.github/workflows/dependency-review-pr.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: ${{ vars.RUNNER_UBUNTU }}
+    runs-on: ubuntu-20.04
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@v3

--- a/.github/workflows/fill-gh-draft-release.yml
+++ b/.github/workflows/fill-gh-draft-release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   update_release_draft:
-    runs-on: ${{ vars.RUNNER_UBUNTU }}
+    runs-on: ubuntu-20.04
     permissions:
       # To create or update releases
       contents: write

--- a/.github/workflows/generate-demo-preview.yml
+++ b/.github/workflows/generate-demo-preview.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   demo_preview: # keep unique across jobs using surge preview (preview url and PR comment id)
-    runs-on: ${{ vars.RUNNER_UBUNTU }}
+    runs-on: ubuntu-20.04
     permissions:
       pull-requests: write # surge-preview: PR comments
     steps:

--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -35,7 +35,7 @@ on:
 jobs:
   doc_preview: # keep unique across jobs using surge preview (preview url and PR comment id)
     if: github.event_name == 'pull_request'
-    runs-on: ${{ vars.RUNNER_UBUNTU }}
+    runs-on: ubuntu-20.04
     permissions:
       pull-requests: write # surge-preview: PR comments
     steps:
@@ -51,7 +51,7 @@ jobs:
 
   generate_doc:
     if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&  github.event.ref == 'refs/heads/master'
-    runs-on: ${{ vars.RUNNER_UBUNTU }}
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Build Setup
@@ -66,7 +66,7 @@ jobs:
 
   push_to_gh_pages:
     if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&  github.event.ref == 'refs/heads/master'
-    runs-on: ${{ vars.RUNNER_UBUNTU }}
+    runs-on: ubuntu-20.04
     needs: generate_doc
     permissions:
       contents: write # Push to gh-pages

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -5,7 +5,7 @@ on:
       -  v*
 jobs:
   build:
-    runs-on: ${{ vars.RUNNER_UBUNTU }}
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Build Setup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
         default: 'patch'
 jobs:
   bumpVersion:
-    runs-on: ${{ vars.RUNNER_UBUNTU }}
+    runs-on: ubuntu-20.04
     steps:
       - run: |
           echo "New version type: ${{ github.event.inputs.type }}"

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -41,15 +41,14 @@ jobs:
       # we want to run the full build on all os: don't cancel running jobs even if one fails
       fail-fast: false
       matrix:
-        # os: ${{ fromJSON('["macos-12", "ubuntu-22.04", "windows-2019"]') }}
-        os: ${{ fromJSON(format('["{0}", "{1}", "{2}"]', vars.RUNNER_MACOS, vars.RUNNER_UBUNTU, vars.RUNNER_WINDOWS)) }}
+        os: [macos-12, ubuntu-20.04, windows-2019]
         browser: [chromium, firefox, chrome]
         include:
           # only test WebKit on macOS
-          - os: ${{ vars.RUNNER_MACOS }}
+          - os: macos-12
             browser: webkit
           # only test Edge on Windows
-          - os: ${{ vars.RUNNER_WINDOWS }}
+          - os: windows-2019
             browser: msedge
     steps:
       - name: Checkout

--- a/.github/workflows/test-performance.yml
+++ b/.github/workflows/test-performance.yml
@@ -27,8 +27,7 @@ jobs:
         #            triggerUncaughtException(err, true /* fromPromise */);
         #            ^
         # cdpSession.detach: Browser closed.
-        # os: ${{ fromJSON('["macos-12", "ubuntu-22.04"]') }}
-        os: ${{ fromJSON(format('["{0}", "{1}"]', vars.RUNNER_MACOS, vars.RUNNER_UBUNTU)) }}
+        os: [macos-12, ubuntu-20.04]
     env:
       # Performance tests rely on chromium API
       browser: chromium

--- a/.github/workflows/upload-demo-archive-and-trigger-examples-repository-update.yml
+++ b/.github/workflows/upload-demo-archive-and-trigger-examples-repository-update.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   upload_demo_archive:
-    runs-on: ${{ vars.RUNNER_UBUNTU }}
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Build Setup

--- a/.github/workflows/upload-npm-package.yml
+++ b/.github/workflows/upload-npm-package.yml
@@ -34,7 +34,7 @@ on:
 
 jobs:
   build_and_test_npm_package:
-    runs-on: ${{ vars.RUNNER_UBUNTU }}
+    runs-on: ubuntu-20.04
     env:
       test-bundles-browser: chromium
     steps:


### PR DESCRIPTION
This reverts commit 49315fa7136776a29053b6724f867329a919a5b7.

Configuration variables are currently not passed to workflows that are triggered by a pull request from a fork and from dependabot.

### Other resources

This revers #2465 
For discussions about the current _Configuration Variables_ limitations, see 
- https://github.com/orgs/community/discussions/44088
- https://github.com/orgs/community/discussions/44322
