### PR TITLE
[INFRA] Rename the GH workflow that build and test the npm package

### DIFF
--- a/.github/workflows/test-npm-package.yml
+++ b/.github/workflows/test-npm-package.yml
@@ -1,4 +1,4 @@
-name: Upload npm package
+name: Test npm package
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
     paths:
       - '.github/actions/build-setup/**/*'
       - '.github/actions/install-playwright-browser/**/*'
-      - '.github/workflows/upload-npm-package.yml'
+      - '.github/workflows/test-npm-package.yml'
       - 'scripts/**/*'
       - 'src/**/*'
       - 'test/typescript-support/**/*'
@@ -22,7 +22,7 @@ on:
     paths:
       - '.github/actions/build-setup/**/*'
       - '.github/actions/install-playwright-browser/**/*'
-      - '.github/workflows/upload-npm-package.yml'
+      - '.github/workflows/test-npm-package.yml'
       - 'scripts/**/*'
       - 'src/**/*'
       - 'test/typescript-support/**/*'


### PR DESCRIPTION
The former name was misleading. The workflow does not upload the package to a shared repository/package. The generated package is uploaded as a GH action artifact for convenience, but it cannot be consumed by a Node package manager.