### PR TITLE
[FEAT] Export the mxgraph context

### DIFF
--- a/src/bpmn-visualization.ts
+++ b/src/bpmn-visualization.ts
@@ -17,7 +17,7 @@
 // Use mxgraph types
 /// <reference types="@typed-mxgraph/typed-mxgraph" />
 
-// export types first, otherwise typedoc doesn't generate the subsequent doc correctly (no category and uses the file header instead of the actual TSDoc)
+// Public API
 export * from './component/options';
 export { BpmnVisualization } from './component/BpmnVisualization';
 export * from './component/registry';
@@ -30,3 +30,6 @@ export { IconPainter } from './component/mxgraph/shape/render/icon-painter';
 export { StyleConfigurator } from './component/mxgraph/config/StyleConfigurator';
 export * from './component/mxgraph/style';
 export * from './component/mxgraph/shape/render';
+
+// the mxGraph context
+export { mxgraph } from './component/mxgraph/initializer';

--- a/src/component/mxgraph/initializer.ts
+++ b/src/component/mxgraph/initializer.ts
@@ -15,6 +15,21 @@
  */
 import factory, { type mxGraphExportObject } from 'mxgraph';
 
+/**
+ * The `mxgraph` context that allows access to the mxGraph objects.
+ *
+ * **WARNING**: this is for advanced users.
+ *
+ * Here are some examples where calling the mxGraph API directly can be useful:
+ * ```javascript
+ * // Get the mxGraph version
+ * const mxGraphVersion = mxgraph.mxClient.VERSION;
+ * // Call mxUtils in custom BPMN Shapes
+ * c.setFillColor(mxgraph.mxUtils.getValue(this.style, BpmnStyleIdentifier.EDGE_START_FILL_COLOR, this.stroke));
+ * ```
+ *
+ * @since 0.30.0
+ */
 export const mxgraph = initialize();
 
 /** @internal */


### PR DESCRIPTION
Also remove the mxgraph import in main ts file as it is not needed.

closes #2480 

### Impact on the files bundled in the npm package

IIFE minified: minimal impact
For other bundles, the increase is mainly due to the comments attached to the new exported `mxgraph` element. This will slightly increase the overall size of the npm package, but this won't have impact for applications integrating `bpmn-visualization`.
#2489 will reduce the impact of the change in this PR.  

bundle name | master eb092f1 | this PR
---- | ---- | ----
bpmn-visualization.d.ts | 42 153 | 42 626
bpmn-visualization.esm.js | 266 241 | 266 729
bpmn-visualization.js | 2 915 673 | 2 916 207
bpmn-visualization.min.js | 982 8**46** | 982 8**70**
not-supported-ts-versions.d.ts | 368 | 368


### Tests integration in external projects/applications 

See https://github.com/process-analytics/bpmn-visualization-examples/pull/449