### PR TITLE
[DOC] Add license header to all dist files in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "generate-types:lib": "tsc --project tsconfig.npm-package.json --emitDeclarationOnly --declaration --declarationDir build/types",
     "generate-types:dist": "api-extractor run --local --verbose",
     "generate-types:not-supported-ts-versions": "node scripts/generate-types-for-not-supported-ts-versions.mjs",
+    "generate-types:add-license-header": "node scripts/add-license-header.mjs",
     "prepack": "run-s clean generate-types build-bundles",
     "demo": "run-s demo:*",
     "demo:build": "tsc --noEmit && vite build",

--- a/scripts/add-license-header.mjs
+++ b/scripts/add-license-header.mjs
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2023 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs, { readFileSync } from 'node:fs';
+import { computeBanner } from './shared/banner.mjs';
+import { getTypeFilesInformation } from './shared/types-info.mjs';
+
+const { notSupportedTSVersionsFilePath, typesFilePath } = getTypeFilesInformation();
+const paths = [typesFilePath, notSupportedTSVersionsFilePath];
+const banner = computeBanner();
+for (let path of paths) {
+  const content = readFileSync(path, 'utf8');
+  fs.writeFileSync(
+    path,
+    `${banner}
+${content}`,
+  );
+}

--- a/scripts/generate-types-for-not-supported-ts-versions.mjs
+++ b/scripts/generate-types-for-not-supported-ts-versions.mjs
@@ -14,20 +14,16 @@
  * limitations under the License.
  */
 
-import assert from 'node:assert';
 import * as fs from 'node:fs';
-// generate warning when running with Node 16
+import { getTypeFilesInformation } from './shared/types-info.mjs';
+// generate warning when running with Node 18
 // (node:75278) ExperimentalWarning: Importing JSON modules is an experimental feature. This feature could change at any time
 import packageJSON from '../package.json' assert { type: 'json' };
 
 // generate a definition file for not supported TS versions. It provokes syntax error to show an explicit message about what are the supported versions.
 // inspired from https://github.com/graphql/graphql-js/blob/743f42b6ef6006d35bf9e0b45e3b70d6e9100596/resources/build-npm.ts#L86-L97
 // found with https://github.com/microsoft/TypeScript/issues/32166
-
-const supportedTSVersions = Object.keys(packageJSON.typesVersions);
-assert(supportedTSVersions.length === 1, 'Property "typesVersions" should have exactly one key in the "package.json" file.');
-// TODO revisit 'not supported ts versions' once TS implements https://github.com/microsoft/TypeScript/issues/32166
-const notSupportedTSVersionsFilePath = packageJSON.types;
+const { notSupportedTSVersionsFilePath, supportedTSVersions } = getTypeFilesInformation();
 
 const destinationDirectoryPath = getDirectorOfPath(notSupportedTSVersionsFilePath);
 // TODO give a try to the 'ensureDirSync' function from 'fs-extra'
@@ -40,7 +36,7 @@ fs.writeFileSync(
   `// When using an unsupported version of TypeScript, this file is used and it generates a more explicit error message than what TypeScript provides out of the box.
 // error TS1003: Identifier expected.
 // "Package 'bpmn-visualization' supports only TypeScript versions that are >=x.y.z"
-"Package 'bpmn-visualization' supports only TypeScript versions that are ${supportedTSVersions[0]}".`,
+"Package 'bpmn-visualization' supports only TypeScript versions that are ${supportedTSVersions}".`,
 );
 
 function getDirectorOfPath(path) {

--- a/scripts/shared/banner.mjs
+++ b/scripts/shared/banner.mjs
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2023 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { readFileSync } from 'node:fs';
+
+export const computeBanner = () => {
+  const bannerTemplate = readFileSync('./config/license-header.js', 'utf8');
+  return bannerTemplate.replace('<%= YEAR %>', `2020-${new Date().getFullYear()}`);
+};

--- a/scripts/shared/types-info.mjs
+++ b/scripts/shared/types-info.mjs
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2023 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import assert from 'node:assert';
+// generate warning when running with Node 18
+// (node:75278) ExperimentalWarning: Importing JSON modules is an experimental feature. This feature could change at any time
+import packageJSON from '../../package.json' assert { type: 'json' };
+
+export const getTypeFilesInformation = () => {
+  const notSupportedTSVersionsFilePath = packageJSON.types;
+  const supportedTSVersions = Object.keys(packageJSON.typesVersions);
+  assert(supportedTSVersions.length === 1, 'Property "typesVersions" should have exactly one key in the "package.json" file.');
+
+  const key = supportedTSVersions[0];
+  const typesFilePath = packageJSON.typesVersions[key]['*'][0];
+
+  return {
+    supportedTSVersions: supportedTSVersions[0],
+    typesFilePath,
+    notSupportedTSVersionsFilePath,
+  };
+};


### PR DESCRIPTION
This applies to JavaScript files and type definition files.

The headers are created using the same template as used for the source files. The minified IIFE bundle receives a specific header to reduce the size of the added content.


covers #2489


### Impact on the size of the bundles of the npm package

Total increase: 2508
Remember that there will be other changes as part of #2489 that will finally decrease the overall size of the package

file | master e16eaf2 | PR 2524 | diff
------ | ------ | ------ | ------
bpmn-visualization.d.ts | 43 249 | 43 851 | 602
bpmn-visualization.esm.js | 267 897 | 268 499 | 602
bpmn-visualization.js | 2 916 667 | 2 917 269 | 602
bpmn-visualization.min.js | 982 739 | 982 839 | 100
not-supported-ts-versions.d.ts | 368 | 970 | 602

### Possible checks for reviewers

The files of the dist folder of the npm package should now all contain the header.
The easiest way to verify it is to retrieve the npm package archive built by the GitHub workflow run for this PR and to check manually.