### PR TITLE
refactor: introduce `batchUpdate` for model transaction

### DIFF
--- a/src/component/mxgraph/BpmnGraph.ts
+++ b/src/component/mxgraph/BpmnGraph.ts
@@ -58,7 +58,6 @@ export class BpmnGraph extends mxgraph.mxGraph {
    * @alpha
    */
   batchUpdate(fn: () => void): void {
-    // TODO should be in the model instead
     this.model.beginUpdate();
     try {
       fn();

--- a/src/component/mxgraph/BpmnGraph.ts
+++ b/src/component/mxgraph/BpmnGraph.ts
@@ -48,6 +48,26 @@ export class BpmnGraph extends mxgraph.mxGraph {
   }
 
   /**
+   * Shortcut for an update of the model within a transaction.
+   *
+   * This method is inspired from {@link https://github.com/maxGraph/maxGraph/blob/v0.1.0/packages/core/src/view/Graph.ts#L487-L494 maxGraph}.
+   *
+   * @param fn the update to be made in the transaction.
+   *
+   * @experimental subject to change, may move to a subclass of `mxGraphModel`
+   * @alpha
+   */
+  batchUpdate(fn: () => void): void {
+    // TODO should be in the model instead
+    this.model.beginUpdate();
+    try {
+      fn();
+    } finally {
+      this.model.endUpdate();
+    }
+  }
+
+  /**
    * Overridden to manage `currentZoomLevel`
    * @internal
    */

--- a/src/component/mxgraph/BpmnRenderer.ts
+++ b/src/component/mxgraph/BpmnRenderer.ts
@@ -40,10 +40,8 @@ export class BpmnRenderer {
   }
 
   private insertShapesAndEdges({ pools, lanes, subprocesses, otherFlowNodes, boundaryEvents, edges }: RenderedModel): void {
-    const model = this.graph.getModel();
-    model.clear(); // ensure to remove manual changes or already loaded graphs
-    model.beginUpdate();
-    try {
+    this.graph.batchUpdate(() => {
+      this.graph.getModel().clear(); // ensure to remove manual changes or already loaded graphs
       this.insertShapes(pools);
       this.insertShapes(lanes);
       this.insertShapes(subprocesses);
@@ -52,9 +50,7 @@ export class BpmnRenderer {
       this.insertShapes(boundaryEvents);
       // at last as edge source and target must be present in the model prior insertion, otherwise they are not rendered
       this.insertEdges(edges);
-    } finally {
-      model.endUpdate();
-    }
+    });
   }
 
   private insertShapes(shapes: Shape[]): void {

--- a/src/component/mxgraph/GraphConfigurator.ts
+++ b/src/component/mxgraph/GraphConfigurator.ts
@@ -69,7 +69,7 @@ export default class GraphConfigurator {
       panningHandler.addListener(mxgraph.mxEvent.PAN_START, this.getPanningHandler('grab'));
       panningHandler.addListener(mxgraph.mxEvent.PAN_END, this.getPanningHandler('default'));
 
-      this.graph.panningHandler.usePopupTrigger = false; // only use the left button to trigger panning
+      panningHandler.usePopupTrigger = false; // only use the left button to trigger panning
       // Reimplement the function as we also want to trigger 'panning on cells' (ignoreCell to true) and only on left-click
       // The mxGraph standard implementation doesn't ignore right click in this case, so do it by ourselves
       panningHandler.isForcePanningEvent = (me): boolean => mxgraph.mxEvent.isLeftMouseButton(me.getEvent()) || mxgraph.mxEvent.isMultiTouchEvent(me.getEvent());


### PR DESCRIPTION
This new method in `BpmnGraph` avoids using the try/catch idiom which is replaced by a simple method call.
It is inspired from the related `maxGraph` function.

Also add the model clear within the transaction in `BpmnRenderer`. This increase the overall speed because the model
changes are all "committed" at the same time. We can then expect better overall rendering performance.

In addition, always use the `panningHandler` const in `GraphConfigurator` for consistency with the rest of the code and
to avoid any future side effects.


### Notes

This has been detected during the `maxGraph@0.1.0` migration POC: #2366 

This will also needed in the future as we are going to use more transactions. See #2539.