### PR TITLE
test: remove duplication in font value computation

### DIFF
--- a/src/component/mxgraph/renderer/StyleComputer.ts
+++ b/src/component/mxgraph/renderer/StyleComputer.ts
@@ -120,7 +120,7 @@ export default class StyleComputer {
     if (font) {
       styleValues.set(mxgraph.mxConstants.STYLE_FONTFAMILY, font.name);
       styleValues.set(mxgraph.mxConstants.STYLE_FONTSIZE, font.size);
-      styleValues.set(mxgraph.mxConstants.STYLE_FONTSTYLE, StyleComputer.getFontStyleValue(font));
+      styleValues.set(mxgraph.mxConstants.STYLE_FONTSTYLE, getFontStyleValue(font));
     }
 
     return styleValues;
@@ -160,21 +160,25 @@ export default class StyleComputer {
   computeMessageFlowIconStyle(edge: Edge): string {
     return `shape=${BpmnStyleIdentifier.MESSAGE_FLOW_ICON};${BpmnStyleIdentifier.IS_INITIATING}=${edge.messageVisibleKind}`;
   }
+}
 
-  private static getFontStyleValue(font: Font): number {
-    let value = 0;
-    if (font.isBold) {
-      value += mxgraph.mxConstants.FONT_BOLD;
-    }
-    if (font.isItalic) {
-      value += mxgraph.mxConstants.FONT_ITALIC;
-    }
-    if (font.isStrikeThrough) {
-      value += mxgraph.mxConstants.FONT_STRIKETHROUGH;
-    }
-    if (font.isUnderline) {
-      value += mxgraph.mxConstants.FONT_UNDERLINE;
-    }
-    return value;
+/**
+ * @internal
+ * @private
+ */
+export function getFontStyleValue(font: Font): number {
+  let value = 0;
+  if (font.isBold) {
+    value += mxgraph.mxConstants.FONT_BOLD;
   }
+  if (font.isItalic) {
+    value += mxgraph.mxConstants.FONT_ITALIC;
+  }
+  if (font.isStrikeThrough) {
+    value += mxgraph.mxConstants.FONT_STRIKETHROUGH;
+  }
+  if (font.isUnderline) {
+    value += mxgraph.mxConstants.FONT_UNDERLINE;
+  }
+  return value;
 }

--- a/test/integration/matchers/matcher-utils.ts
+++ b/test/integration/matchers/matcher-utils.ts
@@ -16,11 +16,12 @@ limitations under the License.
 
 import type { ExpectedEdgeModelElement, ExpectedFont, ExpectedShapeModelElement } from '../helpers/model-expect';
 import { bpmnVisualization } from '../helpers/model-expect';
-import MatcherContext = jest.MatcherContext;
-import CustomMatcherResult = jest.CustomMatcherResult;
-import { mxgraph } from '../../../src/component/mxgraph/initializer';
 import type { mxCell, mxGeometry, StyleMap } from 'mxgraph';
 import type { MxGraphCustomOverlay, MxGraphCustomOverlayStyle } from '../../../src/component/mxgraph/overlay/custom-overlay';
+import { Font } from '../../../src/model/bpmn/internal/Label';
+import { getFontStyleValue as computeFontStyleValue } from '../../../src/component/mxgraph/renderer/StyleComputer';
+import MatcherContext = jest.MatcherContext;
+import CustomMatcherResult = jest.CustomMatcherResult;
 
 export interface ExpectedStateStyle extends StyleMap {
   verticalAlign?: string;
@@ -104,24 +105,12 @@ export function buildCellMatcher<R>(
   return { message: (): string => messagePrefix + messageSuffix, pass };
 }
 
-// TODO test code duplicated from the code under test StyleComputer.getFontStyleValue
 export function getFontStyleValue(expectedFont: ExpectedFont): number {
-  let value = 0;
-  if (expectedFont) {
-    if (expectedFont.isBold) {
-      value += mxgraph.mxConstants.FONT_BOLD;
-    }
-    if (expectedFont.isItalic) {
-      value += mxgraph.mxConstants.FONT_ITALIC;
-    }
-    if (expectedFont.isStrikeThrough) {
-      value += mxgraph.mxConstants.FONT_STRIKETHROUGH;
-    }
-    if (expectedFont.isUnderline) {
-      value += mxgraph.mxConstants.FONT_UNDERLINE;
-    }
-  }
-  return value ? value : undefined;
+  return (
+    (expectedFont
+      ? computeFontStyleValue(new Font(expectedFont.name, expectedFont.size, expectedFont.isBold, expectedFont.isItalic, expectedFont.isUnderline, expectedFont.isStrikeThrough))
+      : 0) || undefined
+  );
 }
 
 export function buildCommonExpectedStateStyle(expectedModel: ExpectedEdgeModelElement | ExpectedShapeModelElement): ExpectedStateStyle {

--- a/test/unit/component/mxgraph/renderer/StyleComputer.test.ts
+++ b/test/unit/component/mxgraph/renderer/StyleComputer.test.ts
@@ -203,7 +203,7 @@ describe('Style Computer', () => {
     [SequenceFlowKind.CONDITIONAL_FROM_ACTIVITY, 'conditional_from_activity'],
     [SequenceFlowKind.DEFAULT, 'default'],
     [SequenceFlowKind.NORMAL, 'normal'],
-  ])('compute style - sequence flows: %s', (kind, expected) => {
+  ])('compute style - sequence flows: %s', (kind: SequenceFlowKind, expected: string) => {
     const edge = new Edge('id', newSequenceFlow(kind));
     expect(computeStyle(edge)).toBe(`sequenceFlow;${expected}`);
   });
@@ -212,7 +212,7 @@ describe('Style Computer', () => {
     [AssociationDirectionKind.NONE, 'None'],
     [AssociationDirectionKind.ONE, 'One'],
     [AssociationDirectionKind.BOTH, 'Both'],
-  ])('compute style - association flows: %s', (kind, expected) => {
+  ])('compute style - association flows: %s', (kind: AssociationDirectionKind, expected: string) => {
     const edge = new Edge('id', newAssociationFlow(kind));
     expect(computeStyle(edge)).toBe(`association;${expected}`);
   });
@@ -220,7 +220,7 @@ describe('Style Computer', () => {
   it.each([
     [MessageVisibleKind.NON_INITIATING, 'non_initiating'],
     [MessageVisibleKind.INITIATING, 'initiating'],
-  ])('compute style - message flow icon: %s', (messageVisibleKind, expected) => {
+  ])('compute style - message flow icon: %s', (messageVisibleKind: MessageVisibleKind, expected: string) => {
     const edge = new Edge('id', newMessageFlow(), undefined, undefined, messageVisibleKind);
     expect(styleComputer.computeMessageFlowIconStyle(edge)).toBe(`shape=bpmn.messageFlowIcon;bpmn.isInitiating=${expected}`);
   });
@@ -274,7 +274,7 @@ describe('Style Computer', () => {
     describe.each([
       ['expanded', []],
       ['collapsed', [ShapeBpmnMarkerKind.EXPAND]],
-    ])(`compute style - %s sub-processes`, (expandKind, markers: ShapeBpmnMarkerKind[]) => {
+    ])(`compute style - %s sub-processes`, (expandKind: string, markers: ShapeBpmnMarkerKind[]) => {
       it(`${expandKind} embedded sub-process without label bounds`, () => {
         const shape = newShape(newShapeBpmnSubProcess(ShapeBpmnSubProcessKind.EMBEDDED, markers), newLabel({ name: 'Arial' }));
         const additionalMarkerStyle = markers.includes(ShapeBpmnMarkerKind.EXPAND) ? ';bpmn.markers=expand' : '';
@@ -297,7 +297,7 @@ describe('Style Computer', () => {
       describe.each([
         ['expanded', []],
         ['collapsed', [ShapeBpmnMarkerKind.EXPAND]],
-      ])(`compute style - %s call activities`, (expandKind, markers: ShapeBpmnMarkerKind[]) => {
+      ])(`compute style - %s call activities`, (expandKind: string, markers: ShapeBpmnMarkerKind[]) => {
         it(`${expandKind} call activity without label bounds`, () => {
           const shape = newShape(newShapeBpmnCallActivityCallingProcess(markers), newLabel({ name: 'Arial' }));
           const additionalMarkerStyle = markers.includes(ShapeBpmnMarkerKind.EXPAND) ? ';bpmn.markers=expand' : '';
@@ -374,7 +374,7 @@ describe('Style Computer', () => {
     it.each([
       ['vertical', false, '1'],
       ['horizontal', true, '0'],
-    ])('%s pool references a Process', (title, isHorizontal: boolean, expected: string) => {
+    ])('%s pool references a Process', (title: string, isHorizontal: boolean, expected: string) => {
       const shape = newShape(newShapeBpmnElement(ShapeBpmnElementKind.POOL), undefined, isHorizontal);
       expect(computeStyle(shape)).toBe(`pool;horizontal=${expected}`);
     });
@@ -384,7 +384,7 @@ describe('Style Computer', () => {
     it.each([
       ['vertical', false, '1'],
       ['horizontal', true, '0'],
-    ])('%s lane', (title, isHorizontal: boolean, expected: string) => {
+    ])('%s lane', (title: string, isHorizontal: boolean, expected: string) => {
       const shape = newShape(newShapeBpmnElement(ShapeBpmnElementKind.LANE), undefined, isHorizontal);
       expect(computeStyle(shape)).toBe(`lane;horizontal=${expected}`);
     });
@@ -450,10 +450,13 @@ describe('Style Computer', () => {
       ${true}      | ${undefined}
       ${true}      | ${'Exclusive'}
       ${true}      | ${'Parallel'}
-    `('event-based gateway when instantiate: $instantiate for gatewayKind: $gatewayKind', ({ instantiate, gatewayKind }) => {
-      const shape = newShape(newShapeBpmnEventBasedGateway(instantiate, gatewayKind), newLabel({ name: 'Arial' }));
-      gatewayKind ??= ShapeBpmnEventBasedGatewayKind.None;
-      expect(computeStyle(shape)).toBe(`eventBasedGateway;bpmn.isInstantiating=${!!instantiate};bpmn.gatewayKind=${gatewayKind};fontFamily=Arial`);
-    });
+    `(
+      'event-based gateway when instantiate: $instantiate for gatewayKind: $gatewayKind',
+      ({ instantiate, gatewayKind }: { instantiate: boolean; gatewayKind: ShapeBpmnEventBasedGatewayKind }) => {
+        const shape = newShape(newShapeBpmnEventBasedGateway(instantiate, gatewayKind), newLabel({ name: 'Arial' }));
+        gatewayKind ??= ShapeBpmnEventBasedGatewayKind.None;
+        expect(computeStyle(shape)).toBe(`eventBasedGateway;bpmn.isInstantiating=${!!instantiate};bpmn.gatewayKind=${gatewayKind};fontFamily=Arial`);
+      },
+    );
   });
 });

--- a/test/unit/component/mxgraph/renderer/style-utils.test.ts
+++ b/test/unit/component/mxgraph/renderer/style-utils.test.ts
@@ -37,7 +37,7 @@ describe('compute base css class names of BPMN elements', () => {
     ${ShapeBpmnElementKind.TASK_SERVICE}             | ${'bpmn-service-task'}
     ${ShapeBpmnElementKind.GROUP}                    | ${'bpmn-group'}
     ${ShapeBpmnElementKind.TEXT_ANNOTATION}          | ${'bpmn-text-annotation'}
-  `('$kind Bpmn base classname', ({ kind, expectedClassName }) => {
+  `('$kind Bpmn base classname', ({ kind, expectedClassName }: { kind: string; expectedClassName: string }) => {
     expect(computeBpmnBaseClassName(kind)).toEqual(expectedClassName);
   });
 });


### PR DESCRIPTION
There was a duplication because the test utility code and the production code do not use the same type to handle the
fonts. The test utility code now calls the production code.
In addition, add missing types in tests function of some unit tests.


### Notes

maxGraph 0.1.0 migration POC: #2366 
This will also be needed by the style API, see #2539