### PR TITLE
refactor: remove StyleUtils

### DIFF
--- a/src/component/mxgraph/renderer/StyleComputer.ts
+++ b/src/component/mxgraph/renderer/StyleComputer.ts
@@ -28,7 +28,7 @@ import {
   ShapeBpmnSubProcess,
 } from '../../../model/bpmn/internal/shape/ShapeBpmnElement';
 import { BpmnStyleIdentifier } from '../style';
-import { ShapeBpmnCallActivityKind, ShapeBpmnElementKind, ShapeBpmnMarkerKind, ShapeUtil } from '../../../model/bpmn/internal';
+import { MessageVisibleKind, ShapeBpmnCallActivityKind, ShapeBpmnElementKind, ShapeBpmnMarkerKind, ShapeUtil } from '../../../model/bpmn/internal';
 import { AssociationFlow, SequenceFlow } from '../../../model/bpmn/internal/edge/flows';
 import type { Font } from '../../../model/bpmn/internal/Label';
 
@@ -158,7 +158,7 @@ export default class StyleComputer {
   }
 
   computeMessageFlowIconStyle(edge: Edge): string {
-    return `shape=${BpmnStyleIdentifier.MESSAGE_FLOW_ICON};${BpmnStyleIdentifier.IS_INITIATING}=${edge.messageVisibleKind}`;
+    return `shape=${BpmnStyleIdentifier.MESSAGE_FLOW_ICON};${BpmnStyleIdentifier.IS_INITIATING}=${edge.messageVisibleKind === MessageVisibleKind.INITIATING}`;
   }
 
   private static getFontStyleValue(font: Font): number {

--- a/src/component/mxgraph/renderer/style-utils.ts
+++ b/src/component/mxgraph/renderer/style-utils.ts
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 import type { mxCell } from 'mxgraph';
-import { mxgraph } from '../initializer';
 import { FlowKind, ShapeUtil } from '../../../model/bpmn/internal';
 import { BpmnStyleIdentifier } from '../style/identifiers';
 
@@ -102,14 +101,4 @@ function isFlowKind(kind: string): boolean {
  */
 export function computeBpmnBaseClassName(bpmnElementKind: string): string {
   return !bpmnElementKind ? '' : 'bpmn-' + bpmnElementKind.replace(/([A-Z])/g, g => '-' + g[0].toLowerCase());
-}
-
-/**
- * Get the BPMN 'instantiate' information from the style.
- * @param style the mxGraph style
- * @internal
- * @private
- */
-export function getBpmnIsInstantiating(style: { [p: string]: unknown }): boolean {
-  return mxgraph.mxUtils.getValue(style, BpmnStyleIdentifier.IS_INSTANTIATING, 'false') == 'true';
 }

--- a/src/component/mxgraph/renderer/style-utils.ts
+++ b/src/component/mxgraph/renderer/style-utils.ts
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 import type { mxCell } from 'mxgraph';
+import { mxgraph } from '../initializer';
 import { FlowKind, ShapeUtil } from '../../../model/bpmn/internal';
-import { MessageVisibleKind } from '../../../model/bpmn/internal/edge/kinds';
 import { BpmnStyleIdentifier } from '../style/identifiers';
 
 /**
@@ -70,7 +70,7 @@ export function computeAllBpmnClassNames(style: string, isLabel: boolean): strin
           classes.push(`bpmn-gateway-kind-${value.toLowerCase()}`);
           break;
         case BpmnStyleIdentifier.IS_INITIATING: // message flow icon
-          classes.push(value == MessageVisibleKind.NON_INITIATING ? 'bpmn-icon-non-initiating' : 'bpmn-icon-initiating');
+          classes.push(value == 'true' ? 'bpmn-icon-initiating' : 'bpmn-icon-non-initiating');
           break;
         case BpmnStyleIdentifier.SUB_PROCESS_KIND:
           classes.push(`bpmn-sub-process-${value.toLowerCase()}`);
@@ -102,4 +102,14 @@ function isFlowKind(kind: string): boolean {
  */
 export function computeBpmnBaseClassName(bpmnElementKind: string): string {
   return !bpmnElementKind ? '' : 'bpmn-' + bpmnElementKind.replace(/([A-Z])/g, g => '-' + g[0].toLowerCase());
+}
+
+/**
+ * Get the BPMN 'instantiate' information from the style.
+ * @param style the mxGraph style
+ * @internal
+ * @private
+ */
+export function getBpmnIsInstantiating(style: { [p: string]: unknown }): boolean {
+  return mxgraph.mxUtils.getValue(style, BpmnStyleIdentifier.IS_INSTANTIATING, 'false') == 'true';
 }

--- a/src/component/mxgraph/shape/activity-shapes.ts
+++ b/src/component/mxgraph/shape/activity-shapes.ts
@@ -16,8 +16,8 @@ limitations under the License.
 
 import type { mxAbstractCanvas2D } from 'mxgraph';
 import { mxgraph } from '../initializer';
-import { getBpmnIsInstantiating } from '../renderer/style-utils';
 import { BpmnStyleIdentifier, StyleDefault } from '../style';
+import { getBpmnIsInstantiating } from '../style/utils';
 import type { BpmnCanvas, PaintParameter, ShapeConfiguration } from './render';
 import { IconPainterProvider } from './render';
 import { buildPaintParameter } from './render/icon-painter';

--- a/src/component/mxgraph/shape/activity-shapes.ts
+++ b/src/component/mxgraph/shape/activity-shapes.ts
@@ -14,14 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { StyleDefault, StyleUtils } from '../style';
+import type { mxAbstractCanvas2D } from 'mxgraph';
+import { mxgraph } from '../initializer';
+import { getBpmnIsInstantiating } from '../renderer/style-utils';
+import { BpmnStyleIdentifier, StyleDefault } from '../style';
 import type { BpmnCanvas, PaintParameter, ShapeConfiguration } from './render';
 import { IconPainterProvider } from './render';
 import { buildPaintParameter } from './render/icon-painter';
 import { ShapeBpmnElementKind, ShapeBpmnMarkerKind, ShapeBpmnSubProcessKind } from '../../../model/bpmn/internal';
 import { orderActivityMarkers } from './render/utils';
-import { mxgraph } from '../initializer';
-import type { mxAbstractCanvas2D } from 'mxgraph';
 
 function paintEnvelopeIcon(paintParameter: PaintParameter, isFilled: boolean): void {
   IconPainterProvider.get().paintEnvelopeIcon({
@@ -51,7 +52,7 @@ export abstract class BaseActivityShape extends mxgraph.mxRectangleShape {
   }
 
   protected paintMarkerIcons(paintParameter: PaintParameter): void {
-    const markers = StyleUtils.getBpmnMarkers(this.style);
+    const markers = mxgraph.mxUtils.getValue(this.style, BpmnStyleIdentifier.MARKERS, undefined);
     if (markers) {
       orderActivityMarkers(markers.split(',')).forEach((marker, idx, allMarkers) => {
         paintParameter = {
@@ -140,7 +141,7 @@ export class UserTaskShape extends BaseTaskShape {
  */
 export class ReceiveTaskShape extends BaseTaskShape {
   protected paintTaskIcon(paintParameter: PaintParameter): void {
-    if (!StyleUtils.getBpmnIsInstantiating(this.style)) {
+    if (!getBpmnIsInstantiating(this.style)) {
       paintEnvelopeIcon(paintParameter, false);
       return;
     }
@@ -212,7 +213,7 @@ export class CallActivityShape extends BaseActivityShape {
 
     const paintParameter = buildPaintParameter({ canvas: c, x, y, width: w, height: h, shape: this });
 
-    switch (StyleUtils.getBpmnGlobalTaskKind(this.style)) {
+    switch (mxgraph.mxUtils.getValue(this.style, BpmnStyleIdentifier.GLOBAL_TASK_KIND, undefined)) {
       case ShapeBpmnElementKind.GLOBAL_TASK_MANUAL:
         this.iconPainter.paintHandIcon({
           ...paintParameter,
@@ -252,7 +253,7 @@ export class CallActivityShape extends BaseActivityShape {
  */
 export class SubProcessShape extends BaseActivityShape {
   override paintBackground(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): void {
-    const subProcessKind = StyleUtils.getBpmnSubProcessKind(this.style);
+    const subProcessKind = mxgraph.mxUtils.getValue(this.style, BpmnStyleIdentifier.SUB_PROCESS_KIND, undefined);
     c.save(); // ensure we can later restore the configuration
     if (subProcessKind === ShapeBpmnSubProcessKind.EVENT) {
       c.setDashed(true, false);

--- a/src/component/mxgraph/shape/event-shapes.ts
+++ b/src/component/mxgraph/shape/event-shapes.ts
@@ -14,13 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import type { mxAbstractCanvas2D } from 'mxgraph';
+import { mxgraph } from '../initializer';
+import { BpmnStyleIdentifier, StyleDefault } from '../style';
 import { ShapeBpmnEventDefinitionKind } from '../../../model/bpmn/internal';
 import type { BpmnCanvas, PaintParameter } from './render';
 import { IconPainterProvider } from './render';
 import { buildPaintParameter } from './render/icon-painter';
-import { StyleDefault, StyleUtils } from '../style';
-import type { mxAbstractCanvas2D } from 'mxgraph';
-import { mxgraph } from '../initializer';
 
 /**
  * @internal
@@ -88,7 +88,7 @@ export class EventShape extends mxgraph.mxEllipse {
   override paintVertexShape(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): void {
     const paintParameter = buildPaintParameter({ canvas: c, x, y, width: w, height: h, shape: this, isFilled: this.withFilledIcon });
 
-    EventShape.setDashedOuterShapePattern(paintParameter, StyleUtils.getBpmnIsInterrupting(this.style));
+    EventShape.setDashedOuterShapePattern(paintParameter, mxgraph.mxUtils.getValue(this.style, BpmnStyleIdentifier.IS_INTERRUPTING, undefined));
     this.paintOuterShape(paintParameter);
     EventShape.restoreOriginalOuterShapePattern(paintParameter);
 
@@ -100,7 +100,9 @@ export class EventShape extends mxgraph.mxEllipse {
   }
 
   private paintInnerShape(paintParameter: PaintParameter): void {
-    const paintIcon = this.iconPainters.get(StyleUtils.getBpmnEventDefinitionKind(this.style)) || (() => this.iconPainter.paintEmptyIcon());
+    const paintIcon =
+      this.iconPainters.get(mxgraph.mxUtils.getValue(this.style, BpmnStyleIdentifier.EVENT_DEFINITION_KIND, ShapeBpmnEventDefinitionKind.NONE)) ??
+      (() => this.iconPainter.paintEmptyIcon());
     paintIcon(paintParameter);
   }
 

--- a/src/component/mxgraph/shape/flow-shapes.ts
+++ b/src/component/mxgraph/shape/flow-shapes.ts
@@ -16,8 +16,7 @@ limitations under the License.
 
 import { IconPainterProvider } from './render';
 import { buildPaintParameter } from './render/icon-painter';
-import { StyleUtils } from '../style';
-import { MessageVisibleKind } from '../../../model/bpmn/internal/edge/kinds';
+import { BpmnStyleIdentifier } from '../style';
 import { mxgraph } from '../initializer';
 import type { mxAbstractCanvas2D, mxRectangle } from 'mxgraph';
 
@@ -32,8 +31,16 @@ export class MessageFlowIconShape extends mxgraph.mxRectangleShape {
   }
 
   override paintVertexShape(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): void {
-    const withFilledIcon = StyleUtils.getBpmnIsInitiating(this.style) === MessageVisibleKind.NON_INITIATING;
-    const paintParameter = buildPaintParameter({ canvas: c, x, y, width: w, height: h, shape: this, ratioFromParent: 1, isFilled: withFilledIcon });
+    const paintParameter = buildPaintParameter({
+      canvas: c,
+      x,
+      y,
+      width: w,
+      height: h,
+      shape: this,
+      ratioFromParent: 1,
+      isFilled: mxgraph.mxUtils.getValue(this.style, BpmnStyleIdentifier.IS_INITIATING, 'true') == 'false',
+    });
 
     this.iconPainter.paintEnvelopeIcon(paintParameter);
   }

--- a/src/component/mxgraph/shape/gateway-shapes.ts
+++ b/src/component/mxgraph/shape/gateway-shapes.ts
@@ -14,12 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { StyleDefault, StyleUtils } from '../style';
+import type { mxAbstractCanvas2D } from 'mxgraph';
+import { mxgraph } from '../initializer';
+import { getBpmnIsInstantiating } from '../renderer/style-utils';
+import { BpmnStyleIdentifier, StyleDefault } from '../style';
+import { ShapeBpmnEventBasedGatewayKind } from '../../../model/bpmn/internal';
 import type { PaintParameter } from './render';
 import { IconPainterProvider } from './render';
 import { buildPaintParameter } from './render/icon-painter';
-import { mxgraph } from '../initializer';
-import type { mxAbstractCanvas2D } from 'mxgraph';
 
 abstract class GatewayShape extends mxgraph.mxRhombus {
   protected iconPainter = IconPainterProvider.get();
@@ -101,7 +103,7 @@ export class EventBasedGatewayShape extends GatewayShape {
       ...paintParameter,
       ratioFromParent: 0.55,
     });
-    if (!StyleUtils.getBpmnIsInstantiating(this.style)) {
+    if (!getBpmnIsInstantiating(this.style)) {
       this.iconPainter.paintCircleIcon({
         ...paintParameter,
         ratioFromParent: 0.45,
@@ -113,7 +115,7 @@ export class EventBasedGatewayShape extends GatewayShape {
       ...paintParameter,
       ratioFromParent: 0.3,
     };
-    if (StyleUtils.getBpmnIsParallelEventBasedGateway(this.style)) {
+    if (mxgraph.mxUtils.getValue(this.style, BpmnStyleIdentifier.EVENT_BASED_GATEWAY_KIND, ShapeBpmnEventBasedGatewayKind.Exclusive) == ShapeBpmnEventBasedGatewayKind.Parallel) {
       this.iconPainter.paintPlusCrossIcon(innerIconPaintParameter);
     } else {
       this.iconPainter.paintPentagon(innerIconPaintParameter);

--- a/src/component/mxgraph/shape/gateway-shapes.ts
+++ b/src/component/mxgraph/shape/gateway-shapes.ts
@@ -16,8 +16,8 @@ limitations under the License.
 
 import type { mxAbstractCanvas2D } from 'mxgraph';
 import { mxgraph } from '../initializer';
-import { getBpmnIsInstantiating } from '../renderer/style-utils';
 import { BpmnStyleIdentifier, StyleDefault } from '../style';
+import { getBpmnIsInstantiating } from '../style/utils';
 import { ShapeBpmnEventBasedGatewayKind } from '../../../model/bpmn/internal';
 import type { PaintParameter } from './render';
 import { IconPainterProvider } from './render';

--- a/src/component/mxgraph/shape/render/icon-painter.ts
+++ b/src/component/mxgraph/shape/render/icon-painter.ts
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { BpmnCanvas } from './BpmnCanvas';
-import { StyleUtils } from '../../style';
-import type { IconStyleConfiguration, ShapeConfiguration, Size } from './render-types';
 import type { mxAbstractCanvas2D, mxShape } from 'mxgraph';
+import { mxgraph } from '../../initializer';
+import { StyleDefault } from '../../style';
+import { BpmnCanvas } from './BpmnCanvas';
+import type { IconStyleConfiguration, ShapeConfiguration, Size } from './render-types';
 
 /**
  * **WARN**: You may use it to customize the BPMN Theme as suggested in the examples. But be aware that the way the default BPMN theme can be modified is subject to change.
@@ -57,10 +58,10 @@ export function buildPaintParameter({
   isFilled?: boolean;
   iconStrokeWidth?: number;
 }): PaintParameter {
-  const shapeStrokeWidth = shape.strokewidth || StyleUtils.getStrokeWidth(shape.style);
-  const fillColor = shape.fill || StyleUtils.getFillColor(shape.style);
-  const strokeColor = shape.stroke || StyleUtils.getStrokeColor(shape.style);
-  const margin = StyleUtils.getMargin(shape.style);
+  const shapeStrokeWidth = shape.strokewidth || mxgraph.mxUtils.getValue(shape.style, mxgraph.mxConstants.STYLE_STROKEWIDTH, StyleDefault.STROKE_WIDTH_THIN);
+  const fillColor = shape.fill || mxgraph.mxUtils.getValue(shape.style, mxgraph.mxConstants.STYLE_FILLCOLOR, StyleDefault.DEFAULT_FILL_COLOR);
+  const strokeColor = shape.stroke || mxgraph.mxUtils.getValue(shape.style, mxgraph.mxConstants.STYLE_STROKECOLOR, StyleDefault.DEFAULT_STROKE_COLOR);
+  const margin = mxgraph.mxUtils.getValue(shape.style, mxgraph.mxConstants.STYLE_MARGIN, StyleDefault.DEFAULT_MARGIN);
   ratioFromParent ??= 0.25;
   isFilled ??= false;
   iconStrokeWidth ??= 0;

--- a/src/component/mxgraph/style/index.ts
+++ b/src/component/mxgraph/style/index.ts
@@ -14,5 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-export * from './utils';
+export { StyleDefault } from './utils';
 export * from './identifiers';

--- a/src/component/mxgraph/style/utils.ts
+++ b/src/component/mxgraph/style/utils.ts
@@ -14,6 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { mxgraph } from '../initializer';
+import { BpmnStyleIdentifier } from './identifiers';
+
 /**
  * Store all rendering defaults used by `bpmn-visualization`.
  *
@@ -58,4 +61,14 @@ export enum StyleDefault {
   SEQUENCE_FLOW_CONDITIONAL_FROM_ACTIVITY_MARKER_FILL_COLOR = 'White',
   MESSAGE_FLOW_MARKER_START_FILL_COLOR = 'White',
   MESSAGE_FLOW_MARKER_END_FILL_COLOR = 'White',
+}
+
+/**
+ * Get the BPMN 'instantiate' information from the style.
+ * @param style the mxGraph style
+ * @internal
+ * @private
+ */
+export function getBpmnIsInstantiating(style: { [p: string]: unknown }): boolean {
+  return mxgraph.mxUtils.getValue(style, BpmnStyleIdentifier.IS_INSTANTIATING, 'false') == 'true';
 }

--- a/src/component/mxgraph/style/utils.ts
+++ b/src/component/mxgraph/style/utils.ts
@@ -69,6 +69,4 @@ export enum StyleDefault {
  * @internal
  * @private
  */
-export function getBpmnIsInstantiating(style: { [p: string]: unknown }): boolean {
-  return mxgraph.mxUtils.getValue(style, BpmnStyleIdentifier.IS_INSTANTIATING, 'false') == 'true';
-}
+export const getBpmnIsInstantiating = (style: { [p: string]: unknown }): boolean => mxgraph.mxUtils.getValue(style, BpmnStyleIdentifier.IS_INSTANTIATING, 'false') == 'true';

--- a/src/component/mxgraph/style/utils.ts
+++ b/src/component/mxgraph/style/utils.ts
@@ -14,11 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import type { GlobalTaskKind, MessageVisibleKind, ShapeBpmnSubProcessKind } from '../../../model/bpmn/internal';
-import { ShapeBpmnEventBasedGatewayKind, ShapeBpmnEventDefinitionKind } from '../../../model/bpmn/internal';
-import { mxgraph } from '../initializer';
-import { BpmnStyleIdentifier } from './identifiers';
-
 /**
  * Store all rendering defaults used by `bpmn-visualization`.
  *
@@ -64,61 +59,3 @@ export enum StyleDefault {
   MESSAGE_FLOW_MARKER_START_FILL_COLOR = 'White',
   MESSAGE_FLOW_MARKER_END_FILL_COLOR = 'White',
 }
-
-/* eslint-disable @typescript-eslint/no-explicit-any,@typescript-eslint/explicit-module-boundary-types */
-/**
- * **WARN**: You may use it to customize the BPMN Theme as suggested in the examples. But be aware that the way the default BPMN theme can be modified is subject to change.
- *
- * @category BPMN Theme
- * @experimental
- */
-export class StyleUtils {
-  static getFillColor(style: any): string {
-    return mxgraph.mxUtils.getValue(style, mxgraph.mxConstants.STYLE_FILLCOLOR, StyleDefault.DEFAULT_FILL_COLOR);
-  }
-
-  static getStrokeColor(style: any): string {
-    return mxgraph.mxUtils.getValue(style, mxgraph.mxConstants.STYLE_STROKECOLOR, StyleDefault.DEFAULT_STROKE_COLOR);
-  }
-
-  static getStrokeWidth(style: any): number {
-    return mxgraph.mxUtils.getValue(style, mxgraph.mxConstants.STYLE_STROKEWIDTH, StyleDefault.STROKE_WIDTH_THIN);
-  }
-
-  static getMargin(style: any): number {
-    return mxgraph.mxUtils.getValue(style, mxgraph.mxConstants.STYLE_MARGIN, StyleDefault.DEFAULT_MARGIN);
-  }
-
-  static getBpmnEventDefinitionKind(style: any): ShapeBpmnEventDefinitionKind {
-    return mxgraph.mxUtils.getValue(style, BpmnStyleIdentifier.EVENT_DEFINITION_KIND, ShapeBpmnEventDefinitionKind.NONE);
-  }
-
-  static getBpmnSubProcessKind(style: any): ShapeBpmnSubProcessKind {
-    return mxgraph.mxUtils.getValue(style, BpmnStyleIdentifier.SUB_PROCESS_KIND, undefined);
-  }
-
-  static getBpmnIsInterrupting(style: any): string {
-    return mxgraph.mxUtils.getValue(style, BpmnStyleIdentifier.IS_INTERRUPTING, undefined);
-  }
-
-  static getBpmnMarkers(style: any): string {
-    return mxgraph.mxUtils.getValue(style, BpmnStyleIdentifier.MARKERS, undefined);
-  }
-
-  static getBpmnIsInstantiating(style: any): boolean {
-    return JSON.parse(mxgraph.mxUtils.getValue(style, BpmnStyleIdentifier.IS_INSTANTIATING, false));
-  }
-
-  static getBpmnIsInitiating(style: any): MessageVisibleKind {
-    return mxgraph.mxUtils.getValue(style, BpmnStyleIdentifier.IS_INITIATING, undefined);
-  }
-
-  static getBpmnIsParallelEventBasedGateway(style: any): boolean {
-    return mxgraph.mxUtils.getValue(style, BpmnStyleIdentifier.EVENT_BASED_GATEWAY_KIND, ShapeBpmnEventBasedGatewayKind.Exclusive) == ShapeBpmnEventBasedGatewayKind.Parallel;
-  }
-
-  static getBpmnGlobalTaskKind(style: any): GlobalTaskKind {
-    return mxgraph.mxUtils.getValue(style, BpmnStyleIdentifier.GLOBAL_TASK_KIND, undefined);
-  }
-}
-/* eslint-enable @typescript-eslint/no-explicit-any,@typescript-eslint/explicit-module-boundary-types */

--- a/test/integration/matchers/toBeEdge/index.ts
+++ b/test/integration/matchers/toBeEdge/index.ts
@@ -64,7 +64,7 @@ function buildExpectedCell(id: string, expectedModel: ExpectedEdgeModelElement |
     expectedCell.children = [
       {
         value: undefined,
-        style: `shape=${BpmnStyleIdentifier.MESSAGE_FLOW_ICON};${BpmnStyleIdentifier.IS_INITIATING}=${expectedModel.messageVisibleKind}`,
+        style: `shape=${BpmnStyleIdentifier.MESSAGE_FLOW_ICON};${BpmnStyleIdentifier.IS_INITIATING}=${expectedModel.messageVisibleKind == MessageVisibleKind.INITIATING}`,
         id: `messageFlowIcon_of_${id}`,
         vertex: true,
       },

--- a/test/unit/component/mxgraph/renderer/StyleComputer.test.ts
+++ b/test/unit/component/mxgraph/renderer/StyleComputer.test.ts
@@ -218,8 +218,8 @@ describe('Style Computer', () => {
   });
 
   it.each([
-    [MessageVisibleKind.NON_INITIATING, 'non_initiating'],
-    [MessageVisibleKind.INITIATING, 'initiating'],
+    [MessageVisibleKind.NON_INITIATING, 'false'],
+    [MessageVisibleKind.INITIATING, 'true'],
   ])('compute style - message flow icon: %s', (messageVisibleKind, expected) => {
     const edge = new Edge('id', newMessageFlow(), undefined, undefined, messageVisibleKind);
     expect(styleComputer.computeMessageFlowIconStyle(edge)).toBe(`shape=bpmn.messageFlowIcon;bpmn.isInitiating=${expected}`);

--- a/test/unit/component/mxgraph/renderer/style-utils.test.ts
+++ b/test/unit/component/mxgraph/renderer/style-utils.test.ts
@@ -66,8 +66,8 @@ describe('compute all css class names based on style input', () => {
     ${FlowKind.MESSAGE_FLOW}                                                             | ${false} | ${['bpmn-type-flow', 'bpmn-message-flow']}
     ${'sequenceFlow;default;fontStyle=4'}                                                | ${false} | ${['bpmn-type-flow', 'bpmn-sequence-flow']}
     ${'shape=bpmn.message-flow-icon'}                                                    | ${false} | ${['bpmn-message-flow-icon']}
-    ${'shape=bpmn.message-flow-icon;bpmn.isInitiating=non_initiating'}                   | ${false} | ${['bpmn-message-flow-icon', 'bpmn-icon-non-initiating']}
-    ${'shape=bpmn.message-flow-icon;bpmn.isInitiating=initiating'}                       | ${true}  | ${['bpmn-message-flow-icon', 'bpmn-icon-initiating', 'bpmn-label']}
+    ${'shape=bpmn.message-flow-icon;bpmn.isInitiating=false'}                            | ${false} | ${['bpmn-message-flow-icon', 'bpmn-icon-non-initiating']}
+    ${'shape=bpmn.message-flow-icon;bpmn.isInitiating=true'}                             | ${true}  | ${['bpmn-message-flow-icon', 'bpmn-icon-initiating', 'bpmn-label']}
   `('style="$style" / isLabel=$isLabel', ({ style, isLabel, expectedClassNames }: { style: string; isLabel: boolean; expectedClassNames: string[] }) => {
     expect(computeAllBpmnClassNames(style, isLabel)).toEqual(expectedClassNames);
   });


### PR DESCRIPTION
Replace `StyleUtils` methods by direct calls: the methods were used only once, so this was an extra indirection (the inline code is explicit enough).

Extract only the `getBpmnIsInstantiating` function because it is used twice and make it internal.

It also changes the way we store `bpmn.isInitiating` in the mxGraph style. Previously, we stored the value from the BPMN Semantic as a string which required a subsequent parsing to know whether it was an "instantiate" value. This was also not consistent with the property name which suggests to store a boolean value.
We now store a boolean value which can be directly used in the Shapes implementation.

--------------------------------------------------------------------------------
BREAKING CHANGES: `StyleUtils` may have been used in rare cases to redefine the way the shapes are rendered. It wasn't used in the examples of `bpmn-visualization`.
`StyleUtils` was mark as experimental and as subject to change as part of BPMN Theme refactoring. So users already knew that a deletion could take place.

### Notes

This has been detected during the `maxGraph@0.1.0` migration POC: #2366 