### PR TITLE
test: improve the layout of the integration test BPMN Diagram

### DIFF
--- a/test/fixtures/bpmn/model-complete-semantic.bpmn
+++ b/test/fixtures/bpmn/model-complete-semantic.bpmn
@@ -15,7 +15,7 @@
                           targetRef="start_event_message_2_1_id" messageRef="message_id" />
     <semantic:messageFlow id="message_flow_non_initiating_message_id" name="Message Flow with non-initiating message" sourceRef="boundary_event_interrupting_message_id"
                           targetRef="start_event_message_2_1_id" messageRef="message_id" />
-    <semantic:messageFlow id="message_flow_no_visible_id" name="Message Flow without message" sourceRef="start_event_message_2_1_id" targetRef="shape_task_with_flows_id" />
+    <semantic:messageFlow id="message_flow_no_visible_id" name="Message Flow without message" sourceRef="task_with_flows_id" targetRef="start_event_message_2_1_id" />
 
     <!-- Groups -->
     <semantic:group id="Group_0_in_collaboration" categoryValueRef="CategoryValue_0" />
@@ -1757,7 +1757,11 @@
           <dc:Bounds x="1515" y="859" width="88" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="edge_message_flow_no_visible_id" bpmnElement="message_flow_no_visible_id" />
+      <bpmndi:BPMNEdge id="edge_message_flow_no_visible_id" bpmnElement="message_flow_no_visible_id">
+        <di:waypoint x="1018" y="1080" />
+        <di:waypoint x="740" y="1080" />
+        <di:waypoint x="740" y="205" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="edge_association_id" bpmnElement="association_id">
         <di:waypoint x="1069" y="1106" />
         <di:waypoint x="1080" y="1210" />

--- a/test/fixtures/bpmn/model-complete-semantic.bpmn
+++ b/test/fixtures/bpmn/model-complete-semantic.bpmn
@@ -1735,8 +1735,28 @@
         <di:waypoint x="1118" y="1090" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="edge_message_flow_initiating_message_id" bpmnElement="message_flow_initiating_message_id" messageVisibleKind="initiating" />
-      <bpmndi:BPMNEdge id="edge_message_flow_non_initiating_message_id" bpmnElement="message_flow_non_initiating_message_id" messageVisibleKind="non_initiating" />
+      <bpmndi:BPMNEdge id="edge_message_flow_initiating_message_id" bpmnElement="message_flow_initiating_message_id" messageVisibleKind="initiating">
+        <di:waypoint x="725" y="1700" />
+        <di:waypoint x="680" y="1700" />
+        <di:waypoint x="680" y="190" />
+        <di:waypoint x="725" y="190" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="594" y="960" width="72" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_message_flow_non_initiating_message_id" bpmnElement="message_flow_non_initiating_message_id" messageVisibleKind="non_initiating">
+        <di:waypoint x="2444" y="1656" />
+        <di:waypoint x="2515" y="1656" />
+        <di:waypoint x="2515" y="1370" />
+        <di:waypoint x="1550" y="1370" />
+        <di:waypoint x="1550" y="390" />
+        <di:waypoint x="790" y="390" />
+        <di:waypoint x="790" y="190" />
+        <di:waypoint x="755" y="190" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1515" y="859" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="edge_message_flow_no_visible_id" bpmnElement="message_flow_no_visible_id" />
       <bpmndi:BPMNEdge id="edge_association_id" bpmnElement="association_id">
         <di:waypoint x="1069" y="1106" />

--- a/test/integration/mxGraph.model.bpmn.elements.test.ts
+++ b/test/integration/mxGraph.model.bpmn.elements.test.ts
@@ -1273,12 +1273,12 @@ describe('mxGraph model - BPMN elements', () => {
         expect('message_flow_initiating_message_id').toBeMessageFlow({
           label: 'Message Flow with initiating message',
           messageVisibleKind: MessageVisibleKind.INITIATING,
-          verticalAlign: 'bottom',
+          verticalAlign: 'top',
         });
         expect('message_flow_non_initiating_message_id').toBeMessageFlow({
           label: 'Message Flow with non-initiating message',
           messageVisibleKind: MessageVisibleKind.NON_INITIATING,
-          verticalAlign: 'bottom',
+          verticalAlign: 'top',
         });
         expect('message_flow_no_visible_id').toBeMessageFlow({ label: 'Message Flow without message', messageVisibleKind: MessageVisibleKind.NONE, verticalAlign: 'bottom' });
       });


### PR DESCRIPTION
The message flows did not declare waypoints, so they passed through many shapes. The diagram was not easy to read. These flows now bypass all shapes.
In addition, a message flow wasn't displayed because of a bad id set in its targetRef. 
Also invert source and target


### Notes

Detected during #2539 

### Screenshots

before | now
---- | ----
![before](https://user-images.githubusercontent.com/27200110/221627419-dd6461b6-6479-45d7-b854-947a53ef1c21.png) | ![now2](https://user-images.githubusercontent.com/27200110/221633580-fe6c1971-3609-4bba-8303-4aef9489acfa.png)


Here is the diagram, before the display of the missing flow nodes (55b610b).

![now](https://user-images.githubusercontent.com/27200110/221627424-37bbb9ef-adf6-4cf3-933b-b8729f7f648b.png)
