### PR TITLE
ci(e2e-tests): fix false positive tests on macOS with Firefox

### DIFF
--- a/dev/public/bpmn-rendering.html
+++ b/dev/public/bpmn-rendering.html
@@ -21,7 +21,7 @@
     <script src="./static/js/bpmn-rendering.js" type="module"></script>
 </head>
 <body>
-    <div id="fetch-status"></div>
+    <div id="status-zone"></div>
     <div id="bpmn-container"></div>
 </body>
 </html>

--- a/dev/public/static/js/bpmn-rendering.js
+++ b/dev/public/static/js/bpmn-rendering.js
@@ -14,12 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { documentReady, startBpmnVisualization } from '../../../ts/dev-bundle-index';
+import { documentReady, log, logError, startBpmnVisualization } from '../../../ts/dev-bundle-index';
 
 function statusFetchKO(errorMsg) {
-  const statusElt = document.getElementById('fetch-status');
+  logError(errorMsg);
+  const statusElt = document.getElementById('status-zone');
   statusElt.innerText = errorMsg;
   statusElt.className = 'status-ko';
+  log('Status zone set with error:', errorMsg);
 }
 
-documentReady(() => startBpmnVisualization({ globalOptions: { container: 'bpmn-container' }, statusFetchKoNotifier: statusFetchKO }));
+documentReady(() => startBpmnVisualization({ globalOptions: { container: 'bpmn-container' }, statusKoNotifier: statusFetchKO }));

--- a/dev/public/static/js/diagram-navigation.js
+++ b/dev/public/static/js/diagram-navigation.js
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { documentReady, startBpmnVisualization, fit, FitType, zoom, ZoomType } from '../../../ts/dev-bundle-index';
+import { documentReady, fit, FitType, startBpmnVisualization, zoom, ZoomType } from '../../../ts/dev-bundle-index';
 import { configureControlsPanel, configureMousePointer } from './helpers/controls.js';
 
 function configureFitAndZoomButtons() {

--- a/dev/public/static/js/elements-identification.js
+++ b/dev/public/static/js/elements-identification.js
@@ -28,6 +28,7 @@ import {
   ShapeUtil,
   startBpmnVisualization,
   updateLoadOptions,
+  windowAlertStatusKoNotifier,
 } from '../../../ts/dev-bundle-index';
 
 let lastIdentifiedBpmnIds = [];
@@ -151,6 +152,7 @@ documentReady(() => {
         enabled: true,
       },
     },
+    statusKoNotifier: windowAlertStatusKoNotifier,
   });
   updateLoadOptions({ type: FitType.Center, margin: 20 });
   configureControls();

--- a/dev/public/static/js/index.js
+++ b/dev/public/static/js/index.js
@@ -27,6 +27,7 @@ import {
   switchTheme,
   zoom,
   ZoomType,
+  windowAlertStatusKoNotifier,
 } from '../../../ts/dev-bundle-index';
 
 let fitOnLoad = true;
@@ -135,6 +136,7 @@ function startDemo() {
         enabled: true,
       },
     },
+    statusKoNotifier: windowAlertStatusKoNotifier,
   });
 
   // Configure custom html elements

--- a/dev/public/static/js/overlays.js
+++ b/dev/public/static/js/overlays.js
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { documentReady, startBpmnVisualization, addOverlays, removeAllOverlays, getElementsByIds } from '../../../ts/dev-bundle-index';
+import { addOverlays, documentReady, getElementsByIds, removeAllOverlays, startBpmnVisualization } from '../../../ts/dev-bundle-index';
 import { configureControlsPanel, configureMousePointer } from './helpers/controls.js';
 
 function addOverlay(overlay) {

--- a/dev/ts/utils/internal-helpers.ts
+++ b/dev/ts/utils/internal-helpers.ts
@@ -30,8 +30,12 @@ export function logStartup(message?: string, ...optionalParams: unknown[]): void
 }
 
 export function logErrorAndOpenAlert(error: unknown, alertMsg?: string): void {
-  console.error(`[DEMO]`, error);
+  logError(error);
   window.alert(alertMsg ?? error);
+}
+
+export function logError(error: unknown): void {
+  console.error(`[DEMO]`, error);
 }
 
 export function logDownload(message?: unknown, ...optionalParams: unknown[]): void {
@@ -42,7 +46,7 @@ export function fetchBpmnContent(url: string): Promise<string> {
   log(`Fetching BPMN content from url ${url}`);
   return fetch(url).then(response => {
     if (!response.ok) {
-      throw Error(String(response.status));
+      throw Error(`HTTP status ${response.status}`);
     }
     return response.text();
   });

--- a/dev/ts/utils/shared-helpers.ts
+++ b/dev/ts/utils/shared-helpers.ts
@@ -29,3 +29,5 @@ export function documentReady(callbackFunction: () => void): void {
 export function log(message?: string, ...optionalParams: unknown[]): void {
   _log('[DEMO]', message, ...optionalParams);
 }
+
+export { logError } from './internal-helpers';


### PR DESCRIPTION
The tests were previously blocked if a fetch diagram error occurred. A `window alert` appeared, which prevented Playwright from interacting with the browser afterwards (for retries and subsequent test runs).

As part of the fix:
- add logs to improve troubleshooting
- do not display `window alert` in test pages when an error occurs on diagram fetch ("diagram-navigation.html" and "overlays.html"). This blocked the browser and all following tests finished in error (Playwright is unable to interact with the page).
- also avoid `window alert` on BPMN load error in the test pages.
- change the error management to only log errors by default. If a new page is created, it won't use `window alert` by mistake.

Fetch errors can occur but this is not an issue as we configure jest retries. Generally, the second time the test runs, there is no fetch error.
About the `window alert`:
- the test and the demo pages share some code for error management
- the demo pages currently display errors in the `window alert` (this will be improve in the future, by displaying the errors in a modal for instance)
- the test pages should have only log errors or display the errors in a dedicated element like this is done in the "bpmn-rendering.html" page. The error management wasn't properly configured, so it used the default which displayed errors in a `window alert`


closes #2555

### Notes

Detailed analysis is available in https://github.com/process-analytics/bpmn-visualization-js/issues/2555#issuecomment-1453888867 and https://github.com/process-analytics/bpmn-visualization-js/issues/2555#issuecomment-1453893115.
Jest retries were configured with #1748 (January 2022)
