### PR TITLE
refactor: remove duplication in the "Update Style" API

### DIFF
--- a/src/component/mxgraph/GraphCellUpdater.ts
+++ b/src/component/mxgraph/GraphCellUpdater.ts
@@ -118,6 +118,10 @@ const updateStroke = (cellStyle: string, stroke: Stroke): string => {
   return cellStyle;
 };
 
+const setStyle = (cellStyle: string, key: string, value: string | undefined): string => {
+  return value == undefined ? cellStyle : mxgraph.mxUtils.setStyle(cellStyle, key, value);
+};
+
 const setStyleFlag = (cellStyle: string, key: string, flag: number, value: boolean | undefined): string => {
   return value == undefined ? cellStyle : mxgraph.mxUtils.setStyleFlag(cellStyle, key, flag, value);
 };
@@ -125,7 +129,7 @@ const setStyleFlag = (cellStyle: string, key: string, flag: number, value: boole
 const updateFont = (cellStyle: string, font: Font): string => {
   font.color && (cellStyle = mxgraph.mxUtils.setStyle(cellStyle, mxgraph.mxConstants.STYLE_FONTCOLOR, convertDefaultValue(font.color)));
   font.size && (cellStyle = mxgraph.mxUtils.setStyle(cellStyle, mxgraph.mxConstants.STYLE_FONTSIZE, font.size));
-  font.family && (cellStyle = mxgraph.mxUtils.setStyle(cellStyle, mxgraph.mxConstants.STYLE_FONTFAMILY, font.family));
+  cellStyle = setStyle(cellStyle, mxgraph.mxConstants.STYLE_FONTFAMILY, font.family);
 
   cellStyle = setStyleFlag(cellStyle, mxgraph.mxConstants.STYLE_FONTSTYLE, mxgraph.mxConstants.FONT_BOLD, font.isBold);
   cellStyle = setStyleFlag(cellStyle, mxgraph.mxConstants.STYLE_FONTSTYLE, mxgraph.mxConstants.FONT_ITALIC, font.isItalic);

--- a/src/component/mxgraph/GraphCellUpdater.ts
+++ b/src/component/mxgraph/GraphCellUpdater.ts
@@ -94,7 +94,7 @@ export default class GraphCellUpdater {
     this.graph.batchUpdate(() => {
       for (const cell of cells) {
         let cellStyle = cell.getStyle();
-        styleUpdate.opacity && (cellStyle = mxgraph.mxUtils.setStyle(cellStyle, mxgraph.mxConstants.STYLE_OPACITY, ensureOpacityValue(styleUpdate.opacity)));
+        cellStyle = setStyle(cellStyle, mxgraph.mxConstants.STYLE_OPACITY, styleUpdate.opacity, ensureOpacityValue);
         styleUpdate.stroke && (cellStyle = updateStroke(cellStyle, styleUpdate.stroke));
         styleUpdate.font && (cellStyle = updateFont(cellStyle, styleUpdate.font));
 
@@ -111,9 +111,9 @@ export default class GraphCellUpdater {
 const convertDefaultValue = (value: string): string | undefined => (value == 'default' ? undefined : value);
 
 const updateStroke = (cellStyle: string, stroke: Stroke): string => {
-  stroke.color && (cellStyle = mxgraph.mxUtils.setStyle(cellStyle, mxgraph.mxConstants.STYLE_STROKECOLOR, convertDefaultValue(stroke.color)));
-  stroke.opacity && (cellStyle = mxgraph.mxUtils.setStyle(cellStyle, mxgraph.mxConstants.STYLE_STROKE_OPACITY, ensureOpacityValue(stroke.opacity)));
-  stroke.width && (cellStyle = mxgraph.mxUtils.setStyle(cellStyle, mxgraph.mxConstants.STYLE_STROKEWIDTH, ensureStrokeWidthValue(stroke.width)));
+  cellStyle = setStyle(cellStyle, mxgraph.mxConstants.STYLE_STROKECOLOR, stroke.color, convertDefaultValue);
+  cellStyle = setStyle(cellStyle, mxgraph.mxConstants.STYLE_STROKE_OPACITY, stroke.opacity, ensureOpacityValue);
+  cellStyle = setStyle(cellStyle, mxgraph.mxConstants.STYLE_STROKEWIDTH, stroke.width, ensureStrokeWidthValue);
 
   return cellStyle;
 };

--- a/src/component/mxgraph/GraphCellUpdater.ts
+++ b/src/component/mxgraph/GraphCellUpdater.ts
@@ -118,8 +118,15 @@ const updateStroke = (cellStyle: string, stroke: Stroke): string => {
   return cellStyle;
 };
 
-const setStyle = (cellStyle: string, key: string, value: string | number | undefined): string => {
-  return value == undefined ? cellStyle : mxgraph.mxUtils.setStyle(cellStyle, key, value);
+const setStyle = <T extends string | number>(
+  cellStyle: string,
+  key: string,
+  value: T | undefined,
+  converter: (value: T) => T | undefined = (value: T) => {
+    return value;
+  },
+): string => {
+  return value == undefined ? cellStyle : mxgraph.mxUtils.setStyle(cellStyle, key, converter(value));
 };
 
 const setStyleFlag = (cellStyle: string, key: string, flag: number, value: boolean | undefined): string => {
@@ -127,7 +134,7 @@ const setStyleFlag = (cellStyle: string, key: string, flag: number, value: boole
 };
 
 const updateFont = (cellStyle: string, font: Font): string => {
-  font.color && (cellStyle = mxgraph.mxUtils.setStyle(cellStyle, mxgraph.mxConstants.STYLE_FONTCOLOR, convertDefaultValue(font.color)));
+  cellStyle = setStyle(cellStyle, mxgraph.mxConstants.STYLE_FONTCOLOR, font.color, convertDefaultValue);
   cellStyle = setStyle(cellStyle, mxgraph.mxConstants.STYLE_FONTSIZE, font.size);
   cellStyle = setStyle(cellStyle, mxgraph.mxConstants.STYLE_FONTFAMILY, font.family);
 

--- a/src/component/mxgraph/GraphCellUpdater.ts
+++ b/src/component/mxgraph/GraphCellUpdater.ts
@@ -118,7 +118,7 @@ const updateStroke = (cellStyle: string, stroke: Stroke): string => {
   return cellStyle;
 };
 
-const setStyle = (cellStyle: string, key: string, value: string | undefined): string => {
+const setStyle = (cellStyle: string, key: string, value: string | number | undefined): string => {
   return value == undefined ? cellStyle : mxgraph.mxUtils.setStyle(cellStyle, key, value);
 };
 
@@ -128,7 +128,7 @@ const setStyleFlag = (cellStyle: string, key: string, flag: number, value: boole
 
 const updateFont = (cellStyle: string, font: Font): string => {
   font.color && (cellStyle = mxgraph.mxUtils.setStyle(cellStyle, mxgraph.mxConstants.STYLE_FONTCOLOR, convertDefaultValue(font.color)));
-  font.size && (cellStyle = mxgraph.mxUtils.setStyle(cellStyle, mxgraph.mxConstants.STYLE_FONTSIZE, font.size));
+  cellStyle = setStyle(cellStyle, mxgraph.mxConstants.STYLE_FONTSIZE, font.size);
   cellStyle = setStyle(cellStyle, mxgraph.mxConstants.STYLE_FONTFAMILY, font.family);
 
   cellStyle = setStyleFlag(cellStyle, mxgraph.mxConstants.STYLE_FONTSTYLE, mxgraph.mxConstants.FONT_BOLD, font.isBold);

--- a/src/component/mxgraph/GraphCellUpdater.ts
+++ b/src/component/mxgraph/GraphCellUpdater.ts
@@ -119,20 +119,12 @@ const updateStroke = (cellStyle: string, stroke: Stroke): string => {
   return cellStyle;
 };
 
-const setStyle = <T extends string | number>(
-  cellStyle: string,
-  key: string,
-  value: T | undefined,
-  converter: (value: T) => T | undefined = (value: T) => {
-    return value;
-  },
-): string => {
+const setStyle = <T extends string | number>(cellStyle: string, key: string, value: T | undefined, converter: (value: T) => T | undefined = (value: T) => value): string => {
   return value == undefined ? cellStyle : mxgraph.mxUtils.setStyle(cellStyle, key, converter(value));
 };
 
-const setStyleFlag = (cellStyle: string, key: string, flag: number, value: boolean | undefined): string => {
-  return value == undefined ? cellStyle : mxgraph.mxUtils.setStyleFlag(cellStyle, key, flag, value);
-};
+const setStyleFlag = (cellStyle: string, key: string, flag: number, value: boolean | undefined): string =>
+  value == undefined ? cellStyle : mxgraph.mxUtils.setStyleFlag(cellStyle, key, flag, value);
 
 const updateFont = (cellStyle: string, font: Font): string => {
   if (font) {

--- a/src/component/mxgraph/GraphCellUpdater.ts
+++ b/src/component/mxgraph/GraphCellUpdater.ts
@@ -118,17 +118,19 @@ const updateStroke = (cellStyle: string, stroke: Stroke): string => {
   return cellStyle;
 };
 
+const setStyleFlag = (cellStyle: string, key: string, flag: number, value: boolean | undefined): string => {
+  return value == undefined ? cellStyle : mxgraph.mxUtils.setStyleFlag(cellStyle, key, flag, value);
+};
+
 const updateFont = (cellStyle: string, font: Font): string => {
   font.color && (cellStyle = mxgraph.mxUtils.setStyle(cellStyle, mxgraph.mxConstants.STYLE_FONTCOLOR, convertDefaultValue(font.color)));
   font.size && (cellStyle = mxgraph.mxUtils.setStyle(cellStyle, mxgraph.mxConstants.STYLE_FONTSIZE, font.size));
   font.family && (cellStyle = mxgraph.mxUtils.setStyle(cellStyle, mxgraph.mxConstants.STYLE_FONTFAMILY, font.family));
 
-  font.isBold !== undefined && (cellStyle = mxgraph.mxUtils.setStyleFlag(cellStyle, mxgraph.mxConstants.STYLE_FONTSTYLE, mxgraph.mxConstants.FONT_BOLD, font.isBold));
-  font.isItalic !== undefined && (cellStyle = mxgraph.mxUtils.setStyleFlag(cellStyle, mxgraph.mxConstants.STYLE_FONTSTYLE, mxgraph.mxConstants.FONT_ITALIC, font.isItalic));
-  font.isUnderline !== undefined &&
-    (cellStyle = mxgraph.mxUtils.setStyleFlag(cellStyle, mxgraph.mxConstants.STYLE_FONTSTYLE, mxgraph.mxConstants.FONT_UNDERLINE, font.isUnderline));
-  font.isStrikeThrough !== undefined &&
-    (cellStyle = mxgraph.mxUtils.setStyleFlag(cellStyle, mxgraph.mxConstants.STYLE_FONTSTYLE, mxgraph.mxConstants.FONT_STRIKETHROUGH, font.isStrikeThrough));
+  cellStyle = setStyleFlag(cellStyle, mxgraph.mxConstants.STYLE_FONTSTYLE, mxgraph.mxConstants.FONT_BOLD, font.isBold);
+  cellStyle = setStyleFlag(cellStyle, mxgraph.mxConstants.STYLE_FONTSTYLE, mxgraph.mxConstants.FONT_ITALIC, font.isItalic);
+  cellStyle = setStyleFlag(cellStyle, mxgraph.mxConstants.STYLE_FONTSTYLE, mxgraph.mxConstants.FONT_UNDERLINE, font.isUnderline);
+  cellStyle = setStyleFlag(cellStyle, mxgraph.mxConstants.STYLE_FONTSTYLE, mxgraph.mxConstants.FONT_STRIKETHROUGH, font.isStrikeThrough);
 
   font.opacity && (cellStyle = mxgraph.mxUtils.setStyle(cellStyle, mxgraph.mxConstants.STYLE_TEXT_OPACITY, ensureOpacityValue(font.opacity)));
 

--- a/src/component/mxgraph/GraphCellUpdater.ts
+++ b/src/component/mxgraph/GraphCellUpdater.ts
@@ -95,11 +95,11 @@ export default class GraphCellUpdater {
       for (const cell of cells) {
         let cellStyle = cell.getStyle();
         cellStyle = setStyle(cellStyle, mxgraph.mxConstants.STYLE_OPACITY, styleUpdate.opacity, ensureOpacityValue);
-        styleUpdate.stroke && (cellStyle = updateStroke(cellStyle, styleUpdate.stroke));
-        styleUpdate.font && (cellStyle = updateFont(cellStyle, styleUpdate.font));
+        cellStyle = updateStroke(cellStyle, styleUpdate.stroke);
+        cellStyle = updateFont(cellStyle, styleUpdate.font);
 
         if (isShapeStyleUpdate(styleUpdate)) {
-          styleUpdate.fill && (cellStyle = updateFill(cellStyle, styleUpdate.fill));
+          cellStyle = updateFill(cellStyle, styleUpdate.fill);
         }
 
         this.graph.model.setStyle(cell, cellStyle);
@@ -111,10 +111,11 @@ export default class GraphCellUpdater {
 const convertDefaultValue = (value: string): string | undefined => (value == 'default' ? undefined : value);
 
 const updateStroke = (cellStyle: string, stroke: Stroke): string => {
-  cellStyle = setStyle(cellStyle, mxgraph.mxConstants.STYLE_STROKECOLOR, stroke.color, convertDefaultValue);
-  cellStyle = setStyle(cellStyle, mxgraph.mxConstants.STYLE_STROKE_OPACITY, stroke.opacity, ensureOpacityValue);
-  cellStyle = setStyle(cellStyle, mxgraph.mxConstants.STYLE_STROKEWIDTH, stroke.width, ensureStrokeWidthValue);
-
+  if (stroke) {
+    cellStyle = setStyle(cellStyle, mxgraph.mxConstants.STYLE_STROKECOLOR, stroke.color, convertDefaultValue);
+    cellStyle = setStyle(cellStyle, mxgraph.mxConstants.STYLE_STROKE_OPACITY, stroke.opacity, ensureOpacityValue);
+    cellStyle = setStyle(cellStyle, mxgraph.mxConstants.STYLE_STROKEWIDTH, stroke.width, ensureStrokeWidthValue);
+  }
   return cellStyle;
 };
 
@@ -134,17 +135,18 @@ const setStyleFlag = (cellStyle: string, key: string, flag: number, value: boole
 };
 
 const updateFont = (cellStyle: string, font: Font): string => {
-  cellStyle = setStyle(cellStyle, mxgraph.mxConstants.STYLE_FONTCOLOR, font.color, convertDefaultValue);
-  cellStyle = setStyle(cellStyle, mxgraph.mxConstants.STYLE_FONTSIZE, font.size);
-  cellStyle = setStyle(cellStyle, mxgraph.mxConstants.STYLE_FONTFAMILY, font.family);
+  if (font) {
+    cellStyle = setStyle(cellStyle, mxgraph.mxConstants.STYLE_FONTCOLOR, font.color, convertDefaultValue);
+    cellStyle = setStyle(cellStyle, mxgraph.mxConstants.STYLE_FONTSIZE, font.size);
+    cellStyle = setStyle(cellStyle, mxgraph.mxConstants.STYLE_FONTFAMILY, font.family);
 
-  cellStyle = setStyleFlag(cellStyle, mxgraph.mxConstants.STYLE_FONTSTYLE, mxgraph.mxConstants.FONT_BOLD, font.isBold);
-  cellStyle = setStyleFlag(cellStyle, mxgraph.mxConstants.STYLE_FONTSTYLE, mxgraph.mxConstants.FONT_ITALIC, font.isItalic);
-  cellStyle = setStyleFlag(cellStyle, mxgraph.mxConstants.STYLE_FONTSTYLE, mxgraph.mxConstants.FONT_UNDERLINE, font.isUnderline);
-  cellStyle = setStyleFlag(cellStyle, mxgraph.mxConstants.STYLE_FONTSTYLE, mxgraph.mxConstants.FONT_STRIKETHROUGH, font.isStrikeThrough);
+    cellStyle = setStyleFlag(cellStyle, mxgraph.mxConstants.STYLE_FONTSTYLE, mxgraph.mxConstants.FONT_BOLD, font.isBold);
+    cellStyle = setStyleFlag(cellStyle, mxgraph.mxConstants.STYLE_FONTSTYLE, mxgraph.mxConstants.FONT_ITALIC, font.isItalic);
+    cellStyle = setStyleFlag(cellStyle, mxgraph.mxConstants.STYLE_FONTSTYLE, mxgraph.mxConstants.FONT_UNDERLINE, font.isUnderline);
+    cellStyle = setStyleFlag(cellStyle, mxgraph.mxConstants.STYLE_FONTSTYLE, mxgraph.mxConstants.FONT_STRIKETHROUGH, font.isStrikeThrough);
 
-  cellStyle = setStyle(cellStyle, mxgraph.mxConstants.STYLE_TEXT_OPACITY, font.opacity, ensureOpacityValue);
-
+    cellStyle = setStyle(cellStyle, mxgraph.mxConstants.STYLE_TEXT_OPACITY, font.opacity, ensureOpacityValue);
+  }
   return cellStyle;
 };
 

--- a/src/component/mxgraph/GraphCellUpdater.ts
+++ b/src/component/mxgraph/GraphCellUpdater.ts
@@ -143,20 +143,21 @@ const updateFont = (cellStyle: string, font: Font): string => {
   cellStyle = setStyleFlag(cellStyle, mxgraph.mxConstants.STYLE_FONTSTYLE, mxgraph.mxConstants.FONT_UNDERLINE, font.isUnderline);
   cellStyle = setStyleFlag(cellStyle, mxgraph.mxConstants.STYLE_FONTSTYLE, mxgraph.mxConstants.FONT_STRIKETHROUGH, font.isStrikeThrough);
 
-  font.opacity && (cellStyle = mxgraph.mxUtils.setStyle(cellStyle, mxgraph.mxConstants.STYLE_TEXT_OPACITY, ensureOpacityValue(font.opacity)));
+  cellStyle = setStyle(cellStyle, mxgraph.mxConstants.STYLE_TEXT_OPACITY, font.opacity, ensureOpacityValue);
 
   return cellStyle;
 };
 
 const updateFill = (cellStyle: string, fill: Fill): string => {
   if (fill.color) {
-    cellStyle = mxgraph.mxUtils.setStyle(cellStyle, mxgraph.mxConstants.STYLE_FILLCOLOR, convertDefaultValue(fill.color));
+    cellStyle = setStyle(cellStyle, mxgraph.mxConstants.STYLE_FILLCOLOR, fill.color, convertDefaultValue);
+
     if (cellStyle.includes(ShapeBpmnElementKind.POOL) || cellStyle.includes(ShapeBpmnElementKind.LANE)) {
-      cellStyle = mxgraph.mxUtils.setStyle(cellStyle, mxgraph.mxConstants.STYLE_SWIMLANE_FILLCOLOR, convertDefaultValue(fill.color));
+      cellStyle = setStyle(cellStyle, mxgraph.mxConstants.STYLE_SWIMLANE_FILLCOLOR, fill.color, convertDefaultValue);
     }
   }
 
-  fill.opacity && (cellStyle = mxgraph.mxUtils.setStyle(cellStyle, mxgraph.mxConstants.STYLE_FILL_OPACITY, ensureOpacityValue(fill.opacity)));
+  cellStyle = setStyle(cellStyle, mxgraph.mxConstants.STYLE_FILL_OPACITY, fill.opacity, ensureOpacityValue);
 
   return cellStyle;
 };


### PR DESCRIPTION
Remove duplication
  - simplify the handling of boolean font properties by introducing a convenient `setStyleFlag` function.
  - simplify string properties management by introducing the  `setStyle` function.

### Notes

Detected while developing https://github.com/process-analytics/bpmn-visualization-js/pull/2585#pullrequestreview-1345638798

> The IDEs pop duplication warnings on this and I should have also introduced the same function for the regular "setStyle" call. Having a guard to check if the variable is defined prior the function call is a big duplication and make the code hard to read.
