### PR TITLE
fix(registry): fix error when no diagram has been loaded

### DIFF
--- a/src/component/registry/bpmn-elements-registry.ts
+++ b/src/component/registry/bpmn-elements-registry.ts
@@ -61,7 +61,7 @@ export class BpmnElementsRegistry {
     private cssRegistry: CssRegistry,
     private graphCellUpdater: GraphCellUpdater,
   ) {
-    this.bpmnModelRegistry.registerOnLoadCallback(this.cssRegistry.clear.bind(this.cssRegistry));
+    this.bpmnModelRegistry.registerOnLoadCallback(this.cssRegistry.clear);
   }
 
   /**

--- a/src/component/registry/bpmn-model-registry.ts
+++ b/src/component/registry/bpmn-model-registry.ts
@@ -45,7 +45,7 @@ export class BpmnModelRegistry {
   }
 
   getBpmnSemantic(bpmnElementId: string): BpmnSemantic | undefined {
-    const element = this.searchableModel.elementById(bpmnElementId);
+    const element = this.searchableModel?.elementById(bpmnElementId);
     if (!element) {
       return undefined;
     }

--- a/src/component/registry/css-registry.ts
+++ b/src/component/registry/css-registry.ts
@@ -20,14 +20,14 @@ import { ensureIsArray } from '../helpers/array-utils';
  * @internal
  */
 export class CssRegistry {
-  private classNamesByBPMNId = new Map<string, Set<string>>();
+  private classNamesByBpmnId = new Map<string, Set<string>>();
 
   /**
    * Clear all classes that were registered.
    */
-  clear(): void {
-    this.classNamesByBPMNId.clear();
-  }
+  clear = (): void => {
+    this.classNamesByBpmnId.clear();
+  };
 
   /**
    * Get the CSS class names for a specific HTML element
@@ -36,7 +36,7 @@ export class CssRegistry {
    * @return the registered CSS class names
    */
   getClassNames(bpmnElementId: string): string[] {
-    return Array.from(this.classNamesByBPMNId.get(bpmnElementId) ?? []);
+    return Array.from(this.classNamesByBpmnId.get(bpmnElementId) ?? []);
   }
 
   /**
@@ -71,10 +71,10 @@ export class CssRegistry {
   }
 
   private getOrInitializeClassNames(bpmnElementId: string): Set<string> {
-    let classNames = this.classNamesByBPMNId.get(bpmnElementId);
+    let classNames = this.classNamesByBpmnId.get(bpmnElementId);
     if (classNames == null) {
       classNames = new Set();
-      this.classNamesByBPMNId.set(bpmnElementId, classNames);
+      this.classNamesByBpmnId.set(bpmnElementId, classNames);
     }
     return classNames;
   }

--- a/test/integration/BpmnVisualization.test.ts
+++ b/test/integration/BpmnVisualization.test.ts
@@ -15,13 +15,14 @@ limitations under the License.
 */
 
 import {
+  type GlobalOptionsWithoutContainer,
   initializeBpmnVisualizationWithContainerId,
   initializeBpmnVisualizationWithHtmlElement,
-  type GlobalOptionsWithoutContainer,
 } from './helpers/bpmn-visualization-initialization';
 import { readFileSync } from '../helpers/file-helper';
 import { allTestedFitTypes } from './helpers/fit-utils';
 import type { FitType } from '../../src/component/options';
+import { ShapeBpmnElementKind } from '../../src/model/bpmn/internal';
 
 describe('BpmnVisualization initialization', () => {
   it.each`
@@ -77,6 +78,31 @@ describe('BpmnVisualization API', () => {
       const newVersion = bpmnVisualization.getVersion();
       expect(newVersion.lib).not.toBe(initialVersion.lib);
       expect(newVersion.dependencies).not.toBe(initialVersion.dependencies);
+    });
+  });
+
+  // The API should not fail
+  describe('Registry access when no loaded diagram', () => {
+    const bv = initializeBpmnVisualizationWithContainerId('bpmn-no-loaded-diagram');
+    const bpmnElementsRegistry = bv.bpmnElementsRegistry;
+
+    it('getElementsByIds', () => {
+      expect(bpmnElementsRegistry.getElementsByIds('fake_id')).toHaveLength(0);
+    });
+    it('getElementsByKinds', () => {
+      expect(bpmnElementsRegistry.getElementsByKinds(ShapeBpmnElementKind.CALL_ACTIVITY)).toHaveLength(0);
+    });
+    it('CSS classes', () => {
+      bpmnElementsRegistry.addCssClasses('fake_id_1', 'class1');
+      bpmnElementsRegistry.removeCssClasses('fake_id_2', 'class2');
+      bpmnElementsRegistry.toggleCssClasses('fake_id_3', 'class3');
+    });
+    it('Overlays', () => {
+      bpmnElementsRegistry.addOverlays('fake_id_1', { label: 'overlay', position: 'top-center' });
+      bpmnElementsRegistry.removeAllOverlays('fake_id_2');
+    });
+    it('updateStyle', () => {
+      bpmnElementsRegistry.updateStyle('fake_id', { fill: { color: 'red' } });
     });
   });
 });


### PR DESCRIPTION
The SearchModelRegistry may not be initialized, so prevent access to an `undefined` instance in this case.

In addition, refactor CSSRegistry:
  - simplify access to CSSRegistry callback registered in the ModelRegistry (avoid `this` bind)
  - use camel case in the 'classNamesByBpmnId' property name (consistency with the rest of the code)

### Notes

This issue has been detected while implementing the bonita day 2023 demo
**TODO link**