### PR TITLE
feat: use the "Update Style" API in the "Elements Identification" demo

### DIFF
--- a/dev/public/elements-identification.html
+++ b/dev/public/elements-identification.html
@@ -170,6 +170,9 @@
     </div>
     <div id="display-options" style="margin-top: 1em;">
       <label for="checkbox-display-overlays">Display overlays</label><input id="checkbox-display-overlays" type="checkbox" />
+
+      <label for="checkbox-css-style" title="To style the BPMN elements, check if you want to use CSS; otherwise not, if you want to use the API" class="tooltip">Use CSS style</label>
+      <input id="checkbox-css-style" type="checkbox" />
     </div>
     <div id="download-controls" style="margin-top: 1em;">
       <button id="btn-dl-svg">Download SVG</button>

--- a/dev/public/static/js/elements-identification.js
+++ b/dev/public/static/js/elements-identification.js
@@ -41,47 +41,34 @@ function updateStyleByAPI(bpmnIds, bpmnKind) {
   const style = { font: { spacing: {} }, fill: {}, stroke: {}, gradient: {}, label: {} };
   switch (bpmnKind) {
     case 'task':
-      style.font.color = 'red !important';
-      style.fill.color = 'aquamarine';
-      break;
     case 'userTask':
-      style.font.color = 'red !important';
-      style.fill.color = 'aquamarine';
-      break;
     case 'scriptTask':
-      style.font.color = 'red !important';
-      style.font.size = 16;
-      style.fill.color = 'aquamarine';
-      break;
     case 'serviceTask':
-      style.font.color = 'red !important';
-      style.font.size = 16;
-      style.fill.color = 'aquamarine';
-      break;
     case 'receiveTask':
     case 'sendTask':
     case 'manualTask':
     case 'businessRuleTask':
-      style.font.color = 'red !important';
-      style.fill.color = 'aquamarine';
-      style.fill.opacity = 40;
+      style.font.color = 'Indigo';
+      style.fill.color = 'gold';
+      style.font.size = 14;
+      style.fill.opacity = 20;
       break;
     case 'startEvent':
     case 'endEvent':
     case 'intermediateCatchEvent':
     case 'intermediateThrowEvent':
     case 'boundaryEvent':
-      style.font.color = 'red !important';
-      style.stroke.color = 'red';
+      style.font.color = 'MediumTurquoise';
+      style.stroke.color = 'MediumTurquoise';
       break;
     case 'exclusiveGateway':
     case 'inclusiveGateway':
     case 'parallelGateway':
     case 'eventBasedGateway':
     case 'complexGateway':
-      style.font.color = 'red !important';
-      style.font.opacity = 60;
-      style.stroke.color = 'chartreuse';
+      style.font.color = 'CadetBlue';
+      style.font.opacity = 85;
+      style.stroke.color = 'OrangeRed';
       style.stroke.width = 4;
       break;
     case 'lane':
@@ -107,24 +94,25 @@ function updateStyleByAPI(bpmnIds, bpmnKind) {
       style.font.isUnderline = true;
       style.font.isStrikeThrough = true;
 
-      style.fill.color = 'MediumVioletRed';
+      style.fill.color = 'MidnightBlue';
       style.opacity = 60;
       break;
     case 'group':
     case 'textAnnotation':
-      style.font.color = 'MidnightBlue';
+      style.font.color = 'Crimson';
       style.font.size = 18;
       style.font.family = 'Verdana';
       style.font.isBold = true;
       style.font.isUnderline = true;
 
       style.stroke.color = 'Chartreuse';
+      style.stroke.width = 6;
       break;
     case 'messageFlow':
     case 'sequenceFlow':
     case 'association':
-      style.font.color = 'dodgerblue !important';
-      style.stroke.color = 'dodgerblue';
+      style.font.color = 'Chocolate';
+      style.stroke.color = 'Chocolate';
       style.stroke.width = 4;
       break;
   }

--- a/dev/public/static/js/elements-identification.js
+++ b/dev/public/static/js/elements-identification.js
@@ -34,6 +34,7 @@ import {
 let lastIdentifiedBpmnIds = [];
 const cssClassName = 'detection';
 let isOverlaysDisplayed = true;
+let useCSS = true;
 
 function updateSelectedBPMNElements(textArea, bpmnKind) {
   log(`Searching for Bpmn elements of '${bpmnKind}' kind`);
@@ -82,15 +83,24 @@ function configureControls() {
     lastIdentifiedBpmnIds = [];
   };
 
-  // display options
+  // display overlay option
   const checkboxDisplayOverlaysElt = document.getElementById('checkbox-display-overlays');
   checkboxDisplayOverlaysElt.addEventListener('change', function () {
     isOverlaysDisplayed = this.checked;
     log('Request overlays display:', isOverlaysDisplayed);
     updateSelectedBPMNElements(textArea, selectedKindElt.value);
   });
+  checkboxDisplayOverlaysElt.checked = isOverlaysDisplayed;
 
-  checkboxDisplayOverlaysElt.checked = true;
+  // use CSS or API to style the BPMN elements
+  const checkboxUseCSSElt = document.getElementById('checkbox-css-style');
+  checkboxUseCSSElt.addEventListener('change', function () {
+    useCSS = this.checked;
+    log('Request CSS style feature:', useCSS);
+    // TODO to change
+    updateSelectedBPMNElements(textArea, selectedKindElt.value);
+  });
+  checkboxUseCSSElt.checked = useCSS;
 }
 
 function getOverlay(bpmnKind) {

--- a/dev/public/static/js/elements-identification.js
+++ b/dev/public/static/js/elements-identification.js
@@ -39,82 +39,63 @@ let useCSS = true;
 
 function updateStyleByAPI(bpmnIds, bpmnKind) {
   const style = { font: { spacing: {} }, fill: {}, stroke: {}, gradient: {}, label: {} };
-  switch (bpmnKind) {
-    case 'task':
-    case 'userTask':
-    case 'scriptTask':
-    case 'serviceTask':
-    case 'receiveTask':
-    case 'sendTask':
-    case 'manualTask':
-    case 'businessRuleTask':
-      style.font.color = 'Indigo';
-      style.fill.color = 'gold';
-      style.font.size = 14;
-      style.fill.opacity = 20;
-      break;
-    case 'startEvent':
-    case 'endEvent':
-    case 'intermediateCatchEvent':
-    case 'intermediateThrowEvent':
-    case 'boundaryEvent':
-      style.font.color = 'MediumTurquoise';
-      style.stroke.color = 'MediumTurquoise';
-      break;
-    case 'exclusiveGateway':
-    case 'inclusiveGateway':
-    case 'parallelGateway':
-    case 'eventBasedGateway':
-    case 'complexGateway':
-      style.font.color = 'CadetBlue';
-      style.font.opacity = 85;
-      style.stroke.color = 'OrangeRed';
-      style.stroke.width = 4;
-      break;
-    case 'lane':
-    case 'pool':
-      style.font.color = 'white !important';
-      style.fill.color = 'deeppink';
-      style.stroke.opacity = 80;
-      break;
-    case 'callActivity':
-      style.font.color = 'white';
-      style.font.family = 'Times New Roman';
-      style.font.isItalic = true;
-      style.font.isStrikeThrough = true;
 
-      style.fill.color = 'LimeGreen';
-      break;
-    case 'subProcess':
-      style.font.color = 'white';
-      style.font.size = 14;
-      style.font.family = 'Dialog';
-      style.font.isBold = true;
-      style.font.isItalic = true;
-      style.font.isUnderline = true;
-      style.font.isStrikeThrough = true;
+  if (ShapeUtil.isTask(bpmnKind)) {
+    style.font.color = 'Indigo';
+    style.fill.color = 'gold';
+    style.font.size = 14;
+    style.fill.opacity = 20;
+  } else if (ShapeUtil.isEvent(bpmnKind)) {
+    style.font.color = 'MediumTurquoise';
+    style.stroke.color = 'MediumTurquoise';
+  } else if (ShapeUtil.isGateway(bpmnKind)) {
+    style.font.color = 'CadetBlue';
+    style.font.opacity = 85;
+    style.stroke.color = 'OrangeRed';
+    style.stroke.width = 4;
+  } else if (ShapeUtil.isPoolOrLane(bpmnKind)) {
+    style.font.color = 'white !important';
+    style.fill.color = 'deeppink';
+    style.stroke.opacity = 80;
+  } else if (ShapeUtil.isCallActivity(bpmnKind)) {
+    style.font.color = 'white';
+    style.font.family = 'Times New Roman';
+    style.font.isItalic = true;
+    style.font.isStrikeThrough = true;
 
-      style.fill.color = 'MidnightBlue';
-      style.opacity = 60;
-      break;
-    case 'group':
-    case 'textAnnotation':
-      style.font.color = 'Crimson';
-      style.font.size = 18;
-      style.font.family = 'Verdana';
-      style.font.isBold = true;
-      style.font.isUnderline = true;
+    style.fill.color = 'LimeGreen';
+  } else if (ShapeUtil.isSubProcess(bpmnKind)) {
+    style.font.color = 'white';
+    style.font.size = 14;
+    style.font.family = 'Dialog';
+    style.font.isBold = true;
+    style.font.isItalic = true;
+    style.font.isUnderline = true;
+    style.font.isStrikeThrough = true;
 
-      style.stroke.color = 'Chartreuse';
-      style.stroke.width = 6;
-      break;
-    case 'messageFlow':
-    case 'sequenceFlow':
-    case 'association':
-      style.font.color = 'Chocolate';
-      style.stroke.color = 'Chocolate';
-      style.stroke.width = 4;
-      break;
+    style.fill.color = 'MidnightBlue';
+    style.opacity = 60;
+  } else {
+    switch (bpmnKind) {
+      case 'group':
+      case 'textAnnotation':
+        style.font.color = 'Crimson';
+        style.font.size = 18;
+        style.font.family = 'Verdana';
+        style.font.isBold = true;
+        style.font.isUnderline = true;
+
+        style.stroke.color = 'Chartreuse';
+        style.stroke.width = 6;
+        break;
+      case 'messageFlow':
+      case 'sequenceFlow':
+      case 'association':
+        style.font.color = 'Chocolate';
+        style.stroke.color = 'Chocolate';
+        style.stroke.width = 4;
+        break;
+    }
   }
 
   updateStyle(bpmnIds, style);

--- a/dev/public/static/js/elements-identification.js
+++ b/dev/public/static/js/elements-identification.js
@@ -101,6 +101,10 @@ function updateStyleByAPI(bpmnIds, bpmnKind) {
   updateStyle(bpmnIds, style);
 }
 
+/**
+Temporary implementation until we have https://github.com/process-analytics/bpmn-visualization-js/issues/2458.
+Note that this implementation has limitations, such as resetting font styles without considering what is originally defined in the BPMN model.
+*/
 function resetStyleByAPI() {
   const style = {
     font: {

--- a/dev/ts/main.ts
+++ b/dev/ts/main.ts
@@ -310,14 +310,18 @@ export function getVersion(): Version {
   return version;
 }
 
+export function updateStyle(bpmnElementIds: string | string[], style: StyleUpdate): void {
+  log('Applying style using the style API: %O', style);
+  bpmnVisualization.bpmnElementsRegistry.updateStyle(bpmnElementIds, style);
+  log('New style applied');
+}
+
 function updateStyleOfElementsIfRequested(): void {
   if (style) {
-    log("Applying style using the style API: '%s'", style);
     const bpmnElementIds = retrieveAllBpmnElementIds();
     log('Number of elements whose style is to be updated', bpmnElementIds.length);
 
-    bpmnVisualization.bpmnElementsRegistry.updateStyle(bpmnElementIds, style);
-    log('New style applied');
+    updateStyle(bpmnElementIds, style);
   }
 }
 

--- a/src/component/registry/types.ts
+++ b/src/component/registry/types.ts
@@ -235,7 +235,10 @@ export type Fill = StyleWithOpacity & {
   color?: 'default' | 'none' | string;
 };
 
-type StyleWithOpacity = {
+/**
+ * @category Element Style
+ */
+export type StyleWithOpacity = {
   /**
    * The value must be between 0 and 100:
    * - If the set value is less than 0, the used value is 0.


### PR DESCRIPTION
- Export missing type for the API documentation : `StyleWithOpacity`
![image](https://user-images.githubusercontent.com/4921914/232789599-ad424506-6d57-494c-99ba-efe37f2d80dd.png)
![image](https://user-images.githubusercontent.com/4921914/232789428-f8696759-c0a3-41f6-a071-e419d2a6bb5b.png)

- Add a radio button to select the mode to apply the style: CSS or API
![image](https://user-images.githubusercontent.com/4921914/232793178-4c0cb9e3-a697-428f-823f-100a55d5a1c1.png)

- Update the style according the selected BPMN kind and the style method (CSS or API). 
When switching from CSS to API, the CSS class applied to the selected BPMN kind are cleared.
- Introduce new function in the `main` JS file for `Elements Identification` demo, to style without parameters: `updateStyle`


Closes #2558 