### PR TITLE
test: remove unnecessary attribute check in json parsing tests

### DIFF
--- a/test/unit/component/parser/json/BpmnJsonParser.callActivity.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.callActivity.test.ts
@@ -57,7 +57,6 @@ describe('parse bpmn as json for callActivity', () => {
 
           verifyShape(model.flowNodes[0], {
             shapeId: 'shape_call_activity_id_0',
-            parentId: undefined,
             bpmnElementId: 'call_activity_id_0',
             bpmnElementName: 'call activity name',
             bpmnElementKind: ShapeBpmnElementKind.CALL_ACTIVITY,
@@ -85,7 +84,6 @@ describe('parse bpmn as json for callActivity', () => {
 
         verifyShape(model.flowNodes[0], {
           shapeId: `shape_call_activity_id_0`,
-          parentId: undefined,
           bpmnElementId: `call_activity_id_0`,
           bpmnElementName: 'call activity name',
           bpmnElementKind: ShapeBpmnElementKind.CALL_ACTIVITY,
@@ -110,7 +108,6 @@ describe('parse bpmn as json for callActivity', () => {
 
         verifyShape(model.flowNodes[0], {
           shapeId: `shape_call_activity_id_1`,
-          parentId: undefined,
           bpmnElementId: `call_activity_id_1`,
           bpmnElementName: undefined,
           bpmnElementKind: ShapeBpmnElementKind.CALL_ACTIVITY,
@@ -139,7 +136,6 @@ describe('parse bpmn as json for callActivity', () => {
 
         verifyShape(model.flowNodes[0], {
           shapeId: 'shape_call_activity_id_0',
-          parentId: undefined,
           bpmnElementId: 'call_activity_id_0',
           bpmnElementName: undefined,
           bpmnElementKind: ShapeBpmnElementKind.CALL_ACTIVITY,
@@ -169,7 +165,6 @@ describe('parse bpmn as json for callActivity', () => {
         expect(model.pools[0].bpmnElement.parentId).toBe('call_activity_id_0');
         verifyShape(model.flowNodes[0], {
           shapeId: 'shape_call_activity_id_0',
-          parentId: undefined,
           bpmnElementId: 'call_activity_id_0',
           bpmnElementName: undefined,
           bpmnElementKind: ShapeBpmnElementKind.CALL_ACTIVITY,
@@ -202,7 +197,6 @@ describe('parse bpmn as json for callActivity', () => {
         expect(model.lanes[0].bpmnElement.parentId).toBe('call_activity_id_0');
         verifyShape(model.flowNodes[0], {
           shapeId: 'shape_call_activity_id_0',
-          parentId: undefined,
           bpmnElementId: 'call_activity_id_0',
           bpmnElementName: undefined,
           bpmnElementKind: ShapeBpmnElementKind.CALL_ACTIVITY,
@@ -241,7 +235,6 @@ describe('parse bpmn as json for callActivity', () => {
           expect(model.flowNodes[0].bpmnElement.parentId).toBe('call_activity_id_0');
           verifyShape(model.flowNodes[1], {
             shapeId: 'shape_call_activity_id_0',
-            parentId: undefined,
             bpmnElementId: 'call_activity_id_0',
             bpmnElementName: undefined,
             bpmnElementKind: ShapeBpmnElementKind.CALL_ACTIVITY,
@@ -287,7 +280,6 @@ describe('parse bpmn as json for callActivity', () => {
         expect(model.flowNodes[0].bpmnElement.parentId).toBe('call_activity_id_0');
         verifyShape(model.flowNodes[1], {
           shapeId: 'shape_call_activity_id_0',
-          parentId: undefined,
           bpmnElementId: 'call_activity_id_0',
           bpmnElementName: undefined,
           bpmnElementKind: ShapeBpmnElementKind.CALL_ACTIVITY,
@@ -325,7 +317,6 @@ describe('parse bpmn as json for callActivity', () => {
           expect(model.flowNodes[0].bpmnElement.parentId).toBe('call_activity_id_0');
           verifyShape(model.flowNodes[1], {
             shapeId: 'shape_call_activity_id_0',
-            parentId: undefined,
             bpmnElementId: 'call_activity_id_0',
             bpmnElementName: undefined,
             bpmnElementKind: ShapeBpmnElementKind.CALL_ACTIVITY,
@@ -359,7 +350,6 @@ describe('parse bpmn as json for callActivity', () => {
         expect(model.flowNodes[0].bpmnElement.parentId).toBe('call_activity_id_0');
         verifyShape(model.flowNodes[1], {
           shapeId: 'shape_call_activity_id_0',
-          parentId: undefined,
           bpmnElementId: 'call_activity_id_0',
           bpmnElementName: undefined,
           bpmnElementKind: ShapeBpmnElementKind.CALL_ACTIVITY,
@@ -399,7 +389,6 @@ describe('parse bpmn as json for callActivity', () => {
         expect(model.flowNodes[1].bpmnElement.parentId).toBe('call_activity_id_0');
         verifyShape(model.flowNodes[2], {
           shapeId: 'shape_call_activity_id_0',
-          parentId: undefined,
           bpmnElementId: 'call_activity_id_0',
           bpmnElementName: undefined,
           bpmnElementKind: ShapeBpmnElementKind.CALL_ACTIVITY,
@@ -428,7 +417,6 @@ describe('parse bpmn as json for callActivity', () => {
 
         verifyShape(model.flowNodes[0], {
           shapeId: 'shape_call_activity_id_0',
-          parentId: undefined,
           bpmnElementId: 'call_activity_id_0',
           bpmnElementName: undefined,
           bpmnElementKind: ShapeBpmnElementKind.CALL_ACTIVITY,
@@ -467,7 +455,6 @@ describe('parse bpmn as json for callActivity', () => {
 
         verifyShape(model.flowNodes[0], {
           shapeId: 'shape_call_activity_id_0',
-          parentId: undefined,
           bpmnElementId: 'call_activity_id_0',
           bpmnElementName: undefined,
           bpmnElementKind: ShapeBpmnElementKind.CALL_ACTIVITY,
@@ -516,7 +503,6 @@ describe('parse bpmn as json for callActivity', () => {
 
         verifyShape(model.flowNodes[0], {
           shapeId: `shape_call_activity_id_0`,
-          parentId: undefined,
           bpmnElementId: `call_activity_id_0`,
           bpmnElementName: `call activity name`,
           bpmnElementKind: ShapeBpmnElementKind.CALL_ACTIVITY,

--- a/test/unit/component/parser/json/BpmnJsonParser.event.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.event.test.ts
@@ -178,7 +178,6 @@ describe('parse bpmn as json for all events', () => {
           executeEventCommonTests(
             { bpmnKind: expectedShapeBpmnElementKind as OtherBuildEventKind | 'startEvent', eventDefinitionParameter: { eventDefinitionKind, eventDefinitionOn } },
             {
-              parentId: undefined,
               bpmnElementKind: expectedShapeBpmnElementKind,
               bpmnElementName: undefined,
               eventDefinitionKind: expectedEventDefinitionKind,
@@ -200,7 +199,6 @@ describe('parse bpmn as json for all events', () => {
                   outgoing: 'flow_out',
                 },
                 {
-                  parentId: undefined,
                   bpmnElementKind: expectedShapeBpmnElementKind,
                   bpmnElementName: undefined,
                   bpmnElementIncomingIds: ['flow_in'],
@@ -227,7 +225,6 @@ describe('parse bpmn as json for all events', () => {
           eventDefinitionParameter: { eventDefinitionKind: 'none', eventDefinitionOn: EventDefinitionOn.NONE },
         },
         {
-          parentId: undefined,
           bpmnElementKind: expectedShapeBpmnElementKind,
           bpmnElementName: undefined,
           eventDefinitionKind: ShapeBpmnEventDefinitionKind.NONE,
@@ -289,7 +286,6 @@ describe('parse bpmn as json for all events', () => {
           bpmnElementId: `none_${expectedShapeBpmnElementKind}_id`,
           bpmnElementName: `none ${expectedShapeBpmnElementKind}`,
           bpmnElementKind: expectedShapeBpmnElementKind,
-          parentId: undefined,
           bounds: {
             x: 362,
             y: 232,

--- a/test/unit/component/parser/json/BpmnJsonParser.group.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.group.test.ts
@@ -68,7 +68,6 @@ describe('parse bpmn as json for group', () => {
       bpmnElementId: 'Group_0',
       bpmnElementName: 'Group 0 label',
       bpmnElementKind: ShapeBpmnElementKind.GROUP,
-      parentId: undefined,
       bounds: {
         x: 160,
         y: 110,
@@ -144,7 +143,6 @@ describe('parse bpmn as json for group', () => {
       bpmnElementId: 'Group_0',
       bpmnElementName: 'Another Group 0 label',
       bpmnElementKind: ShapeBpmnElementKind.GROUP,
-      parentId: undefined,
       bounds: {
         x: 160,
         y: 110,
@@ -157,7 +155,6 @@ describe('parse bpmn as json for group', () => {
       bpmnElementId: 'Group_1',
       bpmnElementName: undefined,
       bpmnElementKind: ShapeBpmnElementKind.GROUP,
-      parentId: undefined,
       bounds: {
         x: 1160,
         y: 1110,

--- a/test/unit/component/parser/json/BpmnJsonParser.lane.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.lane.test.ts
@@ -408,7 +408,6 @@ describe('parse bpmn as json for lane', () => {
         shapeId: 'Lane_1gdg64y_di',
         bpmnElementId: 'Lane_1gdg64y',
         bpmnElementName: undefined,
-        parentId: undefined,
         bpmnElementKind: ShapeBpmnElementKind.LANE,
         bounds: {
           x: 186,
@@ -423,7 +422,6 @@ describe('parse bpmn as json for lane', () => {
         shapeId: 'Lane_040h8y5_di',
         bpmnElementId: 'Lane_040h8y5',
         bpmnElementName: undefined,
-        parentId: undefined,
         bpmnElementKind: ShapeBpmnElementKind.LANE,
         bounds: {
           x: 186,
@@ -492,7 +490,6 @@ describe('parse bpmn as json for lane', () => {
         bpmnElementId: 'Lane_12u5n6x',
         bpmnElementName: undefined,
         bpmnElementKind: ShapeBpmnElementKind.LANE,
-        parentId: undefined,
         bounds: {
           x: 362,
           y: 232,
@@ -530,7 +527,6 @@ describe('parse bpmn as json for lane', () => {
       bpmnElementId: 'Lane_12u5n6x',
       bpmnElementName: undefined,
       bpmnElementKind: ShapeBpmnElementKind.LANE,
-      parentId: undefined,
       bounds: {
         x: 362,
         y: 232,

--- a/test/unit/component/parser/json/BpmnJsonParser.process.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.process.test.ts
@@ -59,7 +59,6 @@ describe('parse bpmn as json for process/pool', () => {
         bpmnElementId: 'Participant_1',
         bpmnElementName: undefined,
         bpmnElementKind: ShapeBpmnElementKind.POOL,
-        parentId: undefined,
         bounds: {
           x: 158,
           y: 50,
@@ -100,7 +99,6 @@ describe('parse bpmn as json for process/pool', () => {
         bpmnElementId: 'Participant_1',
         bpmnElementName: 'Participant without process ref',
         bpmnElementKind: ShapeBpmnElementKind.POOL,
-        parentId: undefined,
         isHorizontal: isHorizontal,
         bounds: {
           x: 158,
@@ -145,7 +143,6 @@ describe('parse bpmn as json for process/pool', () => {
       bpmnElementId: 'Participant_1',
       bpmnElementName: undefined,
       bpmnElementKind: ShapeBpmnElementKind.POOL,
-      parentId: undefined,
       bounds: {
         x: 158,
         y: 50,
@@ -191,7 +188,6 @@ describe('parse bpmn as json for process/pool', () => {
       bpmnElementId: 'Participant_1',
       bpmnElementName: 'Process 1',
       bpmnElementKind: ShapeBpmnElementKind.POOL,
-      parentId: undefined,
       isHorizontal: true,
       bounds: {
         x: 158,
@@ -243,7 +239,6 @@ describe('parse bpmn as json for process/pool', () => {
       bpmnElementId: 'Participant_0nuvj8r',
       bpmnElementName: 'Pool 1',
       bpmnElementKind: ShapeBpmnElementKind.POOL,
-      parentId: undefined,
       isHorizontal: true,
       bounds: {
         x: 158,
@@ -335,7 +330,6 @@ describe('parse bpmn as json for process/pool', () => {
       bpmnElementId: 'Participant_1',
       bpmnElementName: 'Pool 1',
       bpmnElementKind: ShapeBpmnElementKind.POOL,
-      parentId: undefined,
       isHorizontal: true,
       bounds: {
         x: 158,
@@ -349,7 +343,6 @@ describe('parse bpmn as json for process/pool', () => {
       bpmnElementId: 'Participant_2',
       bpmnElementName: 'Pool 2',
       bpmnElementKind: ShapeBpmnElementKind.POOL,
-      parentId: undefined,
       isHorizontal: true,
       bounds: {
         x: 158,
@@ -432,7 +425,6 @@ describe('parse bpmn as json for process/pool', () => {
       bpmnElementId: 'Participant_1',
       bpmnElementName: 'Pool 1',
       bpmnElementKind: ShapeBpmnElementKind.POOL,
-      parentId: undefined,
       isHorizontal: true,
       bounds: {
         x: 158,
@@ -446,7 +438,6 @@ describe('parse bpmn as json for process/pool', () => {
       bpmnElementId: 'Participant_2',
       bpmnElementName: 'Pool 2 without processRef',
       bpmnElementKind: ShapeBpmnElementKind.POOL,
-      parentId: undefined,
       isHorizontal: true,
       bounds: {
         x: 10158,
@@ -501,7 +492,6 @@ describe('parse bpmn as json for process/pool', () => {
       bpmnElementId: 'Participant_1',
       bpmnElementName: 'Pool 1',
       bpmnElementKind: ShapeBpmnElementKind.POOL,
-      parentId: undefined,
       isHorizontal: true,
       bounds: {
         x: 158,


### PR DESCRIPTION
The default value of `parentId` of `ExpectedShape` and `ExpectedEdge` is `undefined`, so no need to specify it, to make the tests more readable.