### PR TITLE
test: improve JsonBuilder for the Sub-Process

### DIFF
--- a/test/unit/component/parser/json/BpmnJsonParser.sub.process.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.sub.process.test.ts
@@ -14,12 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import type { BuildProcessParameter } from '../../../helpers/JsonBuilder';
+import { buildDefinitions } from '../../../helpers/JsonBuilder';
 import { parseJson, parseJsonAndExpectOnlySubProcess, verifySubProcess } from '../../../helpers/JsonTestUtils';
 import { getEventShapes } from '../../../helpers/TestUtils';
 import type { ExpectedShape } from '../../../helpers/bpmn-model-expect';
 import { verifyEdge, verifyShape } from '../../../helpers/bpmn-model-expect';
 
-import type { TProcess } from '../../../../../src/model/bpmn/json/baseElement/rootElement/rootElement';
 import type BpmnModel from '../../../../../src/model/bpmn/internal/BpmnModel';
 import { ShapeBpmnElementKind, ShapeBpmnEventDefinitionKind, ShapeBpmnMarkerKind, ShapeBpmnSubProcessKind } from '../../../../../src/model/bpmn/internal';
 import type { ShapeBpmnEvent } from '../../../../../src/model/bpmn/internal/shape/ShapeBpmnElement';
@@ -49,164 +50,95 @@ describe('parse bpmn as json for sub-process', () => {
       ['expanded', true, []],
       ['collapsed', false, [ShapeBpmnMarkerKind.EXPAND]],
     ])(`parse bpmn as json for %s ${bpmnSubProcessKind} sub-process`, (expandedKind: string, isExpanded: boolean, expectedBpmnElementMarkers: ShapeBpmnMarkerKind[]) => {
-      const processWithSubProcessAsObject = {} as TProcess;
-      processWithSubProcessAsObject['subProcess'] = {
-        id: `sub-process_id_0`,
-        name: `sub-process name`,
-        triggeredByEvent: triggeredByEvent,
-        incoming: ['flow_in_1', 'flow_in_2'],
-        outgoing: 'flow_out_1',
-      };
+      const processWithSubProcessAsObject = {
+        subProcess: {
+          id: 'sub_process_id_0',
+          name: `sub-process name`,
+          triggeredByEvent: triggeredByEvent,
+          incoming: ['flow_in_1', 'flow_in_2'],
+          outgoing: 'flow_out_1',
+          isExpanded,
+        },
+      } as BuildProcessParameter;
 
       it.each([
         ['object', processWithSubProcessAsObject],
         ['array', [processWithSubProcessAsObject]],
       ])(
         `should convert as Shape, when a ${expandedKind} ${bpmnSubProcessKind} sub-process is an attribute (as object) of 'process' (as %s)`,
-        (title: string, processJson: TProcess) => {
-          const json = {
-            definitions: {
-              targetNamespace: '',
-              process: processJson,
-              BPMNDiagram: {
-                name: 'process 0',
-                BPMNPlane: {
-                  BPMNShape: {
-                    id: `shape_sub-process_id_0`,
-                    bpmnElement: `sub-process_id_0`,
-                    Bounds: { x: 362, y: 232, width: 36, height: 45 },
-                    isExpanded: isExpanded,
-                  },
-                },
-              },
-            },
-          };
+        (title: string, processParameter: BuildProcessParameter | BuildProcessParameter[]) => {
+          const json = buildDefinitions({ process: processParameter });
 
           const model = parseJsonAndExpectOnlySubProcess(json, expectedShapeBpmnSubProcessKind, 1);
 
           verifyShape(model.flowNodes[0], {
-            shapeId: 'shape_sub-process_id_0',
-            bpmnElementId: 'sub-process_id_0',
+            shapeId: 'shape_sub_process_id_0',
+            bpmnElementId: 'sub_process_id_0',
             bpmnElementName: 'sub-process name',
             bpmnElementKind: ShapeBpmnElementKind.SUB_PROCESS,
             bpmnElementMarkers: expectedBpmnElementMarkers,
             bpmnElementIncomingIds: ['flow_in_1', 'flow_in_2'],
             bpmnElementOutgoingIds: ['flow_out_1'],
-            bounds: {
-              x: 362,
-              y: 232,
-              width: 36,
-              height: 45,
-            },
+            bounds: { x: 67, y: 23, width: 456, height: 123 },
           });
         },
       );
     });
 
     it(`should convert as Shape, when a ${bpmnSubProcessKind} sub-process (with/without name & isExpanded) is an attribute (as array) of 'process'`, () => {
-      const json = {
-        definitions: {
-          targetNamespace: '',
-          process: {
-            subProcess: [
-              {
-                id: 'sub-process_id_0',
-                name: 'sub-process name',
-                triggeredByEvent: triggeredByEvent,
-              },
-              {
-                id: 'sub-process_id_1',
-                triggeredByEvent: triggeredByEvent,
-              },
-            ],
-          },
-          BPMNDiagram: {
-            name: 'process 0',
-            BPMNPlane: {
-              BPMNShape: [
-                {
-                  id: 'shape_sub-process_id_0',
-                  bpmnElement: 'sub-process_id_0',
-                  Bounds: { x: 362, y: 232, width: 36, height: 45 },
-                  isExpanded: false,
-                },
-                {
-                  id: 'shape_sub-process_id_1',
-                  bpmnElement: 'sub-process_id_1',
-                  Bounds: { x: 365, y: 235, width: 35, height: 46 },
-                },
-              ],
+      const json = buildDefinitions({
+        process: {
+          subProcess: [
+            {
+              id: 'sub_process_id_0',
+              name: 'sub-process name',
+              triggeredByEvent: triggeredByEvent,
+              isExpanded: false,
             },
-          },
+            {
+              id: 'sub_process_id_1',
+              triggeredByEvent: triggeredByEvent,
+            },
+          ],
         },
-      };
+      });
 
       const model = parseJsonAndExpectOnlySubProcess(json, expectedShapeBpmnSubProcessKind, 2);
 
       verifyShape(model.flowNodes[0], {
-        shapeId: 'shape_sub-process_id_0',
-        bpmnElementId: 'sub-process_id_0',
+        shapeId: 'shape_sub_process_id_0',
+        bpmnElementId: 'sub_process_id_0',
         bpmnElementName: 'sub-process name',
         bpmnElementKind: ShapeBpmnElementKind.SUB_PROCESS,
-        bounds: {
-          x: 362,
-          y: 232,
-          width: 36,
-          height: 45,
-        },
+        bounds: { x: 67, y: 23, width: 456, height: 123 },
         bpmnElementMarkers: [ShapeBpmnMarkerKind.EXPAND],
       });
       verifyShape(model.flowNodes[1], {
-        shapeId: 'shape_sub-process_id_1',
-        bpmnElementId: 'sub-process_id_1',
+        shapeId: 'shape_sub_process_id_1',
+        bpmnElementId: 'sub_process_id_1',
         bpmnElementName: undefined,
         bpmnElementKind: ShapeBpmnElementKind.SUB_PROCESS,
-        bounds: {
-          x: 365,
-          y: 235,
-          width: 35,
-          height: 46,
-        },
+        bounds: { x: 67, y: 23, width: 456, height: 123 },
         bpmnElementMarkers: [ShapeBpmnMarkerKind.EXPAND],
       });
     });
 
     if (expectedShapeBpmnSubProcessKind === ShapeBpmnSubProcessKind.EMBEDDED) {
       it(`should convert as Shape, when a embedded sub-process (with/without triggeredByEvent) is an attribute (as object) of 'process'`, () => {
-        const json = {
-          definitions: {
-            targetNamespace: '',
-            process: {
-              subProcess: {
-                id: 'sub-process_id_1',
-              },
-            },
-            BPMNDiagram: {
-              name: 'process 0',
-              BPMNPlane: {
-                BPMNShape: {
-                  id: 'shape_sub-process_id_1',
-                  bpmnElement: 'sub-process_id_1',
-                  Bounds: { x: 365, y: 235, width: 35, height: 46 },
-                },
-              },
-            },
+        const json = buildDefinitions({
+          process: {
+            subProcess: { id: 'sub_process_id_1' },
           },
-        };
+        });
 
         const model = parseJsonAndExpectOnlySubProcess(json, expectedShapeBpmnSubProcessKind, 1);
 
         verifyShape(model.flowNodes[0], {
-          shapeId: 'shape_sub-process_id_1',
-          bpmnElementId: 'sub-process_id_1',
+          shapeId: 'shape_sub_process_id_1',
+          bpmnElementId: 'sub_process_id_1',
           bpmnElementName: undefined,
           bpmnElementKind: ShapeBpmnElementKind.SUB_PROCESS,
-          bounds: {
-            x: 365,
-            y: 235,
-            width: 35,
-            height: 46,
-          },
+          bounds: { x: 67, y: 23, width: 456, height: 123 },
           bpmnElementMarkers: [ShapeBpmnMarkerKind.EXPAND],
         });
       });

--- a/test/unit/helpers/JsonBuilder.test.ts
+++ b/test/unit/helpers/JsonBuilder.test.ts
@@ -2886,10 +2886,10 @@ describe('build json', () => {
   });
 
   describe('build json with subProcess', () => {
-    it('build json of definitions containing one process with subProcess (with id & name)', () => {
+    it('build json of definitions containing one process with subProcess (with id, name, triggeredByEvent, incoming & outgoing)', () => {
       const json = buildDefinitions({
         process: {
-          subProcess: { id: '0', name: 'subProcess name' },
+          subProcess: { id: '0', name: 'subProcess name', triggeredByEvent: true, incoming: 'flow_in', outgoing: ['flow_out_1', 'flow_out_2'] },
         },
       });
 
@@ -2899,7 +2899,7 @@ describe('build json', () => {
           collaboration: { id: 'collaboration_id_0' },
           process: {
             id: '0',
-            subProcess: { id: '0', name: 'subProcess name' },
+            subProcess: { id: '0', name: 'subProcess name', triggeredByEvent: true, incoming: 'flow_in', outgoing: ['flow_out_1', 'flow_out_2'] },
           },
           BPMNDiagram: {
             name: 'process 0',
@@ -2915,7 +2915,7 @@ describe('build json', () => {
       });
     });
 
-    it('build json of definitions containing one process with subProcess (without id & name)', () => {
+    it('build json of definitions containing one process with subProcess (without id, name, triggeredByEvent, incoming & outgoing)', () => {
       const json = buildDefinitions({
         process: {
           subProcess: {},

--- a/test/unit/helpers/JsonBuilder.test.ts
+++ b/test/unit/helpers/JsonBuilder.test.ts
@@ -2748,7 +2748,7 @@ describe('build json', () => {
   );
 
   describe('build json with call activity', () => {
-    it('build json of definitions containing one process with call activity (with id, name and expanded)', () => {
+    it('build json of definitions containing one process with call activity (with id, name and isExpanded)', () => {
       const json = buildDefinitions({
         process: {
           callActivity: { id: '0', name: 'name', calledElement: 'called_process', isExpanded: true },
@@ -2886,10 +2886,10 @@ describe('build json', () => {
   });
 
   describe('build json with subProcess', () => {
-    it('build json of definitions containing one process with subProcess (with id, name, triggeredByEvent, incoming & outgoing)', () => {
+    it('build json of definitions containing one process with subProcess (with id, name, triggeredByEvent, incoming, outgoing & isExpanded)', () => {
       const json = buildDefinitions({
         process: {
-          subProcess: { id: '0', name: 'subProcess name', triggeredByEvent: true, incoming: 'flow_in', outgoing: ['flow_out_1', 'flow_out_2'] },
+          subProcess: { id: '0', name: 'subProcess name', triggeredByEvent: true, incoming: 'flow_in', outgoing: ['flow_out_1', 'flow_out_2'], isExpanded: true },
         },
       });
 
@@ -2908,6 +2908,7 @@ describe('build json', () => {
                 id: 'shape_0',
                 bpmnElement: '0',
                 Bounds: { x: 67, y: 23, width: 456, height: 123 },
+                isExpanded: true,
               },
             },
           },
@@ -2915,7 +2916,7 @@ describe('build json', () => {
       });
     });
 
-    it('build json of definitions containing one process with subProcess (without id, name, triggeredByEvent, incoming & outgoing)', () => {
+    it('build json of definitions containing one process with subProcess (without id, name, triggeredByEvent, incoming, outgoing & isExpanded)', () => {
       const json = buildDefinitions({
         process: {
           subProcess: {},

--- a/test/unit/helpers/JsonBuilder.ts
+++ b/test/unit/helpers/JsonBuilder.ts
@@ -102,7 +102,12 @@ export interface BuildCallActivityParameter extends TFlowNode {
  * If the id field is set, the default id is override.
  * Otherwise, the id has the format: `subProcess_id_${processIndex}_${index}`
  */
-export type BuildSubProcessParameter = TFlowNode & { triggeredByEvent?: boolean };
+export type BuildSubProcessParameter = TFlowNode & {
+  triggeredByEvent?: boolean;
+
+  /** @default undefined */
+  isExpanded?: boolean;
+};
 
 export type BuildGatewayKind = 'complexGateway' | 'eventBasedGateway' | 'exclusiveGateway' | 'inclusiveGateway' | 'parallelGateway';
 /**
@@ -306,8 +311,8 @@ function addElementsOnProcess(processParameter: BuildProcessParameter, json: Bpm
     );
   }
   if (processParameter.subProcess) {
-    (Array.isArray(processParameter.subProcess) ? processParameter.subProcess : [processParameter.subProcess]).forEach((subProcessParameter, index) =>
-      addFlownodeAndShape(json, 'subProcess', { ...subProcessParameter, index, processIndex }, { Bounds: { x: 67, y: 23, width: 456, height: 123 } }),
+    (Array.isArray(processParameter.subProcess) ? processParameter.subProcess : [processParameter.subProcess]).forEach(({ isExpanded, ...rest }, index) =>
+      addFlownodeAndShape(json, 'subProcess', { ...rest, index, processIndex }, { Bounds: { x: 67, y: 23, width: 456, height: 123 }, isExpanded }),
     );
   }
   if (processParameter.event) {

--- a/test/unit/helpers/JsonBuilder.ts
+++ b/test/unit/helpers/JsonBuilder.ts
@@ -82,7 +82,7 @@ export type BuildTaskKind = 'task' | 'businessRuleTask' | 'manualTask' | 'receiv
  * If the id field is set, the default id is override.
  * Otherwise, the id has the format: `task_id_${processIndex}_${index}`
  */
-export interface BuildTaskParameter extends TFlowElement {
+export interface BuildTaskParameter extends TFlowNode {
   /** @default 'task' */
   bpmnKind?: BuildTaskKind;
 }
@@ -102,14 +102,14 @@ export interface BuildCallActivityParameter extends TFlowNode {
  * If the id field is set, the default id is override.
  * Otherwise, the id has the format: `subProcess_id_${processIndex}_${index}`
  */
-export type BuildSubProcessParameter = TFlowElement;
+export type BuildSubProcessParameter = TFlowNode & { triggeredByEvent?: boolean };
 
 export type BuildGatewayKind = 'complexGateway' | 'eventBasedGateway' | 'exclusiveGateway' | 'inclusiveGateway' | 'parallelGateway';
 /**
  * If the id field is set, the default id is override.
  * Otherwise, the id has the format: `exclusiveGateway_id_${processIndex}_${index}`
  */
-export interface BuildGatewayParameter extends TFlowElement {
+export interface BuildGatewayParameter extends TFlowNode {
   bpmnKind: BuildGatewayKind;
 }
 


### PR DESCRIPTION
- Improve the test helper `JsonBuilder` for the Sub-Process 
   - Generate json containing `subProcess` related to a `Shape` with `isExpanded` attribute
   - Generate json containing `subProcess`  with `triggeredByEvent` attribute
   - Generate json containing `subProcess`  with `incoming` attribute
   - Generate json containing `subProcess`  with `outgoing` attribute
- Use the test helper `JsonBuilder` in the unit tests for `BpmnJsonParser` with `subProcess`