### PR TITLE
test: improve JsonBuilder for the Association

### DIFF
--- a/test/unit/component/parser/json/BpmnJsonParser.association.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.association.test.ts
@@ -14,11 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { buildDefinitions } from '../../../helpers/JsonBuilder';
+import type { BuildProcessParameter } from '../../../helpers/JsonBuilder';
 import { parseJsonAndExpectOnlyEdges } from '../../../helpers/JsonTestUtils';
 import { verifyEdge } from '../../../helpers/bpmn-model-expect';
 
 import { Waypoint } from '../../../../../src/model/bpmn/internal/edge/edge';
-import type { TProcess } from '../../../../../src/model/bpmn/json/baseElement/rootElement/rootElement';
 
 describe('parse bpmn as json for association', () => {
   const processJsonAsObjectWithAssociationJsonAsObject = {
@@ -32,73 +33,40 @@ describe('parse bpmn as json for association', () => {
   it.each([
     ['object', processJsonAsObjectWithAssociationJsonAsObject],
     ['array', [processJsonAsObjectWithAssociationJsonAsObject]],
-  ])(`should convert as Edge, when an association is an attribute (as object) of 'process' (as %s)`, (title: string, processJson: TProcess | TProcess[]) => {
-    const json = {
-      definitions: {
-        targetNamespace: '',
-        process: processJson,
-        BPMNDiagram: {
-          name: 'process 0',
-          BPMNPlane: {
-            BPMNEdge: {
-              id: 'edge_association_id_0',
-              bpmnElement: 'association_id_0',
-              waypoint: [{ x: 362, y: 232 }],
-            },
-          },
-        },
-      },
-    };
+  ])(
+    `should convert as Edge, when an association is an attribute (as object) of 'process' (as %s)`,
+    (title: string, processParameter: BuildProcessParameter | BuildProcessParameter[]) => {
+      const json = buildDefinitions({ process: processParameter });
 
-    const model = parseJsonAndExpectOnlyEdges(json, 1);
+      const model = parseJsonAndExpectOnlyEdges(json, 1);
 
-    verifyEdge(model.edges[0], {
-      edgeId: 'edge_association_id_0',
-      bpmnElementId: 'association_id_0',
-      bpmnElementSourceRefId: 'Activity_01',
-      bpmnElementTargetRefId: 'Annotation_01',
-      waypoints: [new Waypoint(362, 232)],
-    });
-  });
+      verifyEdge(model.edges[0], {
+        edgeId: 'edge_association_id_0',
+        bpmnElementId: 'association_id_0',
+        bpmnElementSourceRefId: 'Activity_01',
+        bpmnElementTargetRefId: 'Annotation_01',
+        waypoints: [new Waypoint(45, 78), new Waypoint(51, 78)],
+      });
+    },
+  );
 
   it(`should convert as Edge, when an association is an attribute (as array) of 'process'`, () => {
-    const json = {
-      definitions: {
-        targetNamespace: '',
-        process: {
-          association: [
-            {
-              id: 'association_id_0',
-              sourceRef: 'Activity_01',
-              targetRef: 'Annotation_01',
-            },
-            {
-              id: 'association_id_1',
-              instantiate: true,
-              sourceRef: 'Activity_02',
-              targetRef: 'Annotation_02',
-            },
-          ],
-        },
-        BPMNDiagram: {
-          name: 'process 0',
-          BPMNPlane: {
-            BPMNEdge: [
-              {
-                id: 'edge_association_id_0',
-                bpmnElement: 'association_id_0',
-                waypoint: [{ x: 362, y: 232 }],
-              },
-              {
-                id: 'edge_association_id_1',
-                bpmnElement: 'association_id_1',
-                waypoint: [{ x: 362, y: 232 }],
-              },
-            ],
+    const json = buildDefinitions({
+      process: {
+        association: [
+          {
+            id: 'association_id_0',
+            sourceRef: 'Activity_01',
+            targetRef: 'Annotation_01',
           },
-        },
+          {
+            id: 'association_id_1',
+            sourceRef: 'Activity_02',
+            targetRef: 'Annotation_02',
+          },
+        ],
       },
-    };
+    });
 
     const model = parseJsonAndExpectOnlyEdges(json, 2);
 
@@ -107,7 +75,7 @@ describe('parse bpmn as json for association', () => {
       bpmnElementId: 'association_id_0',
       bpmnElementSourceRefId: 'Activity_01',
       bpmnElementTargetRefId: 'Annotation_01',
-      waypoints: [new Waypoint(362, 232)],
+      waypoints: [new Waypoint(45, 78), new Waypoint(51, 78)],
     });
 
     verifyEdge(model.edges[1], {
@@ -115,7 +83,7 @@ describe('parse bpmn as json for association', () => {
       bpmnElementId: 'association_id_1',
       bpmnElementSourceRefId: 'Activity_02',
       bpmnElementTargetRefId: 'Annotation_02',
-      waypoints: [new Waypoint(362, 232)],
+      waypoints: [new Waypoint(45, 78), new Waypoint(51, 78)],
     });
   });
 

--- a/test/unit/component/parser/json/BpmnJsonParser.sub.process.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.sub.process.test.ts
@@ -22,6 +22,7 @@ import type { ExpectedShape } from '../../../helpers/bpmn-model-expect';
 import { verifyEdge, verifyShape } from '../../../helpers/bpmn-model-expect';
 
 import type BpmnModel from '../../../../../src/model/bpmn/internal/BpmnModel';
+import { Waypoint } from '../../../../../src/model/bpmn/internal/edge/edge';
 import { ShapeBpmnElementKind, ShapeBpmnEventDefinitionKind, ShapeBpmnMarkerKind, ShapeBpmnSubProcessKind } from '../../../../../src/model/bpmn/internal';
 import type { ShapeBpmnEvent } from '../../../../../src/model/bpmn/internal/shape/ShapeBpmnElement';
 import type Shape from '../../../../../src/model/bpmn/internal/shape/Shape';
@@ -144,7 +145,7 @@ describe('parse bpmn as json for sub-process', () => {
       });
     }
 
-    it(`should convert activities, events, gateways and sequence-flows in sub-process`, () => {
+    it(`should convert activities, events, gateways, association and sequence-flows in sub-process`, () => {
       const json = {
         definitions: {
           targetNamespace: '',
@@ -183,6 +184,11 @@ describe('parse bpmn as json for sub-process', () => {
                   targetRef: 'sub-process_id_1_endEvent_1',
                 },
               ],
+              association: {
+                id: 'sub-process_id_association_id_0',
+                sourceRef: 'process_id_1_startEvent_1',
+                targetRef: 'unknown',
+              },
             },
           },
           BPMNDiagram: {
@@ -226,6 +232,14 @@ describe('parse bpmn as json for sub-process', () => {
                   id: 'edge_sub-process_id_1_sequenceFlow_2',
                   bpmnElement: 'sub-process_id_1_sequenceFlow_2',
                   waypoint: [{ x: 20, y: 20 }],
+                },
+                {
+                  id: 'edge_sub-process_id_association_id_0',
+                  bpmnElement: 'sub-process_id_association_id_0',
+                  waypoint: [
+                    { x: 45, y: 78 },
+                    { x: 51, y: 78 },
+                  ],
                 },
               ],
             },
@@ -296,13 +310,21 @@ describe('parse bpmn as json for sub-process', () => {
       });
 
       const edges = model.edges;
-      expect(edges).toHaveLength(2);
+      expect(edges).toHaveLength(3);
       verifyEdge(edges[0], {
         edgeId: 'edge_sub-process_id_1_sequenceFlow_1',
         bpmnElementId: 'sub-process_id_1_sequenceFlow_1',
         bpmnElementSourceRefId: 'sub-process_id_1_startEvent_1',
         bpmnElementTargetRefId: 'sub-process_id_1_userTask_1',
         waypoints: [{ x: 10, y: 10 }],
+      });
+
+      verifyEdge(model.edges[2], {
+        edgeId: 'edge_sub-process_id_association_id_0',
+        bpmnElementId: 'sub-process_id_association_id_0',
+        bpmnElementSourceRefId: 'process_id_1_startEvent_1',
+        bpmnElementTargetRefId: 'unknown',
+        waypoints: [new Waypoint(45, 78), new Waypoint(51, 78)],
       });
     });
 

--- a/test/unit/helpers/JsonBuilder.test.ts
+++ b/test/unit/helpers/JsonBuilder.test.ts
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { tAssociationDirection } from '../../../src/model/bpmn/json/baseElement/artifact';
 import { ShapeBpmnElementKind } from '../../../src/model/bpmn/internal';
 
 import type { BuildEventDefinitionParameter, OtherBuildEventKind, BuildTaskKind, BuildGatewayKind } from './JsonBuilder';
@@ -3369,6 +3370,127 @@ describe('build json', () => {
                   waypoint: [
                     { x: 567, y: 345 },
                     { x: 587, y: 345 },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      });
+    });
+  });
+
+  describe('build json with association', () => {
+    it('build json of definitions containing one process with association (with id, sourceRef, targetRef & associationDirection)', () => {
+      const json = buildDefinitions({
+        process: {
+          association: { id: '0', associationDirection: tAssociationDirection.One, sourceRef: 'source_1', targetRef: 'target_1' },
+        },
+      });
+
+      expect(json).toEqual({
+        definitions: {
+          targetNamespace: '',
+          collaboration: { id: 'collaboration_id_0' },
+          process: {
+            id: '0',
+            association: {
+              id: '0',
+              associationDirection: 'One',
+              sourceRef: 'source_1',
+              targetRef: 'target_1',
+            },
+          },
+          BPMNDiagram: {
+            name: 'process 0',
+            BPMNPlane: {
+              BPMNEdge: {
+                id: 'edge_0',
+                bpmnElement: '0',
+                waypoint: [
+                  { x: 45, y: 78 },
+                  { x: 51, y: 78 },
+                ],
+              },
+            },
+          },
+        },
+      });
+    });
+
+    it('build json of definitions containing one process with association (without id & associationDirection)', () => {
+      const json = buildDefinitions({
+        process: {
+          association: { sourceRef: 'source_1', targetRef: 'target_1' },
+        },
+      });
+
+      expect(json).toEqual({
+        definitions: {
+          targetNamespace: '',
+          collaboration: { id: 'collaboration_id_0' },
+          process: {
+            id: '0',
+            association: {
+              id: 'association_id_0_0',
+              sourceRef: 'source_1',
+              targetRef: 'target_1',
+            },
+          },
+          BPMNDiagram: {
+            name: 'process 0',
+            BPMNPlane: {
+              BPMNEdge: {
+                id: 'edge_association_id_0_0',
+                bpmnElement: 'association_id_0_0',
+                waypoint: [
+                  { x: 45, y: 78 },
+                  { x: 51, y: 78 },
+                ],
+              },
+            },
+          },
+        },
+      });
+    });
+
+    it('build json of definitions containing 2 processes with association (without id)', () => {
+      const json = buildDefinitions({
+        process: [{ association: { sourceRef: 'source_1', targetRef: 'target_1' } }, { association: { sourceRef: 'source_2', targetRef: 'target_2' } }],
+      });
+
+      expect(json).toEqual({
+        definitions: {
+          targetNamespace: '',
+          collaboration: { id: 'collaboration_id_0' },
+          process: [
+            {
+              id: '0',
+              association: { id: 'association_id_0_0', sourceRef: 'source_1', targetRef: 'target_1' },
+            },
+            {
+              id: '1',
+              association: { id: 'association_id_1_0', sourceRef: 'source_2', targetRef: 'target_2' },
+            },
+          ],
+          BPMNDiagram: {
+            name: 'process 0',
+            BPMNPlane: {
+              BPMNEdge: [
+                {
+                  id: 'edge_association_id_0_0',
+                  bpmnElement: 'association_id_0_0',
+                  waypoint: [
+                    { x: 45, y: 78 },
+                    { x: 51, y: 78 },
+                  ],
+                },
+                {
+                  id: 'edge_association_id_1_0',
+                  bpmnElement: 'association_id_1_0',
+                  waypoint: [
+                    { x: 45, y: 78 },
+                    { x: 51, y: 78 },
                   ],
                 },
               ],


### PR DESCRIPTION
- Improve the test helper `JsonBuilder` to generate a JSON containing `association`
- Use the test helper `JsonBuilder` in the unit tests for `BpmnJsonParser` with `association`