### PR TITLE
test: improve JsonBuilder for `global task` and `call activity`

### DIFF
--- a/test/unit/helpers/bpmn-model-expect.ts
+++ b/test/unit/helpers/bpmn-model-expect.ts
@@ -102,7 +102,7 @@ export const verifyShape = (
     expect(bpmnElement.markers).toHaveLength(0);
   }
 
-  if ('callActivityKind' in expectedShape || 'globalTaskKind' in expectedShape) {
+  if (('bpmnElementCallActivityKind' in expectedShape && expectedShape.bpmnElementCallActivityKind) || 'bpmnElementGlobalTaskKind' in expectedShape) {
     expect(bpmnElement instanceof ShapeBpmnCallActivity).toBeTruthy();
     expect((bpmnElement as ShapeBpmnCallActivity).callActivityKind).toEqual((expectedShape as ExpectedCallActivityShape).bpmnElementCallActivityKind);
     expect((bpmnElement as ShapeBpmnCallActivity).globalTaskKind).toEqual((expectedShape as ExpectedCallActivityShape).bpmnElementGlobalTaskKind);


### PR DESCRIPTION
- Improve the test helper `JsonBuilder` to generate a JSON containing `global task`
- Use the test helper `JsonBuilder` in the unit tests for `BpmnJsonParser` with `global task` and `call activity`
- Fix the test verifier for call activity