### PR TITLE
test: improve JsonBuilder for the Text Annotation

### DIFF
--- a/test/unit/component/parser/json/BpmnJsonParser.sub.process.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.sub.process.test.ts
@@ -145,7 +145,7 @@ describe('parse bpmn as json for sub-process', () => {
       });
     }
 
-    it(`should convert activities, events, gateways, association and sequence-flows in sub-process`, () => {
+    it(`should convert activities, events, gateways, textAnnotation, association and sequence-flows in sub-process`, () => {
       const json = {
         definitions: {
           targetNamespace: '',
@@ -189,6 +189,10 @@ describe('parse bpmn as json for sub-process', () => {
                 sourceRef: 'process_id_1_startEvent_1',
                 targetRef: 'unknown',
               },
+              textAnnotation: {
+                id: 'sub-process_id_1_textAnnotation_1',
+                text: 'SubProcess Text Annotation',
+              },
             },
           },
           BPMNDiagram: {
@@ -219,6 +223,11 @@ describe('parse bpmn as json for sub-process', () => {
                 {
                   id: 'shape_sub-process_id_1_endEvent_1',
                   bpmnElement: 'sub-process_id_1_endEvent_1',
+                  Bounds: { x: 565, y: 335, width: 20, height: 20 },
+                },
+                {
+                  id: 'shape_sub-process_id_1_textAnnotation_1',
+                  bpmnElement: 'sub-process_id_1_textAnnotation_1',
                   Bounds: { x: 565, y: 335, width: 20, height: 20 },
                 },
               ],
@@ -306,6 +315,15 @@ describe('parse bpmn as json for sub-process', () => {
         bpmnElementId: 'sub-process_id_1_exclusiveGateway_1',
         bpmnElementName: 'SubProcess Exclusive Gateway',
         bpmnElementKind: ShapeBpmnElementKind.GATEWAY_EXCLUSIVE,
+        bounds: { x: 565, y: 335, width: 20, height: 20 },
+      });
+
+      verifyShape(model.flowNodes[5], {
+        shapeId: 'shape_sub-process_id_1_textAnnotation_1',
+        parentId: 'sub-process_id_1',
+        bpmnElementId: 'sub-process_id_1_textAnnotation_1',
+        bpmnElementName: 'SubProcess Text Annotation',
+        bpmnElementKind: ShapeBpmnElementKind.TEXT_ANNOTATION,
         bounds: { x: 565, y: 335, width: 20, height: 20 },
       });
 

--- a/test/unit/component/parser/json/BpmnJsonParser.text.annotation.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.text.annotation.test.ts
@@ -14,126 +14,71 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { buildDefinitions } from '../../../helpers/JsonBuilder';
+import type { BuildProcessParameter } from '../../../helpers/JsonBuilder';
 import { parseJsonAndExpectOnlyFlowNodes } from '../../../helpers/JsonTestUtils';
 import { verifyShape } from '../../../helpers/bpmn-model-expect';
 
 import { ShapeBpmnElementKind } from '../../../../../src/model/bpmn/internal';
-import type { TProcess } from '../../../../../src/model/bpmn/json/baseElement/rootElement/rootElement';
 
 describe('parse bpmn as json for text annotation', () => {
-  const processWithArtifactAsObject = {} as TProcess;
-  processWithArtifactAsObject['textAnnotation'] = {
-    id: `textAnnotation_id_0`,
-    text: `textAnnotation name`,
+  const processWithArtifactAsObject = {
+    textAnnotation: {
+      id: `textAnnotation_id_0`,
+      text: `textAnnotation name`,
+    },
   };
 
   it.each([
     ['object', processWithArtifactAsObject],
     ['array', [processWithArtifactAsObject]],
-  ])(`should convert as Shape, when a text annotation is an attribute (as object) of 'process' (as %s)`, (title: string, processJson: TProcess) => {
-    const json = {
-      definitions: {
-        targetNamespace: '',
-        process: processJson,
-        BPMNDiagram: {
-          name: 'process 0',
-          BPMNPlane: {
-            BPMNShape: {
-              id: `shape_textAnnotation_id_0`,
-              bpmnElement: `textAnnotation_id_0`,
-              Bounds: { x: 362, y: 232, width: 36, height: 45 },
-            },
-          },
-        },
-      },
-    };
+  ])(
+    `should convert as Shape, when a text annotation is an attribute (as object) of 'process' (as %s)`,
+    (title: string, processParameter: BuildProcessParameter | BuildProcessParameter[]) => {
+      const json = buildDefinitions({ process: processParameter });
 
-    const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
+      const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
-    verifyShape(model.flowNodes[0], {
-      shapeId: `shape_textAnnotation_id_0`,
-      bpmnElementId: `textAnnotation_id_0`,
-      bpmnElementName: `textAnnotation name`,
-      bpmnElementKind: ShapeBpmnElementKind.TEXT_ANNOTATION,
-      bounds: {
-        x: 362,
-        y: 232,
-        width: 36,
-        height: 45,
-      },
-    });
-  });
+      verifyShape(model.flowNodes[0], {
+        shapeId: `shape_textAnnotation_id_0`,
+        bpmnElementId: `textAnnotation_id_0`,
+        bpmnElementName: `textAnnotation name`,
+        bpmnElementKind: ShapeBpmnElementKind.TEXT_ANNOTATION,
+        bounds: { x: 456, y: 23, width: 78, height: 54 },
+      });
+    },
+  );
 
   it(`should convert as Shape, when a text annotation (with/without text) is an attribute (as array) of 'process'`, () => {
-    const json = {
-      definitions: {
-        targetNamespace: '',
-        process: {
-          textAnnotation: [
-            {
-              id: 'TextAnnotation_01',
-              text: 'Task Annotation',
-            },
-            {
-              id: 'TextAnnotation_02',
-            },
-          ],
-        },
-        BPMNDiagram: {
-          name: 'process 0',
-          BPMNPlane: {
-            BPMNShape: [
-              {
-                id: 'TextAnnotation_01_di',
-                bpmnElement: 'TextAnnotation_01',
-                Bounds: {
-                  x: 430,
-                  y: 160,
-                  width: 100,
-                  height: 30,
-                },
-              },
-              {
-                id: 'TextAnnotation_02_di',
-                bpmnElement: 'TextAnnotation_02',
-                Bounds: {
-                  x: 180,
-                  y: 80,
-                  width: 270,
-                  height: 54,
-                },
-              },
-            ],
+    const json = buildDefinitions({
+      process: {
+        textAnnotation: [
+          {
+            id: 'TextAnnotation_01',
+            text: 'Task Annotation',
           },
-        },
+          {
+            id: 'TextAnnotation_02',
+          },
+        ],
       },
-    };
+    });
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
 
     verifyShape(model.flowNodes[0], {
-      shapeId: 'TextAnnotation_01_di',
+      shapeId: 'shape_TextAnnotation_01',
       bpmnElementId: 'TextAnnotation_01',
       bpmnElementName: 'Task Annotation',
       bpmnElementKind: ShapeBpmnElementKind.TEXT_ANNOTATION,
-      bounds: {
-        x: 430,
-        y: 160,
-        width: 100,
-        height: 30,
-      },
+      bounds: { x: 456, y: 23, width: 78, height: 54 },
     });
     verifyShape(model.flowNodes[1], {
-      shapeId: 'TextAnnotation_02_di',
+      shapeId: 'shape_TextAnnotation_02',
       bpmnElementId: 'TextAnnotation_02',
       bpmnElementName: undefined,
       bpmnElementKind: ShapeBpmnElementKind.TEXT_ANNOTATION,
-      bounds: {
-        x: 180,
-        y: 80,
-        width: 270,
-        height: 54,
-      },
+      bounds: { x: 456, y: 23, width: 78, height: 54 },
     });
   });
 });

--- a/test/unit/helpers/JsonBuilder.test.ts
+++ b/test/unit/helpers/JsonBuilder.test.ts
@@ -2987,6 +2987,109 @@ describe('build json', () => {
     });
   });
 
+  describe('build json with textAnnotation on process', () => {
+    it('build json of definitions containing one process with textAnnotation (with id & text)', () => {
+      const json = buildDefinitions({
+        process: {
+          textAnnotation: { id: '0', text: 'my text' },
+        },
+      });
+
+      expect(json).toEqual({
+        definitions: {
+          targetNamespace: '',
+          collaboration: { id: 'collaboration_id_0' },
+          process: {
+            id: '0',
+            textAnnotation: {
+              id: '0',
+              text: 'my text',
+            },
+          },
+          BPMNDiagram: {
+            name: 'process 0',
+            BPMNPlane: {
+              BPMNShape: {
+                id: 'shape_0',
+                bpmnElement: '0',
+                Bounds: { x: 456, y: 23, width: 78, height: 54 },
+              },
+            },
+          },
+        },
+      });
+    });
+
+    it('build json of definitions containing one process with textAnnotation (without id & text)', () => {
+      const json = buildDefinitions({
+        process: {
+          textAnnotation: {},
+        },
+      });
+
+      expect(json).toEqual({
+        definitions: {
+          targetNamespace: '',
+          collaboration: { id: 'collaboration_id_0' },
+          process: {
+            id: '0',
+            textAnnotation: { id: 'textAnnotation_id_0_0' },
+          },
+          BPMNDiagram: {
+            name: 'process 0',
+            BPMNPlane: {
+              BPMNShape: {
+                id: 'shape_textAnnotation_id_0_0',
+                bpmnElement: 'textAnnotation_id_0_0',
+                Bounds: { x: 456, y: 23, width: 78, height: 54 },
+              },
+            },
+          },
+        },
+      });
+    });
+
+    it('build json of definitions containing 2 processes with textAnnotation (without id)', () => {
+      const json = buildDefinitions({
+        process: [{ textAnnotation: {} }, { textAnnotation: {} }],
+      });
+
+      expect(json).toEqual({
+        definitions: {
+          targetNamespace: '',
+          collaboration: { id: 'collaboration_id_0' },
+          process: [
+            {
+              id: '0',
+              textAnnotation: { id: 'textAnnotation_id_0_0' },
+            },
+            {
+              id: '1',
+              textAnnotation: { id: 'textAnnotation_id_1_0' },
+            },
+          ],
+          BPMNDiagram: {
+            name: 'process 0',
+            BPMNPlane: {
+              BPMNShape: [
+                {
+                  id: 'shape_textAnnotation_id_0_0',
+                  bpmnElement: 'textAnnotation_id_0_0',
+                  Bounds: { x: 456, y: 23, width: 78, height: 54 },
+                },
+                {
+                  id: 'shape_textAnnotation_id_1_0',
+                  bpmnElement: 'textAnnotation_id_1_0',
+                  Bounds: { x: 456, y: 23, width: 78, height: 54 },
+                },
+              ],
+            },
+          },
+        },
+      });
+    });
+  });
+
   describe('build json with sequence flow', () => {
     it('build json of definitions containing one process with sequence flow (with id & name)', () => {
       const json = buildDefinitions({

--- a/test/unit/helpers/JsonBuilder.ts
+++ b/test/unit/helpers/JsonBuilder.ts
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import type { TTextAnnotation } from '../../../src/model/bpmn/json/baseElement/artifact';
 import type { TGlobalTask } from '../../../src/model/bpmn/json/baseElement/rootElement/globalTask';
 import type { TArtifact } from '../../../src/model/bpmn/json/baseElement/artifact';
 import type { TAssociation } from '../../../src/model/bpmn/json/baseElement/artifact';
@@ -142,6 +143,12 @@ export interface BuildSequenceFlowParameter extends TFlowElement {
  */
 export type BuildAssociationParameter = Pick<TAssociation, 'id' | 'sourceRef' | 'targetRef' | 'associationDirection'>;
 
+/**
+ * If the id field is set, the default id is override.
+ * Otherwise, the id has the format: `textAnnotation_id_${processIndex}_${index}`
+ */
+export type BuildTextAnnotationParameter = Pick<TTextAnnotation, 'id' | 'text'>;
+
 export interface BuildProcessParameter {
   lane?: BuildLaneParameter | BuildLaneParameter[];
   task?: BuildTaskParameter | BuildTaskParameter[];
@@ -151,6 +158,7 @@ export interface BuildProcessParameter {
   subProcess?: BuildSubProcessParameter | BuildSubProcessParameter[];
   sequenceFlow?: BuildSequenceFlowParameter | BuildSequenceFlowParameter[];
   association?: BuildAssociationParameter | BuildAssociationParameter[];
+  textAnnotation?: BuildTextAnnotationParameter | BuildTextAnnotationParameter[];
 
   /**
    * - If `withParticipant` of `BuildDefinitionParameter` is false, it's corresponding to the id of the process.
@@ -386,6 +394,11 @@ function addElementsOnProcess(processParameter: BuildProcessParameter, json: Bpm
           ],
         },
       ),
+    );
+  }
+  if (processParameter.textAnnotation) {
+    (Array.isArray(processParameter.textAnnotation) ? processParameter.textAnnotation : [processParameter.textAnnotation]).forEach((textAnnotationParameter, index) =>
+      addProcessElementWithShape(json, 'textAnnotation', { ...textAnnotationParameter, index, processIndex }, { Bounds: { x: 456, y: 23, width: 78, height: 54 } }),
     );
   }
 }


### PR DESCRIPTION
- Improve the test helper `JsonBuilder` to generate a JSON containing `textAnnotation`
- Use the test helper `JsonBuilder` in the unit tests for `BpmnJsonParser` with `textAnnotation`
- Add missing unit test for `BpmnJsonParser` with `subProcess` containing `textAnnotation`