### PR TITLE
chore(action): bump sonarcloud-github-action from 1.9 to 1.9.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
       # No need to run the analysis from all environments
       - name: SonarCloud Scan
         if: ${{ success() && contains(matrix.os.coverage, 'coverage') && env.SONAR_TOKEN != '' }}
-        uses: SonarSource/sonarcloud-github-action@v1.9
+        uses: SonarSource/sonarcloud-github-action@v1.9.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
With the `1.9` version of `sonarcloud-github-action`, we have the following error:
![image](https://user-images.githubusercontent.com/4921914/233951195-e249d49f-e862-4d29-910f-37c2b81b1577.png)

The `node.js` version use by this action is deprecated.
So, we need to updated to [`1.9.1`](https://github.com/SonarSource/sonarcloud-github-action/releases/tag/v1.9.1) who support the `node.js 16`.