### PR TITLE
build: replace rollup-plugin-auto-external 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,6 @@
         "prettier": "~2.8.7",
         "rimraf": "~5.0.0",
         "rollup": "~3.21.0",
-        "rollup-plugin-auto-external": "~2.0.0",
         "rollup-plugin-node-externals": "~5.1.2",
         "rollup-plugin-sizes": "~1.0.5",
         "rollup-plugin-typescript2": "~0.34.1",
@@ -4181,22 +4180,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/builtins": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^6.0.0"
-      }
-    },
-    "node_modules/builtins/node_modules/semver": {
-      "version": "6.3.0",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/caching-transform": {
@@ -10736,31 +10719,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/rollup-plugin-auto-external": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "builtins": "^2.0.0",
-        "read-pkg": "^3.0.0",
-        "safe-resolve": "^1.0.0",
-        "semver": "^5.5.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependencies": {
-        "rollup": ">=0.45.2"
-      }
-    },
-    "node_modules/rollup-plugin-auto-external/node_modules/semver": {
-      "version": "5.7.1",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/rollup-plugin-node-externals": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/rollup-plugin-node-externals/-/rollup-plugin-node-externals-5.1.2.tgz",
@@ -10850,11 +10808,6 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/safe-resolve": {
-      "version": "1.0.0",
       "dev": true,
       "license": "MIT"
     },
@@ -15261,19 +15214,6 @@
       "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
       "dev": true
     },
-    "builtins": {
-      "version": "2.0.1",
-      "dev": true,
-      "requires": {
-        "semver": "^6.0.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "dev": true
-        }
-      }
-    },
     "caching-transform": {
       "version": "4.0.0",
       "dev": true,
@@ -19660,22 +19600,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "rollup-plugin-auto-external": {
-      "version": "2.0.0",
-      "dev": true,
-      "requires": {
-        "builtins": "^2.0.0",
-        "read-pkg": "^3.0.0",
-        "safe-resolve": "^1.0.0",
-        "semver": "^5.5.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "dev": true
-        }
-      }
-    },
     "rollup-plugin-node-externals": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/rollup-plugin-node-externals/-/rollup-plugin-node-externals-5.1.2.tgz",
@@ -19737,10 +19661,6 @@
     },
     "safe-buffer": {
       "version": "5.1.2",
-      "dev": true
-    },
-    "safe-resolve": {
-      "version": "1.0.0",
       "dev": true
     },
     "safer-buffer": {

--- a/package.json
+++ b/package.json
@@ -146,7 +146,6 @@
     "prettier": "~2.8.7",
     "rimraf": "~5.0.0",
     "rollup": "~3.21.0",
-    "rollup-plugin-auto-external": "~2.0.0",
     "rollup-plugin-node-externals": "~5.1.2",
     "rollup-plugin-sizes": "~1.0.5",
     "rollup-plugin-typescript2": "~0.34.1",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -20,7 +20,7 @@ import { computeBanner } from './scripts/shared/banner.mjs';
 import pkg from './package.json' assert { type: 'json' };
 
 import terser from '@rollup/plugin-terser';
-import autoExternal from 'rollup-plugin-auto-external';
+import externals from 'rollup-plugin-node-externals';
 import sizes from 'rollup-plugin-sizes';
 
 import typescript from 'rollup-plugin-typescript2';
@@ -75,7 +75,7 @@ const configESM = {
   plugins: [
     typescriptPlugin(),
     // ensure we do not bundle dependencies
-    autoExternal(),
+    externals({ devDeps: true }),
     // to have sizes of dependencies listed at the end of build log
     sizes(),
   ],


### PR DESCRIPTION

Replaced rollup-plugin-auto-external with rollup-plugin-node-externals. 

* The build files are identical 
*  rollup-plugin-node-externals has no dependencies 
*  rollup-plugin-node-externals is compared to rollup-plugin-auto-external  a lot smaller

closes #2196 