### PR TITLE
ci: publish npm package with "provenance"

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -6,13 +6,16 @@ on:
 jobs:
   build:
     runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+      contents: write
     steps:
       - uses: actions/checkout@v3
       - name: Build Setup
         uses: ./.github/actions/build-setup
         with:
           registry-url: 'https://registry.npmjs.org'
-      - run: npm publish
+      - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Send message to Slack channel


### PR DESCRIPTION
This beta feature let users know how the package was published. In our case, the package page will display that it is done using GitHub Actions.

### Notes

Resources
- https://github.blog/changelog/2023-04-19-npm-provenance-public-beta]
- https://docs.npmjs.com/generating-provenance-statements

The publish provenance options is available in the recent npm version, in particular the version used by GH actions
- npm cli documentation: https://docs.npmjs.com/cli/v9/commands/npm-publish
- recent run of GH Actions https://github.com/process-analytics/bpmn-visualization-js/actions/runs/4822107411/jobs/8588897848?pr=2467 
```
Run actions/setup-node@v3
Resolved .nvmrc as 18
Found in cache @ /opt/hostedtoolcache/node/18.16.0/x64
Environment details
node: v18.16.0
npm: 9.5.1
yarn: 1.22.19
```

Local check of "npm: 9.5.1"
```
Now using node v18.16.0 (npm v9.5.1)
$ npm publish --help
Publish a package
Usage:
npm publish <package-spec>
Options:
[--tag <tag>] [--access <restricted|public>] [--dry-run] [--otp <otp>]
[-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
[-ws|--workspaces] [--include-workspace-root] [--provenance]
```
