### PR TITLE
refactor(demo): simplify imports

### DIFF
--- a/dev/ts/component/SvgExporter.ts
+++ b/dev/ts/component/SvgExporter.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { mxgraph } from '../../../src/component/mxgraph/initializer';
+import { mxgraph } from '@lib/component/mxgraph/initializer';
 import type { mxGraph, mxSvgCanvas2D } from 'mxgraph';
 
 interface SvgExportOptions {

--- a/dev/ts/component/ThemedBpmnVisualization.ts
+++ b/dev/ts/component/ThemedBpmnVisualization.ts
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { BpmnVisualization, FlowKind, ShapeBpmnElementKind, ShapeUtil, StyleConfigurator, StyleDefault } from '../../../src/bpmn-visualization';
+import { BpmnVisualization, FlowKind, ShapeBpmnElementKind, ShapeUtil, StyleConfigurator, StyleDefault } from '@lib/bpmn-visualization';
 import { logStartup } from '../utils/internal-helpers';
-import { mxgraph } from '../../../src/component/mxgraph/initializer';
+import { mxgraph } from '@lib/component/mxgraph/initializer';
 
 interface Theme {
   defaultFillColor: string;

--- a/dev/ts/dev-bundle-index.ts
+++ b/dev/ts/dev-bundle-index.ts
@@ -16,4 +16,4 @@ limitations under the License.
 
 export * from './main';
 export * from './utils/shared-helpers';
-export * from '../../src/bpmn-visualization';
+export * from '@lib/bpmn-visualization';

--- a/dev/ts/main.ts
+++ b/dev/ts/main.ts
@@ -27,8 +27,8 @@ import type {
   StyleUpdate,
   Version,
   ZoomType,
-} from '../../src/bpmn-visualization';
-import { FlowKind, ShapeBpmnElementKind } from '../../src/bpmn-visualization';
+} from '@lib/bpmn-visualization';
+import { FlowKind, ShapeBpmnElementKind } from '@lib/bpmn-visualization';
 import { fetchBpmnContent, logDownload, logError, logErrorAndOpenAlert, logStartup, stringify } from './utils/internal-helpers';
 import { log } from './utils/shared-helpers';
 import { DropFileUserInterface } from './component/DropFileUserInterface';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,9 +20,14 @@
     // Vitejs requirements https://vitejs.dev/guide/features.html#typescript-compiler-options
     "isolatedModules": true, // https://esbuild.github.io/content-types/#isolated-modules
     "useDefineForClassFields": true,
+    "baseUrl": ".",
+    "paths": {
+      // allow to import sources directly with "@lib/xx/yy" instead of using relative paths like "../../src/xx/yy"
+      "@lib/*": ["src/*"],
+    }
   },
   "include": [
-    "src/**/*",
-    "dev/ts/**/*"
+    "src/**/*.ts",
+    "dev/ts/**/*.ts"
   ]
 }


### PR DESCRIPTION
Configure tsconfig compiler paths to simplify imports in the demo. This lets replace relative paths like ../../src/xx/yy by "@lib/xx/yy".

References #2467