### PR TITLE
refactor: fix code smells detected by SonarCloud

### DIFF
--- a/src/component/helpers/validators.ts
+++ b/src/component/helpers/validators.ts
@@ -20,9 +20,8 @@ import type { ZoomConfiguration } from '../options';
  * @internal
  */
 export function ensureInRange(value: number, min: number, max: number, defaultValue: number): number {
-  let inRangeValue = value == undefined ? defaultValue : value;
-  inRangeValue = Math.min(Math.max(inRangeValue, min), max);
-  return inRangeValue;
+  const inRangeValue = value ?? defaultValue;
+  return Math.min(Math.max(inRangeValue, min), max);
 }
 
 /**

--- a/src/component/mxgraph/config/ShapeConfigurator.ts
+++ b/src/component/mxgraph/config/ShapeConfigurator.ts
@@ -146,7 +146,7 @@ export default class ShapeConfigurator {
 
       // START bpmn-visualization CUSTOMIZATION
       // add attributes to be able to identify elements in DOM
-      if (this.state && this.state.cell) {
+      if (this.state?.cell) {
         // 'this.state.style' = the style definition associated with the cell
         // 'this.state.cell.style' = the style applied to the cell: 1st element: style name = bpmn shape name
         const cell = this.state.cell;

--- a/src/component/parser/json/converter/DiagramConverter.ts
+++ b/src/component/parser/json/converter/DiagramConverter.ts
@@ -119,7 +119,7 @@ export default class DiagramConverter {
 
       let isHorizontal;
       if (ShapeUtil.isPoolOrLane(bpmnElement.kind)) {
-        isHorizontal = shape.isHorizontal !== undefined ? shape.isHorizontal : true;
+        isHorizontal = shape.isHorizontal ?? true;
       }
 
       const label = this.deserializeLabel(shape.BPMNLabel, shape.id);


### PR DESCRIPTION
- Prefer using nullish coalescing operator (`??`) instead of a ternary expression, as it is simpler to read.
- Prefer using an optional chain expression instead, as it's more concise and easier to read.

### Notes

The issues have not been introduced recently. The TypeScript profile has been updated yesterday with new rules.

![image](https://user-images.githubusercontent.com/27200110/235975863-7d93bf2f-683d-4f13-a773-22997e32411b.png)

The remaining issues are mainly due to the misuse of `enum`. The places were the issues occur are clearly subject to removal (for instance `StyleDefault`). We don't need enum for structures that store data that are not intended to be enumerated.