### PR TITLE
refactor: avoid using "bind" when calling methods in the css registry

### DIFF
--- a/src/component/registry/bpmn-elements-registry.ts
+++ b/src/component/registry/bpmn-elements-registry.ts
@@ -149,7 +149,7 @@ export class BpmnElementsRegistry {
    * @see {@link updateStyle} to directly update the style of BPMN elements.
    */
   addCssClasses(bpmnElementIds: string | string[], classNames: string | string[]): void {
-    this.updateCssClasses(bpmnElementIds, classNames, this.cssRegistry.addClassNames.bind(this.cssRegistry));
+    this.updateCssClasses(bpmnElementIds, classNames, this.cssRegistry.addClassNames);
   }
 
   /**
@@ -172,7 +172,7 @@ export class BpmnElementsRegistry {
    * @see {@link removeAllCssClasses} to remove all CSS classes from a BPMN element.
    */
   removeCssClasses(bpmnElementIds: string | string[], classNames: string | string[]): void {
-    this.updateCssClasses(bpmnElementIds, classNames, this.cssRegistry.removeClassNames.bind(this.cssRegistry));
+    this.updateCssClasses(bpmnElementIds, classNames, this.cssRegistry.removeClassNames);
   }
 
   /**
@@ -233,7 +233,7 @@ export class BpmnElementsRegistry {
    * @see {@link addCssClasses} to add CSS classes to a BPMN element.
    */
   toggleCssClasses(bpmnElementIds: string | string[], classNames: string | string[]): void {
-    this.updateCssClasses(bpmnElementIds, classNames, this.cssRegistry.toggleClassNames.bind(this.cssRegistry));
+    this.updateCssClasses(bpmnElementIds, classNames, this.cssRegistry.toggleClassNames);
   }
 
   private updateCssClasses(bpmnElementIds: string | string[], classNames: string | string[], updateClassNames: (bpmnElementId: string, classNames: string[]) => boolean): void {

--- a/src/component/registry/css-registry.ts
+++ b/src/component/registry/css-registry.ts
@@ -55,9 +55,8 @@ export class CssRegistry {
    * @param classNames the CSS class names to register
    * @return `true` if at least one class name from parameters has been added; `false` otherwise
    */
-  addClassNames(bpmnElementId: string, classNames: string[]): boolean {
-    return this.updateClassNames(bpmnElementId, classNames, (currentClassNames, className) => currentClassNames.add(className));
-  }
+  addClassNames = (bpmnElementId: string, classNames: string[]): boolean =>
+    this.updateClassNames(bpmnElementId, classNames, (currentClassNames, className) => currentClassNames.add(className));
 
   /**
    * Remove the CSS class names for a specific HTML element
@@ -66,9 +65,8 @@ export class CssRegistry {
    * @param classNames the CSS class names to remove
    * @return `true` if at least one class name from parameters has been removed; `false` otherwise
    */
-  removeClassNames(bpmnElementId: string, classNames: string[]): boolean {
-    return this.updateClassNames(bpmnElementId, classNames, (currentClassNames, className) => currentClassNames.delete(className));
-  }
+  removeClassNames = (bpmnElementId: string, classNames: string[]): boolean =>
+    this.updateClassNames(bpmnElementId, classNames, (currentClassNames, className) => currentClassNames.delete(className));
 
   /**
    * Remove all CSS class names for specific HTML element
@@ -90,12 +88,12 @@ export class CssRegistry {
    * @param classNames the CSS class names to toggle
    * @return `true` if `classNames` has at least one element - as toggle will always trigger changes in that case; `false` otherwise
    */
-  toggleClassNames(bpmnElementId: string, classNames: string[]): boolean {
+  toggleClassNames = (bpmnElementId: string, classNames: string[]): boolean => {
     this.updateClassNames(bpmnElementId, classNames, (currentClassNames, className) =>
       currentClassNames.has(className) ? currentClassNames.delete(className) : currentClassNames.add(className),
     );
     return classNames && classNames.length > 0;
-  }
+  };
 
   private updateClassNames(bpmnElementId: string, classNames: string[], manageClassNames: (currentClassNames: Set<string>, className: string) => void): boolean {
     const currentClassNames = this.getOrInitializeClassNames(bpmnElementId);


### PR DESCRIPTION
Use "arrow function style" when declaring the CssRegistry method.

### Notes

Detected during the #2666 developments.