### PR TITLE
docs(release): add tips for referencing the `examples` repository

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -68,6 +68,13 @@ template: |
 
   **TODO: add screenshots and user oriented info**
 
+  **TODO: highlight changes from the `examples` repository**
+  Important updates and/or new features may be available in this repository and are worth mentioning.
+  In this case:
+    - release the `examples` repository first
+    - add a link to the RN https://github.com/$OWNER/bpmn-visualization-examples/releases/tag/v0.34.0
+  Optional: add link to sthe live tatically.io environment including the tag (not the `master` branch) 
+
   # What's Changed
 
   **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$NEXT_PATCH_VERSION


### PR DESCRIPTION
We often forget to mention changes in the `examples` repository in the release notes. So, update the `release-drafter` template to guide the writers.

### Notes

This occured in the 0.34.0 release notes: https://github.com/process-analytics/bpmn-visualization-examples/releases/tag/v0.34.0
In this case, we try to make up for the omission in the following notes but it requires extra work not to forget.
These tips will result in better documentation and less work for the maintainers.