### PR TITLE
docs: improve the README (examples + firefox logo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Planned features:
 
 ## 🌏 Browsers Support
 
-| <img src="https://www.google.com/chrome/static/images/chrome-logo.svg" alt="Chrome" width="18px" height="18px" /> Chrome | <img src="https://user-media-prod-cdn.itsre-sumo.mozilla.net/uploads/products/2020-04-14-08-36-13-8dda6f.png" alt="Firefox" width="18px" height="18px" /> Firefox | <img src="https://upload.wikimedia.org/wikipedia/commons/5/52/Safari_browser_logo.svg" alt="Safari" width="18px" height="18px" /> Safari | <img src="https://avatars0.githubusercontent.com/u/11354582?s=200&v=4" alt="Edge" width="18px" height="18px" /> Edge |
+| <img src="https://www.google.com/chrome/static/images/chrome-logo.svg" alt="Chrome" width="18px" height="18px" /> Chrome | <img src="https://mozilla.design/files/2019/10/logo-firefox.svg" alt="Firefox" height="18px" /> Firefox | <img src="https://upload.wikimedia.org/wikipedia/commons/5/52/Safari_browser_logo.svg" alt="Safari" width="18px" height="18px" /> Safari | <img src="https://avatars0.githubusercontent.com/u/11354582?s=200&v=4" alt="Edge" width="18px" height="18px" /> Edge |
 | :---------: | :---------: | :---------: | :---------: |
 |  ✔️ |  ✔️ |  ✔️ |  ✔️ |
 

--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ Planned features:
 
 ## 🌏 Browsers Support
 
-| <img src="https://www.google.com/chrome/static/images/chrome-logo.svg" alt="Chrome" width="18px" height="18px" /> Chrome | <img src="https://mozilla.design/files/2019/10/logo-firefox.svg" alt="Firefox" height="18px" /> Firefox | <img src="https://upload.wikimedia.org/wikipedia/commons/5/52/Safari_browser_logo.svg" alt="Safari" width="18px" height="18px" /> Safari | <img src="https://avatars0.githubusercontent.com/u/11354582?s=200&v=4" alt="Edge" width="18px" height="18px" /> Edge |
-| :---------: | :---------: | :---------: | :---------: |
-|  ✔️ |  ✔️ |  ✔️ |  ✔️ |
+| <img src="https://www.google.com/chrome/static/images/chrome-logo.svg" alt="Chrome" width="18px" height="18px" /> Chrome | <img src="http://blog.mozilla.org/design/files/2019/10/Fx-Browser-icon-fullColor.svg" alt="Firefox" height="18px" /> Firefox | <img src="https://upload.wikimedia.org/wikipedia/commons/5/52/Safari_browser_logo.svg" alt="Safari" width="18px" height="18px" /> Safari | <img src="https://avatars0.githubusercontent.com/u/11354582?s=200&v=4" alt="Edge" width="18px" height="18px" /> Edge |
+| :---------: |:--------------------------------------------------------------------------------------------------------------------------------------:| :---------: | :---------: |
+|  ✔️ |                                                                   ✔️                                                                   |  ✔️ |  ✔️ |
 
 **Notes**:
 - Chromium based browsers should work (automatic tests are run with Chromium canary releases). In particular, the following

--- a/README.md
+++ b/README.md
@@ -113,10 +113,10 @@ Then use this snippet to load your BPMN diagram in a page:
 ```javascript
 import { BpmnVisualization } from 'bpmn-visualization';
 
-let bpmnContent; // your BPMN 2.0 XML content
 // initialize `bpmn-visualization` and load the BPMN diagram
 // 'bpmn-container' is the id of the HTMLElement that renders the BPMN Diagram
 const bpmnVisualization = new BpmnVisualization({ container: 'bpmn-container' });
+let bpmnContent; // your BPMN 2.0 XML content
 bpmnVisualization.load(bpmnContent);
 ```
 
@@ -155,10 +155,10 @@ In the HTML page:
 <div id="bpmn-container"></div>
 ...
 <script>
-  let bpmnContent; // your BPMN 2.0 XML content
   // initialize `bpmn-visualization` and load the BPMN diagram
   // 'bpmn-container' is the id of the HTMLElement that renders the BPMN Diagram
   const bpmnVisualization = new bpmnvisu.BpmnVisualization({ container: 'bpmn-container'});
+  let bpmnContent; // your BPMN 2.0 XML content
   bpmnVisualization.load(bpmnContent);
 </script>
 ```


### PR DESCRIPTION
Examples: put the variable `bpmnContent` after the initialization of the library. It was not necessary to put it so
prominently. Its new location allows to keep the declaration as close as possible to its use in order to simplify the
reading.

Firefox logo: the URL previously used is no more reachable. Use a new logo taken from the official mozilla.design
website.
We can expect more stability from this source which is the official branding site for mozilla products.


### Notes

Here is what I see when I display the README in the GitHub repository home prior the fix provided by this PR.

![image](https://user-images.githubusercontent.com/27200110/236454808-c31bcb5c-ce48-488d-8442-8a2d2c975b1d.png)
