### PR TITLE
refactor: transform overlay types from interface to type

### DIFF
--- a/src/component/registry/types.ts
+++ b/src/component/registry/types.ts
@@ -74,27 +74,27 @@ export type OverlayPosition = OverlayShapePosition | OverlayEdgePosition;
 /**
  * @category Overlays
  */
-export interface OverlayStyle {
+export type OverlayStyle = {
   font?: OverlayFont;
   fill?: OverlayFill;
   stroke?: OverlayStroke;
-}
+};
 
 /**
  * The font family is {@link StyleDefault.DEFAULT_FONT_FAMILY}.
  * @category Overlays
  */
-export interface OverlayFont {
+export type OverlayFont = {
   /** @default {@link StyleDefault.DEFAULT_OVERLAY_FONT_COLOR} */
   color?: string;
   /** @default {@link StyleDefault.DEFAULT_OVERLAY_FONT_SIZE} */
   size?: number;
-}
+};
 
 /**
  * @category Overlays
  */
-export interface OverlayFill {
+export type OverlayFill = {
   /** @default {@link StyleDefault.DEFAULT_OVERLAY_FILL_COLOR} */
   color?: string;
   /**
@@ -104,12 +104,12 @@ export interface OverlayFill {
    * @default {@link StyleDefault.DEFAULT_OVERLAY_FILL_OPACITY}
    */
   opacity?: number;
-}
+};
 
 /**
  * @category Overlays
  */
-export interface OverlayStroke {
+export type OverlayStroke = {
   /**
    * If you don't want to display a stroke, you can set the color to
    *   * `transparent`
@@ -123,16 +123,16 @@ export interface OverlayStroke {
    * @default {@link StyleDefault.DEFAULT_OVERLAY_STROKE_WIDTH}
    */
   width?: number;
-}
+};
 
 /**
  * @category Overlays
  */
-export interface Overlay {
+export type Overlay = {
   position: OverlayPosition;
   label?: string;
   style?: OverlayStyle;
-}
+};
 
 /**
  * @category Element Style


### PR DESCRIPTION
This pull request proposes a change to the **Overlay** types. 

Previously, these types were defined as `interface`. The changes suggests moving them to `type` aliases, aligning with TypeScript's philosophy. This change does not affect the API contract and is aimed at providing a better match to the intended usage of the structures, and a consistent declaration with the `StyleUpdate` type.

### Notes

1st proposed in #2673

According to the TypeScript documentation on ["Differences Between Type Aliases and Interfaces"](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#differences-between-type-aliases-and-interfaces), the main distinction is that types cannot be extended. 
By using `type` aliases instead of `interface`, we ensure that the **Overlay** types are appropriate for their purpose, as they are not intended to have methods.