### PR TITLE
chore(deps-dev): bump playwright from 1.30.0 to 1.33.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "minimist": "~1.2.8",
         "npm-run-all": "~4.1.5",
         "pinst": "~3.0.0",
-        "playwright": "~1.30.0",
+        "playwright": "~1.33.0",
         "postcss": "~8.4.23",
         "postcss-cli": "~10.1.0",
         "prettier": "~2.8.8",
@@ -9495,13 +9495,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.30.0.tgz",
-      "integrity": "sha512-ENbW5o75HYB3YhnMTKJLTErIBExrSlX2ZZ1C/FzmHjUYIfxj/UnI+DWpQr992m+OQVSg0rCExAOlRwB+x+yyIg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.33.0.tgz",
+      "integrity": "sha512-+zzU3V2TslRX2ETBRgQKsKytYBkJeLZ2xzUj4JohnZnxQnivoUvOvNbRBYWSYykQTO0Y4zb8NwZTYFUO+EpPBQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "playwright-core": "1.30.0"
+        "playwright-core": "1.33.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -9511,9 +9511,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.30.0.tgz",
-      "integrity": "sha512-7AnRmTCf+GVYhHbLJsGUtskWTE33SwMZkybJ0v6rqR1boxq2x36U7p1vDRV7HO2IwTZgmycracLxPEJI49wu4g==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.33.0.tgz",
+      "integrity": "sha512-aizyPE1Cj62vAECdph1iaMILpT0WUDCq3E6rW6I+dleSbBoGbktvJtzS6VHkZ4DKNEOG9qJpiom/ZxO+S15LAw==",
       "dev": true,
       "bin": {
         "playwright": "cli.js"
@@ -18800,18 +18800,18 @@
       }
     },
     "playwright": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.30.0.tgz",
-      "integrity": "sha512-ENbW5o75HYB3YhnMTKJLTErIBExrSlX2ZZ1C/FzmHjUYIfxj/UnI+DWpQr992m+OQVSg0rCExAOlRwB+x+yyIg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.33.0.tgz",
+      "integrity": "sha512-+zzU3V2TslRX2ETBRgQKsKytYBkJeLZ2xzUj4JohnZnxQnivoUvOvNbRBYWSYykQTO0Y4zb8NwZTYFUO+EpPBQ==",
       "dev": true,
       "requires": {
-        "playwright-core": "1.30.0"
+        "playwright-core": "1.33.0"
       }
     },
     "playwright-core": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.30.0.tgz",
-      "integrity": "sha512-7AnRmTCf+GVYhHbLJsGUtskWTE33SwMZkybJ0v6rqR1boxq2x36U7p1vDRV7HO2IwTZgmycracLxPEJI49wu4g==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.33.0.tgz",
+      "integrity": "sha512-aizyPE1Cj62vAECdph1iaMILpT0WUDCq3E6rW6I+dleSbBoGbktvJtzS6VHkZ4DKNEOG9qJpiom/ZxO+S15LAw==",
       "dev": true
     },
     "pngjs": {

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "minimist": "~1.2.8",
     "npm-run-all": "~4.1.5",
     "pinst": "~3.0.0",
-    "playwright": "~1.30.0",
+    "playwright": "~1.33.0",
     "postcss": "~8.4.23",
     "postcss-cli": "~10.1.0",
     "prettier": "~2.8.8",

--- a/test/config/jest.image.ts
+++ b/test/config/jest.image.ts
@@ -119,8 +119,9 @@ function toMatchImageSnapshotCustom(this: MatcherContext, received: Buffer, opti
   jestLog('Test path: %s', this.testPath);
   jestLog('Test name: %s', this.currentTestName);
   const executionCount = retriesCounter.getExecutionCount(testId);
-  jestLog('Execution count: %s', executionCount);
+  jestLog('Ready to execute toMatchImageSnapshot, execution count: %s', executionCount);
   const result = toMatchImageSnapshotWithRealSignature.call(this, received, options);
+  jestLog('toMatchImageSnapshot executed');
 
   if (!result.pass) {
     jestLog('Result: failure');

--- a/test/config/jest.image.ts
+++ b/test/config/jest.image.ts
@@ -14,13 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import debugLogger from 'debug';
 import type { MatchImageSnapshotOptions } from 'jest-image-snapshot';
 import { toMatchImageSnapshot } from 'jest-image-snapshot';
-import { copyFileSync } from 'node:fs';
 import { addAttach } from 'jest-html-reporters/helper';
+import { copyFileSync } from 'node:fs';
 import MatcherContext = jest.MatcherContext;
 import CustomMatcherResult = jest.CustomMatcherResult;
 
+const jestLog = debugLogger('bv:test:jest:img');
 const toMatchImageSnapshotWithRealSignature = toMatchImageSnapshot as (received: unknown, options?: MatchImageSnapshotOptions) => CustomMatcherResult;
 
 // The path is relative from the jest-html-reporters page to the folder storing the images
@@ -39,11 +41,15 @@ class RetriesCounter {
   private readonly retryTimes = parseInt(global[Symbol.for('RETRY_TIMES')], 10) || 0;
 
   hasReachMaxRetries(testId: unknown): boolean {
-    return !this.retryTimes || this.timesCalled.get(testId) > this.retryTimes;
+    return !this.retryTimes || this.getExecutionCount(testId) > this.retryTimes;
   }
 
   incrementExecutionCount(testId: unknown): void {
-    this.timesCalled.set(testId, (this.timesCalled.get(testId) || 0) + 1);
+    this.timesCalled.set(testId, this.getExecutionCount(testId) + 1);
+  }
+
+  getExecutionCount(testId: unknown): number {
+    return this.timesCalled.get(testId) ?? 0;
   }
 }
 
@@ -108,10 +114,16 @@ function saveAndRegisterImages(matcherContext: MatcherContext, received: Buffer,
 // All options properties used here are always set in bpmn-visualization tests
 // If the following implementation would be done directly in jest-image-snapshot, this won't be required as it set default values we cannot access here
 function toMatchImageSnapshotCustom(this: MatcherContext, received: Buffer, options: MatchImageSnapshotOptions): CustomMatcherResult {
+  const testId = this.currentTestName;
+  retriesCounter.incrementExecutionCount(testId);
+  jestLog('Test path: %s', this.testPath);
+  jestLog('Test name: %s', this.currentTestName);
+  const executionCount = retriesCounter.getExecutionCount(testId);
+  jestLog('Execution count: %s', executionCount);
   const result = toMatchImageSnapshotWithRealSignature.call(this, received, options);
+
   if (!result.pass) {
-    const testId = this.currentTestName;
-    retriesCounter.incrementExecutionCount(testId);
+    jestLog('Result: failure');
     if (retriesCounter.hasReachMaxRetries(testId)) {
       saveAndRegisterImages(this, received, options);
     }
@@ -119,8 +131,10 @@ function toMatchImageSnapshotCustom(this: MatcherContext, received: Buffer, opti
     // Add configured failure threshold in the error message
     const messages = result.message().split('\n');
     // For generalization, check options.failureThresholdType for percentage/pixel
-    const newMessage = [`${messages[0]} Failure threshold was set to ${options.failureThreshold * 100}%.`, ...messages.slice(1)].join('\n');
+    const newMessage = [`${messages[0]} Failure threshold was set to ${options.failureThreshold * 100}%. Execution count: ${executionCount}.`, ...messages.slice(1)].join('\n');
     result.message = () => newMessage;
+  } else {
+    jestLog('Result: success');
   }
 
   return result;

--- a/test/config/jest.image.ts
+++ b/test/config/jest.image.ts
@@ -116,8 +116,7 @@ function saveAndRegisterImages(matcherContext: MatcherContext, received: Buffer,
 function toMatchImageSnapshotCustom(this: MatcherContext, received: Buffer, options: MatchImageSnapshotOptions): CustomMatcherResult {
   const testId = this.currentTestName;
   retriesCounter.incrementExecutionCount(testId);
-  jestLog('Test path: %s', this.testPath);
-  jestLog('Test name: %s', this.currentTestName);
+  jestLog("Test: '%s' (test file path: '%s')", this.currentTestName, this.testPath);
   const executionCount = retriesCounter.getExecutionCount(testId);
   jestLog('Ready to execute toMatchImageSnapshot, execution count: %s', executionCount);
   const result = toMatchImageSnapshotWithRealSignature.call(this, received, options);

--- a/test/config/jest.retries.ts
+++ b/test/config/jest.retries.ts
@@ -19,4 +19,4 @@ limitations under the License.
 import envUtils = require('@test/shared/environment-utils.js');
 
 const onCi = envUtils.isRunningOnCi();
-jest.retryTimes(onCi ? 3 : 0);
+jest.retryTimes(onCi ? 3 : 0, { logErrorsBeforeRetry: true });

--- a/test/e2e/diagram.navigation.zoom.pan.test.ts
+++ b/test/e2e/diagram.navigation.zoom.pan.test.ts
@@ -24,7 +24,7 @@ import type { ImageSnapshotThresholdConfig } from './helpers/visu/image-snapshot
 import { ImageSnapshotConfigurator, MultiBrowserImageSnapshotThresholds } from './helpers/visu/image-snapshot-config';
 import { ZoomType } from '@lib/component/options';
 
-const log = debugLogger('bv:test:e2e:navigation:zp');
+const log = debugLogger('bv:test:e2e:navigation:zoom-pan');
 
 class MouseNavigationImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
   constructor() {

--- a/test/e2e/diagram.navigation.zoom.pan.test.ts
+++ b/test/e2e/diagram.navigation.zoom.pan.test.ts
@@ -87,7 +87,7 @@ describe('diagram navigation - zoom and pan with mouse', () => {
       ...config,
       customSnapshotIdentifier: 'mouse.panning',
     });
-    log('Image match done');
+    log('Image match OK');
   });
 
   describe.each([ZoomType.In, ZoomType.Out])(`ctrl + mouse: zoom %s`, (zoomType: ZoomType) => {

--- a/test/e2e/diagram.navigation.zoom.pan.test.ts
+++ b/test/e2e/diagram.navigation.zoom.pan.test.ts
@@ -91,7 +91,7 @@ describe('diagram navigation - zoom and pan with mouse', () => {
   });
 
   describe.each([ZoomType.In, ZoomType.Out])(`ctrl + mouse: zoom %s`, (zoomType: ZoomType) => {
-    it.each([1, 3])('zoom %s times', async (xTimes: number) => {
+    it.each([1, 3])('zoom [%s times]', async (xTimes: number) => {
       await pageTester.mouseZoom({ x: containerCenter.x + 200, y: containerCenter.y }, zoomType, xTimes);
 
       const image = await page.screenshot({ fullPage: true });

--- a/test/e2e/diagram.navigation.zoom.pan.test.ts
+++ b/test/e2e/diagram.navigation.zoom.pan.test.ts
@@ -65,15 +65,13 @@ describe('diagram navigation - zoom and pan with mouse', () => {
   let containerCenter: Point;
 
   beforeEach(async () => {
-    log('Test path: %s', expect.getState().testPath);
-    log('Start test: %s', expect.getState().currentTestName);
+    log("Start test: '%s' (test file path: '%s')", expect.getState().currentTestName, expect.getState().testPath);
 
     await pageTester.gotoPageAndLoadBpmnDiagram(bpmnDiagramName);
     containerCenter = await pageTester.getContainerCenter();
   });
   afterEach(() => {
-    log('Test path: %s', expect.getState().testPath);
-    log('End test: %s', expect.getState().currentTestName);
+    log("End test: '%s' (test file path: '%s')", expect.getState().currentTestName, expect.getState().testPath);
   });
 
   it('mouse panning', async () => {

--- a/test/e2e/diagram.navigation.zoom.pan.test.ts
+++ b/test/e2e/diagram.navigation.zoom.pan.test.ts
@@ -77,14 +77,19 @@ describe('diagram navigation - zoom and pan with mouse', () => {
   });
 
   it('mouse panning', async () => {
+    log('Starting mouse panning checks');
+    log('Doing mouse panning');
     await pageTester.mousePanning({ originPoint: containerCenter, destinationPoint: { x: containerCenter.x + 150, y: containerCenter.y + 40 } });
+    log('Mouse panning done');
 
+    log('Checking image match');
     const image = await page.screenshot({ fullPage: true });
     const config = imageSnapshotConfigurator.getConfig(bpmnDiagramName);
     expect(image).toMatchImageSnapshot({
       ...config,
       customSnapshotIdentifier: 'mouse.panning',
     });
+    log('Image match done');
   });
 
   describe.each([ZoomType.In, ZoomType.Out])(`ctrl + mouse: zoom %s`, (zoomType: ZoomType) => {

--- a/test/e2e/diagram.navigation.zoom.pan.test.ts
+++ b/test/e2e/diagram.navigation.zoom.pan.test.ts
@@ -90,7 +90,14 @@ describe('diagram navigation - zoom and pan with mouse', () => {
     log('Image match OK');
   });
 
-  describe.each([ZoomType.In, ZoomType.Out])(`ctrl + mouse: zoom %s`, (zoomType: ZoomType) => {
+  describe.each([ZoomType.In, ZoomType.Out])(`ctrl + mouse: zoom [%s]`, (zoomType: ZoomType) => {
+    beforeEach(() => {
+      log("Start test: '%s' (test file path: '%s')", expect.getState().currentTestName, expect.getState().testPath);
+    });
+    afterEach(() => {
+      log("End test: '%s' (test file path: '%s')", expect.getState().currentTestName, expect.getState().testPath);
+    });
+
     it.each([1, 3])('zoom [%s times]', async (xTimes: number) => {
       await pageTester.mouseZoom({ x: containerCenter.x + 200, y: containerCenter.y }, zoomType, xTimes);
 

--- a/test/e2e/diagram.navigation.zoom.pan.test.ts
+++ b/test/e2e/diagram.navigation.zoom.pan.test.ts
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import debugLogger from 'debug';
 import 'jest-playwright-preset';
 import { join } from 'node:path';
 import type { Page } from 'playwright';
@@ -22,6 +23,8 @@ import { AvailableTestPages, PageTester } from '@test/shared/visu/bpmn-page-util
 import type { ImageSnapshotThresholdConfig } from './helpers/visu/image-snapshot-config';
 import { ImageSnapshotConfigurator, MultiBrowserImageSnapshotThresholds } from './helpers/visu/image-snapshot-config';
 import { ZoomType } from '@lib/component/options';
+
+const log = debugLogger('bv:test:e2e:navigation:zp');
 
 class MouseNavigationImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
   constructor() {
@@ -62,8 +65,15 @@ describe('diagram navigation - zoom and pan with mouse', () => {
   let containerCenter: Point;
 
   beforeEach(async () => {
+    log('Test path: %s', expect.getState().testPath);
+    log('Start test: %s', expect.getState().currentTestName);
+
     await pageTester.gotoPageAndLoadBpmnDiagram(bpmnDiagramName);
     containerCenter = await pageTester.getContainerCenter();
+  });
+  afterEach(() => {
+    log('Test path: %s', expect.getState().testPath);
+    log('End test: %s', expect.getState().currentTestName);
   });
 
   it('mouse panning', async () => {

--- a/test/e2e/jest.config.js
+++ b/test/e2e/jest.config.js
@@ -24,7 +24,8 @@ module.exports = {
   rootDir: '../..',
   roots: ['./test/e2e'],
   testMatch: ['**/?(*.)+(spec|test).[t]s'],
-  testTimeout: 200000,
+  testTimeout: 200_000,
+  verbose: true, // Report each individual test run with execution time
   transform: {
     '^.+\\.ts?$': [
       'ts-jest',

--- a/test/e2e/jest.config.js
+++ b/test/e2e/jest.config.js
@@ -24,8 +24,8 @@ module.exports = {
   rootDir: '../..',
   roots: ['./test/e2e'],
   testMatch: ['**/?(*.)+(spec|test).[t]s'],
-  testTimeout: 400_000,
-  verbose: true, // Report each individual test run with execution time
+  testTimeout: 100_000,
+  verbose: false, // if true, report each individual test run with execution time
   transform: {
     '^.+\\.ts?$': [
       'ts-jest',

--- a/test/e2e/jest.config.js
+++ b/test/e2e/jest.config.js
@@ -24,7 +24,7 @@ module.exports = {
   rootDir: '../..',
   roots: ['./test/e2e'],
   testMatch: ['**/?(*.)+(spec|test).[t]s'],
-  testTimeout: 200_000,
+  testTimeout: 400_000,
   verbose: true, // Report each individual test run with execution time
   transform: {
     '^.+\\.ts?$': [

--- a/test/e2e/overlays.rendering.test.ts
+++ b/test/e2e/overlays.rendering.test.ts
@@ -327,6 +327,7 @@ describe('Overlay navigation', () => {
     await pageTester.gotoPageAndLoadBpmnDiagram(bpmnDiagramName);
     containerCenter = await pageTester.getContainerCenter();
 
+    log('Adding overlays');
     await pageTester.addOverlays('StartEvent_1', 'bottom-center');
     await pageTester.addOverlays('Activity_1', 'middle-right');
     await pageTester.addOverlays('Gateway_1', 'top-right');

--- a/test/e2e/overlays.rendering.test.ts
+++ b/test/e2e/overlays.rendering.test.ts
@@ -25,6 +25,9 @@ import type { Point } from '@test/shared/visu/bpmn-page-utils';
 import { AvailableTestPages, PageTester } from '@test/shared/visu/bpmn-page-utils';
 import type { ImageSnapshotThresholdConfig } from './helpers/visu/image-snapshot-config';
 import { ImageSnapshotConfigurator, MultiBrowserImageSnapshotThresholds } from './helpers/visu/image-snapshot-config';
+import debugLogger from 'debug';
+
+const log = debugLogger('bv:test:e2e:overlays');
 
 class ImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
   constructor() {
@@ -320,6 +323,7 @@ describe('Overlay navigation', () => {
   const imageSnapshotConfigurator = new ImageSnapshotConfigurator(new OverlayNavigationImageSnapshotThresholds(), 'overlays');
 
   beforeEach(async () => {
+    log("Start test: '%s' (test file path: '%s')", expect.getState().currentTestName, expect.getState().testPath);
     await pageTester.gotoPageAndLoadBpmnDiagram(bpmnDiagramName);
     containerCenter = await pageTester.getContainerCenter();
 
@@ -327,17 +331,26 @@ describe('Overlay navigation', () => {
     await pageTester.addOverlays('Activity_1', 'middle-right');
     await pageTester.addOverlays('Gateway_1', 'top-right');
     await pageTester.addOverlays('Flow_1', 'start');
+    log('Overlays added');
+  });
+  afterEach(() => {
+    log("End test: '%s' (test file path: '%s')", expect.getState().currentTestName, expect.getState().testPath);
   });
 
   it('panning', async () => {
+    log('Starting mouse panning checks');
+    log('Doing mouse panning');
     await pageTester.mousePanning({ originPoint: containerCenter, destinationPoint: { x: containerCenter.x + 150, y: containerCenter.y + 40 } });
+    log('Mouse panning done');
 
+    log('Checking image match');
     const image = await page.screenshot({ fullPage: true });
     const config = imageSnapshotConfigurator.getConfig(bpmnDiagramName);
     expect(image).toMatchImageSnapshot({
       ...config,
       customSnapshotIdentifier: 'panning',
     });
+    log('Image match OK');
   });
 
   it(`zoom out`, async () => {

--- a/test/shared/visu/bpmn-page-utils.ts
+++ b/test/shared/visu/bpmn-page-utils.ts
@@ -267,11 +267,13 @@ export class PageTester {
   }
 
   async mouseZoom(point: Point, zoomType: ZoomType, xTimes = 1): Promise<void> {
+    pageCheckLog('Start mouse zoom - point: %o / type: %o / xTimes: %s', point, zoomType, xTimes);
     for (let i = 0; i < xTimes; i++) {
       await this.mouseZoomNoDelay(point, zoomType);
       // delay here is needed to make the tests pass on macOS, delay must be greater than debounce timing, so it surely gets triggered
       await delay(envUtils.isRunningOnCISlowOS() ? 300 : 150);
     }
+    pageCheckLog('Mouse zoom done');
   }
 }
 

--- a/test/shared/visu/bpmn-page-utils.ts
+++ b/test/shared/visu/bpmn-page-utils.ts
@@ -250,10 +250,12 @@ export class PageTester {
   }
 
   async mousePanning({ originPoint, destinationPoint }: PanningOptions): Promise<void> {
+    pageCheckLog('Start mouse panning. Origin: %o / Destination: %o', originPoint, destinationPoint);
     await this.page.mouse.move(originPoint.x, originPoint.y);
     await this.page.mouse.down();
     await this.page.mouse.move(destinationPoint.x, destinationPoint.y);
     await this.page.mouse.up();
+    pageCheckLog('Mouse panning done');
   }
 
   async mouseZoomNoDelay(point: Point, zoomType: ZoomType): Promise<void> {


### PR DESCRIPTION
**POC: companion of #2567 to see if the firefox issue (macOS and Ubuntu) occurs with a more recent playwright version**
Changes proposed here will be merged through #2690.

When trying to update to playwright 1.31.x, some mouse panning tests seemed blocked and there wasn't enough logs to diagnose the problem.
So, configure jest and update tests to have more debug logs when running e2e tests.

Configuration
  - jest: log before retry to better identify the tests that have been retried
  - jest: reduce the test timeout from 200 seconds to 100 seconds. Normal executions always take less time, so having a large timeout took too much time prior marking the tests as in error. Reducing the value provide a faster feedback.
  - Custom jest image snapshot: add execution logs and execution count in error message

Tests code
  - "PageTester": add logs for mouse panning functions
  - "diagram navigation" tests: add logs for mouse panning and zoom tests + improve some test names for consistency with other tests
  - "overlays" test: add logs to compare with "diagram navigation" tests
