### PR TITLE
ci: run the "performance test" workflow less often

### DIFF
--- a/.github/workflows/test-performance.yml
+++ b/.github/workflows/test-performance.yml
@@ -14,7 +14,7 @@ on:
       - '.github/workflows/test-performance.yml'
       - 'test/*' # root folder
       - 'test/config/**/*'
-      - 'test/fixtures/**/*'
+      - 'test/fixtures/performance/**/*'
       - 'test/performance/**/*'
       - 'test/shared/**/*'
       - '.nvmrc'


### PR DESCRIPTION
It was previously run when any test diagram was changed. This occurs quite often when implementing new features whereas the performance tests don't use them.

Covers #2172