### PR TITLE
chore(deps): bump @typed-mxgraph/typed-mxgraph from 1.0.7 to 1.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.35.0-post",
       "license": "Apache-2.0",
       "dependencies": {
-        "@typed-mxgraph/typed-mxgraph": "~1.0.7",
+        "@typed-mxgraph/typed-mxgraph": "~1.0.8",
         "fast-xml-parser": "4.2.4",
         "lodash-es": "~4.17.21",
         "mxgraph": "4.2.2",
@@ -3275,9 +3275,9 @@
       }
     },
     "node_modules/@typed-mxgraph/typed-mxgraph": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@typed-mxgraph/typed-mxgraph/-/typed-mxgraph-1.0.7.tgz",
-      "integrity": "sha512-TKAgWWcZrBeKglzJ+H6/T4uE6WHHTdL2Nu7xOuQnCm5z4D0poZpn6JSa0FUHYa4HeJuuSFVzFiXkbGY4MqJSYA=="
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@typed-mxgraph/typed-mxgraph/-/typed-mxgraph-1.0.8.tgz",
+      "integrity": "sha512-rzTbmD/XofRq0YZMY/BU9cjbCTw9q8rpIvWRhQO0DcgCx3+rpHTsVOk3pfuhcnUigUYNFkljmDkRuVjbl7zZoQ=="
     },
     "node_modules/@types/argparse": {
       "version": "1.0.38",
@@ -14830,9 +14830,9 @@
       "dev": true
     },
     "@typed-mxgraph/typed-mxgraph": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@typed-mxgraph/typed-mxgraph/-/typed-mxgraph-1.0.7.tgz",
-      "integrity": "sha512-TKAgWWcZrBeKglzJ+H6/T4uE6WHHTdL2Nu7xOuQnCm5z4D0poZpn6JSa0FUHYa4HeJuuSFVzFiXkbGY4MqJSYA=="
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@typed-mxgraph/typed-mxgraph/-/typed-mxgraph-1.0.8.tgz",
+      "integrity": "sha512-rzTbmD/XofRq0YZMY/BU9cjbCTw9q8rpIvWRhQO0DcgCx3+rpHTsVOk3pfuhcnUigUYNFkljmDkRuVjbl7zZoQ=="
     },
     "@types/argparse": {
       "version": "1.0.38",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "utils:test:model": "node ./scripts/utils/dist/utils.mjs test/fixtures/bpmn/simple-start-task-end.bpmn --output model"
   },
   "dependencies": {
-    "@typed-mxgraph/typed-mxgraph": "~1.0.7",
+    "@typed-mxgraph/typed-mxgraph": "~1.0.8",
     "fast-xml-parser": "4.2.4",
     "lodash-es": "~4.17.21",
     "mxgraph": "4.2.2",


### PR DESCRIPTION
https://github.com/typed-mxgraph/typed-mxgraph/releases/tag/v1.0.8