### PR TITLE
refactor!: make `StyleConfigurator` internal

### DIFF
--- a/src/bpmn-visualization.ts
+++ b/src/bpmn-visualization.ts
@@ -27,7 +27,6 @@ export * from './model/bpmn/internal';
 
 // not part of the public API but needed for the custom theme examples
 export { IconPainter } from './component/mxgraph/shape/render/icon-painter';
-export { StyleConfigurator } from './component/mxgraph/config/StyleConfigurator';
 export * from './component/mxgraph/style';
 export * from './component/mxgraph/shape/render';
 

--- a/src/component/mxgraph/config/StyleConfigurator.ts
+++ b/src/component/mxgraph/config/StyleConfigurator.ts
@@ -24,11 +24,7 @@ const arrowDefaultSize = 12;
 
 /**
  * Configure the styles used for BPMN rendering.
- *
- * **WARN**: You may use it to customize the BPMN Theme as suggested in the examples. But be aware that the way the default BPMN theme can be modified is subject to change.
- *
- * @category BPMN Theme
- * @experimental
+ * @internal
  */
 export class StyleConfigurator {
   private specificFlowStyles = new MapWithDefault<FlowKind>([


### PR DESCRIPTION
`StyleConfigurator` was previously exported for customization of the BPMN theme. These customizations were closely linked to the StyleConfigurator implementation, so they were fragile and could break quite often. We now have simpler ways of configuring the theme, even if the final implementation is not available. So, we can make `StyleConfigurator` internal.

### Notes

This class was marked as experimental so it is valid to remove it.
Examples update: https://github.com/process-analytics/bpmn-visualization-examples/pull/504

### Tasks

- [ ] no more in the API doc in HTML
- [ ] no more exported in the types in the npm package
- [ ] no more exported in the bundles of the npm package