### PR TITLE
chore(dependabot): groups dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,31 @@ updates:
       - skip-changelog
     reviewers:
       - process-analytics/pa-collaborators
+    groups:
+       css:
+          patterns:
+            - "autoprefixer"
+            - "cssnano"
+            - "postcss*"
+            - "tailwindcss"
+       jest:
+          patterns:
+            - "@types/jest-*"
+            - "jest"
+            - "jest-*"
+            - "ts-jest"
+       lint:
+          patterns:
+            - "@typescript-eslint/*"
+            - "eslint"
+            - "eslint-*"
+            - "lint-staged"
+            - "prettier"
+       rollup:
+          patterns:
+            - "@rollup/*"
+            - "rollup"
+            - "rollup-plugin-*"
 
   - package-ecosystem: "github-actions"
     # Workflow files stored in the default location of `.github/workflows`


### PR DESCRIPTION
Configure the new beta `groups` options to update development dependencies by group of features.
This reduces the number of Pull Requests to be reviewed  and ensure that related dependencies are updated at the same time.

closes #2511 

### Notes
Validated with https://github.com/tbouffard/experiment-dependabot-groups.
This is the same configuration as in the test repository expect the `eslint` group which has been renamed (and then moved to keep alphabetic order) into `lint` (more general as it also includes prettier and other libs.

### Resources

- https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/
- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups