### PR TITLE
chore(eslint): fix the notice rule in the typescript-support /test/folder

### DIFF
--- a/test/typescript-support/.eslintrc.js
+++ b/test/typescript-support/.eslintrc.js
@@ -1,0 +1,21 @@
+/*
+Copyright 2023 Bonitasoft S.A.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+module.exports = {
+  rules: {
+    'notice/notice': 'off',
+  },
+};


### PR DESCRIPTION
Fix following error in **IntelliJ 2023.2**:

> Error: Error while loading rule 'notice/notice': Can't find templateFile @ .../BPMN-Visualization/test/typescript-support/config/license-header.js Occurred while linting .../BPMN-Visualization/test/typescript-support/src/index.ts


