### PR TITLE
fix: reset the style of elements only when passing nullish param

### DIFF
--- a/src/component/mxgraph/GraphCellUpdater.ts
+++ b/src/component/mxgraph/GraphCellUpdater.ts
@@ -122,9 +122,9 @@ export default class GraphCellUpdater {
     });
   }
 
-  resetStyle(bpmnElementIds: string[]): void {
+  resetStyle(bpmnElementIds: string | string[]): void {
     this.graph.batchUpdate(() => {
-      if (bpmnElementIds.length == 0) {
+      if (!bpmnElementIds) {
         this.styleManager.resetAllStyles();
       } else {
         for (const id of withCellIdsOfMessageFlowIcons(bpmnElementIds)) {

--- a/src/component/registry/bpmn-elements-registry.ts
+++ b/src/component/registry/bpmn-elements-registry.ts
@@ -71,7 +71,7 @@ export class BpmnElementsRegistry {
   /**
    * Get all elements by ids. The returned array contains elements in the order of the `bpmnElementIds` parameter.
    *
-   * Not found elements are not returned as undefined in the array, so the returned array contains at most as much elements as the `bpmnElementIds` parameter.
+   * Not found elements are not returned as undefined in the array, so the returned array contains at most as many elements as the `bpmnElementIds` parameter.
    *
    * ```javascript
    * ...
@@ -144,7 +144,7 @@ export class BpmnElementsRegistry {
    * bpmnVisualization.bpmnElementsRegistry.addCssClasses('task_3', ['suspicious-path', 'additional-info']);
    * ```
    *
-   * @param bpmnElementIds The BPMN ID of the element(s) to add the CSS classes to.
+   * @param bpmnElementIds The BPMN ID of the element(s) to add the CSS classes to. Passing a nullish parameter or an empty array has no effect.
    * @param classNames The name of the class(es) to add to the BPMN element(s).
    *
    * @see {@link removeCssClasses} to remove specific CSS classes from a BPMN element.
@@ -159,7 +159,7 @@ export class BpmnElementsRegistry {
   /**
    * Remove one or more CSS classes that were previously added to one or more BPMN elements using the {@link addCssClasses} or the {@link toggleCssClasses} methods.
    *
-   * **Note**: If an ID is passed that does not reference an existing BPMN element, no rendering changes are made.
+   * **Note**: If you pass IDs that are not related to existing BPMN elements, they will be ignored and no changes will be made to the rendering.
    *
    * @example
    * ```javascript
@@ -170,7 +170,7 @@ export class BpmnElementsRegistry {
    * bpmnVisualization.bpmnElementsRegistry.removeCssClasses('task_3', ['running', 'additional-info']);
    * ```
    *
-   * @param bpmnElementIds The BPMN ID of the element(s) from which to remove the CSS classes.
+   * @param bpmnElementIds The BPMN ID of the element(s) from which to remove the CSS classes. Passing a nullish parameter or an empty array has no effect.
    * @param classNames The name of the class(es) to remove from the BPMN element(s).
    *
    * @see {@link removeAllCssClasses} to remove all CSS classes from a BPMN element.
@@ -182,7 +182,7 @@ export class BpmnElementsRegistry {
   /**
    * Remove any CSS classes that were previously added to one or more BPMN elements using the {@link addCssClasses} or the {@link toggleCssClasses} methods.
    *
-   * **Note**: If an ID is passed that does not reference an existing BPMN element, no rendering changes are made.
+   * **Note**: If you pass IDs that are not related to existing BPMN elements, they will be ignored and no changes will be made to the rendering.
    *
    * @example
    * ```javascript
@@ -197,7 +197,7 @@ export class BpmnElementsRegistry {
    * ```
    *
    * @param bpmnElementIds The BPMN ID of the element(s) from which to remove all CSS classes.
-   * If no IDs are specified, all CSS classes associated with BPMN elements will be removed.
+   * When passing a nullish parameter, all CSS classes associated with all BPMN elements will be removed. Passing an empty array has no effect.
    *
    * @see {@link removeCssClasses} to remove specific classes from a BPMN element.
    * @since 0.34.0
@@ -229,7 +229,7 @@ export class BpmnElementsRegistry {
    * bpmnVisualization.bpmnElementsRegistry.toggleCssClasses('task_3', ['running', 'additional-info']);
    * ```
    *
-   * @param bpmnElementIds The BPMN ID of the element(s) on which to toggle the CSS classes.
+   * @param bpmnElementIds The BPMN ID of the element(s) on which to toggle the CSS classes. Passing a nullish parameter or an empty array has no effect.
    * @param classNames The name of the class(es) to toggle on the BPMN element(s).
    *
    * @see {@link removeCssClasses} to remove specific CSS classes from a BPMN element.
@@ -365,12 +365,12 @@ export class BpmnElementsRegistry {
    *
    * - This method is intended to update the style of specific elements, e.g. to update their colors. When rendering a BPMN diagram, `bpmn-visualization` applies style properties
    * to all elements according to their types.
-   * So if you want to style all elements of a certain type, change the default configuration of the styles instead of updating the element afterwards. See the repository providing the
+   * So if you want to style all elements of a certain type, change the default configuration of the styles instead of updating the element afterward. See the repository providing the
    * [examples of the `bpmn-visualization` TypeScript library](https://github.com/process-analytics/bpmn-visualization-examples/) for more details.
    * - If you pass IDs that are not related to existing BPMN elements, they will be ignored and no changes will be made to the rendering.
    *
    * @param bpmnElementIds The BPMN ID of the element(s) whose style must be reset.
-   * If no IDs are specified, the style of all BPMN elements will be reset.
+   * When passing a nullish parameter, the style of all BPMN elements will be reset. Passing an empty array has no effect.
    *
    * @see {@link updateStyle} to update the style of one or several BPMN elements.
    * @see {@link addCssClasses} to add CSS classes to a BPMN element.
@@ -380,7 +380,7 @@ export class BpmnElementsRegistry {
    * @since 0.37.0
    */
   resetStyle(bpmnElementIds?: string | string[]): void {
-    this.graphCellUpdater.resetStyle(ensureIsArray<string>(bpmnElementIds));
+    this.graphCellUpdater.resetStyle(bpmnElementIds);
   }
 }
 

--- a/test/integration/jest.config.js
+++ b/test/integration/jest.config.js
@@ -43,6 +43,7 @@ module.exports = {
   coverageReporters: ['lcov', 'text-summary'],
   coverageDirectory: 'build/test-report/integration',
   setupFilesAfterEnv: [
+    'jest-extended/all',
     './test/integration/config/mxgraph-config.ts',
     // put at the latest place to see logs that could be displayed by setup files
     './test/integration/config/hide-console-warnings.js',

--- a/test/integration/mxGraph.model.css.api.test.ts
+++ b/test/integration/mxGraph.model.css.api.test.ts
@@ -24,8 +24,10 @@ describe('mxGraph model - CSS API', () => {
     bpmnVisualization.load(readFileSync('../fixtures/bpmn/registry/1-pool-3-lanes-message-start-end-intermediate-events.bpmn'));
   });
 
+  const bpmnElementsRegistry = bpmnVisualization.bpmnElementsRegistry;
+
   test('Add CSS classes on Shape', () => {
-    bpmnVisualization.bpmnElementsRegistry.addCssClasses('userTask_2_2', ['class#1', 'class#2']);
+    bpmnElementsRegistry.addCssClasses('userTask_2_2', ['class#1', 'class#2']);
     expect('userTask_2_2').toBeUserTask({
       extraCssClasses: ['class#1', 'class#2'],
       // not under test
@@ -35,12 +37,84 @@ describe('mxGraph model - CSS API', () => {
   });
 
   test('Add CSS classes on Edge', () => {
-    bpmnVisualization.bpmnElementsRegistry.addCssClasses('sequenceFlow_lane_3_elt_3', ['class-1', 'class-2', 'class-3']);
+    bpmnElementsRegistry.addCssClasses('sequenceFlow_lane_3_elt_3', ['class-1', 'class-2', 'class-3']);
     expect('sequenceFlow_lane_3_elt_3').toBeSequenceFlow({
       extraCssClasses: ['class-1', 'class-2', 'class-3'],
       // not under test
       parentId: 'lane_03',
       verticalAlign: 'bottom',
+    });
+  });
+
+  describe('Remove CSS classes - special cases', () => {
+    const emptyArray: string[] = [];
+    it.each([null, undefined, emptyArray])('Remove CSS classes with parameter: %s', (bpmnElementIds: string) => {
+      // ensure we pass an empty array
+      if (bpmnElementIds) {
+        // eslint-disable-next-line jest/no-conditional-expect -- here we only validate the test parameter
+        expect(emptyArray).toBeArray();
+        // eslint-disable-next-line jest/no-conditional-expect
+        expect(emptyArray).toHaveLength(0);
+      }
+
+      bpmnElementsRegistry.addCssClasses(['userTask_2_2', 'sequenceFlow_lane_3_elt_3'], ['class1', 'class2']);
+
+      // should have no effect
+      bpmnElementsRegistry.removeCssClasses(bpmnElementIds, ['class1', 'class3']);
+
+      expect('userTask_2_2').toBeUserTask({
+        extraCssClasses: ['class1', 'class2'],
+        // not under test
+        parentId: 'lane_02',
+        label: 'User Task 2.2',
+      });
+      expect('sequenceFlow_lane_3_elt_3').toBeSequenceFlow({
+        extraCssClasses: ['class1', 'class2'],
+        // not under test
+        parentId: 'lane_03',
+        verticalAlign: 'bottom',
+      });
+    });
+  });
+
+  describe('Remove all CSS classes - special cases', () => {
+    it.each([null, undefined])('Remove all CSS classes with nullish parameter: %s', (nullishResetParameter: string) => {
+      bpmnElementsRegistry.addCssClasses(['userTask_2_2', 'sequenceFlow_lane_3_elt_3'], ['class1', 'class2']);
+
+      bpmnElementsRegistry.removeAllCssClasses(nullishResetParameter);
+
+      expect('userTask_2_2').toBeUserTask({
+        extraCssClasses: undefined,
+        // not under test
+        parentId: 'lane_02',
+        label: 'User Task 2.2',
+      });
+      expect('sequenceFlow_lane_3_elt_3').toBeSequenceFlow({
+        extraCssClasses: undefined,
+        // not under test
+        parentId: 'lane_03',
+        verticalAlign: 'bottom',
+      });
+    });
+
+    it('Remove all CSS classes with an empty array', () => {
+      bpmnElementsRegistry.addCssClasses(['userTask_2_2', 'sequenceFlow_lane_3_elt_3'], ['class#1', 'class#2']);
+
+      // should have no effect
+      bpmnElementsRegistry.removeAllCssClasses([]);
+
+      expect('userTask_2_2').toBeUserTask({
+        extraCssClasses: ['class#1', 'class#2'],
+        // not under test
+        parentId: 'lane_02',
+        label: 'User Task 2.2',
+      });
+      expect('sequenceFlow_lane_3_elt_3').toBeSequenceFlow({
+        extraCssClasses: ['class#1', 'class#2'],
+        // not under test
+        parentId: 'lane_03',
+        verticalAlign: 'bottom',
+      });
     });
   });
 });

--- a/test/integration/mxGraph.model.style.api.test.ts
+++ b/test/integration/mxGraph.model.style.api.test.ts
@@ -1128,6 +1128,60 @@ describe('mxGraph model - reset style', () => {
         verticalAlign: 'bottom',
       });
     });
+
+    describe('Reset style - special cases', () => {
+      const bpmnElementsRegistry = bpmnVisualization.bpmnElementsRegistry;
+
+      it.each([null, undefined])('Reset style with nullish parameter: %s', (nullishResetParameter: string) => {
+        // Apply custom style
+        const customStyle: StyleUpdate = {
+          font: { color: 'blue' },
+        };
+        bpmnElementsRegistry.updateStyle(['startEvent_lane_1', 'sequenceFlow_lane_1_elt_1'], customStyle);
+
+        // Reset style
+        bpmnElementsRegistry.resetStyle(nullishResetParameter);
+
+        // Check that the style has been reset to default values for each element
+        expect('startEvent_lane_1').toBeStartEvent({
+          // not under test
+          eventDefinitionKind: ShapeBpmnEventDefinitionKind.MESSAGE,
+          parentId: 'lane_01',
+          label: 'message start 1',
+        });
+        expect('sequenceFlow_lane_1_elt_1').toBeSequenceFlow({
+          // not under test
+          parentId: 'lane_01',
+          verticalAlign: 'bottom',
+        });
+      });
+
+      it('Reset style with an empty array', () => {
+        // Apply custom style
+        const customStyle: StyleUpdate = {
+          opacity: 25,
+        };
+        bpmnElementsRegistry.updateStyle(['startEvent_lane_1', 'sequenceFlow_lane_1_elt_1'], customStyle);
+
+        // Reset style. It should have no effect.
+        bpmnElementsRegistry.resetStyle([]);
+
+        // Check that the style has been reset to default values for each element
+        expect('startEvent_lane_1').toBeStartEvent({
+          opacity: 25,
+          // not under test
+          eventDefinitionKind: ShapeBpmnEventDefinitionKind.MESSAGE,
+          parentId: 'lane_01',
+          label: 'message start 1',
+        });
+        expect('sequenceFlow_lane_1_elt_1').toBeSequenceFlow({
+          opacity: 25,
+          // not under test
+          parentId: 'lane_01',
+          verticalAlign: 'bottom',
+        });
+      });
+    });
   });
 
   // Check that there is no bad interactions between the two features


### PR DESCRIPTION
Previously, passing an empty array acts like passing a nullish parameter. The style of all elements was reset.

Also update the JSDoc of some methods of `BpmnElementsRegistry` to clarify what exactly happen when passing nullish or empty array as parameter for the ids of the BPMN elements. Create the corresponding integration tests to confirm the actual behavior.

covers https://github.com/process-analytics/bv-experimental-add-ons/issues/67