### PR TITLE
chore(release): publish announce tweet manually

### DIFF
--- a/.github/workflows/announce-new-release.yml
+++ b/.github/workflows/announce-new-release.yml
@@ -12,25 +12,6 @@ on:
         required: true
 
 jobs:
-  publish_tweet:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Publish a tweet
-        uses: snow-actions/tweet@v1.4.0
-        with:
-          status: |
-            📣 bpmn-visualization ${{ github.event.inputs.version }} is out! 🎉
-
-            ${{ github.event.inputs.description }}
-
-            #bpmnvisualization #bpmn #visualization #typescript #opensource
-            ${{ github.server_url }}/${{ github.repository }}/releases/tag/v${{ github.event.inputs.version }}
-        env:
-          CONSUMER_API_KEY: ${{ secrets.TWITTER_CONSUMER_API_KEY }}
-          CONSUMER_API_SECRET_KEY: ${{ secrets.TWITTER_CONSUMER_API_SECRET_KEY }}
-          ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
-          ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
-
   publish_discord_post:
     runs-on: ubuntu-22.04
     steps:

--- a/docs/contributors/maintainers.md
+++ b/docs/contributors/maintainers.md
@@ -174,11 +174,13 @@ ___
 - Provide parameter values for _version_ and _description_
 - Click on the button 'Run workflow'
 - Make sure job execution was successful by checking the status
-- If all is good, you should see a new tweet on [ProcessAnalyti1](https://twitter.com/ProcessAnalyti1) and a new message on the [news](https://discord.com/channels/1011911769607913562/1024329159033499780) channel of Process Analytics server on Discord.
+- If all is good, you should see a new message on the [news](https://discord.com/channels/1011911769607913562/1024329159033499780) channel of Process Analytics server on Discord.
 
-___
-⚠️⚠️⚠️ _**Only if the [jobs](https://github.com/process-analytics/bpmn-visualization-js/actions/workflows/announce-new-release.yml) does NOT work!**_  ⚠️⚠️⚠️
 ### Twitter
+
+It is no longer possible to post a tweet with the API without a paid plan (and we only have a free plan). See [#2676](https://github.com/process-analytics/bpmn-visualization-js/issues/2676) for more details.
+
+So, create the tweet manually on [ProcessAnalyti1](https://twitter.com/ProcessAnalyti1).
 
 You can use this template:
 
@@ -190,6 +192,8 @@ You can use this template:
 >
 > https://github.com/process-analytics/bpmn-visualization-js/releases/tag/v{version}
 
+___
+⚠️⚠️⚠️ _**Only if the [jobs](https://github.com/process-analytics/bpmn-visualization-js/actions/workflows/announce-new-release.yml) does NOT work!**_  ⚠️⚠️⚠️
 ### Discord
 
 Channel: [news](https://discord.com/channels/1011911769607913562/1024329159033499780)


### PR DESCRIPTION
It is no longer possible to post a tweet with the API without a paid plan (and we only have a free plan). So, remove the automation and documentation how to do it manually.

closes #2676