### PR TITLE
test: refactor JsonParser unit tests and type handling enhancements

### DIFF
--- a/src/component/parser/json/converter/ProcessConverter.ts
+++ b/src/component/parser/json/converter/ProcessConverter.ts
@@ -194,11 +194,8 @@ export default class ProcessConverter {
         shapeBpmnElement = new ShapeBpmnElement(bpmnElement.id, name, kind, parentId, bpmnElement.instantiate);
       }
 
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- We know that the 'default' field is not on all types, but it's already tested
-      // @ts-ignore
-      const defaultFlow = bpmnElement.default;
-      if (ShapeUtil.isWithDefaultSequenceFlow(kind) && defaultFlow) {
-        this.defaultSequenceFlowIds.push(defaultFlow);
+      if ('default' in bpmnElement && ShapeUtil.isWithDefaultSequenceFlow(kind)) {
+        this.defaultSequenceFlowIds.push(bpmnElement.default);
       }
 
       if (shapeBpmnElement) {

--- a/test/unit/component/parser/json/BpmnJsonParser.association.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.association.test.ts
@@ -14,12 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 import { buildDefinitions } from '../../../helpers/JsonBuilder';
 import type { BuildProcessParameter } from '../../../helpers/JsonBuilder';
 import { parseJsonAndExpectOnlyEdges } from '../../../helpers/JsonTestUtils';
 import { verifyEdge } from '../../../helpers/bpmn-model-expect';
 
+import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 import { Waypoint } from '@lib/model/bpmn/internal/edge/edge';
 
 describe('parse bpmn as json for association', () => {

--- a/test/unit/component/parser/json/BpmnJsonParser.association.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.association.test.ts
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 import { buildDefinitions } from '../../../helpers/JsonBuilder';
 import type { BuildProcessParameter } from '../../../helpers/JsonBuilder';
 import { parseJsonAndExpectOnlyEdges } from '../../../helpers/JsonTestUtils';
@@ -88,7 +89,7 @@ describe('parse bpmn as json for association', () => {
   });
 
   it('should convert as Edge, when BPMNDiagram is an array', () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         process: processJsonAsObjectWithAssociationJsonAsObject,

--- a/test/unit/component/parser/json/BpmnJsonParser.edge.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.edge.test.ts
@@ -14,13 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 import { expectAsWarning, parseJsonAndExpectOnlyWarnings, parsingMessageCollector } from '../../../helpers/JsonTestUtils';
 import { EdgeUnknownBpmnElementWarning } from '@lib/component/parser/json/warnings';
 
 describe('parse bpmn as json for edges', () => {
   // this also covers unsupported bpmn element types that are then not retrieved during the parsing
   it('should not convert as Edge without related BPMN element', () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         process: '',

--- a/test/unit/component/parser/json/BpmnJsonParser.edge.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.edge.test.ts
@@ -14,8 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 import { expectAsWarning, parseJsonAndExpectOnlyWarnings, parsingMessageCollector } from '../../../helpers/JsonTestUtils';
+
+import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 import { EdgeUnknownBpmnElementWarning } from '@lib/component/parser/json/warnings';
 
 describe('parse bpmn as json for edges', () => {

--- a/test/unit/component/parser/json/BpmnJsonParser.flowNode.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.flowNode.test.ts
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 import { buildDefinitions } from '../../../helpers/JsonBuilder';
 import { parseJsonAndExpectOnlyEdgesAndFlowNodes, parseJsonAndExpectOnlyFlowNodes } from '../../../helpers/JsonTestUtils';
 import type { ExpectedShape } from '../../../helpers/bpmn-model-expect';
@@ -48,7 +49,7 @@ describe.each([
     ['object', processWithFlowNodeAsObject],
     ['array', [processWithFlowNodeAsObject]],
   ])(`should convert as Shape, when a ${bpmnKind} is an attribute (as object) of 'process' (as %s)`, (title: string, processJson: TProcess) => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         process: processJson,
@@ -77,7 +78,7 @@ describe.each([
   });
 
   it(`should convert as Shape, when a ${bpmnKind} (with/without name) is an attribute (as array) of 'process'`, () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         process: {},
@@ -140,7 +141,7 @@ describe.each([
 
   if (expectedShapeBpmnElementKind === ShapeBpmnElementKind.TASK_RECEIVE) {
     it(`should convert as Shape, when a ${bpmnKind} (with/without instantiate) is an attribute (as array) of 'process'`, () => {
-      const json = {
+      const json: BpmnJsonModel = {
         definitions: {
           targetNamespace: '',
           process: {},
@@ -207,7 +208,7 @@ describe.each([
 
   if (expectedShapeBpmnElementKind === ShapeBpmnElementKind.GATEWAY_EVENT_BASED) {
     it(`should convert as Shape, when a ${bpmnKind} (with/without instantiate) is an attribute (as array) of 'process'`, () => {
-      const json = {
+      const json: BpmnJsonModel = {
         definitions: {
           targetNamespace: '',
           process: {},

--- a/test/unit/component/parser/json/BpmnJsonParser.flowNode.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.flowNode.test.ts
@@ -202,8 +202,7 @@ describe.each([
             [bpmnKind]: [
               { id: `${bpmnKind}_id_1` },
               { id: `${bpmnKind}_id_2`, eventGatewayType: 'Exclusive' },
-              // forbidden by the BPMN spec, only valid when 'instantiate: true'
-              { id: `${bpmnKind}_id_3`, eventGatewayType: 'Parallel' },
+              { id: `${bpmnKind}_id_3`, eventGatewayType: 'Parallel' }, // forbidden by the BPMN spec, only valid when 'instantiate: true'
               { id: `${bpmnKind}_id_11`, instantiate: true },
               { id: `${bpmnKind}_id_12`, instantiate: true, eventGatewayType: 'Exclusive' },
               { id: `${bpmnKind}_id_13`, instantiate: true, eventGatewayType: 'Parallel' },

--- a/test/unit/component/parser/json/BpmnJsonParser.flowNode.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.flowNode.test.ts
@@ -39,16 +39,17 @@ describe.each([
   ['eventBasedGateway', ShapeBpmnElementKind.GATEWAY_EVENT_BASED],
   ['complexGateway', ShapeBpmnElementKind.GATEWAY_COMPLEX],
 ])('parse bpmn as json for %s', (bpmnKind: string, expectedShapeBpmnElementKind: ShapeBpmnElementKind) => {
-  const processWithFlowNodeAsObject = {} as TProcess;
-  processWithFlowNodeAsObject[`${bpmnKind}`] = {
-    id: `${bpmnKind}_id_0`,
-    name: `${bpmnKind} name`,
+  const processWithFlowNodeAsObject: TProcess = {
+    [bpmnKind]: {
+      id: `${bpmnKind}_id_0`,
+      name: `${bpmnKind} name`,
+    },
   };
 
   it.each([
     ['object', processWithFlowNodeAsObject],
     ['array', [processWithFlowNodeAsObject]],
-  ])(`should convert as Shape, when a ${bpmnKind} is an attribute (as object) of 'process' (as %s)`, (title: string, processJson: TProcess) => {
+  ])(`should convert as Shape, when a ${bpmnKind} is an attribute (as object) of 'process' (as %s)`, (title: string, processJson: TProcess | TProcess[]) => {
     const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
@@ -81,7 +82,9 @@ describe.each([
     const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
-        process: {},
+        process: {
+          [bpmnKind]: [{ id: `${bpmnKind}_id_0`, name: `${bpmnKind} name` }, { id: `${bpmnKind}_id_1` }],
+        },
         BPMNDiagram: {
           name: 'process 0',
           BPMNPlane: {
@@ -101,15 +104,6 @@ describe.each([
         },
       },
     };
-    (json.definitions.process as TProcess)[`${bpmnKind}`] = [
-      {
-        id: `${bpmnKind}_id_0`,
-        name: `${bpmnKind} name`,
-      },
-      {
-        id: `${bpmnKind}_id_1`,
-      },
-    ];
 
     const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
 
@@ -144,7 +138,9 @@ describe.each([
       const json: BpmnJsonModel = {
         definitions: {
           targetNamespace: '',
-          process: {},
+          process: {
+            [bpmnKind]: [{ id: `${bpmnKind}_id_0` }, { id: `${bpmnKind}_id_1`, instantiate: true }],
+          },
           BPMNDiagram: {
             name: 'process 0',
             BPMNPlane: {
@@ -164,15 +160,6 @@ describe.each([
           },
         },
       };
-      (json.definitions.process as TProcess)[`${bpmnKind}`] = [
-        {
-          id: `${bpmnKind}_id_0`,
-        },
-        {
-          id: `${bpmnKind}_id_1`,
-          instantiate: true,
-        },
-      ];
 
       const model = parseJsonAndExpectOnlyFlowNodes(json, 2);
 
@@ -211,7 +198,17 @@ describe.each([
       const json: BpmnJsonModel = {
         definitions: {
           targetNamespace: '',
-          process: {},
+          process: {
+            [bpmnKind]: [
+              { id: `${bpmnKind}_id_1` },
+              { id: `${bpmnKind}_id_2`, eventGatewayType: 'Exclusive' },
+              // forbidden by the BPMN spec, only valid when 'instantiate: true'
+              { id: `${bpmnKind}_id_3`, eventGatewayType: 'Parallel' },
+              { id: `${bpmnKind}_id_11`, instantiate: true },
+              { id: `${bpmnKind}_id_12`, instantiate: true, eventGatewayType: 'Exclusive' },
+              { id: `${bpmnKind}_id_13`, instantiate: true, eventGatewayType: 'Parallel' },
+            ],
+          },
           BPMNDiagram: {
             name: 'process 0',
             BPMNPlane: {
@@ -251,33 +248,6 @@ describe.each([
           },
         },
       };
-      (json.definitions.process as TProcess)[`${bpmnKind}`] = [
-        {
-          id: `${bpmnKind}_id_1`,
-        },
-        {
-          id: `${bpmnKind}_id_2`,
-          eventGatewayType: 'Exclusive',
-        },
-        {
-          id: `${bpmnKind}_id_3`,
-          eventGatewayType: 'Parallel', // forbidden by the BPMN spec, only valid when 'instantiate: true'
-        },
-        {
-          id: `${bpmnKind}_id_11`,
-          instantiate: true,
-        },
-        {
-          id: `${bpmnKind}_id_12`,
-          instantiate: true,
-          eventGatewayType: 'Exclusive',
-        },
-        {
-          id: `${bpmnKind}_id_13`,
-          instantiate: true,
-          eventGatewayType: 'Parallel',
-        },
-      ];
 
       const model = parseJsonAndExpectOnlyFlowNodes(json, 6);
 

--- a/test/unit/component/parser/json/BpmnJsonParser.flowNode.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.flowNode.test.ts
@@ -14,12 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 import { buildDefinitions } from '../../../helpers/JsonBuilder';
 import { parseJsonAndExpectOnlyEdgesAndFlowNodes, parseJsonAndExpectOnlyFlowNodes } from '../../../helpers/JsonTestUtils';
 import type { ExpectedShape } from '../../../helpers/bpmn-model-expect';
 import { verifyShape } from '../../../helpers/bpmn-model-expect';
 
+import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 import type { TProcess } from '@lib/model/bpmn/json/baseElement/rootElement/rootElement';
 import { ShapeBpmnElementKind, ShapeBpmnEventBasedGatewayKind, ShapeUtil } from '@lib/model/bpmn/internal';
 import type { ShapeBpmnEventBasedGateway } from '@lib/model/bpmn/internal/shape/ShapeBpmnElement';

--- a/test/unit/component/parser/json/BpmnJsonParser.group.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.group.test.ts
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 import {
   expectAsWarning,
   parseJsonAndExpectOnlyFlowNodes,
@@ -24,6 +23,8 @@ import {
   parsingMessageCollector,
 } from '../../../helpers/JsonTestUtils';
 import { verifyShape } from '../../../helpers/bpmn-model-expect';
+
+import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 import { ShapeBpmnElementKind } from '@lib/model/bpmn/internal';
 import { GroupUnknownCategoryValueWarning, ShapeUnknownBpmnElementWarning } from '@lib/component/parser/json/warnings';
 

--- a/test/unit/component/parser/json/BpmnJsonParser.group.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.group.test.ts
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 import {
   expectAsWarning,
   parseJsonAndExpectOnlyFlowNodes,
@@ -28,7 +29,7 @@ import { GroupUnknownCategoryValueWarning, ShapeUnknownBpmnElementWarning } from
 
 describe('parse bpmn as json for group', () => {
   it('Single Group with label in process', () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         process: {
@@ -78,7 +79,7 @@ describe('parse bpmn as json for group', () => {
   });
 
   it('Several Groups with or without label in process', () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         process: {
@@ -165,7 +166,7 @@ describe('parse bpmn as json for group', () => {
   });
 
   it('Single Group with label in collaboration', () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         collaboration: {
@@ -241,7 +242,7 @@ describe('parse bpmn as json for group', () => {
 
   describe('Robustness', () => {
     it('Single Group in process without matching categoryValueRef', () => {
-      const json = {
+      const json: BpmnJsonModel = {
         definitions: {
           targetNamespace: '',
           process: {
@@ -284,7 +285,7 @@ describe('parse bpmn as json for group', () => {
     }
 
     it('Single Group in collaboration without matching categoryValueRef', () => {
-      const json = {
+      const json: BpmnJsonModel = {
         definitions: {
           targetNamespace: '',
           collaboration: {

--- a/test/unit/component/parser/json/BpmnJsonParser.label.bounds.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.label.bounds.test.ts
@@ -17,9 +17,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 import { parseJsonAndExpectOnlyEdges, parseJsonAndExpectOnlyFlowNodes, verifyLabelBounds } from '../../../helpers/JsonTestUtils';
 import { shapeBpmnElementKindForLabelTests } from '../../../helpers/TestUtils';
+
+import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 
 describe('parse bpmn as json for label bounds', () => {
   describe.each(shapeBpmnElementKindForLabelTests)('parse bpmn as json for label bounds on %s', sourceKind => {

--- a/test/unit/component/parser/json/BpmnJsonParser.label.bounds.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.label.bounds.test.ts
@@ -18,13 +18,14 @@ limitations under the License.
 */
 
 import type { TProcess } from '@lib/model/bpmn/json/baseElement/rootElement/rootElement';
+import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 import { parseJsonAndExpectOnlyEdges, parseJsonAndExpectOnlyFlowNodes, verifyLabelBounds } from '../../../helpers/JsonTestUtils';
 import { shapeBpmnElementKindForLabelTests } from '../../../helpers/TestUtils';
 
 describe('parse bpmn as json for label bounds', () => {
   describe.each(shapeBpmnElementKindForLabelTests)('parse bpmn as json for label bounds on %s', sourceKind => {
     it(`should convert as Shape, when a BPMNShape (attached to ${sourceKind} & with bounds with all attributes) is an attribute (as object) of 'BPMNPlane' (as object)`, () => {
-      const json = {
+      const json: BpmnJsonModel = {
         definitions: {
           targetNamespace: '',
           process: {
@@ -55,7 +56,7 @@ describe('parse bpmn as json for label bounds', () => {
     });
 
     it(`should convert as Shape, when a BPMNShape (attached to ${sourceKind} & without bounds) is an attribute (as object) of 'BPMNPlane' (as object)`, () => {
-      const json = {
+      const json: BpmnJsonModel = {
         definitions: {
           targetNamespace: '',
           process: {},
@@ -84,7 +85,7 @@ describe('parse bpmn as json for label bounds', () => {
   });
 
   it(`should convert as Edge, when a BPMNEdge (with bounds with all attributes) is an attribute (as object) of 'BPMNPlane' (as object)`, () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         process: {
@@ -118,7 +119,7 @@ describe('parse bpmn as json for label bounds', () => {
   });
 
   it(`should convert as Edge, when a BPMNEdge (without bounds) is an attribute (as object) of 'BPMNPlane' (as object)`, () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         process: {

--- a/test/unit/component/parser/json/BpmnJsonParser.label.bounds.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.label.bounds.test.ts
@@ -17,7 +17,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import type { TProcess } from '@lib/model/bpmn/json/baseElement/rootElement/rootElement';
 import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 import { parseJsonAndExpectOnlyEdges, parseJsonAndExpectOnlyFlowNodes, verifyLabelBounds } from '../../../helpers/JsonTestUtils';
 import { shapeBpmnElementKindForLabelTests } from '../../../helpers/TestUtils';
@@ -30,6 +29,7 @@ describe('parse bpmn as json for label bounds', () => {
           targetNamespace: '',
           process: {
             id: 'Process_1',
+            [sourceKind]: { id: 'source_id_0', name: `${sourceKind}_id_0` },
           },
           BPMNDiagram: {
             id: 'BpmnDiagram_1',
@@ -48,7 +48,6 @@ describe('parse bpmn as json for label bounds', () => {
           },
         },
       };
-      (json.definitions.process as TProcess)[`${sourceKind}`] = { id: 'source_id_0', name: `${sourceKind}_id_0` };
 
       const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
@@ -59,7 +58,9 @@ describe('parse bpmn as json for label bounds', () => {
       const json: BpmnJsonModel = {
         definitions: {
           targetNamespace: '',
-          process: {},
+          process: {
+            [sourceKind]: { id: 'source_id_0', name: `${sourceKind}_id_0` },
+          },
           BPMNDiagram: {
             id: 'BpmnDiagram_1',
             BPMNPlane: {
@@ -76,7 +77,6 @@ describe('parse bpmn as json for label bounds', () => {
           },
         },
       };
-      (json.definitions.process as TProcess)[`${sourceKind}`] = { id: 'source_id_0', name: `${sourceKind}_id_0` };
 
       const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 

--- a/test/unit/component/parser/json/BpmnJsonParser.label.font.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.label.font.test.ts
@@ -17,6 +17,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 import { expectAsWarning, parseJsonAndExpectOnlyEdges, parseJsonAndExpectOnlyFlowNodes, parsingMessageCollector, verifyLabelFont } from '../../../helpers/JsonTestUtils';
 import { shapeBpmnElementKindForLabelTests } from '../../../helpers/TestUtils';
 
@@ -33,7 +34,7 @@ describe('parse bpmn as json for label font', () => {
   it.each(shapeBpmnElementKindForLabelTests)(
     "should convert as Shape with Font, when a BPMNShape (attached to %s & who references a BPMNLabelStyle with font) is an attribute (as object) of 'BPMNPlane' (as object)",
     sourceKind => {
-      const json = {
+      const json: BpmnJsonModel = {
         definitions: {
           targetNamespace: '',
           process: {
@@ -72,7 +73,7 @@ describe('parse bpmn as json for label font', () => {
   );
 
   it("should convert as Edge with Font, when a BPMNEdge (which references a BPMNLabelStyle with font) is an attribute (as object) of 'BPMNPlane' (as object)", () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         process: {
@@ -113,7 +114,7 @@ describe('parse bpmn as json for label font', () => {
   });
 
   it("should convert as Shape[] with Font, when several BPMNShapes (who reference the same BPMNLabelStyle) are an attribute (as array) of 'BPMNPlane' (as object)", () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         process: {
@@ -167,7 +168,7 @@ describe('parse bpmn as json for label font', () => {
   });
 
   it("should convert as Edge[] with Font, when several BPMNEdges (who reference the same BPMNLabelStyle) are an attribute (as array) of 'BPMNPlane' (as object)", () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         process: {
@@ -225,7 +226,7 @@ describe('parse bpmn as json for label font', () => {
   });
 
   it("should convert as Shape[] without Font, when BPMNShapes (who reference a BPMNLabelStyle) are an attribute (as array) of 'BPMNPlane' (as object) & BPMNLabelStyle (with font with/without all attributes) is an attribute (as array) of 'BPMNDiagram' (as object)", () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         process: {
@@ -267,7 +268,6 @@ describe('parse bpmn as json for label font', () => {
             {
               id: 'style_id_1',
               Font: {
-                id: '1',
                 isBold: false,
                 isItalic: false,
                 isStrikeThrough: false,
@@ -293,7 +293,7 @@ describe('parse bpmn as json for label font', () => {
   });
 
   it("should convert as Edge[] without Font, when BPMNEdges (which reference a BPMNLabelStyle) are an attribute (as array) of 'BPMNPlane' (as object) & BPMNLabelStyle (with font with/without all attributes) is an attribute (as array) of 'BPMNDiagram' (as object)", () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         process: {
@@ -339,7 +339,6 @@ describe('parse bpmn as json for label font', () => {
             {
               id: 'style_id_1',
               Font: {
-                id: '1',
                 isBold: false,
                 isItalic: false,
                 isStrikeThrough: false,
@@ -365,7 +364,7 @@ describe('parse bpmn as json for label font', () => {
   });
 
   it("should convert as Shape without Font, when a BPMNShape (who references a BPMNLabelStyle without font) is an attribute (as object) of 'BPMNPlane' (as object)", () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         process: {
@@ -402,7 +401,7 @@ describe('parse bpmn as json for label font', () => {
   });
 
   it("should convert as Edge without Font, when a BPMNEdge (which references a BPMNLabelStyle without font) is an attribute (as object) of 'BPMNPlane' (as object)", () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         process: {
@@ -440,7 +439,7 @@ describe('parse bpmn as json for label font', () => {
   });
 
   it("should convert as Shape without Font, when a BPMNShape (who references a non-existing BPMNLabelStyle) is an attribute (as object) of 'BPMNPlane' (as object)", () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         process: {
@@ -474,7 +473,7 @@ describe('parse bpmn as json for label font', () => {
   });
 
   it("should convert as Edge without Font, when a BPMNEdge (which references a non-existing BPMNLabelStyle) is an attribute (as object) of 'BPMNPlane' (as object)", () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         process: {

--- a/test/unit/component/parser/json/BpmnJsonParser.label.font.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.label.font.test.ts
@@ -17,10 +17,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 import { expectAsWarning, parseJsonAndExpectOnlyEdges, parseJsonAndExpectOnlyFlowNodes, parsingMessageCollector, verifyLabelFont } from '../../../helpers/JsonTestUtils';
 import { shapeBpmnElementKindForLabelTests } from '../../../helpers/TestUtils';
 
+import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 import { LabelStyleMissingFontWarning } from '@lib/component/parser/json/warnings';
 
 function expectMissingFontWarning(shapeOrEdgeId: string, labelStyleId: string): void {

--- a/test/unit/component/parser/json/BpmnJsonParser.label.font.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.label.font.test.ts
@@ -21,7 +21,6 @@ import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 import { expectAsWarning, parseJsonAndExpectOnlyEdges, parseJsonAndExpectOnlyFlowNodes, parsingMessageCollector, verifyLabelFont } from '../../../helpers/JsonTestUtils';
 import { shapeBpmnElementKindForLabelTests } from '../../../helpers/TestUtils';
 
-import type { TProcess } from '@lib/model/bpmn/json/baseElement/rootElement/rootElement';
 import { LabelStyleMissingFontWarning } from '@lib/component/parser/json/warnings';
 
 function expectMissingFontWarning(shapeOrEdgeId: string, labelStyleId: string): void {
@@ -39,6 +38,7 @@ describe('parse bpmn as json for label font', () => {
           targetNamespace: '',
           process: {
             id: 'Process_1',
+            [sourceKind]: { id: 'source_id_0', name: `${sourceKind}_id_0` },
           },
           BPMNDiagram: {
             id: 'BpmnDiagram_1',
@@ -64,7 +64,6 @@ describe('parse bpmn as json for label font', () => {
           },
         },
       };
-      (json.definitions.process as TProcess)[`${sourceKind}`] = { id: 'source_id_0', name: `${sourceKind}_id_0` };
 
       const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 

--- a/test/unit/component/parser/json/BpmnJsonParser.label.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.label.test.ts
@@ -17,6 +17,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 import { parseJsonAndExpectOnlyEdges, parseJsonAndExpectOnlyFlowNodes } from '../../../helpers/JsonTestUtils';
 import { shapeBpmnElementKindForLabelTests } from '../../../helpers/TestUtils';
 
@@ -26,7 +27,7 @@ describe('parse bpmn as json for label', () => {
   it.each(shapeBpmnElementKindForLabelTests)(
     "should convert as Shape without Label, when a BPMNShape (attached to %s & with empty BPMNLabel) is an attribute (as object) of 'BPMNPlane' (as object)",
     sourceKind => {
-      const json = {
+      const json: BpmnJsonModel = {
         definitions: {
           targetNamespace: '',
           process: {
@@ -55,7 +56,7 @@ describe('parse bpmn as json for label', () => {
   );
 
   it("should convert as Edge without Label, when a BPMNEdge (with empty BPMNLabel) is an attribute (as object) of 'BPMNPlane' (as object)", () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         process: {
@@ -86,7 +87,7 @@ describe('parse bpmn as json for label', () => {
   });
 
   it("should convert as Shape without Label, when a BPMNShape (with BPMNLabel with just id) is an attribute (as object) of 'BPMNPlane' (as object)", () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         process: {
@@ -118,7 +119,7 @@ describe('parse bpmn as json for label', () => {
   });
 
   it("should convert as Edge without Label, when a BPMNEdge (with BPMNLabel with just id) is an attribute (as object) of 'BPMNPlane' (as object)", () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         process: {
@@ -151,7 +152,7 @@ describe('parse bpmn as json for label', () => {
   });
 
   it("should convert as Shape without Label, when a BPMNShape (without BPMNLabel) is an attribute (as object) of 'BPMNPlane' (as object)", () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         process: {
@@ -180,7 +181,7 @@ describe('parse bpmn as json for label', () => {
   });
 
   it("should convert as Edge without Label, when a BPMNEdge (without BPMNLabel) is an attribute (as object) of 'BPMNPlane' (as object)", () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         process: {

--- a/test/unit/component/parser/json/BpmnJsonParser.label.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.label.test.ts
@@ -17,9 +17,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 import { parseJsonAndExpectOnlyEdges, parseJsonAndExpectOnlyFlowNodes } from '../../../helpers/JsonTestUtils';
 import { shapeBpmnElementKindForLabelTests } from '../../../helpers/TestUtils';
+
+import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 
 describe('parse bpmn as json for label', () => {
   it.each(shapeBpmnElementKindForLabelTests)(

--- a/test/unit/component/parser/json/BpmnJsonParser.label.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.label.test.ts
@@ -21,8 +21,6 @@ import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 import { parseJsonAndExpectOnlyEdges, parseJsonAndExpectOnlyFlowNodes } from '../../../helpers/JsonTestUtils';
 import { shapeBpmnElementKindForLabelTests } from '../../../helpers/TestUtils';
 
-import type { TProcess } from '@lib/model/bpmn/json/baseElement/rootElement/rootElement';
-
 describe('parse bpmn as json for label', () => {
   it.each(shapeBpmnElementKindForLabelTests)(
     "should convert as Shape without Label, when a BPMNShape (attached to %s & with empty BPMNLabel) is an attribute (as object) of 'BPMNPlane' (as object)",
@@ -32,6 +30,7 @@ describe('parse bpmn as json for label', () => {
           targetNamespace: '',
           process: {
             id: 'Process_1',
+            [sourceKind]: { id: 'source_id_0', name: `${sourceKind}_id_0` },
           },
           BPMNDiagram: {
             id: 'BpmnDiagram_1',
@@ -47,7 +46,6 @@ describe('parse bpmn as json for label', () => {
           },
         },
       };
-      (json.definitions.process as TProcess)[`${sourceKind}`] = { id: 'source_id_0', name: `${sourceKind}_id_0` };
 
       const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 

--- a/test/unit/component/parser/json/BpmnJsonParser.lane.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.lane.test.ts
@@ -16,13 +16,14 @@ limitations under the License.
 
 import { ShapeBpmnElementKind } from '@lib/model/bpmn/internal';
 import { LaneUnknownFlowNodeRefWarning } from '@lib/component/parser/json/warnings';
+import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 
 import { expectAsWarning, parseJson, parseJsonAndExpectOnlyLanes, parsingMessageCollector } from '../../../helpers/JsonTestUtils';
 import { verifyShape } from '../../../helpers/bpmn-model-expect';
 
 describe('parse bpmn as json for lane', () => {
   it('json containing one process with a single lane without flowNodeRef', () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         process: {
@@ -59,7 +60,7 @@ describe('parse bpmn as json for lane', () => {
   });
 
   it('json containing one process with a single lane with flowNodeRef as object & flowNode already parsed', () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         process: {
@@ -108,7 +109,7 @@ describe('parse bpmn as json for lane', () => {
   });
 
   it('json containing one process with a single lane with flowNodeRef as object & flowNode not parsed', () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         process: {
@@ -149,11 +150,13 @@ describe('parse bpmn as json for lane', () => {
   });
 
   it('json containing one process with a single lane with flowNodeRef as array', () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         process: {
-          lane: { id: 'Lane_12u5n6x', flowNodeRef: ['event_id_0'] },
+          laneSet: {
+            lane: { id: 'Lane_12u5n6x', flowNodeRef: ['event_id_0'] },
+          },
           startEvent: { id: 'event_id_0' },
         },
         BPMNDiagram: {
@@ -198,7 +201,7 @@ describe('parse bpmn as json for lane', () => {
   });
 
   it('json containing one process declared as array with a laneSet', () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         process: [
@@ -240,7 +243,7 @@ describe('parse bpmn as json for lane', () => {
   });
 
   it('json containing one process with an array of lanes with & without name', () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         process: {
@@ -313,7 +316,7 @@ describe('parse bpmn as json for lane', () => {
     ['horizontal', true],
   ])('parse bpmn as json for %s lane', (title: string, isHorizontal: boolean) => {
     it(`json containing one process declared as array with a ${title} laneSet with childLaneSet`, () => {
-      const json = {
+      const json: BpmnJsonModel = {
         definitions: {
           targetNamespace: '',
           process: [
@@ -464,7 +467,7 @@ describe('parse bpmn as json for lane', () => {
     });
 
     it(`json containing one process with a ${title} lane`, () => {
-      const json = {
+      const json: BpmnJsonModel = {
         definitions: {
           targetNamespace: '',
           process: {
@@ -502,7 +505,7 @@ describe('parse bpmn as json for lane', () => {
   });
 
   it("json containing one process with a lane without 'isHorizontal' attribute", () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         process: {

--- a/test/unit/component/parser/json/BpmnJsonParser.marker.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.marker.test.ts
@@ -18,7 +18,6 @@ import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 import { parseJsonAndExpectOnlyFlowNodes } from '../../../helpers/JsonTestUtils';
 import { getExpectedMarkers, verifyShape } from '../../../helpers/bpmn-model-expect';
 
-import type { TProcess } from '@lib/model/bpmn/json/baseElement/rootElement/rootElement';
 import type { TMultiInstanceLoopCharacteristics, TStandardLoopCharacteristics } from '@lib/model/bpmn/json/baseElement/loopCharacteristics';
 import { ShapeBpmnCallActivityKind, ShapeBpmnElementKind, ShapeBpmnMarkerKind } from '@lib/model/bpmn/internal';
 
@@ -57,7 +56,9 @@ describe.each([
         const json: BpmnJsonModel = {
           definitions: {
             targetNamespace: '',
-            process: {},
+            process: {
+              [bpmnSemanticType]: { id: `${bpmnSemanticType}_id_0`, name: `${bpmnSemanticType} name`, [bpmnLoopCharacteristicsKind]: loopCharacteristics },
+            },
             BPMNDiagram: {
               name: 'process 0',
               BPMNPlane: {
@@ -71,11 +72,6 @@ describe.each([
             },
           },
         };
-        (json.definitions.process as TProcess)[bpmnSemanticType] = {
-          id: `${bpmnSemanticType}_id_0`,
-          name: `${bpmnSemanticType} name`,
-        };
-        (json.definitions.process as TProcess)[bpmnSemanticType][bpmnLoopCharacteristicsKind] = loopCharacteristics;
 
         const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
@@ -97,7 +93,13 @@ describe.each([
         const json: BpmnJsonModel = {
           definitions: {
             targetNamespace: '',
-            process: {},
+            process: {
+              [bpmnSemanticType]: {
+                id: `${bpmnSemanticType}_id_0`,
+                name: `${bpmnSemanticType} name`,
+                [bpmnLoopCharacteristicsKind]: '',
+              },
+            },
             BPMNDiagram: {
               name: 'process 0',
               BPMNPlane: {
@@ -111,11 +113,6 @@ describe.each([
             },
           },
         };
-        (json.definitions.process as TProcess)[bpmnSemanticType] = {
-          id: `${bpmnSemanticType}_id_0`,
-          name: `${bpmnSemanticType} name`,
-        };
-        (json.definitions.process as TProcess)[bpmnSemanticType][bpmnLoopCharacteristicsKind] = '';
 
         const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
 
@@ -143,7 +140,13 @@ describe.each([
         const json: BpmnJsonModel = {
           definitions: {
             targetNamespace: '',
-            process: {},
+            process: {
+              [bpmnSemanticType]: {
+                id: `${bpmnSemanticType}_id_0`,
+                name: `${bpmnSemanticType} name`,
+                multiInstanceLoopCharacteristics: loopCharacteristics,
+              },
+            },
             BPMNDiagram: {
               name: 'process 0',
               BPMNPlane: {
@@ -156,11 +159,6 @@ describe.each([
               },
             },
           },
-        };
-        (json.definitions.process as TProcess)[bpmnSemanticType] = {
-          id: `${bpmnSemanticType}_id_0`,
-          name: `${bpmnSemanticType} name`,
-          multiInstanceLoopCharacteristics: loopCharacteristics,
         };
 
         const model = parseJsonAndExpectOnlyFlowNodes(json, 1);
@@ -183,7 +181,13 @@ describe.each([
         const json: BpmnJsonModel = {
           definitions: {
             targetNamespace: '',
-            process: {},
+            process: {
+              [bpmnSemanticType]: {
+                id: `${bpmnSemanticType}_id_0`,
+                name: `${bpmnSemanticType} name`,
+                multiInstanceLoopCharacteristics: { isSequential },
+              },
+            },
             BPMNDiagram: {
               name: 'process 0',
               BPMNPlane: {
@@ -196,11 +200,6 @@ describe.each([
               },
             },
           },
-        };
-        (json.definitions.process as TProcess)[bpmnSemanticType] = {
-          id: `${bpmnSemanticType}_id_0`,
-          name: `${bpmnSemanticType} name`,
-          multiInstanceLoopCharacteristics: { isSequential },
         };
 
         const model = parseJsonAndExpectOnlyFlowNodes(json, 1);

--- a/test/unit/component/parser/json/BpmnJsonParser.marker.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.marker.test.ts
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 import { parseJsonAndExpectOnlyFlowNodes } from '../../../helpers/JsonTestUtils';
 import { getExpectedMarkers, verifyShape } from '../../../helpers/bpmn-model-expect';
 
@@ -53,7 +54,7 @@ describe.each([
           | TMultiInstanceLoopCharacteristics
           | (string | TStandardLoopCharacteristics | TMultiInstanceLoopCharacteristics)[],
       ) => {
-        const json = {
+        const json: BpmnJsonModel = {
           definitions: {
             targetNamespace: '',
             process: {},
@@ -93,7 +94,7 @@ describe.each([
 
     if (expectedShapeBpmnElementKind === ShapeBpmnElementKind.SUB_PROCESS) {
       it(`should convert as Shape with ${expectedMarkerKind} & expand markers, when '${bpmnLoopCharacteristicsKind}' is an attribute of '${bpmnSemanticType}' and BPMNShape is NOT expanded`, () => {
-        const json = {
+        const json: BpmnJsonModel = {
           definitions: {
             targetNamespace: '',
             process: {},
@@ -139,7 +140,7 @@ describe.each([
     ])(
       `should convert as Shape with ${expectedMarkerKind} marker, when 'isSequential' is an attribute (as ${isSequential}) of 'multiInstanceLoopCharacteristics' (as %s) of '${bpmnSemanticType}'  and BPMNShape is expanded`,
       (title: string, loopCharacteristics: TMultiInstanceLoopCharacteristics | TMultiInstanceLoopCharacteristics[]) => {
-        const json = {
+        const json: BpmnJsonModel = {
           definitions: {
             targetNamespace: '',
             process: {},
@@ -179,7 +180,7 @@ describe.each([
 
     if (expectedShapeBpmnElementKind === ShapeBpmnElementKind.SUB_PROCESS || expectedShapeBpmnElementKind === ShapeBpmnElementKind.CALL_ACTIVITY) {
       it(`should convert as Shape with ${expectedMarkerKind} & expand markers, when 'isSequential' is an attribute (as ${isSequential}) of 'multiInstanceLoopCharacteristics' of '${bpmnSemanticType}' and BPMNShape is NOT expanded`, () => {
-        const json = {
+        const json: BpmnJsonModel = {
           definitions: {
             targetNamespace: '',
             process: {},

--- a/test/unit/component/parser/json/BpmnJsonParser.marker.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.marker.test.ts
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 import { parseJsonAndExpectOnlyFlowNodes } from '../../../helpers/JsonTestUtils';
 import { getExpectedMarkers, verifyShape } from '../../../helpers/bpmn-model-expect';
 
+import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 import type { TMultiInstanceLoopCharacteristics, TStandardLoopCharacteristics } from '@lib/model/bpmn/json/baseElement/loopCharacteristics';
 import { ShapeBpmnCallActivityKind, ShapeBpmnElementKind, ShapeBpmnMarkerKind } from '@lib/model/bpmn/internal';
 

--- a/test/unit/component/parser/json/BpmnJsonParser.messageFlow.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.messageFlow.test.ts
@@ -32,7 +32,7 @@ import { verifyEdge } from '../../../helpers/bpmn-model-expect';
 
 describe('parse bpmn as json for message flow', () => {
   it(`should convert as Edge, when an message flow is an attribute (as object) of 'collaboration' (as object)`, () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         collaboration: {
@@ -72,7 +72,7 @@ describe('parse bpmn as json for message flow', () => {
   });
 
   it(`should convert as Edge, when an message flow (with/without name) is an attribute (as array) of 'collaboration'`, () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         collaboration: {
@@ -134,7 +134,7 @@ describe('parse bpmn as json for message flow', () => {
   });
 
   it(`should convert as Edge, when an message flow (with one & several waypoints) is an attribute (as array) of 'collaboration'`, () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         collaboration: {
@@ -209,7 +209,7 @@ describe('parse bpmn as json for message flow', () => {
   });
 
   it(`should convert as Edge, when none/initiating/non-initiating message flows are an attribute (as array) of 'collaboration'`, () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         collaboration: {

--- a/test/unit/component/parser/json/BpmnJsonParser.messageFlow.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.messageFlow.test.ts
@@ -14,9 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { ShapeBpmnElementKind, ShapeUtil } from '@lib/model/bpmn/internal';
-
 /** Internal model */
+import { ShapeBpmnElementKind, ShapeUtil } from '@lib/model/bpmn/internal';
 import { Waypoint } from '@lib/model/bpmn/internal/edge/edge';
 import { MessageVisibleKind } from '@lib/model/bpmn/internal/edge/kinds';
 

--- a/test/unit/component/parser/json/BpmnJsonParser.process.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.process.test.ts
@@ -72,7 +72,7 @@ describe('parse bpmn as json for process/pool', () => {
     });
 
     it(`json containing one ${title} participant without related process`, () => {
-      const json = {
+      const json: BpmnJsonModel = {
         definitions: {
           targetNamespace: '',
           collaboration: {
@@ -156,7 +156,7 @@ describe('parse bpmn as json for process/pool', () => {
   });
 
   it('json containing one participant without name and the related process has a name', () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         collaboration: {
@@ -200,8 +200,8 @@ describe('parse bpmn as json for process/pool', () => {
     });
   });
 
-  it('json containing one participant referencing a process (with a single lane without flowNodeRef)', () => {
-    const json = {
+  it('json containing one participant referencing a process (with a single laneSet without flowNodeRef)', () => {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         collaboration: {
@@ -211,7 +211,7 @@ describe('parse bpmn as json for process/pool', () => {
           id: 'Process_0vbjbkf',
           name: 'RequestLoan',
           isExecutable: false,
-          lane: { id: 'Lane_12u5n6x' },
+          laneSet: { lane: { id: 'Lane_12u5n6x' } },
         },
         BPMNDiagram: {
           BPMNPlane: {
@@ -267,8 +267,8 @@ describe('parse bpmn as json for process/pool', () => {
     });
   });
 
-  it('json containing several participants referencing processes (with lane or laneset)', () => {
-    const json = {
+  it('json containing several participants referencing processes (with laneSet)', () => {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         collaboration: {
@@ -282,7 +282,9 @@ describe('parse bpmn as json for process/pool', () => {
             id: 'Process_1',
             name: 'process 1',
             isExecutable: false,
-            lane: { id: 'Lane_1_1' },
+            laneSet: {
+              lane: { id: 'Lane_1_1' },
+            },
           },
           {
             id: 'Process_2',
@@ -385,7 +387,7 @@ describe('parse bpmn as json for process/pool', () => {
   });
 
   it('json containing participants with and without processRef (black box pool)', () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         collaboration: {
@@ -451,7 +453,7 @@ describe('parse bpmn as json for process/pool', () => {
   });
 
   it('json containing one participant referencing a process (with flowNode and without lane)', () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         collaboration: {
@@ -520,7 +522,7 @@ describe('parse bpmn as json for process/pool', () => {
   });
 
   it('json containing one participant referencing a process (without displaying the participant/pool, but with displaying process elements)', () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         collaboration: {
@@ -566,7 +568,7 @@ describe('parse bpmn as json for process/pool', () => {
 
   it('json containing no participant, but one process (with bpmn elements)', () => {
     // json generated from https://github.com/bpmn-miwg/bpmn-miwg-test-suite/blob/b1569235563b58d7216caa880c447bafee3e23cf/Reference/A.1.0.bpmn
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         id: '_1373649849716',
         name: 'A.1.0',

--- a/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.conditional.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.conditional.test.ts
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 import { parseJsonAndExpectOnlyEdgesAndFlowNodes } from '../../../helpers/JsonTestUtils';
 import { verifyEdge } from '../../../helpers/bpmn-model-expect';
 
@@ -40,7 +41,7 @@ describe('parse bpmn as json for conditional sequence flow', () => {
   ])(
     `should convert as Edge, when an sequence flow (defined as conditional in %s) is an attribute (as object) of 'process' (as object)`,
     (sourceKind, expectedSequenceFlowKind) => {
-      const json = {
+      const json: BpmnJsonModel = {
         definitions: {
           targetNamespace: '',
           process: {
@@ -91,7 +92,7 @@ describe('parse bpmn as json for conditional sequence flow', () => {
   );
 
   it(`should NOT convert, when an sequence flow (defined as conditional) is an attribute of 'process' and attached to a flow node where is NOT possible in BPMN Semantic`, () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         process: {

--- a/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.conditional.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.conditional.test.ts
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 import { parseJsonAndExpectOnlyEdgesAndFlowNodes } from '../../../helpers/JsonTestUtils';
 import { verifyEdge } from '../../../helpers/bpmn-model-expect';
 
+import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 import { SequenceFlowKind } from '@lib/model/bpmn/internal';
 import { Waypoint } from '@lib/model/bpmn/internal/edge/edge';
 

--- a/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.conditional.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.conditional.test.ts
@@ -19,8 +19,6 @@ import { parseJsonAndExpectOnlyEdgesAndFlowNodes } from '../../../helpers/JsonTe
 import { verifyEdge } from '../../../helpers/bpmn-model-expect';
 
 import { SequenceFlowKind } from '@lib/model/bpmn/internal';
-import type { TProcess } from '@lib/model/bpmn/json/baseElement/rootElement/rootElement';
-import type { TSequenceFlow } from '@lib/model/bpmn/json/baseElement/flowElement';
 import { Waypoint } from '@lib/model/bpmn/internal/edge/edge';
 
 describe('parse bpmn as json for conditional sequence flow', () => {
@@ -52,8 +50,10 @@ describe('parse bpmn as json for conditional sequence flow', () => {
               targetRef: 'targetRef_RLk',
               conditionExpression: {
                 evaluatesToTypeRef: 'java:java.lang.Boolean',
+                '#text': '&quot;Contract to be written&quot;.equals(loanRequested.status)',
               },
             },
+            [sourceKind]: { id: 'source_id_0' },
           },
           BPMNDiagram: {
             id: 'BpmnDiagram_1',
@@ -73,9 +73,6 @@ describe('parse bpmn as json for conditional sequence flow', () => {
           },
         },
       };
-      const process = json.definitions.process as TProcess;
-      process[`${sourceKind}`] = { id: 'source_id_0' };
-      (process.sequenceFlow as TSequenceFlow).conditionExpression['#text'] = '&quot;Contract to be written&quot;.equals(loanRequested.status)';
 
       const model = parseJsonAndExpectOnlyEdgesAndFlowNodes(json, 1, 1);
 

--- a/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.default.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.default.test.ts
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 import { parseJsonAndExpectOnlyEdgesAndFlowNodes } from '../../../helpers/JsonTestUtils';
 import { verifyEdge } from '../../../helpers/bpmn-model-expect';
 
+import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 import { SequenceFlowKind } from '@lib/model/bpmn/internal';
 import { Waypoint } from '@lib/model/bpmn/internal/edge/edge';
 

--- a/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.default.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.default.test.ts
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 import { parseJsonAndExpectOnlyEdgesAndFlowNodes } from '../../../helpers/JsonTestUtils';
 import { verifyEdge } from '../../../helpers/bpmn-model-expect';
 
@@ -37,7 +38,7 @@ describe('parse bpmn as json for default sequence flow', () => {
     ['callActivity'],
     ['subProcess'],
   ])(`should convert as Edge, when an sequence flow (defined as default in %s) is an attribute (as object) of 'process' (as object)`, sourceKind => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         process: {
@@ -82,11 +83,14 @@ describe('parse bpmn as json for default sequence flow', () => {
   });
 
   it(`should NOT convert, when an sequence flow (defined as default) is an attribute of 'process' and attached to a flow node where is NOT possible in BPMN Semantic`, () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         process: {
           id: 'Process_1',
+          // To enforce the type and test a case who never should happen
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
           parallelGateway: { id: 'gateway_id_0', default: 'sequenceFlow_id_0' },
           sequenceFlow: {
             id: 'sequenceFlow_id_0',

--- a/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.default.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.default.test.ts
@@ -87,7 +87,7 @@ describe('parse bpmn as json for default sequence flow', () => {
         targetNamespace: '',
         process: {
           id: 'Process_1',
-          // To enforce the type and test a case who never should happen
+          // Enforcement of the 'default' property in case the XML BPMN content is malformed
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
           parallelGateway: { id: 'gateway_id_0', default: 'sequenceFlow_id_0' },

--- a/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.default.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.default.test.ts
@@ -20,7 +20,6 @@ import { verifyEdge } from '../../../helpers/bpmn-model-expect';
 
 import { SequenceFlowKind } from '@lib/model/bpmn/internal';
 import { Waypoint } from '@lib/model/bpmn/internal/edge/edge';
-import type { TProcess } from '@lib/model/bpmn/json/baseElement/rootElement/rootElement';
 
 describe('parse bpmn as json for default sequence flow', () => {
   it.each([
@@ -48,6 +47,7 @@ describe('parse bpmn as json for default sequence flow', () => {
             sourceRef: 'source_id_0',
             targetRef: 'targetRef_RLk',
           },
+          [sourceKind]: { id: 'source_id_0', default: 'sequenceFlow_id_0' },
         },
         BPMNDiagram: {
           id: 'BpmnDiagram_1',
@@ -67,7 +67,6 @@ describe('parse bpmn as json for default sequence flow', () => {
         },
       },
     };
-    (json.definitions.process as TProcess)[`${sourceKind}`] = { id: 'source_id_0', default: 'sequenceFlow_id_0' };
 
     const model = parseJsonAndExpectOnlyEdgesAndFlowNodes(json, 1, 1);
 

--- a/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.normal.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.normal.test.ts
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 import { parseJsonAndExpectOnlyEdges } from '../../../helpers/JsonTestUtils';
 import { verifyEdge } from '../../../helpers/bpmn-model-expect';
 
+import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 import { Waypoint } from '@lib/model/bpmn/internal/edge/edge';
 import type { TProcess } from '@lib/model/bpmn/json/baseElement/rootElement/rootElement';
 

--- a/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.normal.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.sequenceFlow.normal.test.ts
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 import { parseJsonAndExpectOnlyEdges } from '../../../helpers/JsonTestUtils';
 import { verifyEdge } from '../../../helpers/bpmn-model-expect';
 
@@ -33,8 +34,8 @@ describe('parse bpmn as json for sequence flow', () => {
   it.each([
     ['object', processWithSequenceFlowAsObject],
     ['array', [processWithSequenceFlowAsObject]],
-  ])(`should convert as Edge, when a sequence flow is an attribute (as object) of 'process' (as %s)`, (title: string, processJson: TProcess) => {
-    const json = {
+  ])(`should convert as Edge, when a sequence flow is an attribute (as object) of 'process' (as %s)`, (title: string, processJson: TProcess | TProcess[]) => {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         process: processJson,
@@ -64,7 +65,7 @@ describe('parse bpmn as json for sequence flow', () => {
   });
 
   it(`should convert as Edge, when a sequence flow (with/without name) is an attribute (as array) of 'process'`, () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         process: {
@@ -125,7 +126,7 @@ describe('parse bpmn as json for sequence flow', () => {
   });
 
   it(`should convert as Edge, when a sequence flow (with 2 & several waypoints) is an attribute (as array) of 'process'`, () => {
-    const json = {
+    const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
         process: {

--- a/test/unit/component/parser/json/BpmnJsonParser.sub.process.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.sub.process.test.ts
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 import type { BuildProcessParameter } from '../../../helpers/JsonBuilder';
 import { buildDefinitions } from '../../../helpers/JsonBuilder';
 import {
@@ -28,6 +27,7 @@ import { getEventShapes } from '../../../helpers/TestUtils';
 import type { ExpectedActivityShape, ExpectedBounds, ExpectedShape } from '../../../helpers/bpmn-model-expect';
 import { getExpectedMarkers, verifyEdge, verifyShape } from '../../../helpers/bpmn-model-expect';
 
+import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 import type BpmnModel from '@lib/model/bpmn/internal/BpmnModel';
 import { Waypoint } from '@lib/model/bpmn/internal/edge/edge';
 import { ShapeBpmnElementKind, ShapeBpmnEventDefinitionKind, ShapeBpmnMarkerKind, ShapeBpmnSubProcessKind } from '@lib/model/bpmn/internal';

--- a/test/unit/component/parser/json/BpmnJsonParser.sub.process.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.sub.process.test.ts
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
 import type { BuildProcessParameter } from '../../../helpers/JsonBuilder';
 import { buildDefinitions } from '../../../helpers/JsonBuilder';
 import {
@@ -307,7 +308,7 @@ describe('parse bpmn as json for sub-process', () => {
     }
 
     it(`should convert activities, events, gateways, textAnnotation, association and sequence-flows in sub-process`, () => {
-      const json = {
+      const json: BpmnJsonModel = {
         definitions: {
           targetNamespace: '',
           process: {
@@ -511,7 +512,7 @@ describe('parse bpmn as json for sub-process', () => {
     if (expectedShapeBpmnSubProcessKind === ShapeBpmnSubProcessKind.EVENT) {
       it(`should convert error start event in '${expectedShapeBpmnSubProcessKind} sub-process'`, () => {
         const errorStartEventName = `${expectedShapeBpmnSubProcessKind} SubProcess Error Event`;
-        const json = {
+        const json: BpmnJsonModel = {
           definitions: {
             targetNamespace: '',
             process: {


### PR DESCRIPTION
This pull request makes three improvements to `JsonParser` and its associated unit tests:

- Enforce the `BpmnJsonModel` type for the JsonParser dataset in the unit tests: This is a first step in addressing issue #2188.
This enforcement ensures that the JSON passed to the parser adheres to the required format. 
ℹ️ It's worth noting that I have observed cases where TypeScript failed to detect incorrect JSON formats when the type was not explicitly set.

- Simplified JSON data initialization for `JsonParser` unit tests: This makes our test code more readable and easier to maintain.

- Detection of the TypeScript-based `default` property of `TProcess` in the `ProcessConverter`.

These improvements enhance code reliability, readability and accuracy.
