### PR TITLE
refactor: remove extra constructors

### DIFF
--- a/src/component/mxgraph/shape/edges.ts
+++ b/src/component/mxgraph/shape/edges.ts
@@ -19,10 +19,6 @@ import type { mxAbstractCanvas2D, mxPoint } from 'mxgraph';
 import { BpmnStyleIdentifier } from '../style';
 
 export class BpmnConnector extends mxgraph.mxConnector {
-  constructor(points: mxPoint[], stroke: string, strokewidth?: number) {
-    super(points, stroke, strokewidth);
-  }
-
   override paintEdgeShape(c: mxAbstractCanvas2D, pts: mxPoint[]): void {
     // The indirection via functions for markers is needed in
     // order to apply the offsets before painting the line and

--- a/src/component/mxgraph/shape/flow-shapes.ts
+++ b/src/component/mxgraph/shape/flow-shapes.ts
@@ -18,17 +18,13 @@ import { IconPainterProvider } from './render';
 import { buildPaintParameter } from './render/icon-painter';
 import { BpmnStyleIdentifier } from '../style';
 import { mxRectangleShape, mxUtils } from '../initializer';
-import type { mxAbstractCanvas2D, mxRectangle } from 'mxgraph';
+import type { mxAbstractCanvas2D } from 'mxgraph';
 
 /**
  * @internal
  */
 export class MessageFlowIconShape extends mxRectangleShape {
   protected iconPainter = IconPainterProvider.get();
-
-  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth: number) {
-    super(bounds, fill, stroke, strokewidth);
-  }
 
   override paintVertexShape(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): void {
     const paintParameter = buildPaintParameter({


### PR DESCRIPTION
They were located in mxGraph custom shapes.

This has been detected by SonarCloud with rule `typescript:S6647`.
"If the class declaration does not include a constructor, one is automatically created, so there is no need to provide an empty constructor, or one that just delegates to the parent class."

### SonarCloud analysis

These new Code Smells have been recently detected after the builtin Quality Profiles were updated with new rules.

![image](https://github.com/process-analytics/bpmn-visualization-js/assets/27200110/063f5025-52ea-4555-a5ea-dc2ab8cfb176)



![image](https://github.com/process-analytics/bpmn-visualization-js/assets/27200110/0d765b26-03b3-49a5-8a66-8ef973cc9252)
