### PR TITLE
fix: remove extra parsing of lane elements which are not in the BPMN spec

### DIFF
--- a/src/component/parser/json/converter/EventDefinitionConverter.ts
+++ b/src/component/parser/json/converter/EventDefinitionConverter.ts
@@ -20,6 +20,8 @@ import type { TEventDefinition } from '../../../../model/bpmn/json/baseElement/r
 import type { ConvertedElements } from './utils';
 import { ensureIsArray } from '../../../helpers/array-utils';
 
+type EventDefinitions = string | TEventDefinition | (string | TEventDefinition)[];
+
 /**
  * @internal
  */
@@ -28,8 +30,8 @@ export default class EventDefinitionConverter {
 
   deserialize(definitions: TDefinitions): void {
     eventDefinitionKinds.forEach(eventDefinitionKind => {
-      // sometimes eventDefinition is simple and therefore it is parsed as empty string "", in that case eventDefinition will be converted to an empty object
-      const eventDefinitions: string | TEventDefinition | (string | TEventDefinition)[] = definitions[eventDefinitionKind + 'EventDefinition'];
+      // sometimes eventDefinition is simple, and therefore it is parsed as empty string "", in that case eventDefinition will be converted to an empty object
+      const eventDefinitions = definitions[(eventDefinitionKind + 'EventDefinition') as keyof TDefinitions] as EventDefinitions;
       ensureIsArray<TEventDefinition>(eventDefinitions, true).forEach(eventDefinition =>
         this.convertedElements.registerEventDefinitionsOfDefinition(eventDefinition.id, eventDefinitionKind),
       );

--- a/src/component/parser/json/converter/ProcessConverter.ts
+++ b/src/component/parser/json/converter/ProcessConverter.ts
@@ -70,9 +70,9 @@ const computeSubProcessKind = (processedSemanticType: BpmnSemanticType, bpmnElem
   }
 };
 
-const orderedFlowNodeBpmnTypes: BpmnSemanticType[] = ['adHocSubProcess', 'transaction'] // specific management for adhoc and transaction sub-processes which are handled with a dedicated ShapeBpmnSubProcessKind
+const orderedFlowNodeBpmnTypes: BpmnSemanticType[] = (['adHocSubProcess', 'transaction'] as BpmnSemanticType[]) // specific management for adhoc and transaction sub-processes which are handled with a dedicated ShapeBpmnSubProcessKind
   // process boundary events afterward as we need its parent activity to be available when building it
-  .concat(ShapeUtil.flowNodeKinds().filter(kind => kind != ShapeBpmnElementKind.EVENT_BOUNDARY))
+  .concat(ShapeUtil.flowNodeKinds().filter(kind => kind != ShapeBpmnElementKind.EVENT_BOUNDARY) as BpmnSemanticType[])
   .concat([ShapeBpmnElementKind.EVENT_BOUNDARY]);
 
 function getShapeBpmnElementKind(bpmnSemanticType: BpmnSemanticType): ShapeBpmnElementKind {
@@ -152,7 +152,6 @@ export default class ProcessConverter {
     // flow nodes
     orderedFlowNodeBpmnTypes.forEach(bpmnType => this.buildFlowNodeBpmnElements(process[bpmnType], getShapeBpmnElementKind(bpmnType), parentId, process.id, bpmnType));
     // containers
-    this.buildLaneBpmnElements(process[ShapeBpmnElementKind.LANE], parentId, process.id);
     this.buildLaneSetBpmnElements(process.laneSet, parentId, process.id);
 
     // flows

--- a/src/model/bpmn/json/BPMN20.ts
+++ b/src/model/bpmn/json/BPMN20.ts
@@ -107,9 +107,6 @@ export interface TDefinitions {
   typeLanguage?: string; // default="http://www.w3.org/2001/XMLSchema"
   exporter?: string;
   exporterVersion?: string;
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: any;
 }
 
 export interface TImport {

--- a/src/model/bpmn/json/baseElement/rootElement/rootElement.ts
+++ b/src/model/bpmn/json/baseElement/rootElement/rootElement.ts
@@ -166,9 +166,6 @@ export interface TProcess extends TCallableElement {
   isClosed?: boolean; // default="false"
   isExecutable?: boolean;
   definitionalCollaborationRef?: string;
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: any;
 }
 
 export enum tProcessType {

--- a/test/unit/component/parser/json/BpmnJsonParser.flowNode.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.flowNode.test.ts
@@ -38,7 +38,7 @@ describe.each([
   ['parallelGateway', ShapeBpmnElementKind.GATEWAY_PARALLEL],
   ['eventBasedGateway', ShapeBpmnElementKind.GATEWAY_EVENT_BASED],
   ['complexGateway', ShapeBpmnElementKind.GATEWAY_COMPLEX],
-])('parse bpmn as json for %s', (bpmnKind: string, expectedShapeBpmnElementKind: ShapeBpmnElementKind) => {
+] as [keyof TProcess, ShapeBpmnElementKind][])('parse bpmn as json for %s', (bpmnKind: keyof TProcess, expectedShapeBpmnElementKind: ShapeBpmnElementKind) => {
   const processWithFlowNodeAsObject: TProcess = {
     [bpmnKind]: {
       id: `${bpmnKind}_id_0`,

--- a/test/unit/component/parser/json/BpmnJsonParser.lane.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.lane.test.ts
@@ -26,9 +26,7 @@ describe('parse bpmn as json for lane', () => {
     const json: BpmnJsonModel = {
       definitions: {
         targetNamespace: '',
-        process: {
-          lane: { id: 'Lane_12u5n6x' },
-        },
+        process: { laneSet: { lane: { id: 'Lane_12u5n6x' } } },
         BPMNDiagram: {
           BPMNPlane: {
             BPMNShape: {
@@ -64,7 +62,7 @@ describe('parse bpmn as json for lane', () => {
       definitions: {
         targetNamespace: '',
         process: {
-          lane: { id: 'Lane_12u5n6x', flowNodeRef: 'event_id_0' },
+          laneSet: { lane: { id: 'Lane_12u5n6x', flowNodeRef: 'event_id_0' } },
           startEvent: { id: 'event_id_0' },
         },
         BPMNDiagram: {
@@ -113,7 +111,7 @@ describe('parse bpmn as json for lane', () => {
       definitions: {
         targetNamespace: '',
         process: {
-          lane: { id: 'Lane_12u5n6x', flowNodeRef: 'event_id_0' },
+          laneSet: { lane: { id: 'Lane_12u5n6x', flowNodeRef: 'event_id_0' } },
         },
         BPMNDiagram: {
           BPMNPlane: {
@@ -471,7 +469,7 @@ describe('parse bpmn as json for lane', () => {
         definitions: {
           targetNamespace: '',
           process: {
-            lane: { id: 'Lane_12u5n6x' },
+            laneSet: { lane: { id: 'Lane_12u5n6x' } },
           },
           BPMNDiagram: {
             BPMNPlane: {
@@ -509,7 +507,7 @@ describe('parse bpmn as json for lane', () => {
       definitions: {
         targetNamespace: '',
         process: {
-          lane: { id: 'Lane_12u5n6x' },
+          laneSet: { lane: { id: 'Lane_12u5n6x' } },
         },
         BPMNDiagram: {
           BPMNPlane: {

--- a/test/unit/component/parser/json/BpmnJsonParser.marker.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.marker.test.ts
@@ -18,6 +18,7 @@ import { parseJsonAndExpectOnlyFlowNodes } from '../../../helpers/JsonTestUtils'
 import { getExpectedMarkers, verifyShape } from '../../../helpers/bpmn-model-expect';
 
 import type { BpmnJsonModel } from '@lib/model/bpmn/json/BPMN20';
+import type { TProcess } from '@lib/model/bpmn/json/baseElement/rootElement/rootElement';
 import type { TMultiInstanceLoopCharacteristics, TStandardLoopCharacteristics } from '@lib/model/bpmn/json/baseElement/loopCharacteristics';
 import { ShapeBpmnCallActivityKind, ShapeBpmnElementKind, ShapeBpmnMarkerKind } from '@lib/model/bpmn/internal';
 
@@ -34,7 +35,7 @@ describe.each([
   ['manualTask', ShapeBpmnElementKind.TASK_MANUAL],
   ['scriptTask', ShapeBpmnElementKind.TASK_SCRIPT],
   ['businessRuleTask', ShapeBpmnElementKind.TASK_BUSINESS_RULE],
-])(`parse bpmn as json for '%s'`, (bpmnSemanticType: string, expectedShapeBpmnElementKind: ShapeBpmnElementKind) => {
+] as [keyof TProcess, ShapeBpmnElementKind][])(`parse bpmn as json for '%s'`, (bpmnSemanticType: keyof TProcess, expectedShapeBpmnElementKind: ShapeBpmnElementKind) => {
   describe.each([
     ['standardLoopCharacteristics', ShapeBpmnMarkerKind.LOOP],
     ['multiInstanceLoopCharacteristics', ShapeBpmnMarkerKind.MULTI_INSTANCE_PARALLEL],

--- a/test/unit/helpers/JsonBuilder.ts
+++ b/test/unit/helpers/JsonBuilder.ts
@@ -289,13 +289,13 @@ function addParticipantProcessAndElements(processParameter: BuildProcessParamete
   if (processParameter.withParticipant) {
     addParticipant(id, jsonModel);
   }
-  jsonModel.definitions.process = getBpmnElementNewValue(jsonModel.definitions.process as TProcess | TProcess[], { id: processParameter.withParticipant ? `process_${id}` : id });
+  jsonModel.definitions.process = enrichBpmnElement(jsonModel.definitions.process as TProcess | TProcess[], { id: processParameter.withParticipant ? `process_${id}` : id });
   addElementsOnProcess(processParameter, jsonModel, index);
 }
 
 function addParticipant(id: string, jsonModel: BpmnJsonModel): void {
   const collaboration: TCollaboration = getElementOfArray<TProcess>(jsonModel.definitions.collaboration as TCollaboration);
-  collaboration.participant = getBpmnElementNewValue(collaboration.participant, { id: id, processRef: `process_${id}` });
+  collaboration.participant = enrichBpmnElement(collaboration.participant, { id: id, processRef: `process_${id}` });
 
   const shape = {
     id: `shape_${id}`,
@@ -309,7 +309,7 @@ function addMessageFlow(messageFlowParameter: BuildMessageFlowParameter, jsonMod
   const messageFlow: TMessageFlow = messageFlowParameter;
 
   const collaboration: TCollaboration = getElementOfArray<TCollaboration>(jsonModel.definitions.collaboration as TCollaboration);
-  collaboration.messageFlow = getBpmnElementNewValue(collaboration.messageFlow, messageFlow);
+  collaboration.messageFlow = enrichBpmnElement(collaboration.messageFlow, messageFlow);
 
   addEdge(jsonModel, {
     bpmnElement: messageFlow.id,
@@ -327,7 +327,7 @@ const addGlobalTask = ({ id, bpmnKind = 'globalTask', ...rest }: BuildGlobalTask
   };
 
   const definitions = jsonModel.definitions;
-  definitions[bpmnKind] = getBpmnElementNewValue(definitions[bpmnKind], globalTask);
+  definitions[bpmnKind] = enrichBpmnElement(definitions[bpmnKind], globalTask);
 };
 
 function addElementsOnProcess(processParameter: BuildProcessParameter, json: BpmnJsonModel, processIndex: number): void {
@@ -418,17 +418,17 @@ function getElementOfArray<T>(object: T | T[], index = 0): T {
   }
 }
 
-function getBpmnElementNewValue<T extends TBaseElement | DiagramElement>(currentValue: T | T[], elementToAdd: T): T | T[] {
-  if (currentValue) {
-    if (!Array.isArray(currentValue)) {
-      return [currentValue, elementToAdd];
-    } else {
-      currentValue.push(elementToAdd);
-      return currentValue;
-    }
-  } else {
+function enrichBpmnElement<T extends TBaseElement | DiagramElement>(currentElement: T | T[], elementToAdd: T): T | T[] {
+  if (!currentElement) {
     return elementToAdd;
   }
+
+  if (Array.isArray(currentElement)) {
+    currentElement.push(elementToAdd);
+    return currentElement;
+  }
+
+  return [currentElement, elementToAdd];
 }
 
 function addLane(jsonModel: BpmnJsonModel, { id, name, ...rest }: BuildLaneParameter, index: number, processIndex: number): void {
@@ -441,7 +441,7 @@ function addLane(jsonModel: BpmnJsonModel, { id, name, ...rest }: BuildLaneParam
   }
 
   const laneSet = getElementOfArray<TProcess>(jsonModel.definitions.process as TProcess | TProcess[], processIndex).laneSet as TLaneSet;
-  laneSet.lane = getBpmnElementNewValue(laneSet.lane, lane);
+  laneSet.lane = enrichBpmnElement(laneSet.lane, lane);
 
   const shape = {
     id: `shape_${lane.id}`,
@@ -474,7 +474,7 @@ function addProcessElement(jsonModel: BpmnJsonModel, bpmnKind: keyof TProcess, {
   };
 
   const process: TProcess = getElementOfArray<TProcess>(jsonModel.definitions.process as TProcess | TProcess[], processIndex);
-  (process[bpmnKind] as TFlowElement | TArtifact | TFlowNode[] | TArtifact[]) = getBpmnElementNewValue<TFlowElement | TArtifact>(
+  (process[bpmnKind] as TFlowElement | TArtifact | TFlowNode[] | TArtifact[]) = enrichBpmnElement<TFlowElement | TArtifact>(
     process[bpmnKind] as TFlowElement | TArtifact | TFlowNode[] | TArtifact[],
     processElement,
   );
@@ -483,7 +483,7 @@ function addProcessElement(jsonModel: BpmnJsonModel, bpmnKind: keyof TProcess, {
 
 function addShape(jsonModel: BpmnJsonModel, shape: BPMNShape): void {
   const bpmnPlane: BPMNPlane = getElementOfArray(jsonModel.definitions.BPMNDiagram).BPMNPlane;
-  bpmnPlane.BPMNShape = getBpmnElementNewValue(bpmnPlane.BPMNShape, {
+  bpmnPlane.BPMNShape = enrichBpmnElement(bpmnPlane.BPMNShape, {
     id: `shape_${shape.bpmnElement}`,
     ...shape,
   });
@@ -491,7 +491,7 @@ function addShape(jsonModel: BpmnJsonModel, shape: BPMNShape): void {
 
 function addEdge(jsonModel: BpmnJsonModel, edge: BPMNEdge): void {
   const bpmnPlane: BPMNPlane = getElementOfArray(jsonModel.definitions.BPMNDiagram).BPMNPlane;
-  bpmnPlane.BPMNEdge = getBpmnElementNewValue(bpmnPlane.BPMNEdge, {
+  bpmnPlane.BPMNEdge = enrichBpmnElement(bpmnPlane.BPMNEdge, {
     id: `edge_${edge.bpmnElement}`,
     ...edge,
   });


### PR DESCRIPTION
1.  **Fix in `TProcess` parsing:** Removed unnecessary parsing of `lane` elements of the `TProcess` type that are not specified in the BPMN specification. This ensures correct parsing behavior.
2.  **Property removal:** The `[key: string]: any;` property has been removed from both the `TProcess` and `TDefinitions` classes. This prevents inadvertent access to non-existent properties within these objects.
3.  **JSONBuilder Function Renaming and Enhancement:** Renamed the `updateBpmnElement` function within the `JSONBuilder` class for better clarity. The function code has also been streamlined to improve readability and comprehension.

Closes #2188