### PR TITLE
ci: restore "--ignore-scripts" option for `npm ci`

### DIFF
--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -23,5 +23,4 @@ runs:
         # Do not install browsers https://playwright.dev/docs/browsers#installing-browsers
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
       with:
-        # restore --ignore-scripts when https://github.com/playwright-community/jest-playwright/issues/808 is fixed
-        install-command: npm ci --prefer-offline --audit false
+        install-command: npm ci --ignore-scripts --prefer-offline --audit false


### PR DESCRIPTION
It had been removed because an issue `jest-playwright` that is now marked as resolved.

### Resources

https://github.com/playwright-community/jest-playwright/issues/808#issuecomment-1304862603