### PR TITLE
test(e2e): fix e2e thresholds on macOS

### DIFF
--- a/test/e2e/bpmn.colors.test.ts
+++ b/test/e2e/bpmn.colors.test.ts
@@ -23,7 +23,7 @@ import type { Page } from 'playwright';
 class ImageSnapshotThresholdsModelColors extends MultiBrowserImageSnapshotThresholds {
   constructor() {
     // threshold for webkit is taken from macOS only
-    super({ chromium: 0.04 / 100, firefox: 0.006 / 100, webkit: 0.07 / 100 });
+    super({ chromium: 0.07 / 100, firefox: 0.006 / 100, webkit: 0.07 / 100 });
   }
 
   protected override getChromiumThresholds(): Map<string, ImageSnapshotThresholdConfig> {
@@ -31,7 +31,7 @@ class ImageSnapshotThresholdsModelColors extends MultiBrowserImageSnapshotThresh
       [
         'elements.colors.02.labels',
         {
-          macos: 0.15 / 100, // 0.14367268757742302%
+          macos: 0.16 / 100, // 0.15342106983194936%
           windows: 0.13 / 100, // 0.1213310788226063%
         },
       ],
@@ -66,7 +66,7 @@ class ImageSnapshotThresholdsModelColors extends MultiBrowserImageSnapshotThresh
 class ImageSnapshotThresholdsIgnoreBpmnColors extends MultiBrowserImageSnapshotThresholds {
   constructor() {
     // threshold for webkit is taken from macOS only
-    super({ chromium: 0.03 / 100, firefox: 0.007 / 100, webkit: 0.07 / 100 });
+    super({ chromium: 0.07 / 100, firefox: 0.007 / 100, webkit: 0.07 / 100 });
   }
 
   protected override getChromiumThresholds(): Map<string, ImageSnapshotThresholdConfig> {
@@ -74,7 +74,7 @@ class ImageSnapshotThresholdsIgnoreBpmnColors extends MultiBrowserImageSnapshotT
       [
         'elements.colors.02.labels',
         {
-          macos: 0.12 / 100, // 0.1103917951008726%
+          macos: 0.13 / 100, // 0.1212088519104926%
           windows: 0.13 / 100, // 0.1213310788226063%
         },
       ],

--- a/test/e2e/bpmn.elements.collapsed.test.ts
+++ b/test/e2e/bpmn.elements.collapsed.test.ts
@@ -44,10 +44,10 @@ const getElementsToCollapse = (bpmnDiagramName: string): Array<string> => {
 describe('Collapse BPMN elements', () => {
   const diagramSubfolder = 'collapse-expand';
   const imageSnapshotConfigurator = new CollapsedElementImageSnapshotConfigurator(
-    // chromium: max 0.037293933208770724%
+    // chromium: max 0.0696236566863573%
     // firefox: max 0.10839637777485533%
     // webkit: max 0.14363687914162873%
-    new MultiBrowserImageSnapshotThresholds({ chromium: 0.04 / 100, firefox: 0.11 / 100, webkit: 0.15 / 100 }),
+    new MultiBrowserImageSnapshotThresholds({ chromium: 0.07 / 100, firefox: 0.11 / 100, webkit: 0.15 / 100 }),
     diagramSubfolder,
   );
   const pageTester = new PageTester({ targetedPage: AvailableTestPages.BPMN_RENDERING, diagramSubfolder }, <Page>page);

--- a/test/e2e/bpmn.elements.filter.pools.test.ts
+++ b/test/e2e/bpmn.elements.filter.pools.test.ts
@@ -30,10 +30,10 @@ class FilterPoolsImageSnapshotConfigurator extends ImageSnapshotConfigurator {
 describe('Filter pools', () => {
   const diagramSubfolder = 'filter';
   const imageSnapshotConfigurator = new FilterPoolsImageSnapshotConfigurator(
-    // chromium: 0.01961843254507656% max
+    // chromium: 0.07789950491838837% max
     // firefox: 0.012128385807519404% max
     // webkit: 0.160355447672067% max
-    new MultiBrowserImageSnapshotThresholds({ chromium: 0.02 / 100, firefox: 0.013 / 100, webkit: 0.17 / 100 }),
+    new MultiBrowserImageSnapshotThresholds({ chromium: 0.08 / 100, firefox: 0.013 / 100, webkit: 0.17 / 100 }),
     diagramSubfolder,
   );
   const pageTester = new PageTester({ targetedPage: AvailableTestPages.BPMN_RENDERING, diagramSubfolder }, <Page>page);

--- a/test/e2e/bpmn.rendering.test.ts
+++ b/test/e2e/bpmn.rendering.test.ts
@@ -61,7 +61,7 @@ class ImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
         'labels.01.general',
         {
           linux: 0.02 / 100, // 0.017198744741930838%
-          macos: 0.61 / 100, // 0.602778890243727%
+          macos: 0.8 / 100, // 0.7941577314545922%
           windows: 0.52 / 100, // 0.5122398889742197%
         },
       ],
@@ -69,7 +69,7 @@ class ImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
         'labels.02.position.and.line.breaks',
         {
           linux: 0.05 / 100, // 0.04820572362378428%
-          macos: 0.96 / 100, // 0.9536040534832702%
+          macos: 0.97 / 100, // 0.9608986974041889%
           windows: 0.63 / 100, // 0.6249408985672167%
         },
       ],
@@ -77,83 +77,221 @@ class ImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
         'labels.03.default.position',
         {
           linux: 0.02 / 100, // 0.012776491483779129%
-          macos: 0.37 / 100, // 0.36428234685847993%
+          macos: 0.38 / 100, // 0.37323579648680383%
           windows: 0.33 / 100, // 0.3203254635281927%
         },
       ],
       [
         'labels.04.fonts',
         {
-          macos: 0.18 / 100, // 0.17224316335068268%
+          macos: 0.2 / 100, // 0.1880729042500584%
           windows: 0.22 / 100, // 0.2109362424737582%
         },
       ],
       [
         'labels.05.default.position.activities',
         {
-          macos: 0.28 / 100, // 0.2780854945044653%
+          macos: 0.35 / 100, // 0.3364682783477235%
           windows: 0.47 / 100, // 0.46907051252580434%
         },
       ],
       [
         'pools.01.labels.and.lanes',
         {
-          macos: 0.09 / 100, // 0.08291308761130267%
+          macos: 0.13 / 100, // 0.1226965940445024%
           windows: 0.23 / 100, // 0.21990738071808735%
         },
       ],
       [
         'pools.02.vertical.with.lanes',
         {
-          macos: 0.13 / 100, // 0.12482014769641389%
+          macos: 0.16 / 100, // 0.15541529608473773%
           windows: 0.14 / 100, // 0.13308164928160784%
         },
       ],
       [
         'pools.03.black.box',
         {
-          macos: 0.095 / 100, // 0.0935782032063015%
+          macos: 0.11 / 100, // 0.10700131148185799%
           windows: 0.12 / 100, // 0.1184446265753869%
+        },
+      ],
+      [
+        'pools.04.not.displayed.with.elements',
+        {
+          macos: 0.011 / 100, // 0.010651827942065317%
         },
       ],
       // tests without labels
       [
+        'associations.and.annotations.01.general',
+        {
+          macos: 0.032 / 100, // 0.03104752073704864%
+        },
+      ],
+      [
         'associations.and.annotations.02.complex.paths',
         {
           linux: 0.015 / 100, // 0.014863828948641356%
-          macos: 0.015 / 100, // 0.014863828948641356%
+          macos: 0.053 / 100, // 0.052455761998149164%
           windows: 0.015 / 100, // 0.014863828948641356%
+        },
+      ],
+      [
+        'associations.and.annotations.03.waypoints.01.inside.shape',
+        {
+          macos: 0.01 / 100, // 0.009821122543585137%
+        },
+      ],
+      [
+        'associations.and.annotations.03.waypoints.02.outside.shape',
+        {
+          macos: 0.046 / 100, // 0.04565435126099304%
+        },
+      ],
+      [
+        'associations.and.annotations.03.waypoints.03.none',
+        {
+          macos: 0.013 / 100, // 0.012421906075676947%
+        },
+      ],
+      [
+        'associations.and.annotations.04.target.edges',
+        {
+          macos: 0.013 / 100, // 0.012958722982014947%
+        },
+      ],
+      [
+        'associations.and.annotations.05.target.edges.no.waypoints',
+        {
+          macos: 0.013 / 100, // 0.012481029857225323%
+        },
+      ],
+      [
+        'call.activities',
+        {
+          macos: 0.015 / 100, // 0.014471908405144784%
         },
       ],
       [
         'events',
         {
           linux: 0.07 / 100, // 0.06873063882651965%
-          macos: 0.07 / 100, // 0.06873063882651965%
+          macos: 0.15 / 100, // 0.1429705389616731%
           windows: 0.07 / 100, // 0.06873063882651965%
+        },
+      ],
+      [
+        'flows.message.01.icons',
+        {
+          macos: 0.09 / 100, // 0.08622016687080958%
+        },
+      ],
+      [
+        'flows.message.02.labels.and.complex.paths',
+        {
+          macos: 0.074 / 100, // 0.07351618297872786%
+        },
+      ],
+      [
+        'flows.message.03.waypoints.01.none',
+        {
+          macos: 0.014 / 100, // 0.013230216124793248%
+        },
+      ],
+      [
+        'flows.message.03.waypoints.02.inside',
+        {
+          macos: 0.018 / 100, // 0.017396505351174874%
+        },
+      ],
+      [
+        'flows.message.03.waypoints.03.outside',
+        {
+          macos: 0.018 / 100, // 0.017448981233758598%
+        },
+      ],
+      [
+        'flows.message.03.waypoints.04.outside.segments.no.intersection.with.shapes',
+        {
+          macos: 0.018 / 100, // 0.01705591121203831%
+        },
+      ],
+      [
+        'flows.sequence.01.kinds.and.complex.paths',
+        {
+          macos: 0.046 / 100, // 0.04525235200248945%
+        },
+      ],
+      [
+        'flows.sequence.02.events.from.to',
+        {
+          macos: 0.033 / 100, // 0.03252073308086523%
+        },
+      ],
+      [
+        'flows.sequence.03.gateways.from.to',
+        {
+          macos: 0.025 / 100, // 0.024563288410006656%
         },
       ],
       [
         'flows.sequence.04.waypoints.01.none',
         {
           linux: 0.013 / 100, // 0.012784947599830954%
-          macos: 0.013 / 100, // 0.012784947599830954%
+          macos: 0.034 / 100, // 0.03348060921085638%
           windows: 0.013 / 100, // 0.012784947599830954%
+        },
+      ],
+      [
+        'flows.sequence.04.waypoints.02.terminal.inside.shapes',
+        {
+          macos: 0.032 / 100, // 0.03182084724950851%
+        },
+      ],
+      [
+        'flows.sequence.04.waypoints.03.terminal.outside.shapes.01.general',
+        {
+          macos: 0.026 / 100, // 0.025442484061721782%
+        },
+      ],
+      [
+        'flows.sequence.04.waypoints.03.terminal.outside.shapes.02.segments.no.intersection.with.shapes',
+        {
+          macos: 0.039 / 100, // 0.03833616437499687%
         },
       ],
       [
         'flows.sequence.04.waypoints.04.terminal.bonita.events',
         {
           linux: 0.013 / 100, // 0.012102508336264695%
-          macos: 0.013 / 100, // 0.012102508336264695%
+          macos: 0.023 / 100, // 0.02240063479596044%
           windows: 0.013 / 100, // 0.012102508336264695%
+        },
+      ],
+      [
+        'flows.sequence.04.waypoints.05.terminal.bonita.gateways',
+        {
+          macos: 0.019 / 100, // 0.018518769555930792%
+        },
+      ],
+      [
+        'flows.sequence.05.markers',
+        {
+          macos: 0.031 / 100, // 0.030249892742950646%
+        },
+      ],
+      [
+        'gateways',
+        {
+          macos: 0.015 / 100, // 0.014442981030360347%
         },
       ],
       [
         'group.03.several.groups.different.size',
         {
           linux: 0.019 / 100, // 0.01833011862978351%
-          macos: 0.019 / 100, // 0.01833011862978351%
+          macos: 0.037 / 100, // 0.03616235985035576%
           windows: 0.019 / 100, // 0.01833011862978351%
         },
       ],
@@ -169,15 +307,33 @@ class ImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
         'markers.01.positioning',
         {
           linux: 0.08 / 100, // 0.0709857394639246%
-          macos: 0.08 / 100, // 0.0709857394639246%
+          macos: 0.12 / 100, // 0.11335331404938032%
           windows: 0.08 / 100, // 0.0709857394639246%
+        },
+      ],
+      [
+        'markers.02.different.tasks.sizes',
+        {
+          macos: 0.02 / 100, // 0.018522656298003426%
+        },
+      ],
+      [
+        'subprocess.01.with.lanes',
+        {
+          macos: 0.05 / 100, // 0.04841555756042171%
+        },
+      ],
+      [
+        'subprocess.02.with.inner.subprocess',
+        {
+          macos: 0.03 / 100, // 0.029195380649782443%
         },
       ],
       [
         'subprocess.03.collapsed.with.elements',
         {
           linux: 0.013 / 100, // 0.01247161458035606%
-          macos: 0.013 / 100, // 0.01247161458035606%
+          macos: 0.024 / 100, // 0.023238318327312157%
           windows: 0.013 / 100, // 0.01247161458035606%
         },
       ],
@@ -185,8 +341,14 @@ class ImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
         'subprocess.04.expanded.with.elements',
         {
           linux: 0.031 / 100, // 0.030667450146004693%
-          macos: 0.031 / 100, // 0.030667450146004693%
+          macos: 0.04 / 100, // 0.039096596863918975%
           windows: 0.031 / 100, // 0.030667450146004693%
+        },
+      ],
+      [
+        'tasks',
+        {
+          macos: 0.05 / 100, // 0.04267935203429163%
         },
       ],
     ]);

--- a/test/e2e/bpmn.rendering.test.ts
+++ b/test/e2e/bpmn.rendering.test.ts
@@ -25,7 +25,7 @@ import { ImageSnapshotConfigurator, MultiBrowserImageSnapshotThresholds } from '
 class ImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
   constructor() {
     // threshold for webkit is taken from macOS only
-    super({ chromium: 0.16 / 100, firefox: 0.09 / 100, webkit: 0.12 / 100 });
+    super({ chromium: 0.16 / 100, firefox: 0.09 / 100, webkit: 0.14 / 100 });
   }
 
   protected override getChromiumThresholds(): Map<string, ImageSnapshotThresholdConfig> {

--- a/test/e2e/bpmn.rendering.test.ts
+++ b/test/e2e/bpmn.rendering.test.ts
@@ -25,7 +25,7 @@ import { ImageSnapshotConfigurator, MultiBrowserImageSnapshotThresholds } from '
 class ImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
   constructor() {
     // threshold for webkit is taken from macOS only
-    super({ chromium: 0.009 / 100, firefox: 0.02 / 100, webkit: 0.12 / 100 });
+    super({ chromium: 0.16 / 100, firefox: 0.09 / 100, webkit: 0.12 / 100 });
   }
 
   protected override getChromiumThresholds(): Map<string, ImageSnapshotThresholdConfig> {
@@ -34,33 +34,8 @@ class ImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
     return new Map<string, ImageSnapshotThresholdConfig>([
       // start with diagram including labels
       [
-        'flows.message.02.labels.and.complex.paths',
-        {
-          linux: 0.03 / 100, // 0.021112197671391275%
-          macos: 0.07 / 100, // 0.06413016822180982%
-          windows: 0.15 / 100, // 0.1429326405050113%
-        },
-      ],
-      [
-        'group.01.in.process.with.label',
-        {
-          linux: 0.03 / 100, // 0.027579683731493443%
-          macos: 0.05 / 100, // 0.04504221581033141%
-          windows: 0.06 / 100, // 0.0563456027189768%
-        },
-      ],
-      [
-        'group.02.in.collaboration.with.label',
-        {
-          linux: 0.02 / 100, // 0.013564051057024518%
-          macos: 0.03 / 100, // 0.024852910755979174%
-          windows: 0.05 / 100, // 0.044700592690916086%
-        },
-      ],
-      [
         'labels.01.general',
         {
-          linux: 0.02 / 100, // 0.017198744741930838%
           macos: 0.8 / 100, // 0.7941577314545922%
           windows: 0.52 / 100, // 0.5122398889742197%
         },
@@ -68,7 +43,6 @@ class ImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
       [
         'labels.02.position.and.line.breaks',
         {
-          linux: 0.05 / 100, // 0.04820572362378428%
           macos: 0.97 / 100, // 0.9608986974041889%
           windows: 0.63 / 100, // 0.6249408985672167%
         },
@@ -76,7 +50,6 @@ class ImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
       [
         'labels.03.default.position',
         {
-          linux: 0.02 / 100, // 0.012776491483779129%
           macos: 0.38 / 100, // 0.37323579648680383%
           windows: 0.33 / 100, // 0.3203254635281927%
         },
@@ -98,257 +71,7 @@ class ImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
       [
         'pools.01.labels.and.lanes',
         {
-          macos: 0.13 / 100, // 0.1226965940445024%
           windows: 0.23 / 100, // 0.21990738071808735%
-        },
-      ],
-      [
-        'pools.02.vertical.with.lanes',
-        {
-          macos: 0.16 / 100, // 0.15541529608473773%
-          windows: 0.14 / 100, // 0.13308164928160784%
-        },
-      ],
-      [
-        'pools.03.black.box',
-        {
-          macos: 0.11 / 100, // 0.10700131148185799%
-          windows: 0.12 / 100, // 0.1184446265753869%
-        },
-      ],
-      [
-        'pools.04.not.displayed.with.elements',
-        {
-          macos: 0.011 / 100, // 0.010651827942065317%
-        },
-      ],
-      // tests without labels
-      [
-        'associations.and.annotations.01.general',
-        {
-          macos: 0.032 / 100, // 0.03104752073704864%
-        },
-      ],
-      [
-        'associations.and.annotations.02.complex.paths',
-        {
-          linux: 0.015 / 100, // 0.014863828948641356%
-          macos: 0.053 / 100, // 0.052455761998149164%
-          windows: 0.015 / 100, // 0.014863828948641356%
-        },
-      ],
-      [
-        'associations.and.annotations.03.waypoints.01.inside.shape',
-        {
-          macos: 0.01 / 100, // 0.009821122543585137%
-        },
-      ],
-      [
-        'associations.and.annotations.03.waypoints.02.outside.shape',
-        {
-          macos: 0.046 / 100, // 0.04565435126099304%
-        },
-      ],
-      [
-        'associations.and.annotations.03.waypoints.03.none',
-        {
-          macos: 0.013 / 100, // 0.012421906075676947%
-        },
-      ],
-      [
-        'associations.and.annotations.04.target.edges',
-        {
-          macos: 0.013 / 100, // 0.012958722982014947%
-        },
-      ],
-      [
-        'associations.and.annotations.05.target.edges.no.waypoints',
-        {
-          macos: 0.013 / 100, // 0.012481029857225323%
-        },
-      ],
-      [
-        'call.activities',
-        {
-          macos: 0.015 / 100, // 0.014471908405144784%
-        },
-      ],
-      [
-        'events',
-        {
-          linux: 0.07 / 100, // 0.06873063882651965%
-          macos: 0.15 / 100, // 0.1429705389616731%
-          windows: 0.07 / 100, // 0.06873063882651965%
-        },
-      ],
-      [
-        'flows.message.01.icons',
-        {
-          macos: 0.09 / 100, // 0.08622016687080958%
-        },
-      ],
-      [
-        'flows.message.02.labels.and.complex.paths',
-        {
-          macos: 0.074 / 100, // 0.07351618297872786%
-        },
-      ],
-      [
-        'flows.message.03.waypoints.01.none',
-        {
-          macos: 0.014 / 100, // 0.013230216124793248%
-        },
-      ],
-      [
-        'flows.message.03.waypoints.02.inside',
-        {
-          macos: 0.018 / 100, // 0.017396505351174874%
-        },
-      ],
-      [
-        'flows.message.03.waypoints.03.outside',
-        {
-          macos: 0.018 / 100, // 0.017448981233758598%
-        },
-      ],
-      [
-        'flows.message.03.waypoints.04.outside.segments.no.intersection.with.shapes',
-        {
-          macos: 0.018 / 100, // 0.01705591121203831%
-        },
-      ],
-      [
-        'flows.sequence.01.kinds.and.complex.paths',
-        {
-          macos: 0.046 / 100, // 0.04525235200248945%
-        },
-      ],
-      [
-        'flows.sequence.02.events.from.to',
-        {
-          macos: 0.033 / 100, // 0.03252073308086523%
-        },
-      ],
-      [
-        'flows.sequence.03.gateways.from.to',
-        {
-          macos: 0.025 / 100, // 0.024563288410006656%
-        },
-      ],
-      [
-        'flows.sequence.04.waypoints.01.none',
-        {
-          linux: 0.013 / 100, // 0.012784947599830954%
-          macos: 0.034 / 100, // 0.03348060921085638%
-          windows: 0.013 / 100, // 0.012784947599830954%
-        },
-      ],
-      [
-        'flows.sequence.04.waypoints.02.terminal.inside.shapes',
-        {
-          macos: 0.032 / 100, // 0.03182084724950851%
-        },
-      ],
-      [
-        'flows.sequence.04.waypoints.03.terminal.outside.shapes.01.general',
-        {
-          macos: 0.026 / 100, // 0.025442484061721782%
-        },
-      ],
-      [
-        'flows.sequence.04.waypoints.03.terminal.outside.shapes.02.segments.no.intersection.with.shapes',
-        {
-          macos: 0.039 / 100, // 0.03833616437499687%
-        },
-      ],
-      [
-        'flows.sequence.04.waypoints.04.terminal.bonita.events',
-        {
-          linux: 0.013 / 100, // 0.012102508336264695%
-          macos: 0.023 / 100, // 0.02240063479596044%
-          windows: 0.013 / 100, // 0.012102508336264695%
-        },
-      ],
-      [
-        'flows.sequence.04.waypoints.05.terminal.bonita.gateways',
-        {
-          macos: 0.019 / 100, // 0.018518769555930792%
-        },
-      ],
-      [
-        'flows.sequence.05.markers',
-        {
-          macos: 0.031 / 100, // 0.030249892742950646%
-        },
-      ],
-      [
-        'gateways',
-        {
-          macos: 0.015 / 100, // 0.014442981030360347%
-        },
-      ],
-      [
-        'group.03.several.groups.different.size',
-        {
-          linux: 0.019 / 100, // 0.01833011862978351%
-          macos: 0.037 / 100, // 0.03616235985035576%
-          windows: 0.019 / 100, // 0.01833011862978351%
-        },
-      ],
-      [
-        'group.05.cross.pools',
-        {
-          linux: 0.017 / 100, // 0.016330929320085286%
-          macos: 0.017 / 100, // 0.016330929320085286%
-          windows: 0.017 / 100, // 0.016330929320085286%
-        },
-      ],
-      [
-        'markers.01.positioning',
-        {
-          linux: 0.08 / 100, // 0.0709857394639246%
-          macos: 0.12 / 100, // 0.11335331404938032%
-          windows: 0.08 / 100, // 0.0709857394639246%
-        },
-      ],
-      [
-        'markers.02.different.tasks.sizes',
-        {
-          macos: 0.02 / 100, // 0.018522656298003426%
-        },
-      ],
-      [
-        'subprocess.01.with.lanes',
-        {
-          macos: 0.05 / 100, // 0.04841555756042171%
-        },
-      ],
-      [
-        'subprocess.02.with.inner.subprocess',
-        {
-          macos: 0.03 / 100, // 0.029195380649782443%
-        },
-      ],
-      [
-        'subprocess.03.collapsed.with.elements',
-        {
-          linux: 0.013 / 100, // 0.01247161458035606%
-          macos: 0.024 / 100, // 0.023238318327312157%
-          windows: 0.013 / 100, // 0.01247161458035606%
-        },
-      ],
-      [
-        'subprocess.04.expanded.with.elements',
-        {
-          linux: 0.031 / 100, // 0.030667450146004693%
-          macos: 0.04 / 100, // 0.039096596863918975%
-          windows: 0.031 / 100, // 0.030667450146004693%
-        },
-      ],
-      [
-        'tasks',
-        {
-          macos: 0.05 / 100, // 0.04267935203429163%
         },
       ],
     ]);
@@ -359,7 +82,6 @@ class ImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
       [
         'flows.message.02.labels.and.complex.paths',
         {
-          linux: 0.09 / 100, // 0.08377044926310973%
           macos: 0.13 / 100, // 0.12624011437493143%
           windows: 0.73 / 100, // 0.7275118149390969%
         },
@@ -425,7 +147,6 @@ class ImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
       [
         'pools.01.labels.and.lanes',
         {
-          macos: 0.09 / 100, // 0.08552532456441721%
           windows: 0.56 / 100, // 0.5571042176931162%
         },
       ],
@@ -439,26 +160,8 @@ class ImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
       [
         'pools.03.black.box',
         {
-          linux: 0.08 / 100, // 0.07283646777227482%
           macos: 0.14 / 100, // 0.13474247576623632%
           windows: 0.66 / 100, // 0.6566433292574891%
-        },
-      ],
-      // tests without labels
-      [
-        'associations.and.annotations.01.general',
-        {
-          linux: 0.074 / 100, // 0.07377888682271738%
-          macos: 0.074 / 100, // 0.07377888682271738%
-          windows: 0.074 / 100, // 0.07377888682271738%
-        },
-      ],
-      [
-        'markers.02.different.tasks.sizes',
-        {
-          linux: 0.00026, // 0.02578305330844799%
-          macos: 0.00026, // 0.02578305330844799%
-          windows: 0.00026, // 0.02578305330844799%
         },
       ],
     ]);
@@ -520,13 +223,6 @@ class ImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
         'pools.03.black.box',
         {
           macos: 0.36 / 100, // 0.3576987596416892%
-        },
-      ],
-      // tests without labels
-      [
-        'events',
-        {
-          macos: 0.0014, // 0.1397832014147449%
         },
       ],
     ]);

--- a/test/e2e/bpmn.theme.test.ts
+++ b/test/e2e/bpmn.theme.test.ts
@@ -47,11 +47,11 @@ const styleOptionsPerUseCase = new Map<string, StyleOptions>([
 ]);
 
 describe('BPMN theme', () => {
-  // chromium max: 0.046637742713451225%
+  // chromium max: 0.11331452736599301%
   // firefox max for all OS: 0.07136751215260918%
   // webkit max: 0.10454002395935413%
   const imageSnapshotConfigurator = new ImageSnapshotConfigurator(
-    new MultiBrowserImageSnapshotThresholds({ chromium: 0.047 / 100, firefox: 0.072 / 100, webkit: 0.105 / 100 }),
+    new MultiBrowserImageSnapshotThresholds({ chromium: 0.12 / 100, firefox: 0.072 / 100, webkit: 0.105 / 100 }),
     'theme',
   );
 

--- a/test/e2e/diagram.navigation.fit.test.ts
+++ b/test/e2e/diagram.navigation.fit.test.ts
@@ -109,6 +109,17 @@ class ImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
       ],
     ]);
   }
+
+  protected override getWebkitThresholds(): Map<string, ImageSnapshotThresholdConfig> {
+    return new Map<string, ImageSnapshotThresholdConfig>([
+      [
+        'with.outside.labels',
+        {
+          macos: 0.39 / 100, // max 0.38104004012843307%
+        },
+      ],
+    ]);
+  }
 }
 
 describe('diagram navigation - fit', () => {

--- a/test/e2e/diagram.navigation.fit.test.ts
+++ b/test/e2e/diagram.navigation.fit.test.ts
@@ -63,8 +63,7 @@ const bpmnDiagramNames = getBpmnDiagramNames(diagramSubfolder);
 
 class ImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
   constructor() {
-    const defaultFailureThreshold = 0.006 / 100; // all OS 0.005379276499073438%
-    super({ chromium: defaultFailureThreshold, firefox: defaultFailureThreshold, webkit: defaultFailureThreshold });
+    super({ chromium: 0.006 / 100, firefox: 0.042 / 100, webkit: 0.058 / 100 });
   }
   protected override getChromiumThresholds(): Map<string, ImageSnapshotThresholdConfig> {
     // if no dedicated information, set minimal threshold to make test pass on GitHub Workflow
@@ -101,65 +100,11 @@ class ImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
   protected override getFirefoxThresholds(): Map<string, ImageSnapshotThresholdConfig> {
     return new Map<string, ImageSnapshotThresholdConfig>([
       [
-        'horizontal',
-        {
-          linux: 0.0003, // max 0.024774485137324387%
-          macos: 0.0003, // max 0.024774485137324387%
-          windows: 0.0003, // max 0.024774485137324387%
-        },
-      ],
-      [
-        'vertical',
-        {
-          linux: 0.00042, // max 0.041092716803170504%
-          macos: 0.00042, // max 0.041092716803170504%
-          windows: 0.00042, // max 0.041092716803170504%
-        },
-      ],
-      [
-        'with.outside.flows',
-        {
-          linux: 0.014 / 100, // max 0.013336184209755686%
-          macos: 0.014 / 100, // max 0.013336184209755686%
-          windows: 0.014 / 100, // max 0.013336184209755686%
-        },
-      ],
-      [
         'with.outside.labels',
         {
-          linux: 0.01 / 100, // max 0.009366366103591428%
           macos: 0.25 / 100, // max 0.24536808515324138%
           // TODO possible rendering issue so high threshold value
           windows: 4.4 / 100, // max 4.039381490979144%
-        },
-      ],
-    ]);
-  }
-
-  protected override getWebkitThresholds(): Map<string, ImageSnapshotThresholdConfig> {
-    return new Map<string, ImageSnapshotThresholdConfig>([
-      [
-        'horizontal',
-        {
-          macos: 0.0005, // max is 0.040879927795189897%
-        },
-      ],
-      [
-        'vertical',
-        {
-          macos: 0.0006, // max is 0.05782432968098884%
-        },
-      ],
-      [
-        'with.outside.flows',
-        {
-          macos: 0.03 / 100, // max is 0.029136454748612817%
-        },
-      ],
-      [
-        'with.outside.labels',
-        {
-          macos: 0.39 / 100, // max is 0.3810397001432486%
         },
       ],
     ]);

--- a/test/e2e/diagram.navigation.fit.test.ts
+++ b/test/e2e/diagram.navigation.fit.test.ts
@@ -71,9 +71,27 @@ class ImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
     // linux threshold are set for Ubuntu
     return new Map<string, ImageSnapshotThresholdConfig>([
       [
+        'horizontal',
+        {
+          macos: 0.026, // max 0.025094962866600845%
+        },
+      ],
+      [
+        'vertical',
+        {
+          macos: 0.026, // max 0.025094962866600845%
+        },
+      ],
+      [
+        'with.outside.flows',
+        {
+          macos: 0.04 / 100, // max 0.033407969331455956%%
+        },
+      ],
+      [
         'with.outside.labels',
         {
-          macos: 0.25 / 100, // max 0.24369443621680142%
+          macos: 0.26 / 100, // max 0.2520311140280951%
           windows: 0.39 / 100, // max 0.38276450047973753%
         },
       ],

--- a/test/e2e/diagram.navigation.zoom.pan.test.ts
+++ b/test/e2e/diagram.navigation.zoom.pan.test.ts
@@ -33,6 +33,16 @@ class MouseNavigationImageSnapshotThresholds extends MultiBrowserImageSnapshotTh
 
   // if no dedicated information, set minimal threshold to make test pass on GitHub Workflow
   // linux threshold are set for Ubuntu
+  protected override getChromiumThresholds(): Map<string, ImageSnapshotThresholdConfig> {
+    return new Map<string, ImageSnapshotThresholdConfig>([
+      [
+        'simple.2.start.events.1.task',
+        {
+          macos: 0.02 / 100, // 0.015022037589296211%
+        },
+      ],
+    ]);
+  }
   protected override getWebkitThresholds(): Map<string, ImageSnapshotThresholdConfig> {
     return new Map<string, ImageSnapshotThresholdConfig>([
       [
@@ -123,7 +133,7 @@ async function doZoomWithButton(zoomType: ZoomType, xTimes = 1): Promise<void> {
 describe('diagram navigation - zoom with buttons', () => {
   const imageSnapshotConfigurator = new ImageSnapshotConfigurator(
     new MultiBrowserImageSnapshotThresholds({
-      chromium: 0.03 / 100, // max 0.029310570733620533%
+      chromium: 0.04 / 100, // max 0.03513530712989654%
       firefox: 0.03 / 100, // max 0.029286409410644865%
       webkit: 0.034 / 100, // max 0.03302199927066596%
     }),
@@ -161,7 +171,7 @@ describe('diagram navigation - zoom with buttons', () => {
 describe('diagram navigation - zoom with buttons and mouse', () => {
   const imageSnapshotConfigurator = new ImageSnapshotConfigurator(
     new MultiBrowserImageSnapshotThresholds({
-      chromium: 0.03 / 100, // max 0.029310570733620533%
+      chromium: 0.04 / 100, // max 0.03513530712989654%
       firefox: 0.03 / 100, // max 0.029286409410644865%
       webkit: 0.035 / 100, // max 0.03302199927066596%
     }),

--- a/test/e2e/overlays.rendering.test.ts
+++ b/test/e2e/overlays.rendering.test.ts
@@ -42,7 +42,7 @@ class ImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
         'overlays.start.flow.task.gateway',
         {
           linux: 0.0008 / 100, // max 0.0007333061246894701%
-          macos: 0.1 / 100, // max 0.09371109158465839%
+          macos: 0.11 / 100, // max 0.10064076292350954%
           windows: 0.12 / 100, // max 0.11574540756377205%
         },
       ],
@@ -291,7 +291,7 @@ describe('Overlay navigation', () => {
           'overlays.start.flow.task.gateway',
           {
             linux: 0.002 / 100, // max 0.0013092137383430291%
-            macos: 0.09 / 100, // max 0.08430877145797488%
+            macos: 0.1 / 100, // max 0.09067455596909468%
             windows: 0.12 / 100, // max 0.11213898282994572%
           },
         ],
@@ -388,7 +388,7 @@ describe('Overlay style', () => {
           'fill',
           {
             linux: 0.001 / 100, // 0.0007276893557062181%
-            macos: 0.016 / 100, // 0.01515942258121239%
+            macos: 0.03 / 100, // 0.022672389461708686%
             windows: 0.03 / 100, // 0.021221138510052473%
           },
         ],
@@ -404,7 +404,7 @@ describe('Overlay style', () => {
           'stroke',
           {
             linux: 0.001 / 100, // 0.0007363497292800503%
-            macos: 0.18 / 100, // 0.1787876617120987%
+            macos: 0.19 / 100, // 0.18879188656002463%
             windows: 0.22 / 100, // 0.2184761338537622%
           },
         ],

--- a/test/e2e/overlays.rendering.test.ts
+++ b/test/e2e/overlays.rendering.test.ts
@@ -31,7 +31,7 @@ const log = debugLogger('bv:test:e2e:overlays');
 
 class ImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
   constructor() {
-    super({ chromium: 0.0005 / 100, firefox: 0.04 / 100, webkit: 0 });
+    super({ chromium: 0.17 / 100, firefox: 0.44 / 100, webkit: 0.59 / 100 });
   }
 
   protected override getChromiumThresholds(): Map<string, ImageSnapshotThresholdConfig> {
@@ -39,26 +39,11 @@ class ImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
     // linux threshold are set for Ubuntu
     return new Map<string, ImageSnapshotThresholdConfig>([
       [
-        'overlays.start.flow.task.gateway',
-        {
-          linux: 0.0008 / 100, // max 0.0007333061246894701%
-          macos: 0.11 / 100, // max 0.10064076292350954%
-          windows: 0.12 / 100, // max 0.11574540756377205%
-        },
-      ],
-      [
         'overlays.edges.associations.complex.paths',
         {
           linux: 0.31 / 100, // max 0.30203253615374015%
           macos: 0.31 / 100, // max 0.3006830880479039%
           windows: 0.31 / 100, // max 0.3013649459581602%
-        },
-      ],
-      [
-        'overlays.edges.message.flows.complex.paths',
-        {
-          macos: 0.17 / 100, // 0.16085016564131302%
-          windows: 0.08 / 100, // 0.07293820549113537%
         },
       ],
       [
@@ -77,17 +62,13 @@ class ImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
       [
         'overlays.start.flow.task.gateway',
         {
-          linux: 0.44 / 100, // max 0.435363088442553%
           macos: 0.71 / 100, // max 0.7027880077090211%
-          windows: 0.14 / 100, // max 0.13629575601151744%
         },
       ],
       [
         'overlays.edges.associations.complex.paths',
         {
-          linux: 0.4 / 100, // max 0.3964089055703668%
           macos: 0.53 / 100, // max 0.5254958628580608%
-          windows: 0.43 / 100, // max 0.42268320684041294%
         },
       ],
       [
@@ -101,38 +82,7 @@ class ImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
       [
         'overlays.edges.sequence.flows.complex.paths',
         {
-          linux: 0.36 / 100, // max 0.35664699175183%
           macos: 0.44 / 100, // max 0.43144267510022427%
-          windows: 0.3 / 100, // max 0.2931831722714717%
-        },
-      ],
-    ]);
-  }
-
-  protected override getWebkitThresholds(): Map<string, ImageSnapshotThresholdConfig> {
-    return new Map<string, ImageSnapshotThresholdConfig>([
-      [
-        'overlays.start.flow.task.gateway',
-        {
-          macos: 0.59 / 100, // max 0.5856189551567081%
-        },
-      ],
-      [
-        'overlays.edges.associations.complex.paths',
-        {
-          macos: 0.48 / 100, // max 0.4771582239915584%
-        },
-      ],
-      [
-        'overlays.edges.message.flows.complex.paths',
-        {
-          macos: 0.35 / 100, // max 0.3492043109226462%
-        },
-      ],
-      [
-        'overlays.edges.sequence.flows.complex.paths',
-        {
-          macos: 0.39 / 100, // max 0.3876107955861241%
         },
       ],
     ]);
@@ -282,20 +232,7 @@ describe('Overlay navigation', () => {
   class OverlayNavigationImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
     constructor() {
       // don't set defaults as we defined thresholds for all style variants
-      super({ chromium: 0, firefox: 0, webkit: 0 });
-    }
-
-    protected override getChromiumThresholds(): Map<string, ImageSnapshotThresholdConfig> {
-      return new Map<string, ImageSnapshotThresholdConfig>([
-        [
-          'overlays.start.flow.task.gateway',
-          {
-            linux: 0.002 / 100, // max 0.0013092137383430291%
-            macos: 0.1 / 100, // max 0.09067455596909468%
-            windows: 0.12 / 100, // max 0.11213898282994572%
-          },
-        ],
-      ]);
+      super({ chromium: 0.12 / 100, firefox: 0.23 / 100, webkit: 0.36 / 100 });
     }
 
     protected override getFirefoxThresholds(): Map<string, ImageSnapshotThresholdConfig> {
@@ -303,20 +240,7 @@ describe('Overlay navigation', () => {
         [
           'overlays.start.flow.task.gateway',
           {
-            linux: 0.23 / 100, // max 0.22238155947217342%
             macos: 0.58 / 100, // max 0.5781644435027378%
-            windows: 0.12 / 100, // max 0.11775550254274902%
-          },
-        ],
-      ]);
-    }
-
-    protected override getWebkitThresholds(): Map<string, ImageSnapshotThresholdConfig> {
-      return new Map<string, ImageSnapshotThresholdConfig>([
-        [
-          'overlays.start.flow.task.gateway',
-          {
-            macos: 0.36 / 100, // max 0.35907994310595553%
           },
         ],
       ]);
@@ -377,7 +301,7 @@ describe('Overlay style', () => {
   class OverlayStylesImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
     constructor() {
       // don't set defaults as we defined thresholds for all style variants
-      super({ chromium: 0, firefox: 0, webkit: 0 });
+      super({ chromium: 0.03 / 100, firefox: 0.38 / 100, webkit: 0.33 / 100 });
     }
 
     protected override getChromiumThresholds(): Map<string, ImageSnapshotThresholdConfig> {
@@ -385,17 +309,8 @@ describe('Overlay style', () => {
       // linux threshold are set for Ubuntu
       return new Map<string, ImageSnapshotThresholdConfig>([
         [
-          'fill',
-          {
-            linux: 0.001 / 100, // 0.0007276893557062181%
-            macos: 0.03 / 100, // 0.022672389461708686%
-            windows: 0.03 / 100, // 0.021221138510052473%
-          },
-        ],
-        [
           'font',
           {
-            linux: 0.001 / 100, // 0.0007342796874976187%
             macos: 0.56 / 100, // 0.5500536579274629%
             windows: 0.33 / 100, // 0.3231773603294519%
           },
@@ -403,7 +318,6 @@ describe('Overlay style', () => {
         [
           'stroke',
           {
-            linux: 0.001 / 100, // 0.0007363497292800503%
             macos: 0.19 / 100, // 0.18879188656002463%
             windows: 0.22 / 100, // 0.2184761338537622%
           },
@@ -414,28 +328,11 @@ describe('Overlay style', () => {
     protected override getFirefoxThresholds(): Map<string, ImageSnapshotThresholdConfig> {
       return new Map<string, ImageSnapshotThresholdConfig>([
         [
-          'fill',
-          {
-            linux: 0.16 / 100, // 0.15701274621052752
-            macos: 0.38 / 100, // 0.37208408401212534%
-            windows: 0.036 / 100, // 0.03540156823378382%
-          },
-        ],
-        [
           'font',
           {
             linux: 0.7 / 100, // 0.6957363425958542%
             // TODO very large threshold on Firefox macOS for font overlay styles
             macos: 2.01 / 100, // 2.0033547194979073%
-            windows: 0.34 / 100, // 0.33890377031536856%
-          },
-        ],
-        [
-          'stroke',
-          {
-            linux: 0.13 / 100, // 0.12558613624870096%
-            macos: 0.36 / 100, // 0.35018722925578283%
-            windows: 0.24 / 100, // 0.23760788536359984%
           },
         ],
       ]);
@@ -444,21 +341,9 @@ describe('Overlay style', () => {
     protected override getWebkitThresholds(): Map<string, ImageSnapshotThresholdConfig> {
       return new Map<string, ImageSnapshotThresholdConfig>([
         [
-          'fill',
-          {
-            macos: 0.17 / 100, // 0.1664526237549535%
-          },
-        ],
-        [
           'font',
           {
             macos: 1.24 / 100, // 1.2343878983440026%
-          },
-        ],
-        [
-          'stroke',
-          {
-            macos: 0.33 / 100, // 0.325165957934348%
           },
         ],
       ]);

--- a/test/e2e/style.api.test.ts
+++ b/test/e2e/style.api.test.ts
@@ -45,6 +45,24 @@ class StyleImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
           windows: 0.11 / 100, // 0.10872082550010823%
         },
       ],
+      [
+        'fill.color.string',
+        {
+          macos: 0.11 / 100, // 0.10486874434754156%
+        },
+      ],
+      [
+        'fill.color.opacity.group',
+        {
+          macos: 0.13 / 100, // 0.12861950774821773%
+        },
+      ],
+      [
+        'stroke.color',
+        {
+          macos: 0.09 / 100, // 0.08553874565668806%
+        },
+      ],
     ]);
   }
 


### PR DESCRIPTION
A lot of e2e tests failed in local on macOS (13.5.1) due to low threshold configuration.
To avoid to list all files, I increased the global threshold too.