### PR TITLE
fix(shape): fix wrong value for style[mxConstants.STYLE_PERIMETER] for events and gateways

### DIFF
--- a/src/component/mxgraph/config/StyleConfigurator.ts
+++ b/src/component/mxgraph/config/StyleConfigurator.ts
@@ -17,7 +17,7 @@ limitations under the License.
 import { AssociationDirectionKind, FlowKind, SequenceFlowKind, ShapeBpmnElementKind, ShapeUtil } from '../../../model/bpmn/internal';
 import { BpmnStyleIdentifier, MarkerIdentifier, StyleDefault } from '../style';
 import type { BpmnGraph } from '../BpmnGraph';
-import { mxConstants, mxPerimeter } from '../initializer';
+import { mxConstants } from '../initializer';
 import type { mxStylesheet, StyleMap } from 'mxgraph';
 
 const arrowDefaultSize = 12;
@@ -168,7 +168,7 @@ export class StyleConfigurator {
     ShapeUtil.eventKinds().forEach(kind => {
       const style: StyleMap = {};
       style[mxConstants.STYLE_SHAPE] = kind;
-      style[mxConstants.STYLE_PERIMETER] = mxPerimeter.EllipsePerimeter;
+      style[mxConstants.STYLE_PERIMETER] = mxConstants.PERIMETER_ELLIPSE;
       style[mxConstants.STYLE_STROKEWIDTH] = kind == ShapeBpmnElementKind.EVENT_END ? StyleDefault.STROKE_WIDTH_THICK : StyleDefault.STROKE_WIDTH_THIN;
       style[mxConstants.STYLE_VERTICAL_LABEL_POSITION] = mxConstants.ALIGN_BOTTOM;
       this.putCellStyle(kind, style);
@@ -215,7 +215,7 @@ export class StyleConfigurator {
     ShapeUtil.gatewayKinds().forEach(kind => {
       const style: StyleMap = {};
       style[mxConstants.STYLE_SHAPE] = kind;
-      style[mxConstants.STYLE_PERIMETER] = mxPerimeter.RhombusPerimeter;
+      style[mxConstants.STYLE_PERIMETER] = mxConstants.PERIMETER_RHOMBUS;
       style[mxConstants.STYLE_STROKEWIDTH] = StyleDefault.STROKE_WIDTH_THIN;
       style[mxConstants.STYLE_VERTICAL_ALIGN] = mxConstants.ALIGN_TOP;
 


### PR DESCRIPTION
With the POC PR #2812, I detected we don't set correctly the perimeter on the style for the shape of events and gateways.

ℹ️ [https://github.com/process-analytics/bpmn-visualization-js/pull/2812/files#diff-a300f361268bb23a2f79e4fb89f4b4743b6334d78e532f8d6ddef6c1ec3b4f5b](https://github.com/process-analytics/bpmn-visualization-js/pull/2812/files#diff-a300f361268bb23a2f79e4fb89f4b4743b6334d78e532f8d6ddef6c1ec3b4f5b)

<table><tbody><tr><td>Before</td><td>Now</td></tr><tr><td><figure class="image"><img src="https://github.com/process-analytics/bpmn-visualization-js/assets/4921914/3b07a9e3-1727-4c42-99f7-3b1ab3633647"></figure></td><td><figure class="image"><img src="https://github.com/process-analytics/bpmn-visualization-js/assets/4921914/e3d33d4a-e04e-4bd1-ab28-522d76674f60"></figure></td></tr><tr><td><figure class="image"><img src="https://github.com/process-analytics/bpmn-visualization-js/assets/4921914/96c3e1e1-e642-4530-aa63-fb28c84310b4"></figure></td><td><figure class="image"><img src="https://github.com/process-analytics/bpmn-visualization-js/assets/4921914/07f26cee-e9d4-4b4a-8968-db37b3d0e857"></figure></td></tr><tr><td><figure class="image"><img src="https://github.com/process-analytics/bpmn-visualization-js/assets/4921914/79616b29-e79b-4107-8d86-e982e85377f5"></figure></td><td><figure class="image"><img src="https://github.com/process-analytics/bpmn-visualization-js/assets/4921914/51288a78-3874-4109-a59d-624d872a4ff6"></figure></td></tr></tbody></table>