### PR TITLE
refactor: remove unnecessary type casting

### DIFF
--- a/dev/ts/pages/elements-identification.ts
+++ b/dev/ts/pages/elements-identification.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import type { BpmnElement, BpmnElementKind, Overlay, ShapeStyleUpdate, StyleUpdate, FlowKind } from '../dev-bundle-index';
+import type { BpmnElement, BpmnElementKind, Overlay, ShapeStyleUpdate, StyleUpdate } from '../dev-bundle-index';
 import {
   addCssClasses,
   addOverlays,
@@ -49,7 +49,7 @@ function computeStyleUpdateByKind(bpmnKind: BpmnElementKind): StyleUpdate {
   const style: ShapeStyleUpdate = { font: {}, fill: {}, stroke: {} };
 
   if (isFlowKind(bpmnKind)) {
-    switch (bpmnKind as FlowKind) {
+    switch (bpmnKind) {
       case 'messageFlow':
       case 'sequenceFlow':
       case 'association':
@@ -292,7 +292,7 @@ documentReady(() => {
   startBpmnVisualization({
     globalOptions: {
       // Use a DOM element without id to test the fix for https://github.com/process-analytics/bpmn-visualization-js/issues/2270
-      container: <HTMLElement>document.querySelector('.bpmn-container'),
+      container: document.querySelector<HTMLElement>('.bpmn-container'),
       navigation: {
         enabled: true,
       },

--- a/test/bundles/bundles.test.ts
+++ b/test/bundles/bundles.test.ts
@@ -30,7 +30,7 @@ describe('bundles', () => {
         },
         bpmnContainerId: 'bpmn-container-for-iife-bundle',
       },
-      <Page>page,
+      page,
     );
     await pageTester.gotoPageAndLoadBpmnDiagram();
 

--- a/test/e2e/bpmn.colors.test.ts
+++ b/test/e2e/bpmn.colors.test.ts
@@ -18,7 +18,6 @@ import type { ImageSnapshotThresholdConfig } from './helpers/visu/image-snapshot
 import { ImageSnapshotConfigurator, MultiBrowserImageSnapshotThresholds } from './helpers/visu/image-snapshot-config';
 import { AvailableTestPages, PageTester } from '@test/shared/visu/bpmn-page-utils';
 import { getBpmnDiagramNames } from '@test/shared/visu/test-utils';
-import type { Page } from 'playwright';
 
 class ImageSnapshotThresholdsModelColors extends MultiBrowserImageSnapshotThresholds {
   constructor() {
@@ -108,7 +107,7 @@ class ImageSnapshotThresholdsIgnoreBpmnColors extends MultiBrowserImageSnapshotT
 
 describe('BPMN in color', () => {
   const diagramSubfolder = 'bpmn-in-color';
-  const pageTester = new PageTester({ targetedPage: AvailableTestPages.BPMN_RENDERING, diagramSubfolder }, <Page>page);
+  const pageTester = new PageTester({ targetedPage: AvailableTestPages.BPMN_RENDERING, diagramSubfolder }, page);
   const bpmnDiagramNames = getBpmnDiagramNames(diagramSubfolder);
 
   describe.each([false, true])('Ignore BPMN colors: %s', (ignoreBpmnColors: boolean) => {

--- a/test/e2e/bpmn.elements.collapsed.test.ts
+++ b/test/e2e/bpmn.elements.collapsed.test.ts
@@ -17,7 +17,6 @@ limitations under the License.
 import type { MatchImageSnapshotOptions } from 'jest-image-snapshot';
 import { ImageSnapshotConfigurator, MultiBrowserImageSnapshotThresholds } from './helpers/visu/image-snapshot-config';
 import { AvailableTestPages, PageTester } from '@test/shared/visu/bpmn-page-utils';
-import type { Page } from 'playwright';
 import { getBpmnDiagramNames } from '@test/shared/visu/test-utils';
 
 // key: diagram name
@@ -50,7 +49,7 @@ describe('Collapse BPMN elements', () => {
     new MultiBrowserImageSnapshotThresholds({ chromium: 0.07 / 100, firefox: 0.11 / 100, webkit: 0.15 / 100 }),
     diagramSubfolder,
   );
-  const pageTester = new PageTester({ targetedPage: AvailableTestPages.BPMN_RENDERING, diagramSubfolder }, <Page>page);
+  const pageTester = new PageTester({ targetedPage: AvailableTestPages.BPMN_RENDERING, diagramSubfolder }, page);
   const bpmnDiagramNames = getBpmnDiagramNames(diagramSubfolder);
 
   describe.each(bpmnDiagramNames)(`%s`, (bpmnDiagramName: string) => {

--- a/test/e2e/bpmn.elements.filter.pools.test.ts
+++ b/test/e2e/bpmn.elements.filter.pools.test.ts
@@ -16,7 +16,6 @@ limitations under the License.
 
 import { ImageSnapshotConfigurator, MultiBrowserImageSnapshotThresholds } from './helpers/visu/image-snapshot-config';
 import { AvailableTestPages, PageTester } from '@test/shared/visu/bpmn-page-utils';
-import type { Page } from 'playwright';
 import type { MatchImageSnapshotOptions } from 'jest-image-snapshot';
 
 class FilterPoolsImageSnapshotConfigurator extends ImageSnapshotConfigurator {
@@ -36,7 +35,7 @@ describe('Filter pools', () => {
     new MultiBrowserImageSnapshotThresholds({ chromium: 0.08 / 100, firefox: 0.013 / 100, webkit: 0.17 / 100 }),
     diagramSubfolder,
   );
-  const pageTester = new PageTester({ targetedPage: AvailableTestPages.BPMN_RENDERING, diagramSubfolder }, <Page>page);
+  const pageTester = new PageTester({ targetedPage: AvailableTestPages.BPMN_RENDERING, diagramSubfolder }, page);
 
   // Participant_1 start/task/end
   // Participant_2 black box pool

--- a/test/e2e/bpmn.rendering.test.ts
+++ b/test/e2e/bpmn.rendering.test.ts
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 import 'jest-playwright-preset';
-import type { Page } from 'playwright';
 import { getBpmnDiagramNames } from '@test/shared/visu/test-utils';
 import type { StyleOptions } from '@test/shared/visu/bpmn-page-utils';
 import { AvailableTestPages, PageTester } from '@test/shared/visu/bpmn-page-utils';
@@ -242,7 +241,7 @@ describe('BPMN rendering', () => {
   const imageSnapshotConfigurator = new ImageSnapshotConfigurator(new ImageSnapshotThresholds(), 'bpmn-rendering');
 
   const diagramSubfolder = 'bpmn-rendering';
-  const pageTester = new PageTester({ targetedPage: AvailableTestPages.BPMN_RENDERING, diagramSubfolder }, <Page>page);
+  const pageTester = new PageTester({ targetedPage: AvailableTestPages.BPMN_RENDERING, diagramSubfolder }, page);
   const bpmnDiagramNames = getBpmnDiagramNames(diagramSubfolder);
 
   describe('BPMN diagram files are present', () => {

--- a/test/e2e/bpmn.theme.test.ts
+++ b/test/e2e/bpmn.theme.test.ts
@@ -17,7 +17,6 @@ limitations under the License.
 import type { StyleOptions } from '@test/shared/visu/bpmn-page-utils';
 import { AvailableTestPages, PageTester } from '@test/shared/visu/bpmn-page-utils';
 import { ImageSnapshotConfigurator, MultiBrowserImageSnapshotThresholds } from './helpers/visu/image-snapshot-config';
-import type { Page } from 'playwright';
 
 const styleOptionsPerUseCase = new Map<string, StyleOptions>([
   [
@@ -55,7 +54,7 @@ describe('BPMN theme', () => {
     'theme',
   );
 
-  const pageTester = new PageTester({ targetedPage: AvailableTestPages.BPMN_RENDERING, diagramSubfolder: 'theme' }, <Page>page);
+  const pageTester = new PageTester({ targetedPage: AvailableTestPages.BPMN_RENDERING, diagramSubfolder: 'theme' }, page);
   const useCases = Array.from(styleOptionsPerUseCase.keys());
 
   it.each(useCases)(`Use case %s`, async (useCase: string) => {

--- a/test/e2e/diagram.navigation.fit.test.ts
+++ b/test/e2e/diagram.navigation.fit.test.ts
@@ -17,7 +17,6 @@ limitations under the License.
 import type { MatchImageSnapshotOptions } from 'jest-image-snapshot';
 import 'jest-playwright-preset';
 import { join } from 'node:path';
-import type { Page } from 'playwright';
 import { FitType } from '@lib/component/options';
 import { getBpmnDiagramNames } from '@test/shared/visu/test-utils';
 import { AvailableTestPages, PageTester } from '@test/shared/visu/bpmn-page-utils';
@@ -125,7 +124,7 @@ class ImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
 describe('diagram navigation - fit', () => {
   const imageSnapshotConfigurator = new FitImageSnapshotConfigurator(new ImageSnapshotThresholds(), 'fit');
 
-  const pageTester = new PageTester({ targetedPage: AvailableTestPages.DIAGRAM_NAVIGATION, diagramSubfolder }, <Page>page);
+  const pageTester = new PageTester({ targetedPage: AvailableTestPages.DIAGRAM_NAVIGATION, diagramSubfolder }, page);
 
   const fitTypes: FitType[] = [FitType.None, FitType.HorizontalVertical, FitType.Horizontal, FitType.Vertical, FitType.Center];
   describe.each(fitTypes)('load options - fit %s', (onLoadFitType: FitType) => {

--- a/test/e2e/diagram.navigation.zoom.pan.test.ts
+++ b/test/e2e/diagram.navigation.zoom.pan.test.ts
@@ -17,7 +17,6 @@ limitations under the License.
 import debugLogger from 'debug';
 import 'jest-playwright-preset';
 import { join } from 'node:path';
-import type { Page } from 'playwright';
 import type { Point } from '@test/shared/visu/bpmn-page-utils';
 import { AvailableTestPages, PageTester } from '@test/shared/visu/bpmn-page-utils';
 import type { ImageSnapshotThresholdConfig } from './helpers/visu/image-snapshot-config';
@@ -55,7 +54,7 @@ class MouseNavigationImageSnapshotThresholds extends MultiBrowserImageSnapshotTh
   }
 }
 
-const pageTester = new PageTester({ targetedPage: AvailableTestPages.DIAGRAM_NAVIGATION, diagramSubfolder: 'navigation' }, <Page>page);
+const pageTester = new PageTester({ targetedPage: AvailableTestPages.DIAGRAM_NAVIGATION, diagramSubfolder: 'navigation' }, page);
 const bpmnDiagramName = 'simple.2.start.events.1.task';
 
 describe('diagram navigation - zoom and pan with mouse', () => {

--- a/test/e2e/generated.svg.test.ts
+++ b/test/e2e/generated.svg.test.ts
@@ -15,14 +15,13 @@ limitations under the License.
 */
 
 import 'jest-playwright-preset';
-import type { Page } from 'playwright';
 import { AvailableTestPages, BpmnPageSvgTester } from '@test/shared/visu/bpmn-page-utils';
 
 const diagramSubfolder = 'svg';
 
 describe('Check generated SVG in demo page', () => {
   it('should display diagram in page', async () => {
-    const pageTester = new BpmnPageSvgTester({ targetedPage: AvailableTestPages.INDEX, diagramSubfolder }, <Page>page);
+    const pageTester = new BpmnPageSvgTester({ targetedPage: AvailableTestPages.INDEX, diagramSubfolder }, page);
     await pageTester.gotoPageAndLoadBpmnDiagram('simple-start-task-end');
 
     await pageTester.expectEvent('StartEvent_1', 'Start Event 1');
@@ -41,7 +40,7 @@ describe('Check generated SVG in lib-integration page', () => {
         bpmnContainerId: 'bpmn-container-custom',
         diagramSubfolder,
       },
-      <Page>page,
+      page,
     );
     await pageTester.gotoPageAndLoadBpmnDiagram();
 

--- a/test/e2e/overlays.rendering.test.ts
+++ b/test/e2e/overlays.rendering.test.ts
@@ -16,7 +16,6 @@ limitations under the License.
 
 import 'jest-playwright-preset';
 import { join } from 'node:path';
-import type { Page } from 'playwright';
 import { ensureIsArray } from '@lib/component/helpers/array-utils';
 import type { OverlayEdgePosition, OverlayPosition, OverlayShapePosition } from '@lib/component/registry';
 import { ZoomType } from '@lib/component/options';
@@ -119,7 +118,7 @@ class OverlaysPageTester extends PageTester {
   }
 }
 
-const pageTester = new OverlaysPageTester({ targetedPage: AvailableTestPages.OVERLAYS, diagramSubfolder: 'overlays' }, <Page>page);
+const pageTester = new OverlaysPageTester({ targetedPage: AvailableTestPages.OVERLAYS, diagramSubfolder: 'overlays' }, page);
 
 describe('BPMN Shapes with overlays', () => {
   const bpmnDiagramName = 'overlays.start.flow.task.gateway';

--- a/test/e2e/style.api.test.ts
+++ b/test/e2e/style.api.test.ts
@@ -17,7 +17,6 @@ limitations under the License.
 import { AvailableTestPages, PageTester } from '@test/shared/visu/bpmn-page-utils';
 import type { ImageSnapshotThresholdConfig } from './helpers/visu/image-snapshot-config';
 import { ImageSnapshotConfigurator, MultiBrowserImageSnapshotThresholds } from './helpers/visu/image-snapshot-config';
-import type { Page } from 'playwright';
 
 class StyleImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
   constructor() {
@@ -132,7 +131,7 @@ class StyleImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
 describe('Style API', () => {
   const imageSnapshotConfigurator = new ImageSnapshotConfigurator(new StyleImageSnapshotThresholds(), 'style');
 
-  const pageTester = new PageTester({ targetedPage: AvailableTestPages.BPMN_RENDERING, diagramSubfolder: 'theme' }, <Page>page);
+  const pageTester = new PageTester({ targetedPage: AvailableTestPages.BPMN_RENDERING, diagramSubfolder: 'theme' }, page);
 
   it(`Update 'stroke.color'`, async () => {
     await pageTester.gotoPageAndLoadBpmnDiagram('01.most.bpmn.types.without.label', {
@@ -193,7 +192,7 @@ describe('Style API', () => {
   });
 
   it(`Update 'color' and 'opacity' of 'fill' for task`, async () => {
-    const pageTester = new PageTester({ targetedPage: AvailableTestPages.BPMN_RENDERING, diagramSubfolder: 'bpmn-rendering' }, <Page>page);
+    const pageTester = new PageTester({ targetedPage: AvailableTestPages.BPMN_RENDERING, diagramSubfolder: 'bpmn-rendering' }, page);
     await pageTester.gotoPageAndLoadBpmnDiagram('tasks', {
       styleOptions: {
         styleUpdate: { fill: { color: 'chartreuse', opacity: 15 } },
@@ -206,7 +205,7 @@ describe('Style API', () => {
   });
 
   it(`Update 'color' and 'opacity' of 'font'`, async () => {
-    const pageTester = new PageTester({ targetedPage: AvailableTestPages.BPMN_RENDERING, diagramSubfolder: 'bpmn-rendering' }, <Page>page);
+    const pageTester = new PageTester({ targetedPage: AvailableTestPages.BPMN_RENDERING, diagramSubfolder: 'bpmn-rendering' }, page);
     await pageTester.gotoPageAndLoadBpmnDiagram('labels.04.fonts', {
       styleOptions: {
         styleUpdate: {

--- a/test/integration/matchers/toBeEdge/index.ts
+++ b/test/integration/matchers/toBeEdge/index.ts
@@ -47,7 +47,7 @@ function buildExpectedMsgFlowIconCellStyle(expectedModel: ExpectedEdgeModelEleme
 function buildExpectedEdgeStylePropertyRegexp(expectedModel: ExpectedEdgeModelElement | ExpectedSequenceFlowModelElement): string {
   let expectedStyle: string = expectedModel.kind;
   if ('sequenceFlowKind' in expectedModel) {
-    expectedStyle = expectedStyle + `;${(expectedModel as ExpectedSequenceFlowModelElement).sequenceFlowKind}`;
+    expectedStyle = expectedStyle + `;${expectedModel.sequenceFlowKind}`;
   }
   return expectedStyle + '.*';
 }

--- a/test/performance/bpmn.load.performance.test.ts
+++ b/test/performance/bpmn.load.performance.test.ts
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 import * as fs from 'node:fs';
-import type { Page } from 'playwright';
 import { AvailableTestPages, PageTester } from '@test/shared/visu/bpmn-page-utils';
 import { ChromiumMetricsCollector } from './helpers/metrics-chromium';
 import type { ChartData, PerformanceMetric } from './helpers/perf-utils';
@@ -26,10 +25,10 @@ const metricsArray: Array<PerformanceMetric> = [];
 
 let metricsCollector: ChromiumMetricsCollector;
 beforeAll(async () => {
-  metricsCollector = await ChromiumMetricsCollector.create(<Page>page);
+  metricsCollector = await ChromiumMetricsCollector.create(page);
 });
 describe('load performance', () => {
-  const pageTester = new PageTester({ targetedPage: AvailableTestPages.DIAGRAM_NAVIGATION, diagramSubfolder: 'performance' }, <Page>page);
+  const pageTester = new PageTester({ targetedPage: AvailableTestPages.DIAGRAM_NAVIGATION, diagramSubfolder: 'performance' }, page);
   const bpmnDiagramName = 'B.2.0';
 
   it.each([1, 2, 3, 4, 5])('run %s - file loading and displaying diagram with FitType.HorizontalVertical', async run => {

--- a/test/performance/bpmn.navigation.performance.test.ts
+++ b/test/performance/bpmn.navigation.performance.test.ts
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 import * as fs from 'node:fs';
-import type { Page } from 'playwright';
 import { delay } from '@test/shared/visu/test-utils';
 import type { Point } from '@test/shared/visu/bpmn-page-utils';
 import { AvailableTestPages, PageTester } from '@test/shared/visu/bpmn-page-utils';
@@ -29,10 +28,10 @@ const metricsArray: Array<PerformanceMetric> = [];
 
 let metricsCollector: ChromiumMetricsCollector;
 beforeAll(async () => {
-  metricsCollector = await ChromiumMetricsCollector.create(<Page>page);
+  metricsCollector = await ChromiumMetricsCollector.create(page);
 });
 describe('Mouse wheel zoom performance', () => {
-  const pageTester = new PageTester({ targetedPage: AvailableTestPages.DIAGRAM_NAVIGATION, diagramSubfolder: 'performance' }, <Page>page);
+  const pageTester = new PageTester({ targetedPage: AvailableTestPages.DIAGRAM_NAVIGATION, diagramSubfolder: 'performance' }, page);
 
   const bpmnDiagramName = 'B.2.0';
   let containerCenter: Point;

--- a/test/shared/visu/bpmn-page-utils.ts
+++ b/test/shared/visu/bpmn-page-utils.ts
@@ -23,7 +23,7 @@ import 'expect-playwright';
 import type { PageWaitForSelectorOptions } from 'expect-playwright';
 import type { ElementHandle, Page } from 'playwright';
 import { type LoadOptions, FitType, ZoomType } from '@lib/component/options';
-import type { ShapeStyleUpdate, StyleUpdate } from '@lib/component/registry';
+import type { StyleUpdate } from '@lib/component/registry';
 import { BpmnQuerySelectorsForTests } from '@test/shared/query-selectors';
 import { delay } from './test-utils';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -228,7 +228,7 @@ export class PageTester {
       }
 
       if ('fill' in styleUpdate) {
-        const fill = (<ShapeStyleUpdate>styleUpdate).fill;
+        const fill = styleUpdate.fill;
 
         const fillColor = fill.color;
         if (typeof fillColor === 'object') {

--- a/test/unit/helpers/JsonTestUtils.ts
+++ b/test/unit/helpers/JsonTestUtils.ts
@@ -117,7 +117,7 @@ export function parseJsonAndExpectOnlyEdgesAndFlowNodes(json: BpmnJsonModel, num
 export function verifySubProcess(model: BpmnModel, kind: ShapeBpmnSubProcessKind, expectedNumber: number): void {
   const subProcesses = model.flowNodes.filter(shape => {
     const bpmnElement = shape.bpmnElement;
-    return bpmnElement instanceof ShapeBpmnSubProcess && (bpmnElement as ShapeBpmnSubProcess).subProcessKind === kind;
+    return bpmnElement instanceof ShapeBpmnSubProcess && bpmnElement.subProcessKind === kind;
   });
   expect(subProcesses).toHaveLength(expectedNumber);
 }
@@ -170,7 +170,7 @@ export function parseJsonAndExpectEvent(json: BpmnJsonModel, eventDefinitionKind
 
   const events = model.flowNodes.filter(shape => {
     const bpmnElement = shape.bpmnElement;
-    return bpmnElement instanceof ShapeBpmnEvent && (bpmnElement as ShapeBpmnEvent).eventDefinitionKind === eventDefinitionKind;
+    return bpmnElement instanceof ShapeBpmnEvent && bpmnElement.eventDefinitionKind === eventDefinitionKind;
   });
   expect(events).toHaveLength(expectedNumber);
 

--- a/test/unit/helpers/bpmn-model-expect.ts
+++ b/test/unit/helpers/bpmn-model-expect.ts
@@ -116,8 +116,8 @@ export const verifyShape = (
 
   if (('bpmnElementCallActivityKind' in expectedShape && expectedShape.bpmnElementCallActivityKind) || 'bpmnElementGlobalTaskKind' in expectedShape) {
     expect(bpmnElement instanceof ShapeBpmnCallActivity).toBeTruthy();
-    expect((bpmnElement as ShapeBpmnCallActivity).callActivityKind).toEqual((expectedShape as ExpectedCallActivityShape).bpmnElementCallActivityKind);
-    expect((bpmnElement as ShapeBpmnCallActivity).globalTaskKind).toEqual((expectedShape as ExpectedCallActivityShape).bpmnElementGlobalTaskKind);
+    expect((bpmnElement as ShapeBpmnCallActivity).callActivityKind).toEqual(expectedShape.bpmnElementCallActivityKind);
+    expect((bpmnElement as ShapeBpmnCallActivity).globalTaskKind).toEqual(expectedShape.bpmnElementGlobalTaskKind);
   }
 
   if ('eventDefinitionKind' in expectedShape) {
@@ -127,7 +127,7 @@ export const verifyShape = (
 
   if ('isInterrupting' in expectedShape) {
     expect(bpmnElement instanceof ShapeBpmnBoundaryEvent).toBeTruthy();
-    expect((bpmnElement as ShapeBpmnBoundaryEvent).isInterrupting).toEqual((expectedShape as ExpectedBoundaryEventShape).isInterrupting);
+    expect((bpmnElement as ShapeBpmnBoundaryEvent).isInterrupting).toEqual(expectedShape.isInterrupting);
   }
 
   const bounds = shape.bounds;


### PR DESCRIPTION
By including the `@typescript-eslint/recommended-type-checked` rule in pull request #2812, we identify some unnecessary type casting.

Covers #2742