### PR TITLE
chore(eslint): use `eslint-plugin-jest-extended`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "bpmn-visualization",
-      "version": "0.38.1",
+      "version": "0.38.1-post",
       "license": "Apache-2.0",
       "dependencies": {
         "@typed-mxgraph/typed-mxgraph": "~1.0.8",
@@ -35,6 +35,7 @@
         "eslint": "~8.47.0",
         "eslint-config-prettier": "~9.0.0",
         "eslint-plugin-jest": "~27.2.3",
+        "eslint-plugin-jest-extended": "^2.0.0",
         "eslint-plugin-notice": "~0.9.10",
         "eslint-plugin-playwright": "~0.15.3",
         "eslint-plugin-prettier": "~5.0.0",
@@ -5879,6 +5880,21 @@
         "jest": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-plugin-jest-extended": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest-extended/-/eslint-plugin-jest-extended-2.0.0.tgz",
+      "integrity": "sha512-nMhVVsVcG/+Q6FMshql35WBxwx8xlBhxKgAG08WP3BYWfXrp28oxLpJVu9JSbMpfmfKGVrHwMYJGfPLRKlGB8w==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/utils": "^5.10.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/eslint-plugin-notice": {
@@ -17169,6 +17185,15 @@
       "version": "27.2.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.2.3.tgz",
       "integrity": "sha512-sRLlSCpICzWuje66Gl9zvdF6mwD5X86I4u55hJyFBsxYOsBCmT5+kSUjf+fkFWVMMgpzNEupjW8WzUqi83hJAQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/utils": "^5.10.0"
+      }
+    },
+    "eslint-plugin-jest-extended": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest-extended/-/eslint-plugin-jest-extended-2.0.0.tgz",
+      "integrity": "sha512-nMhVVsVcG/+Q6FMshql35WBxwx8xlBhxKgAG08WP3BYWfXrp28oxLpJVu9JSbMpfmfKGVrHwMYJGfPLRKlGB8w==",
       "dev": true,
       "requires": {
         "@typescript-eslint/utils": "^5.10.0"

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "eslint": "~8.47.0",
     "eslint-config-prettier": "~9.0.0",
     "eslint-plugin-jest": "~27.2.3",
+    "eslint-plugin-jest-extended": "^2.0.0",
     "eslint-plugin-notice": "~0.9.10",
     "eslint-plugin-playwright": "~0.15.3",
     "eslint-plugin-prettier": "~5.0.0",

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 module.exports = {
-  plugins: ['jest'],
+  plugins: ['jest', 'jest-extended'],
   env: {
     'jest/globals': true,
   },
@@ -24,7 +24,7 @@ module.exports = {
       version: require('jest/package.json').version,
     },
   },
-  extends: ['plugin:jest/recommended', 'plugin:jest/style'],
+  extends: ['plugin:jest/recommended', 'plugin:jest/style', 'plugin:jest-extended/all'],
   rules: {
     /* The rule list: https://github.com/jest-community/eslint-plugin-jest#rules */
     'jest/prefer-expect-resolves': 'warn',

--- a/test/performance/bpmn.load.performance.test.ts
+++ b/test/performance/bpmn.load.performance.test.ts
@@ -38,7 +38,7 @@ describe('load performance', () => {
 
     const metric = { ...calculateMetrics(metricsStart, metricsEnd), run: run };
     metricsArray.push(metric);
-    expect(true).toBe(true);
+    expect(true).toBeTrue();
   });
 });
 afterAll(() => {

--- a/test/performance/bpmn.navigation.performance.test.ts
+++ b/test/performance/bpmn.navigation.performance.test.ts
@@ -63,7 +63,7 @@ describe('Mouse wheel zoom performance', () => {
 
     const metric = { ...calculateMetrics(metricsStart, metricsEnd), run: run };
     metricsArray.push(metric);
-    expect(true).toBe(true);
+    expect(true).toBeTrue();
   });
 });
 afterAll(() => {

--- a/test/unit/component/registry/bpmn-model-registry.test.ts
+++ b/test/unit/component/registry/bpmn-model-registry.test.ts
@@ -27,7 +27,7 @@ describe('Bpmn Model registry', () => {
     const callback = jest.fn();
     bpmnModelRegistry.registerOnLoadCallback(callback);
     bpmnModelRegistry.load(startEventInModel('id', 'name'));
-    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledOnce();
   });
 
   it('search sequence flow', () => {


### PR DESCRIPTION
This pull request introduces changes to enhance the code quality and maintainability of the project. 

- Added `eslint-plugin-jest-extended` as a development dependency.
- Updated the ESLint configuration for the test files to use the rules of `eslint-plugin-jest-extended`.
- Fixed linting issues detected by `eslint-plugin-jest-extended`.

Covers #2742