### PR TITLE
chore(eslint): replace 'plugin:@typescript-eslint/stylistic' by 'plugin:@typescript-eslint/stylistic-type-checked' rules

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,5 +4,6 @@
 /config/
 /dist/
 node_modules/
-scripts/utils/dist/
+/scripts/utils/dist/
+/scripts/utils/build/
 test/performance/data/

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -94,7 +94,7 @@ module.exports = {
       extends: [
         'plugin:@typescript-eslint/recommended', // Uses the recommended rules from the @typescript-eslint/eslint-plugin
         'plugin:prettier/recommended', // Enables eslint-plugin-prettier and eslint-config-prettier. This will display prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
-        'plugin:@typescript-eslint/stylistic',
+        'plugin:@typescript-eslint/stylistic-type-checked',
         'plugin:import/typescript',
       ],
       settings: {

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /dist/
 node_modules/
 /scripts/utils/dist/
+/scripts/utils/build
 
 # npm build
 *.tgz

--- a/dev/ts/component/ThemedBpmnVisualization.ts
+++ b/dev/ts/component/ThemedBpmnVisualization.ts
@@ -144,43 +144,43 @@ export class ThemedBpmnVisualization extends BpmnVisualization {
         }
       }
       const style = styleSheet.styles[kind];
-      style['fillColor'] = fillColor;
-      style['strokeColor'] = strokeColor;
+      style.fillColor = fillColor;
+      style.strokeColor = strokeColor;
     }
 
     // TASK
     for (const kind of ShapeUtil.taskKinds()) {
       const style = styleSheet.styles[kind];
-      style['fillColor'] = theme.taskAndCallActivityFillColor;
+      style.fillColor = theme.taskAndCallActivityFillColor;
     }
 
     // CALL ACTIVITY
     const callActivityStyle = styleSheet.styles[ShapeBpmnElementKind.CALL_ACTIVITY];
-    callActivityStyle['fillColor'] = theme.taskAndCallActivityFillColor;
+    callActivityStyle.fillColor = theme.taskAndCallActivityFillColor;
 
     // TEXT ANNOTATION
     const textAnnotationStyle = styleSheet.styles[ShapeBpmnElementKind.TEXT_ANNOTATION];
-    textAnnotationStyle['fillColor'] = theme.textAnnotationFillColor ?? StyleDefault.TEXT_ANNOTATION_FILL_COLOR;
+    textAnnotationStyle.fillColor = theme.textAnnotationFillColor ?? StyleDefault.TEXT_ANNOTATION_FILL_COLOR;
 
     // POOL
     const poolStyle = styleSheet.styles[ShapeBpmnElementKind.POOL];
-    poolStyle['fillColor'] = theme.poolFillColor;
-    poolStyle['swimlaneFillColor'] = theme.defaultFillColor;
+    poolStyle.fillColor = theme.poolFillColor;
+    poolStyle.swimlaneFillColor = theme.defaultFillColor;
 
     // LANE
     const laneStyle = styleSheet.styles[ShapeBpmnElementKind.LANE];
-    laneStyle['fillColor'] = theme.laneFillColor;
+    laneStyle.fillColor = theme.laneFillColor;
 
     // DEFAULTS
     const defaultVertexStyle = styleSheet.getDefaultVertexStyle();
-    defaultVertexStyle['fontColor'] = theme.defaultFontColor;
-    defaultVertexStyle['fillColor'] = theme.defaultFillColor;
-    defaultVertexStyle['strokeColor'] = theme.defaultStrokeColor;
+    defaultVertexStyle.fontColor = theme.defaultFontColor;
+    defaultVertexStyle.fillColor = theme.defaultFillColor;
+    defaultVertexStyle.strokeColor = theme.defaultStrokeColor;
 
     const defaultEdgeStyle = styleSheet.getDefaultEdgeStyle();
-    defaultEdgeStyle['fontColor'] = theme.defaultFontColor;
-    defaultEdgeStyle['fillColor'] = theme.defaultFillColor;
-    defaultEdgeStyle['strokeColor'] = theme.flowColor ?? theme.defaultStrokeColor;
+    defaultEdgeStyle.fontColor = theme.defaultFontColor;
+    defaultEdgeStyle.fillColor = theme.defaultFillColor;
+    defaultEdgeStyle.strokeColor = theme.flowColor ?? theme.defaultStrokeColor;
 
     // theme configuration completed
     return true;

--- a/dev/ts/pages/diagram-navigation.ts
+++ b/dev/ts/pages/diagram-navigation.ts
@@ -26,7 +26,7 @@ function configureFitAndZoomButtons(): void {
 }
 
 function configureZoomThrottleInput(parameters: URLSearchParams): HTMLInputElement {
-  const zoomThrottleElement = document.querySelector('#zoom-throttle') as HTMLInputElement;
+  const zoomThrottleElement = document.querySelector('#zoom-throttle')!;
   if (parameters.get('zoomThrottle')) {
     zoomThrottleElement.value = parameters.get('zoomThrottle');
   }
@@ -34,7 +34,7 @@ function configureZoomThrottleInput(parameters: URLSearchParams): HTMLInputEleme
 }
 
 function configureZoomDebounceInput(parameters: URLSearchParams): HTMLInputElement {
-  const zoomDebounceElement = document.querySelector('#zoom-debounce') as HTMLInputElement;
+  const zoomDebounceElement = document.querySelector('#zoom-debounce')!;
   if (parameters.get('zoomDebounce')) {
     zoomDebounceElement.value = parameters.get('zoomDebounce');
   }

--- a/dev/ts/pages/elements-identification.ts
+++ b/dev/ts/pages/elements-identification.ts
@@ -185,7 +185,7 @@ function updateSelectedBPMNElements(bpmnKind: ShapeBpmnElementKind): void {
 }
 
 function updateTextArea(elementsByKinds: BpmnSemantic[], bpmnKind: string): void {
-  const textArea = document.querySelector('#elements-result') as HTMLTextAreaElement;
+  const textArea = document.querySelector('#elements-result')!;
 
   const textHeader = `Found ${elementsByKinds.length} ${bpmnKind}(s)`;
   log(textHeader);
@@ -196,12 +196,12 @@ function updateTextArea(elementsByKinds: BpmnSemantic[], bpmnKind: string): void
 }
 
 function resetTextArea(): void {
-  const textArea = document.querySelector('#elements-result') as HTMLTextAreaElement;
+  const textArea = document.querySelector('#elements-result')!;
   textArea.value = '';
 }
 
 function configureControls(): void {
-  const selectedKindElt = document.querySelector('#bpmn-kinds-select') as HTMLSelectElement;
+  const selectedKindElt = document.querySelector('#bpmn-kinds-select')!;
   selectedKindElt.addEventListener('change', event => updateSelectedBPMNElements((event.target as HTMLSelectElement).value as ShapeBpmnElementKind));
   document.addEventListener('diagramLoaded', () => updateSelectedBPMNElements(selectedKindElt.value as ShapeBpmnElementKind), false);
 
@@ -216,7 +216,7 @@ function configureControls(): void {
   });
 
   // display overlay option
-  const checkboxDisplayOverlaysElt = document.querySelector('#checkbox-display-overlays') as HTMLInputElement;
+  const checkboxDisplayOverlaysElt = document.querySelector('#checkbox-display-overlays')!;
   checkboxDisplayOverlaysElt.addEventListener('change', function () {
     isOverlaysDisplayed = this.checked;
     log('Request overlays display:', isOverlaysDisplayed);
@@ -225,7 +225,7 @@ function configureControls(): void {
   checkboxDisplayOverlaysElt.checked = isOverlaysDisplayed;
 
   // use CSS or API to style the BPMN elements
-  const checkboxUseCSSElt = document.querySelector('#checkbox-css-style') as HTMLInputElement;
+  const checkboxUseCSSElt = document.querySelector('#checkbox-css-style')!;
   checkboxUseCSSElt.addEventListener('change', function () {
     useCSS = this.checked;
     log('Request CSS style feature:', useCSS);

--- a/dev/ts/pages/index.ts
+++ b/dev/ts/pages/index.ts
@@ -36,7 +36,7 @@ let fitOnLoad = true;
 let fitOptions: FitOptions = {};
 
 function configureFitOnLoadCheckBox(): void {
-  const fitOnLoadElt = document.querySelector('#fitOnLoad') as HTMLInputElement;
+  const fitOnLoadElt = document.querySelector('#fitOnLoad')!;
   fitOnLoadElt.addEventListener('change', event => {
     fitOnLoad = (event.target as HTMLInputElement).checked;
     log('Fit on load updated!', fitOnLoad);
@@ -60,7 +60,7 @@ function updateFitConfig(config: FitOptions): void {
 }
 
 function configureFitTypeSelect(): void {
-  const fitTypeSelectedElt = document.querySelector('#fitType-selected') as HTMLSelectElement;
+  const fitTypeSelectedElt = document.querySelector('#fitType-selected')!;
   fitTypeSelectedElt.addEventListener('change', event => {
     updateFitConfig({ type: (event.target as HTMLSelectElement).value as FitType });
     fit(fitOptions);
@@ -74,7 +74,7 @@ function configureFitTypeSelect(): void {
 }
 
 function configureFitMarginInput(): void {
-  const fitMarginElt = document.querySelector('#fit-margin') as HTMLInputElement;
+  const fitMarginElt = document.querySelector('#fit-margin')!;
   fitMarginElt.addEventListener('change', event => {
     updateFitConfig({ margin: Number((event.target as HTMLInputElement).value) });
     fit(fitOptions);
@@ -95,7 +95,7 @@ function configureZoomButtons(): void {
 }
 
 function configureThemeSelect(): void {
-  const themeSelectedElt = document.querySelector('#theme-selected') as HTMLSelectElement;
+  const themeSelectedElt = document.querySelector('#theme-selected')!;
   themeSelectedElt.addEventListener('change', event => {
     switchTheme((event.target as HTMLSelectElement).value);
   });

--- a/dev/ts/pages/overlays.ts
+++ b/dev/ts/pages/overlays.ts
@@ -26,7 +26,7 @@ import {
   startBpmnVisualization,
 } from '../development-bundle-index';
 
-const bpmnIdInputElt = document.querySelector('#bpmn-id-input') as HTMLInputElement;
+const bpmnIdInputElt = document.querySelector('#bpmn-id-input')!;
 
 function addOverlay(overlay: Overlay): void {
   const bpmnId = bpmnIdInputElt.value;

--- a/scripts/utils/parseBpmn.ts
+++ b/scripts/utils/parseBpmn.ts
@@ -30,7 +30,7 @@ import { readFileSync } from '../../test/shared/file-helper';
 const __dirname = resolvePath();
 const argv = parseArgs(process.argv.slice(2));
 const bpmnFilePath = argv._[0];
-const outputType = argv['output'] || 'json';
+const outputType = argv.output || 'json';
 
 // eslint-disable-next-line no-console
 console.info('Generating BPMN in the "%s" output type', outputType);

--- a/src/component/parser/json/converter/DiagramConverter.ts
+++ b/src/component/parser/json/converter/DiagramConverter.ts
@@ -137,12 +137,12 @@ export default class DiagramConverter {
     if ('background-color' in bpmnShape) {
       shape.extensions.fillColor = bpmnShape['background-color'] as string;
     } else if ('fill' in bpmnShape) {
-      shape.extensions.fillColor = bpmnShape['fill'] as string;
+      shape.extensions.fillColor = bpmnShape.fill as string;
     }
     if ('border-color' in bpmnShape) {
       shape.extensions.strokeColor = bpmnShape['border-color'] as string;
     } else if ('stroke' in bpmnShape) {
-      shape.extensions.strokeColor = bpmnShape['stroke'] as string;
+      shape.extensions.strokeColor = bpmnShape.stroke as string;
     }
   }
 
@@ -182,7 +182,7 @@ export default class DiagramConverter {
     if ('border-color' in bpmnEdge) {
       edge.extensions.strokeColor = bpmnEdge['border-color'] as string;
     } else if ('stroke' in bpmnEdge) {
-      edge.extensions.strokeColor = bpmnEdge['stroke'] as string;
+      edge.extensions.strokeColor = bpmnEdge.stroke as string;
     }
   }
 

--- a/src/component/registry/css-registry.ts
+++ b/src/component/registry/css-registry.ts
@@ -43,7 +43,7 @@ export class CssClassesRegistryImpl implements CssClassesRegistry {
   }
 
   removeAllCssClasses(bpmnElementIds?: string | string[]): void {
-    if (bpmnElementIds || bpmnElementIds == '') {
+    if (bpmnElementIds || bpmnElementIds === '') {
       for (const bpmnElementId of ensureIsArray<string>(bpmnElementIds)) {
         const isChanged = this.cssClassesCache.removeAllClassNames(bpmnElementId);
         this.updateCellIfChanged(isChanged, bpmnElementId);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
     // Vitejs requirements https://vitejs.dev/guide/features.html#typescript-compiler-options
     "isolatedModules": true, // https://esbuild.github.io/content-types/#isolated-modules
     "useDefineForClassFields": true,
+    "strictNullChecks": true
   },
   "include": [
     "src/**/*",


### PR DESCRIPTION
:information\_source: See [`configs/stylistic-type-checked.ts`](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/stylistic-type-checked.ts) for the exact contents of this config.

Covers #2742  
  