### PR TITLE
refactor: improving code safety with nullish coalescing operator

### DIFF
--- a/dev/ts/pages/index.ts
+++ b/dev/ts/pages/index.ts
@@ -47,7 +47,7 @@ function configureFitOnLoadCheckBox(): void {
 function updateFitConfig(config: FitOptions): void {
   log('Updating fit config', config);
 
-  fitOptions.margin = config.margin || fitOptions.margin;
+  fitOptions.margin = config.margin ?? fitOptions.margin;
   if (config.type) {
     fitOptions.type = config.type;
   }

--- a/dev/ts/shared/main.ts
+++ b/dev/ts/shared/main.ts
@@ -217,7 +217,7 @@ function logOnlyStatusKoNotifier(errorMsg: string): void {
 }
 
 function getFitOptionsFromParameters(config: BpmnVisualizationDemoConfiguration, parameters: URLSearchParams): FitOptions {
-  const fitOptions: FitOptions = config.loadOptions?.fit || {};
+  const fitOptions: FitOptions = config.loadOptions?.fit ?? {};
   const parameterFitType: string = parameters.get('fitTypeOnLoad');
   if (parameterFitType) {
     // As the parameter is a string, and the load/fit APIs accept only enum to avoid error, we need to convert it
@@ -320,7 +320,7 @@ export function startBpmnVisualization(config: BpmnVisualizationDemoConfiguratio
   statusKoNotifier = config.statusKoNotifier ?? logOnlyStatusKoNotifier;
 
   log('Configuring Load Options');
-  loadOptions = config.loadOptions || {};
+  loadOptions = config.loadOptions ?? {};
   loadOptions.fit = getFitOptionsFromParameters(config, parameters);
   loadOptions.modelFilter = configurePoolsFilteringFromParameters(parameters);
 

--- a/src/component/helpers/validators.ts
+++ b/src/component/helpers/validators.ts
@@ -28,7 +28,7 @@ export function ensureInRange(value: number, min: number, max: number, defaultVa
  * @internal
  */
 export function ensurePositiveValue(input: number | undefined | null): number {
-  return Math.max(input || 0, 0);
+  return Math.max(input ?? 0, 0);
 }
 
 /**

--- a/src/component/parser/json/converter/ProcessConverter.ts
+++ b/src/component/parser/json/converter/ProcessConverter.ts
@@ -371,7 +371,7 @@ const buildMarkers = (bpmnElement: TActivity): ShapeBpmnMarkerKind[] => {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- We know that the multiInstanceLoopCharacteristics field is not on all types, but it's already tested
   // @ts-ignore
   const multiInstanceLoopCharacteristics = ensureIsArray(bpmnElement.multiInstanceLoopCharacteristics, true)[0];
-  if (standardLoopCharacteristics || standardLoopCharacteristics === '') {
+  if (standardLoopCharacteristics ?? standardLoopCharacteristics === '') {
     markers.push(ShapeBpmnMarkerKind.LOOP);
   } else if (multiInstanceLoopCharacteristics) {
     markers.push(multiInstanceLoopCharacteristics.isSequential ? ShapeBpmnMarkerKind.MULTI_INSTANCE_SEQUENTIAL : ShapeBpmnMarkerKind.MULTI_INSTANCE_PARALLEL);

--- a/src/component/parser/json/converter/ProcessConverter.ts
+++ b/src/component/parser/json/converter/ProcessConverter.ts
@@ -365,13 +365,9 @@ export default class ProcessConverter {
 
 const buildMarkers = (bpmnElement: TActivity): ShapeBpmnMarkerKind[] => {
   const markers: ShapeBpmnMarkerKind[] = [];
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- We know that the standardLoopCharacteristics field is not on all types, but it's already tested
-  // @ts-ignore
   const standardLoopCharacteristics = bpmnElement.standardLoopCharacteristics;
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- We know that the multiInstanceLoopCharacteristics field is not on all types, but it's already tested
-  // @ts-ignore
   const multiInstanceLoopCharacteristics = ensureIsArray(bpmnElement.multiInstanceLoopCharacteristics, true)[0];
-  if (standardLoopCharacteristics ?? standardLoopCharacteristics === '') {
+  if (standardLoopCharacteristics !== undefined) {
     markers.push(ShapeBpmnMarkerKind.LOOP);
   } else if (multiInstanceLoopCharacteristics) {
     markers.push(multiInstanceLoopCharacteristics.isSequential ? ShapeBpmnMarkerKind.MULTI_INSTANCE_SEQUENTIAL : ShapeBpmnMarkerKind.MULTI_INSTANCE_PARALLEL);

--- a/test/e2e/helpers/visu/image-snapshot-config.ts
+++ b/test/e2e/helpers/visu/image-snapshot-config.ts
@@ -71,7 +71,7 @@ export class ImageSnapshotConfigurator {
       configLog(`Using dedicated image snapshot threshold for '${fileName}'`);
       const simplePlatformName = getSimplePlatformName();
       configLog(`Simple platform name: ${simplePlatformName}`);
-      failureThreshold = config[simplePlatformName] || failureThreshold;
+      failureThreshold = config[simplePlatformName] ?? failureThreshold;
     } else {
       configLog(`Using default image snapshot threshold for '${fileName}'`);
     }

--- a/test/performance/helpers/metrics-chromium.ts
+++ b/test/performance/helpers/metrics-chromium.ts
@@ -94,7 +94,7 @@ const supportedMetrics = new Set<string>([
 
 function buildMetricsObject(metrics?: Array<Metric>): Metrics {
   const result: Metrics = {};
-  for (const metric of metrics || []) {
+  for (const metric of metrics ?? []) {
     if (supportedMetrics.has(metric.name)) {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore

--- a/test/unit/helpers/bpmn-model-expect.ts
+++ b/test/unit/helpers/bpmn-model-expect.ts
@@ -114,7 +114,7 @@ export const verifyShape = (
     expect(bpmnElement.markers).toHaveLength(0);
   }
 
-  if ('bpmnElementCallActivityKind' in expectedShape || 'bpmnElementGlobalTaskKind' in expectedShape) {
+  if ('bpmnElementCallActivityKind' in expectedShape) {
     expect(bpmnElement instanceof ShapeBpmnCallActivity).toBeTruthy();
     expect((bpmnElement as ShapeBpmnCallActivity).callActivityKind).toEqual(expectedShape.bpmnElementCallActivityKind);
     expect((bpmnElement as ShapeBpmnCallActivity).globalTaskKind).toEqual(expectedShape.bpmnElementGlobalTaskKind);

--- a/test/unit/helpers/bpmn-model-expect.ts
+++ b/test/unit/helpers/bpmn-model-expect.ts
@@ -114,7 +114,7 @@ export const verifyShape = (
     expect(bpmnElement.markers).toHaveLength(0);
   }
 
-  if (('bpmnElementCallActivityKind' in expectedShape && expectedShape.bpmnElementCallActivityKind) || 'bpmnElementGlobalTaskKind' in expectedShape) {
+  if (('bpmnElementCallActivityKind' in expectedShape && expectedShape.bpmnElementCallActivityKind) ?? 'bpmnElementGlobalTaskKind' in expectedShape) {
     expect(bpmnElement instanceof ShapeBpmnCallActivity).toBeTruthy();
     expect((bpmnElement as ShapeBpmnCallActivity).callActivityKind).toEqual(expectedShape.bpmnElementCallActivityKind);
     expect((bpmnElement as ShapeBpmnCallActivity).globalTaskKind).toEqual(expectedShape.bpmnElementGlobalTaskKind);

--- a/test/unit/helpers/bpmn-model-expect.ts
+++ b/test/unit/helpers/bpmn-model-expect.ts
@@ -43,7 +43,7 @@ export interface ExpectedActivityShape extends ExpectedShape {
 
 export interface ExpectedCallActivityShape extends ExpectedActivityShape {
   bpmnElementGlobalTaskKind?: GlobalTaskKind;
-  bpmnElementCallActivityKind?: ShapeBpmnCallActivityKind;
+  bpmnElementCallActivityKind: ShapeBpmnCallActivityKind;
 }
 
 export interface ExpectedEventShape extends ExpectedShape {
@@ -114,7 +114,7 @@ export const verifyShape = (
     expect(bpmnElement.markers).toHaveLength(0);
   }
 
-  if (('bpmnElementCallActivityKind' in expectedShape && expectedShape.bpmnElementCallActivityKind) ?? 'bpmnElementGlobalTaskKind' in expectedShape) {
+  if ('bpmnElementCallActivityKind' in expectedShape || 'bpmnElementGlobalTaskKind' in expectedShape) {
     expect(bpmnElement instanceof ShapeBpmnCallActivity).toBeTruthy();
     expect((bpmnElement as ShapeBpmnCallActivity).callActivityKind).toEqual(expectedShape.bpmnElementCallActivityKind);
     expect((bpmnElement as ShapeBpmnCallActivity).globalTaskKind).toEqual(expectedShape.bpmnElementGlobalTaskKind);

--- a/test/unit/helpers/bpmn-model-expect.ts
+++ b/test/unit/helpers/bpmn-model-expect.ts
@@ -114,7 +114,7 @@ export const verifyShape = (
     expect(bpmnElement.markers).toHaveLength(0);
   }
 
-  if ('bpmnElementCallActivityKind' in expectedShape) {
+  if ('bpmnElementCallActivityKind' in expectedShape && expectedShape.bpmnElementCallActivityKind) {
     expect(bpmnElement instanceof ShapeBpmnCallActivity).toBeTruthy();
     expect((bpmnElement as ShapeBpmnCallActivity).callActivityKind).toEqual(expectedShape.bpmnElementCallActivityKind);
     expect((bpmnElement as ShapeBpmnCallActivity).globalTaskKind).toEqual(expectedShape.bpmnElementGlobalTaskKind);


### PR DESCRIPTION
Resolved the error reported by `plugin:@typescript-eslint/stylistic-type-checked` rules by replacing the logical OR (`||`) operator with the nullish coalescing operator (`??`). 
This change contributes to safer and more predictable code behavior, aligning with the recommendations of `@typescript-eslint/prefer-nullish-coalescing`.