### PR TITLE
chore(dependabot): improve groups configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,6 +42,10 @@ updates:
             - "@rollup/*"
             - "rollup"
             - "rollup-plugin-*"
+       typescript:
+          patterns:
+            - "typedoc"
+            - "typescript"
 
   - package-ecosystem: "github-actions"
     # Workflow files stored in the default location of `.github/workflows`

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,7 @@ updates:
        jest:
           patterns:
             - "@types/jest-*"
+            - "expect-playwright"
             - "jest"
             - "jest-*"
             - "ts-jest"


### PR DESCRIPTION
Create a new _typescript_ group:
  - Group `typedoc` and `typescript` together because `typedoc` supports a specific range of TypeScript versions.
  - Switching from TypeScript to a minor or major version alone breaks `npm install` because the current version of `typedoc` doesn't support it.

Update the _jest_ group:
  - add `expect-playwright` that was missing

### Notes

#2829 shows the problem with TypeScript dependencies.