### PR TITLE
refactor: introduce registry interfaces

### DIFF
--- a/src/component/registry/bpmn-elements-registry.ts
+++ b/src/component/registry/bpmn-elements-registry.ts
@@ -18,11 +18,11 @@ import { ensureIsArray } from '../helpers/array-utils';
 import type { BpmnGraph } from '../mxgraph/BpmnGraph';
 import { computeBpmnBaseClassName } from '../mxgraph/renderer/style-utils';
 import type { BpmnModelRegistry } from './bpmn-model-registry';
-import { createNewCssRegistry, type CssClassesRegistry } from './css-registry';
-import { createNewOverlaysRegistry, type OverlaysRegistry } from './overlays-registry';
+import { createNewCssRegistry, type CssClassesRegistryImpl } from './css-registry';
+import { createNewOverlaysRegistry } from './overlays-registry';
 import { BpmnQuerySelectors } from './query-selectors';
-import { createNewStyleRegistry, type StyleRegistry } from './style-registry';
-import type { BpmnElement, Overlay, StyleUpdate } from './types';
+import { createNewStyleRegistry, type StyleRegistryImpl } from './style-registry';
+import type { BpmnElement, CssClassesRegistry, ElementsRegistry, Overlay, OverlaysRegistry, StyleRegistry, StyleUpdate } from './types';
 import type { BpmnElementKind } from '../../model/bpmn/internal';
 
 /**
@@ -57,16 +57,16 @@ export function createNewBpmnElementsRegistry(bpmnModelRegistry: BpmnModelRegist
  *  @category Custom Behavior
  *  @experimental
  */
-export class BpmnElementsRegistry {
+export class BpmnElementsRegistry implements CssClassesRegistry, ElementsRegistry, OverlaysRegistry, StyleRegistry {
   /**
    * @internal
    */
   constructor(
     private readonly bpmnModelRegistry: BpmnModelRegistry,
     private readonly htmlElementRegistry: HtmlElementRegistry,
-    private readonly cssClassesRegistry: CssClassesRegistry,
+    private readonly cssClassesRegistry: CssClassesRegistryImpl,
     private readonly overlaysRegistry: OverlaysRegistry,
-    private readonly styleRegistry: StyleRegistry,
+    private readonly styleRegistry: StyleRegistryImpl,
   ) {
     this.bpmnModelRegistry.registerOnLoadCallback(() => {
       this.cssClassesRegistry.clearCache();
@@ -74,23 +74,6 @@ export class BpmnElementsRegistry {
     });
   }
 
-  /**
-   * Get all elements by ids. The returned array contains elements in the order of the `bpmnElementIds` parameter.
-   *
-   * Not found elements are not returned as undefined in the array, so the returned array contains at most as many elements as the `bpmnElementIds` parameter.
-   *
-   * ```javascript
-   * ...
-   * // Find all elements by specified id or ids
-   * const bpmnElements1 = bpmnVisualization.bpmnElementsRegistry.getElementsByIds('userTask_1');
-   * const bpmnElements2 = bpmnVisualization.bpmnElementsRegistry.getElementsByIds(['startEvent_3', 'userTask_2']);
-   * // now you can do whatever you want with the elements
-   * ...
-   * ```
-   *
-   * **WARNING**: this method is not designed to accept a large amount of ids. It does DOM lookup to retrieve the HTML elements relative to the BPMN elements.
-   * Attempts to retrieve too many elements, especially on large BPMN diagram, may lead to performance issues.
-   */
   getElementsByIds(bpmnElementIds: string | string[]): BpmnElement[] {
     return ensureIsArray<string>(bpmnElementIds)
       .map(id => this.bpmnModelRegistry.getBpmnSemantic(id))
@@ -98,21 +81,6 @@ export class BpmnElementsRegistry {
       .map(bpmnSemantic => ({ bpmnSemantic: bpmnSemantic, htmlElement: this.htmlElementRegistry.getBpmnHtmlElement(bpmnSemantic.id) }));
   }
 
-  /**
-   * Get all elements by kinds.
-   *
-   * ```javascript
-   * ...
-   * // Find all elements by desired type or types
-   * const bpmnTaskElements = bpmnVisualization.bpmnElementsRegistry.getElementsByKinds(ShapeBpmnElementKind.TASK);
-   * const bpmnEndEventAndPoolElements = bpmnVisualization.bpmnElementsRegistry.getElementsByKinds([ShapeBpmnElementKind.EVENT_END, ShapeBpmnElementKind.POOL]);
-   * // now you can do whatever you want with the elements
-   * ...
-   * ```
-   *
-   * **WARNING**: this method is not designed to accept a large amount of types. It does DOM lookup to retrieve the HTML elements relative to the BPMN elements.
-   * Attempts to retrieve too many elements, especially on large BPMN diagrams, may lead to performance issues.
-   */
   getElementsByKinds(bpmnKinds: BpmnElementKind | BpmnElementKind[]): BpmnElement[] {
     return ensureIsArray<BpmnElementKind>(bpmnKinds)
       .map(kind =>
@@ -127,243 +95,34 @@ export class BpmnElementsRegistry {
       }, []);
   }
 
-  /**
-   * Add one or more CSS classes to one or more BPMN elements.
-   *
-   * **Notes**:
-   *
-   * - If an ID is passed that does not reference an existing BPMN element, its reference is retained in the registry, but no rendering changes are made.
-   * - This method is intended to set CSS classes on specific elements, e.g. to hide or highlight them. During BPMN diagram rendering, `bpmn-visualization` sets specific CSS classes to all elements based on their types.
-   * - To style all elements of a given type, use the default classes instead of adding new ones. The classes allow identification of elements of the same `family' and of the same specific type.
-   * - For example, a BPMN Service Task is an `Activity` and a `Task`. So it has the `bpmn-type-activity` and the `bpmn-type-task` classes. It shares these classes with all types of `Tasks`.
-   * - It also has the specific `bpmn-service-task` to distinguish it from a BPMN User Task which has a `bpmn-user-task`.
-   * - In addition, labels also have the `bpmn-label` classes.
-   *
-   * See the repository providing the [examples of the `bpmn-visualization` TypeScript library](https://github.com/process-analytics/bpmn-visualization-examples/) for more details.
-   *
-   * @example
-   * ```javascript
-   * // Add 'success-path' to BPMN elements with id: flow_1 and flow_5
-   * bpmnVisualization.bpmnElementsRegistry.addCssClasses(['flow_1', 'flow_5'], 'success-path');
-   *
-   * // Add 'suspicious-path' and 'additional-info' to BPMN element with id: task_3
-   * bpmnVisualization.bpmnElementsRegistry.addCssClasses('task_3', ['suspicious-path', 'additional-info']);
-   * ```
-   *
-   * @param bpmnElementIds The BPMN ID of the element(s) to add the CSS classes to. Passing a nullish parameter or an empty array has no effect.
-   * @param classNames The name of the class(es) to add to the BPMN element(s).
-   *
-   * @see {@link removeCssClasses} to remove specific CSS classes from a BPMN element.
-   * @see {@link removeAllCssClasses} to remove all CSS classes from a BPMN element.
-   * @see {@link toggleCssClasses} to toggle CSS classes on a BPMN element.
-   * @see {@link updateStyle} to directly update the style of BPMN elements.
-   */
   addCssClasses(bpmnElementIds: string | string[], classNames: string | string[]): void {
     this.cssClassesRegistry.addCssClasses(bpmnElementIds, classNames);
   }
 
-  /**
-   * Remove one or more CSS classes that were previously added to one or more BPMN elements using the {@link addCssClasses} or the {@link toggleCssClasses} methods.
-   *
-   * **Note**: If you pass IDs that are not related to existing BPMN elements, they will be ignored and no changes will be made to the rendering.
-   *
-   * @example
-   * ```javascript
-   * // Remove 'highlight' from BPMN elements with ID: activity_1 and activity_2
-   * bpmnVisualization.bpmnElementsRegistry.removeCssClasses(['activity_1', 'activity_2'], 'highlight');
-   *
-   * // Remove 'running' and 'additional-info' from BPMN element with ID: task_3
-   * bpmnVisualization.bpmnElementsRegistry.removeCssClasses('task_3', ['running', 'additional-info']);
-   * ```
-   *
-   * @param bpmnElementIds The BPMN ID of the element(s) from which to remove the CSS classes. Passing a nullish parameter or an empty array has no effect.
-   * @param classNames The name of the class(es) to remove from the BPMN element(s).
-   *
-   * @see {@link removeAllCssClasses} to remove all CSS classes from a BPMN element.
-   */
   removeCssClasses(bpmnElementIds: string | string[], classNames: string | string[]): void {
     this.cssClassesRegistry.removeCssClasses(bpmnElementIds, classNames);
   }
 
-  /**
-   * Remove any CSS classes that were previously added to one or more BPMN elements using the {@link addCssClasses} or the {@link toggleCssClasses} methods.
-   *
-   * **Note**: If you pass IDs that are not related to existing BPMN elements, they will be ignored and no changes will be made to the rendering.
-   *
-   * @example
-   * ```javascript
-   * // Remove all CSS classes from all BPMN elements
-   * bpmnVisualization.bpmnElementsRegistry.removeAllCssClasses();
-   *
-   * // Remove all CSS classes from BPMN elements with ID: activity_1 and activity_2
-   * bpmnVisualization.bpmnElementsRegistry.removeAllCssClasses(['activity_1', 'activity_2']);
-   *
-   * // Remove all CSS classes from BPMN element with ID: task_3
-   * bpmnVisualization.bpmnElementsRegistry.removeAllCssClasses('task_3');
-   * ```
-   *
-   * @param bpmnElementIds The BPMN ID of the element(s) from which to remove all CSS classes.
-   * When passing a nullish parameter, all CSS classes associated with all BPMN elements will be removed. Passing an empty array has no effect.
-   *
-   * @see {@link removeCssClasses} to remove specific classes from a BPMN element.
-   * @since 0.34.0
-   */
   removeAllCssClasses(bpmnElementIds?: string | string[]): void {
     this.cssClassesRegistry.removeAllCssClasses(bpmnElementIds);
   }
 
-  /**
-   * Toggle one or more CSS classes on one or more BPMN elements.
-   *
-   * **Note**: If an ID is passed that does not reference an existing BPMN element, its reference is retained in the registry, but no rendering changes are made.
-   *
-   * @example
-   * ```javascript
-   * // Toggle 'highlight' for BPMN elements with ID: activity_1 and activity_2
-   * bpmnVisualization.bpmnElementsRegistry.toggleCssClasses(['activity_1', 'activity_2'], 'highlight');
-   *
-   * // Toggle 'running' and 'additional-info' for BPMN element with ID: task_3
-   * bpmnVisualization.bpmnElementsRegistry.toggleCssClasses('task_3', ['running', 'additional-info']);
-   * ```
-   *
-   * @param bpmnElementIds The BPMN ID of the element(s) on which to toggle the CSS classes. Passing a nullish parameter or an empty array has no effect.
-   * @param classNames The name of the class(es) to toggle on the BPMN element(s).
-   *
-   * @see {@link removeCssClasses} to remove specific CSS classes from a BPMN element.
-   * @see {@link removeAllCssClasses} to remove all CSS classes from a BPMN element.
-   * @see {@link addCssClasses} to add CSS classes to a BPMN element.
-   */
   toggleCssClasses(bpmnElementIds: string | string[], classNames: string | string[]): void {
     this.cssClassesRegistry.toggleCssClasses(bpmnElementIds, classNames);
   }
 
-  /**
-   * Add one/several overlays to a BPMN element.
-   *
-   * Notice that if you pass an id that is not related to an existing BPMN element, nothing happens on the rendering side.
-   *
-   * @example
-   * ```javascript
-   * // Add an overlay to BPMN elements with id 'task_1'
-   * bpmnVisualization.bpmnElementsRegistry.addOverlays('task_1', {
-   *    position: 'top-left',
-   *    label: '40',
-   *    style: {
-   *      font: { color: 'Chartreuse', size: 8 },
-   *      fill: { color: 'Pink', opacity: 50 },
-   *      stroke: { color: 'DarkSeaGreen', width: 2 }
-   *    }
-   * });
-   *
-   * // Add several overlays to BPMN element with id 'task_3'
-   * bpmnVisualization.bpmnElementsRegistry.addOverlays('task_3', [
-   *    {
-   *      position: 'bottom-right',
-   *      label: '110',
-   *      style: {
-   *        font: { color: '#663399', size: 8 },
-   *        fill: { color: '#FFDAB9', opacity: 50 },
-   *        stroke: { color: 'DarkSeaGreen', width: 2 }
-   *      }
-   *    },
-   *    {
-   *      position: 'top-left',
-   *      label: '40',
-   *      style: {
-   *        font: { color: 'MidnightBlue', size: 30 },
-   *        fill: { color: 'Aquamarine', opacity: 70 },
-   *        stroke: { color: '#4B0082', width: 1 }
-   *      }
-   *    }
-   * ]);
-   * ```
-   *
-   * @param bpmnElementId The BPMN id of the element where to add the overlays
-   * @param overlays The overlays to add to the BPMN element
-   */
   addOverlays(bpmnElementId: string, overlays: Overlay | Overlay[]): void {
     this.overlaysRegistry.addOverlays(bpmnElementId, overlays);
   }
 
-  /**
-   * Remove all overlays of a BPMN element.
-   *
-   * Notice that if you pass an id that is not related to an existing BPMN element, nothing happens on the rendering side.
-   *
-   * <b>WARNING</b>: could be renamed when adding support for removal of one or several specific overlays.
-   *
-   * @example
-   * ```javascript
-   * //  all overlays of the BPMN element with id: activity_1
-   * bpmnVisualization.bpmnElementsRegistry.removeAllOverlays('activity_1');
-   * ```
-   *
-   * @param bpmnElementId The BPMN id of the element where to remove the overlays
-   */
   removeAllOverlays(bpmnElementId: string): void {
     this.overlaysRegistry.removeAllOverlays(bpmnElementId);
   }
 
-  /**
-   * Update the style of one or several BPMN elements.
-   *
-   * @example
-   * ```javascript
-   * bpmnVisualization.bpmnElementsRegistry.updateStyle('activity_1', {
-   *   stroke: {
-   *     color: 'red',
-   *   },
-   * });
-   * ```
-   *
-   * **Notes**:
-   *
-   * - This method is intended to update the style of specific elements, e.g. to update their colors. When rendering a BPMN diagram, `bpmn-visualization` applies style properties
-   * to all elements according to their types.
-   * So if you want to style all elements of a certain type, change the default configuration of the styles instead of updating the element afterwards. See the repository providing the
-   * [examples of the `bpmn-visualization` TypeScript library](https://github.com/process-analytics/bpmn-visualization-examples/) for more details.
-   * - If you pass IDs that are not related to existing BPMN elements, they will be ignored and no changes will be made to the rendering.
-   *
-   * @param bpmnElementIds The BPMN ID of the element(s) whose style must be updated.
-   * @param styleUpdate The style properties to update.
-   *
-   * @see {@link resetStyle} to reset the style of one or several BPMN elements.
-   * @see {@link addCssClasses} to add CSS classes to a BPMN element.
-   * @see {@link removeCssClasses} to remove specific classes from a BPMN element.
-   * @see {@link removeAllCssClasses} to remove all CSS classes from a BPMN element.
-   * @see {@link toggleCssClasses} to toggle CSS classes on a BPMN element.
-   * @since 0.33.0
-   */
   updateStyle(bpmnElementIds: string | string[], styleUpdate: StyleUpdate): void {
     this.styleRegistry.updateStyle(bpmnElementIds, styleUpdate);
   }
 
-  /**
-   * Reset the style that were previously updated to one or more BPMN elements using the {@link updateStyle} method.
-   *
-   * @example
-   * ```javascript
-   * bpmnVisualization.bpmnElementsRegistry.resetStyle('activity_1');
-   * ```
-   *
-   * **Notes**:
-   *
-   * - This method is intended to update the style of specific elements, e.g. to update their colors. When rendering a BPMN diagram, `bpmn-visualization` applies style properties
-   * to all elements according to their types.
-   * So if you want to style all elements of a certain type, change the default configuration of the styles instead of updating the element afterward. See the repository providing the
-   * [examples of the `bpmn-visualization` TypeScript library](https://github.com/process-analytics/bpmn-visualization-examples/) for more details.
-   * - If you pass IDs that are not related to existing BPMN elements, they will be ignored and no changes will be made to the rendering.
-   *
-   * @param bpmnElementIds The BPMN ID of the element(s) whose style must be reset.
-   * When passing a nullish parameter, the style of all BPMN elements will be reset. Passing an empty array has no effect.
-   *
-   * @see {@link updateStyle} to update the style of one or several BPMN elements.
-   * @see {@link addCssClasses} to add CSS classes to a BPMN element.
-   * @see {@link removeCssClasses} to remove specific classes from a BPMN element.
-   * @see {@link removeAllCssClasses} to remove all CSS classes from a BPMN element.
-   * @see {@link toggleCssClasses} to toggle CSS classes on a BPMN element.
-   * @since 0.37.0
-   */
   resetStyle(bpmnElementIds?: string | string[]): void {
     this.styleRegistry.resetStyle(bpmnElementIds);
   }

--- a/src/component/registry/css-registry.ts
+++ b/src/component/registry/css-registry.ts
@@ -14,15 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import type { CssClassesRegistry } from './types';
 import { ensureIsArray } from '../helpers/array-utils';
 import type { BpmnGraph } from '../mxgraph/BpmnGraph';
 import { createNewCssClassesUpdater, type CssClassesUpdater } from '../mxgraph/style/css-classes-updater';
 
-export function createNewCssRegistry(graph: BpmnGraph): CssClassesRegistry {
-  return new CssClassesRegistry(createNewCssClassesUpdater(graph), new CssClassesCache());
+export function createNewCssRegistry(graph: BpmnGraph): CssClassesRegistryImpl {
+  return new CssClassesRegistryImpl(createNewCssClassesUpdater(graph), new CssClassesCache());
 }
 
-export class CssClassesRegistry {
+export class CssClassesRegistryImpl implements CssClassesRegistry {
   constructor(
     private readonly cssClassesUpdater: CssClassesUpdater,
     private readonly cssClassesCache: CssClassesCache,

--- a/src/component/registry/overlays-registry.ts
+++ b/src/component/registry/overlays-registry.ts
@@ -14,15 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import type { Overlay } from './types';
+import type { Overlay, OverlaysRegistry } from './types';
 import { createNewOverlaysUpdater, type OverlaysUpdater } from '../mxgraph/overlay/updater';
 import type { BpmnGraph } from '../mxgraph/BpmnGraph';
 
 export function createNewOverlaysRegistry(graph: BpmnGraph): OverlaysRegistry {
-  return new OverlaysRegistry(createNewOverlaysUpdater(graph));
+  return new OverlaysRegistryImpl(createNewOverlaysUpdater(graph));
 }
 
-export class OverlaysRegistry {
+class OverlaysRegistryImpl implements OverlaysRegistry {
   constructor(private readonly overlaysUpdater: OverlaysUpdater) {}
 
   addOverlays(bpmnElementId: string, overlays: Overlay | Overlay[]): void {

--- a/src/component/registry/style-registry.ts
+++ b/src/component/registry/style-registry.ts
@@ -14,15 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import type { StyleRegistry, StyleUpdate } from './types';
 import type { BpmnGraph } from '../mxgraph/BpmnGraph';
 import { createNewStyleUpdater, type StyleUpdater } from '../mxgraph/style/style-updater';
-import type { StyleUpdate } from './types';
 
-export function createNewStyleRegistry(graph: BpmnGraph): StyleRegistry {
-  return new StyleRegistry(createNewStyleUpdater(graph));
+export function createNewStyleRegistry(graph: BpmnGraph): StyleRegistryImpl {
+  return new StyleRegistryImpl(createNewStyleUpdater(graph));
 }
 
-export class StyleRegistry {
+export class StyleRegistryImpl implements StyleRegistry {
   constructor(private readonly styleUpdater: StyleUpdater) {}
 
   clearCache(): void {

--- a/src/component/registry/types.ts
+++ b/src/component/registry/types.ts
@@ -17,6 +17,287 @@ limitations under the License.
 import type { BpmnElementKind } from '../../model/bpmn/internal';
 
 /**
+ * @category Element Style
+ */
+export interface CssClassesRegistry {
+  /**
+   * Add one or more CSS classes to one or more BPMN elements.
+   *
+   * **Notes**:
+   *
+   * - If an ID is passed that does not reference an existing BPMN element, its reference is retained in the registry, but no rendering changes are made.
+   * - This method is intended to set CSS classes on specific elements, e.g. to hide or highlight them. During BPMN diagram rendering, `bpmn-visualization` sets specific CSS classes to all elements based on their types.
+   * - To style all elements of a given type, use the default classes instead of adding new ones. The classes allow identification of elements of the same `family' and of the same specific type.
+   * - For example, a BPMN Service Task is an `Activity` and a `Task`. So it has the `bpmn-type-activity` and the `bpmn-type-task` classes. It shares these classes with all types of `Tasks`.
+   * - It also has the specific `bpmn-service-task` to distinguish it from a BPMN User Task which has a `bpmn-user-task`.
+   * - In addition, labels also have the `bpmn-label` classes.
+   *
+   * See the repository providing the [examples of the `bpmn-visualization` TypeScript library](https://github.com/process-analytics/bpmn-visualization-examples/) for more details.
+   *
+   * @example
+   * ```javascript
+   * // Add 'success-path' to BPMN elements with id: flow_1 and flow_5
+   * bpmnVisualization.bpmnElementsRegistry.addCssClasses(['flow_1', 'flow_5'], 'success-path');
+   *
+   * // Add 'suspicious-path' and 'additional-info' to BPMN element with id: task_3
+   * bpmnVisualization.bpmnElementsRegistry.addCssClasses('task_3', ['suspicious-path', 'additional-info']);
+   * ```
+   *
+   * @param bpmnElementIds The BPMN ID of the element(s) to add the CSS classes to. Passing a nullish parameter or an empty array has no effect.
+   * @param classNames The name of the class(es) to add to the BPMN element(s).
+   *
+   * @see {@link removeCssClasses} to remove specific CSS classes from a BPMN element.
+   * @see {@link removeAllCssClasses} to remove all CSS classes from a BPMN element.
+   * @see {@link toggleCssClasses} to toggle CSS classes on a BPMN element.
+   * @see {@link StyleRegistry#updateStyle} to directly update the style of BPMN elements.
+   */
+  addCssClasses(bpmnElementIds: string | string[], classNames: string | string[]): void;
+
+  /**
+   * Remove one or more CSS classes that were previously added to one or more BPMN elements using the {@link addCssClasses} or the {@link toggleCssClasses} methods.
+   *
+   * **Note**: If you pass IDs that are not related to existing BPMN elements, they will be ignored and no changes will be made to the rendering.
+   *
+   * @example
+   * ```javascript
+   * // Remove 'highlight' from BPMN elements with ID: activity_1 and activity_2
+   * bpmnVisualization.bpmnElementsRegistry.removeCssClasses(['activity_1', 'activity_2'], 'highlight');
+   *
+   * // Remove 'running' and 'additional-info' from BPMN element with ID: task_3
+   * bpmnVisualization.bpmnElementsRegistry.removeCssClasses('task_3', ['running', 'additional-info']);
+   * ```
+   *
+   * @param bpmnElementIds The BPMN ID of the element(s) from which to remove the CSS classes. Passing a nullish parameter or an empty array has no effect.
+   * @param classNames The name of the class(es) to remove from the BPMN element(s).
+   *
+   * @see {@link removeAllCssClasses} to remove all CSS classes from a BPMN element.
+   */
+  removeCssClasses(bpmnElementIds: string | string[], classNames: string | string[]): void;
+
+  /**
+   * Remove any CSS classes that were previously added to one or more BPMN elements using the {@link addCssClasses} or the {@link toggleCssClasses} methods.
+   *
+   * **Note**: If you pass IDs that are not related to existing BPMN elements, they will be ignored and no changes will be made to the rendering.
+   *
+   * @example
+   * ```javascript
+   * // Remove all CSS classes from all BPMN elements
+   * bpmnVisualization.bpmnElementsRegistry.removeAllCssClasses();
+   *
+   * // Remove all CSS classes from BPMN elements with ID: activity_1 and activity_2
+   * bpmnVisualization.bpmnElementsRegistry.removeAllCssClasses(['activity_1', 'activity_2']);
+   *
+   * // Remove all CSS classes from BPMN element with ID: task_3
+   * bpmnVisualization.bpmnElementsRegistry.removeAllCssClasses('task_3');
+   * ```
+   *
+   * @param bpmnElementIds The BPMN ID of the element(s) from which to remove all CSS classes.
+   * When passing a nullish parameter, all CSS classes associated with all BPMN elements will be removed. Passing an empty array has no effect.
+   *
+   * @see {@link removeCssClasses} to remove specific classes from a BPMN element.
+   * @since 0.34.0
+   */
+  removeAllCssClasses(bpmnElementIds?: string | string[]): void;
+
+  /**
+   * Toggle one or more CSS classes on one or more BPMN elements.
+   *
+   * **Note**: If an ID is passed that does not reference an existing BPMN element, its reference is retained in the registry, but no rendering changes are made.
+   *
+   * @example
+   * ```javascript
+   * // Toggle 'highlight' for BPMN elements with ID: activity_1 and activity_2
+   * bpmnVisualization.bpmnElementsRegistry.toggleCssClasses(['activity_1', 'activity_2'], 'highlight');
+   *
+   * // Toggle 'running' and 'additional-info' for BPMN element with ID: task_3
+   * bpmnVisualization.bpmnElementsRegistry.toggleCssClasses('task_3', ['running', 'additional-info']);
+   * ```
+   *
+   * @param bpmnElementIds The BPMN ID of the element(s) on which to toggle the CSS classes. Passing a nullish parameter or an empty array has no effect.
+   * @param classNames The name of the class(es) to toggle on the BPMN element(s).
+   *
+   * @see {@link removeCssClasses} to remove specific CSS classes from a BPMN element.
+   * @see {@link removeAllCssClasses} to remove all CSS classes from a BPMN element.
+   * @see {@link addCssClasses} to add CSS classes to a BPMN element.
+   */
+  toggleCssClasses(bpmnElementIds: string | string[], classNames: string | string[]): void;
+}
+
+/**
+ * @category Custom Behavior
+ */
+export interface ElementsRegistry {
+  /**
+   * Get all elements by ids. The returned array contains elements in the order of the `bpmnElementIds` parameter.
+   *
+   * Not found elements are not returned as undefined in the array, so the returned array contains at most as many elements as the `bpmnElementIds` parameter.
+   *
+   * ```javascript
+   * ...
+   * // Find all elements by specified id or ids
+   * const bpmnElements1 = bpmnVisualization.bpmnElementsRegistry.getElementsByIds('userTask_1');
+   * const bpmnElements2 = bpmnVisualization.bpmnElementsRegistry.getElementsByIds(['startEvent_3', 'userTask_2']);
+   * // now you can do whatever you want with the elements
+   * ...
+   * ```
+   *
+   * **WARNING**: this method is not designed to accept a large amount of ids. It does DOM lookup to retrieve the HTML elements relative to the BPMN elements.
+   * Attempts to retrieve too many elements, especially on large BPMN diagram, may lead to performance issues.
+   */
+  getElementsByIds(bpmnElementIds: string | string[]): BpmnElement[];
+
+  /**
+   * Get all elements by kinds.
+   *
+   * ```javascript
+   * ...
+   * // Find all elements by desired type or types
+   * const bpmnTaskElements = bpmnVisualization.bpmnElementsRegistry.getElementsByKinds(ShapeBpmnElementKind.TASK);
+   * const bpmnEndEventAndPoolElements = bpmnVisualization.bpmnElementsRegistry.getElementsByKinds([ShapeBpmnElementKind.EVENT_END, ShapeBpmnElementKind.POOL]);
+   * // now you can do whatever you want with the elements
+   * ...
+   * ```
+   *
+   * **WARNING**: this method is not designed to accept a large amount of types. It does DOM lookup to retrieve the HTML elements relative to the BPMN elements.
+   * Attempts to retrieve too many elements, especially on large BPMN diagrams, may lead to performance issues.
+   */
+  getElementsByKinds(bpmnKinds: BpmnElementKind | BpmnElementKind[]): BpmnElement[];
+}
+
+/**
+ * @category Overlays
+ */
+export interface OverlaysRegistry {
+  /**
+   * Add one/several overlays to a BPMN element.
+   *
+   * Notice that if you pass an id that is not related to an existing BPMN element, nothing happens on the rendering side.
+   *
+   * @example
+   * ```javascript
+   * // Add an overlay to BPMN elements with id 'task_1'
+   * bpmnVisualization.bpmnElementsRegistry.addOverlays('task_1', {
+   *    position: 'top-left',
+   *    label: '40',
+   *    style: {
+   *      font: { color: 'Chartreuse', size: 8 },
+   *      fill: { color: 'Pink', opacity: 50 },
+   *      stroke: { color: 'DarkSeaGreen', width: 2 }
+   *    }
+   * });
+   *
+   * // Add several overlays to BPMN element with id 'task_3'
+   * bpmnVisualization.bpmnElementsRegistry.addOverlays('task_3', [
+   *    {
+   *      position: 'bottom-right',
+   *      label: '110',
+   *      style: {
+   *        font: { color: '#663399', size: 8 },
+   *        fill: { color: '#FFDAB9', opacity: 50 },
+   *        stroke: { color: 'DarkSeaGreen', width: 2 }
+   *      }
+   *    },
+   *    {
+   *      position: 'top-left',
+   *      label: '40',
+   *      style: {
+   *        font: { color: 'MidnightBlue', size: 30 },
+   *        fill: { color: 'Aquamarine', opacity: 70 },
+   *        stroke: { color: '#4B0082', width: 1 }
+   *      }
+   *    }
+   * ]);
+   * ```
+   *
+   * @param bpmnElementId The BPMN id of the element where to add the overlays
+   * @param overlays The overlays to add to the BPMN element
+   */
+  addOverlays(bpmnElementId: string, overlays: Overlay | Overlay[]): void;
+
+  /**
+   * Remove all overlays of a BPMN element.
+   *
+   * Notice that if you pass an id that is not related to an existing BPMN element, nothing happens on the rendering side.
+   *
+   * <b>WARNING</b>: could be renamed when adding support for removal of one or several specific overlays.
+   *
+   * @example
+   * ```javascript
+   * //  all overlays of the BPMN element with id: activity_1
+   * bpmnVisualization.bpmnElementsRegistry.removeAllOverlays('activity_1');
+   * ```
+   *
+   * @param bpmnElementId The BPMN id of the element where to remove the overlays
+   */
+  removeAllOverlays(bpmnElementId: string): void;
+}
+
+/**
+ * @category Element Style
+ */
+export interface StyleRegistry {
+  /**
+   * Update the style of one or several BPMN elements.
+   *
+   * @example
+   * ```javascript
+   * bpmnVisualization.bpmnElementsRegistry.updateStyle('activity_1', {
+   *   stroke: {
+   *     color: 'red',
+   *   },
+   * });
+   * ```
+   *
+   * **Notes**:
+   *
+   * - This method is intended to update the style of specific elements, e.g. to update their colors. When rendering a BPMN diagram, `bpmn-visualization` applies style properties
+   * to all elements according to their types.
+   * So if you want to style all elements of a certain type, change the default configuration of the styles instead of updating the element afterwards. See the repository providing the
+   * [examples of the `bpmn-visualization` TypeScript library](https://github.com/process-analytics/bpmn-visualization-examples/) for more details.
+   * - If you pass IDs that are not related to existing BPMN elements, they will be ignored and no changes will be made to the rendering.
+   *
+   * @param bpmnElementIds The BPMN ID of the element(s) whose style must be updated.
+   * @param styleUpdate The style properties to update.
+   *
+   * @see {@link resetStyle} to reset the style of one or several BPMN elements.
+   * @see {@link CssClassesRegistry#addCssClasses} to add CSS classes to a BPMN element.
+   * @see {@link CssClassesRegistry#removeCssClasses} to remove specific classes from a BPMN element.
+   * @see {@link CssClassesRegistry#removeAllCssClasses} to remove all CSS classes from a BPMN element.
+   * @see {@link CssClassesRegistry#toggleCssClasses} to toggle CSS classes on a BPMN element.
+   * @since 0.33.0
+   */
+  updateStyle(bpmnElementIds: string | string[], styleUpdate: StyleUpdate): void;
+
+  /**
+   * Reset the style that were previously updated to one or more BPMN elements using the {@link updateStyle} method.
+   *
+   * @example
+   * ```javascript
+   * bpmnVisualization.bpmnElementsRegistry.resetStyle('activity_1');
+   * ```
+   *
+   * **Notes**:
+   *
+   * - This method is intended to update the style of specific elements, e.g. to update their colors. When rendering a BPMN diagram, `bpmn-visualization` applies style properties
+   * to all elements according to their types.
+   * So if you want to style all elements of a certain type, change the default configuration of the styles instead of updating the element afterward. See the repository providing the
+   * [examples of the `bpmn-visualization` TypeScript library](https://github.com/process-analytics/bpmn-visualization-examples/) for more details.
+   * - If you pass IDs that are not related to existing BPMN elements, they will be ignored and no changes will be made to the rendering.
+   *
+   * @param bpmnElementIds The BPMN ID of the element(s) whose style must be reset.
+   * When passing a nullish parameter, the style of all BPMN elements will be reset. Passing an empty array has no effect.
+   *
+   * @see {@link updateStyle} to update the style of one or several BPMN elements.
+   * @see {@link CssClassesRegistry#addCssClasses} to add CSS classes to a BPMN element.
+   * @see {@link CssClassesRegistry#removeCssClasses} to remove specific classes from a BPMN element.
+   * @see {@link CssClassesRegistry#removeAllCssClasses} to remove all CSS classes from a BPMN element.
+   * @see {@link CssClassesRegistry#toggleCssClasses} to toggle CSS classes on a BPMN element.
+   * @since 0.37.0
+   */
+  resetStyle(bpmnElementIds?: string | string[]): void;
+}
+
+/**
  * @category Custom Behavior
  */
 export interface BaseBpmnSemantic {


### PR DESCRIPTION
Extract interfaces to ensure that all methods are implemented in both `BpmnElementsRegistry` and the specific registries. This will also let reuse the method signatures in
  - `CssClassesRegistry`
  - `ElementsRegistry`
  - `OverlaysRegistry`
  - `StyleRegistry`

Add JSDoc existing category to interfaces and make links in "see" directive works (at least in the HTML report produced by `typedoc`)

closes #2803
covers #2813