### PR TITLE
feat: add a method to only get BPMN semantic of elements by id

### DIFF
--- a/src/component/registry/bpmn-elements-registry.ts
+++ b/src/component/registry/bpmn-elements-registry.ts
@@ -22,7 +22,7 @@ import { createNewCssRegistry, type CssClassesRegistryImpl } from './css-registr
 import { createNewOverlaysRegistry } from './overlays-registry';
 import { BpmnQuerySelectors } from './query-selectors';
 import { createNewStyleRegistry, type StyleRegistryImpl } from './style-registry';
-import type { BpmnElement, CssClassesRegistry, ElementsRegistry, Overlay, OverlaysRegistry, StyleRegistry, StyleUpdate } from './types';
+import type { BpmnElement, BpmnSemantic, CssClassesRegistry, ElementsRegistry, Overlay, OverlaysRegistry, StyleRegistry, StyleUpdate } from './types';
 import type { BpmnElementKind } from '../../model/bpmn/internal';
 
 /**
@@ -74,11 +74,17 @@ export class BpmnElementsRegistry implements CssClassesRegistry, ElementsRegistr
     });
   }
 
-  getElementsByIds(bpmnElementIds: string | string[]): BpmnElement[] {
+  getModelElementsByIds(bpmnElementIds: string | string[]): BpmnSemantic[] {
     return ensureIsArray<string>(bpmnElementIds)
       .map(id => this.bpmnModelRegistry.getBpmnSemantic(id))
-      .filter(Boolean)
-      .map(bpmnSemantic => ({ bpmnSemantic: bpmnSemantic, htmlElement: this.htmlElementRegistry.getBpmnHtmlElement(bpmnSemantic.id) }));
+      .filter(Boolean);
+  }
+
+  getElementsByIds(bpmnElementIds: string | string[]): BpmnElement[] {
+    return this.getModelElementsByIds(bpmnElementIds).map(bpmnSemantic => ({
+      bpmnSemantic: bpmnSemantic,
+      htmlElement: this.htmlElementRegistry.getBpmnHtmlElement(bpmnSemantic.id),
+    }));
   }
 
   getElementsByKinds(bpmnKinds: BpmnElementKind | BpmnElementKind[]): BpmnElement[] {

--- a/src/component/registry/types.ts
+++ b/src/component/registry/types.ts
@@ -128,6 +128,26 @@ export interface CssClassesRegistry {
  */
 export interface ElementsRegistry {
   /**
+   * Get all model elements by ids. The returned array contains elements in the order of the `bpmnElementIds` parameter.
+   *
+   * Not found elements are not returned as undefined in the array, so the returned array contains at most as many elements as the `bpmnElementIds` parameter.
+   *
+   * ```javascript
+   * ...
+   * // Find all elements by specified id or ids
+   * const bpmnElements1 = bpmnVisualization.bpmnElementsRegistry.getModelElementsByIds('userTask_1');
+   * const bpmnElements2 = bpmnVisualization.bpmnElementsRegistry.getModelElementsByIds(['startEvent_3', 'userTask_2']);
+   * // now you can do whatever you want with the elements
+   * ...
+   * ```
+   *
+   * If you also need to retrieve the related DOM elements and more information, use {@link getElementsByIds} instead.
+   *
+   * @param bpmnElementIds The BPMN ID of the element(s) to retrieve.
+   */
+  getModelElementsByIds(bpmnElementIds: string | string[]): BpmnSemantic[];
+
+  /**
    * Get all elements by ids. The returned array contains elements in the order of the `bpmnElementIds` parameter.
    *
    * Not found elements are not returned as undefined in the array, so the returned array contains at most as many elements as the `bpmnElementIds` parameter.
@@ -143,6 +163,10 @@ export interface ElementsRegistry {
    *
    * **WARNING**: this method is not designed to accept a large amount of ids. It does DOM lookup to retrieve the HTML elements relative to the BPMN elements.
    * Attempts to retrieve too many elements, especially on large BPMN diagram, may lead to performance issues.
+   *
+   * @see {@link getModelElementsByIds}
+   *
+   * @param bpmnElementIds The BPMN ID of the element(s) to retrieve.
    */
   getElementsByIds(bpmnElementIds: string | string[]): BpmnElement[];
 

--- a/test/integration/model.elements.api.test.ts
+++ b/test/integration/model.elements.api.test.ts
@@ -1,0 +1,74 @@
+/*
+Copyright 2023 Bonitasoft S.A.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import type { EdgeBpmnSemantic, ShapeBpmnSemantic } from '@lib/component/registry';
+import { readFileSync } from '@test/shared/file-helper';
+import { expectBoundaryEvent, expectSequenceFlow, expectStartEvent, expectSubprocess } from '@test/shared/model/bpmn-semantic-utils';
+import { bpmnVisualization } from './helpers/model-expect';
+
+describe('Registry API - retrieve Model Bpmn elements', () => {
+  bpmnVisualization.load(readFileSync('../fixtures/bpmn/model-complete-semantic.bpmn'));
+  const bpmnElementsRegistry = bpmnVisualization.bpmnElementsRegistry;
+
+  describe('Get by ids', () => {
+    test('Pass a single existing id', () => {
+      const modelElements = bpmnElementsRegistry.getModelElementsByIds('start_event_message_id');
+
+      expect(modelElements).toHaveLength(1);
+
+      expectStartEvent(modelElements[0] as ShapeBpmnSemantic, { id: 'start_event_message_id', name: 'Message Start Event', outgoing: ['message_flow_initiating_message_id'] });
+    });
+
+    test('Pass several existing ids', () => {
+      const modelElements = bpmnElementsRegistry.getModelElementsByIds(['expanded_event_sub_process_with_loop_id', 'sequence_flow_in_sub_process_1_id']);
+
+      expect(modelElements).toHaveLength(2);
+
+      expectSubprocess(modelElements[0] as ShapeBpmnSemantic, { id: 'expanded_event_sub_process_with_loop_id', name: 'Expanded Event Sub-Process With Loop' });
+      expectSequenceFlow(modelElements[1] as EdgeBpmnSemantic, {
+        id: 'sequence_flow_in_sub_process_1_id',
+        source: 'start_event_in_sub_process_id',
+        target: 'task_in_sub_process_id',
+      });
+    });
+
+    test('Pass a single non existing id', () => {
+      expect(bpmnElementsRegistry.getModelElementsByIds('unknown')).toHaveLength(0);
+    });
+
+    test.each([null, undefined])('Pass nullish parameter: %s', (nullishResetParameter: string) => {
+      expect(bpmnElementsRegistry.getModelElementsByIds(nullishResetParameter)).toHaveLength(0);
+    });
+
+    test('Pass existing and non existing ids', () => {
+      const modelElements = bpmnElementsRegistry.getModelElementsByIds([
+        'boundary_event_non_interrupting_signal_id',
+        'unknown',
+        'conditional_sequence_flow_from_activity_id',
+        'another_unknown',
+      ]);
+
+      expect(modelElements).toHaveLength(2);
+
+      expectBoundaryEvent(modelElements[0] as ShapeBpmnSemantic, { id: 'boundary_event_non_interrupting_signal_id', name: 'Non-interrupting Signal Boundary Intermediate Event' });
+      expectSequenceFlow(modelElements[1] as EdgeBpmnSemantic, {
+        id: 'conditional_sequence_flow_from_activity_id',
+        source: 'task_with_flows_id',
+        target: 'gateway_with_flows_id',
+      });
+    });
+  });
+});

--- a/test/shared/model/bpmn-semantic-utils.ts
+++ b/test/shared/model/bpmn-semantic-utils.ts
@@ -77,6 +77,11 @@ export function expectEndEvent(bpmnSemantic: BpmnSemantic, expected: ExpectedBas
   expect(bpmnSemantic.kind).toEqual(ShapeBpmnElementKind.EVENT_END);
 }
 
+export function expectBoundaryEvent(bpmnSemantic: ShapeBpmnSemantic, expected: ExpectedFlowNodeElement): void {
+  expect(bpmnSemantic.kind).toEqual(ShapeBpmnElementKind.EVENT_BOUNDARY);
+  expectedFlowNode(bpmnSemantic, expected);
+}
+
 export function expectLane(bpmnSemantic: BpmnSemantic, expected: ExpectedBaseBpmnElement): void {
   expectShape(bpmnSemantic, expected);
   expect(bpmnSemantic.kind).toEqual(ShapeBpmnElementKind.LANE);
@@ -95,4 +100,9 @@ export function expectTask(bpmnSemantic: ShapeBpmnSemantic, expected: ExpectedFl
 export function expectServiceTask(bpmnSemantic: BpmnSemantic, expected: ExpectedBaseBpmnElement): void {
   expectShape(bpmnSemantic, expected);
   expect(bpmnSemantic.kind).toEqual(ShapeBpmnElementKind.TASK_SERVICE);
+}
+
+export function expectSubprocess(bpmnSemantic: ShapeBpmnSemantic, expected: ExpectedFlowNodeElement): void {
+  expectedFlowNode(bpmnSemantic, expected);
+  expect(bpmnSemantic.kind).toEqual(ShapeBpmnElementKind.SUB_PROCESS);
 }


### PR DESCRIPTION
Complement the existing method that also retrieves DOM information. This simplifies the API usage and reduce the amount of retrieved data when the caller only needs to get the information from the model.

covers #2813