### PR TITLE
feat: add a method to only get BPMN semantic of elements by kind

### DIFF
--- a/dev/ts/pages/elements-identification.ts
+++ b/dev/ts/pages/elements-identification.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import type { BpmnElement, BpmnElementKind, Overlay, ShapeStyleUpdate, StyleUpdate } from '../dev-bundle-index';
+import type { BpmnElementKind, BpmnSemantic, Overlay, ShapeStyleUpdate, StyleUpdate } from '../dev-bundle-index';
 import {
   addCssClasses,
   addOverlays,
@@ -22,7 +22,7 @@ import {
   downloadPng,
   downloadSvg,
   FitType,
-  getElementsByKinds,
+  getModelElementsByKinds,
   log,
   removeAllOverlays,
   removeCssClasses,
@@ -125,7 +125,7 @@ function updateStyleByAPI(bpmnIds: string[], bpmnKind: ShapeBpmnElementKind): vo
   const otherIds = bpmnIds.filter(bpmnId => !subProcessChildrenIds.includes(bpmnId));
 
   if (subProcessChildrenIds.length > 0) {
-    styledPoolAndLaneIds = getElementsByKinds([ShapeBpmnElementKind.POOL, ShapeBpmnElementKind.LANE]).map(element => element.bpmnSemantic.id);
+    styledPoolAndLaneIds = getModelElementsByKinds([ShapeBpmnElementKind.POOL, ShapeBpmnElementKind.LANE]).map(element => element.id);
     updateStyle(styledPoolAndLaneIds, { opacity: 5, font: { color: 'blue', opacity: 5 }, fill: { color: 'pink' }, stroke: { color: 'green' } });
   }
   updateStyle(subProcessChildrenIds, { fill: { color: 'swimlane' }, stroke: { color: 'swimlane' }, font: { color: 'swimlane' } });
@@ -168,12 +168,12 @@ function manageOverlays(idsToAddOverlay: string[], bpmnKind: ShapeBpmnElementKin
 
 function updateSelectedBPMNElements(bpmnKind: ShapeBpmnElementKind): void {
   log(`Searching for Bpmn elements of '${bpmnKind}' kind`);
-  const elementsByKinds = getElementsByKinds(bpmnKind);
+  const elementsByKinds = getModelElementsByKinds(bpmnKind);
 
   updateTextArea(elementsByKinds, bpmnKind);
 
   // newly identified elements and values
-  const newlyIdentifiedBpmnIds = elementsByKinds.map(elt => elt.bpmnSemantic.id);
+  const newlyIdentifiedBpmnIds = elementsByKinds.map(elt => elt.id);
   useCSS ? styleByCSS(newlyIdentifiedBpmnIds) : styleByAPI(newlyIdentifiedBpmnIds, bpmnKind);
   manageOverlays(newlyIdentifiedBpmnIds, bpmnKind);
 
@@ -181,12 +181,12 @@ function updateSelectedBPMNElements(bpmnKind: ShapeBpmnElementKind): void {
   lastIdentifiedBpmnIds = newlyIdentifiedBpmnIds;
 }
 
-function updateTextArea(elementsByKinds: BpmnElement[], bpmnKind: string): void {
+function updateTextArea(elementsByKinds: BpmnSemantic[], bpmnKind: string): void {
   const textArea = document.getElementById('elements-result') as HTMLTextAreaElement;
 
   const textHeader = `Found ${elementsByKinds.length} ${bpmnKind}(s)`;
   log(textHeader);
-  const lines = elementsByKinds.map(elt => `  - ${elt.bpmnSemantic.id}: '${elt.bpmnSemantic.name}'`).join('\n');
+  const lines = elementsByKinds.map(elt => `  - ${elt.id}: '${elt.name}'`).join('\n');
 
   textArea.value += [textHeader, lines].join('\n') + '\n';
   textArea.scrollTop = textArea.scrollHeight;

--- a/dev/ts/shared/main.ts
+++ b/dev/ts/shared/main.ts
@@ -16,12 +16,13 @@ limitations under the License.
 
 import type { mxCell } from 'mxgraph';
 import type {
-  BpmnElement,
   BpmnElementKind,
   BpmnSemantic,
+  FillColorGradient,
   FitOptions,
   FitType,
   GlobalOptions,
+  GradientDirection,
   LoadOptions,
   ModelFilter,
   Overlay,
@@ -29,8 +30,6 @@ import type {
   StyleUpdate,
   Version,
   ZoomType,
-  FillColorGradient,
-  GradientDirection,
 } from '../../../src/bpmn-visualization';
 import { FlowKind, ShapeBpmnElementKind } from '../../../src/bpmn-visualization';
 import { fetchBpmnContent, logDownload, logError, logErrorAndOpenAlert, logStartup } from './internal-helpers';
@@ -101,8 +100,8 @@ export function zoom(zoomType: ZoomType): void {
   log('Zoom done');
 }
 
-export function getElementsByKinds(bpmnKinds: BpmnElementKind | BpmnElementKind[]): BpmnElement[] {
-  return bpmnVisualization.bpmnElementsRegistry.getElementsByKinds(bpmnKinds);
+export function getModelElementsByKinds(bpmnKinds: BpmnElementKind | BpmnElementKind[]): BpmnSemantic[] {
+  return bpmnVisualization.bpmnElementsRegistry.getModelElementsByKinds(bpmnKinds);
 }
 
 export function getModelElementsByIds(bpmnIds: string | string[]): BpmnSemantic[] {
@@ -379,8 +378,7 @@ function updateStyleOfElementsIfRequested(): void {
 function retrieveAllBpmnElementIds(): string[] {
   log('Retrieving ids of all BPMN elements');
   const allKinds = [...Object.values(ShapeBpmnElementKind), ...Object.values(FlowKind)];
-  const elements = bpmnVisualization.bpmnElementsRegistry.getElementsByKinds(allKinds);
-  const bpmnElementsIds = elements.map(elt => elt.bpmnSemantic.id);
+  const bpmnElementsIds = bpmnVisualization.bpmnElementsRegistry.getModelElementsByKinds(allKinds).map(elt => elt.id);
   log('All BPMN elements ids retrieved:', bpmnElementsIds.length);
   return bpmnElementsIds;
 }

--- a/src/component/registry/bpmn-elements-registry.ts
+++ b/src/component/registry/bpmn-elements-registry.ts
@@ -87,18 +87,24 @@ export class BpmnElementsRegistry implements CssClassesRegistry, ElementsRegistr
     }));
   }
 
+  getModelElementsByKinds(bpmnKinds: BpmnElementKind | BpmnElementKind[]): BpmnSemantic[] {
+    return ensureIsArray<BpmnElementKind>(bpmnKinds)
+      .map(kind => this.htmlElementRegistry.getBpmnHtmlElements(kind))
+      .flat()
+      .map(htmlElement => this.bpmnModelRegistry.getBpmnSemantic(htmlElement.getAttribute('data-bpmn-id')));
+  }
+
   getElementsByKinds(bpmnKinds: BpmnElementKind | BpmnElementKind[]): BpmnElement[] {
     return ensureIsArray<BpmnElementKind>(bpmnKinds)
-      .map(kind =>
-        this.htmlElementRegistry.getBpmnHtmlElements(kind).map(htmlElement => ({
-          htmlElement: htmlElement,
-          bpmnSemantic: this.bpmnModelRegistry.getBpmnSemantic(htmlElement.getAttribute('data-bpmn-id')),
-        })),
-      )
-      .reduce((accumulator, bpmnElements) => {
-        accumulator.push(...bpmnElements);
-        return accumulator;
-      }, []);
+      .map(kind => this.htmlElementRegistry.getBpmnHtmlElements(kind))
+      .flat()
+      .map(
+        htmlElement =>
+          ({
+            htmlElement,
+            bpmnSemantic: this.bpmnModelRegistry.getBpmnSemantic(htmlElement.getAttribute('data-bpmn-id')),
+          }) as BpmnElement,
+      );
   }
 
   addCssClasses(bpmnElementIds: string | string[], classNames: string | string[]): void {

--- a/src/component/registry/bpmn-elements-registry.ts
+++ b/src/component/registry/bpmn-elements-registry.ts
@@ -91,20 +91,18 @@ export class BpmnElementsRegistry implements CssClassesRegistry, ElementsRegistr
     return ensureIsArray<BpmnElementKind>(bpmnKinds)
       .map(kind => this.htmlElementRegistry.getBpmnHtmlElements(kind))
       .flat()
-      .map(htmlElement => this.bpmnModelRegistry.getBpmnSemantic(htmlElement.getAttribute('data-bpmn-id')));
+      .map(htmlElement => this.getRelatedBpmnSemantic(htmlElement));
   }
 
   getElementsByKinds(bpmnKinds: BpmnElementKind | BpmnElementKind[]): BpmnElement[] {
     return ensureIsArray<BpmnElementKind>(bpmnKinds)
       .map(kind => this.htmlElementRegistry.getBpmnHtmlElements(kind))
       .flat()
-      .map(
-        htmlElement =>
-          ({
-            htmlElement,
-            bpmnSemantic: this.bpmnModelRegistry.getBpmnSemantic(htmlElement.getAttribute('data-bpmn-id')),
-          }) as BpmnElement,
-      );
+      .map(htmlElement => ({ htmlElement, bpmnSemantic: this.getRelatedBpmnSemantic(htmlElement) }));
+  }
+
+  private getRelatedBpmnSemantic(htmlElement: HTMLElement): BpmnSemantic {
+    return this.bpmnModelRegistry.getBpmnSemantic(htmlElement.getAttribute('data-bpmn-id'));
   }
 
   addCssClasses(bpmnElementIds: string | string[], classNames: string | string[]): void {

--- a/src/component/registry/types.ts
+++ b/src/component/registry/types.ts
@@ -128,7 +128,7 @@ export interface CssClassesRegistry {
  */
 export interface ElementsRegistry {
   /**
-   * Get all model elements by ids. The returned array contains elements in the order of the `bpmnElementIds` parameter.
+   * Get all model elements in the form of {@link BpmnSemantic} objects corresponding to the identifiers supplied. The returned array contains elements in the order of the `bpmnElementIds` parameter.
    *
    * Not found elements are not returned as undefined in the array, so the returned array contains at most as many elements as the `bpmnElementIds` parameter.
    *
@@ -144,6 +144,7 @@ export interface ElementsRegistry {
    * If you also need to retrieve the related DOM elements and more information, use {@link getElementsByIds} instead.
    *
    * @param bpmnElementIds The BPMN ID of the element(s) to retrieve.
+   * @since 0.39.0
    */
   getModelElementsByIds(bpmnElementIds: string | string[]): BpmnSemantic[];
 
@@ -164,11 +165,30 @@ export interface ElementsRegistry {
    * **WARNING**: this method is not designed to accept a large amount of ids. It does DOM lookup to retrieve the HTML elements relative to the BPMN elements.
    * Attempts to retrieve too many elements, especially on large BPMN diagram, may lead to performance issues.
    *
-   * @see {@link getModelElementsByIds}
+   * If you only need to retrieve the BPMN model data, use {@link getModelElementsByIds} instead.
    *
    * @param bpmnElementIds The BPMN ID of the element(s) to retrieve.
    */
   getElementsByIds(bpmnElementIds: string | string[]): BpmnElement[];
+
+  /**
+   * Get all model elements in the form of {@link BpmnSemantic} objects corresponding to the BPMN kinds supplied
+   *
+   * ```javascript
+   * ...
+   * // Find all elements by specified id or ids
+   * const bpmnElements1 = bpmnVisualization.bpmnElementsRegistry.getModelElementsByIds('userTask_1');
+   * const bpmnElements2 = bpmnVisualization.bpmnElementsRegistry.getModelElementsByIds(['startEvent_3', 'userTask_2']);
+   * // now you can do whatever you want with the elements
+   * ...
+   * ```
+   *
+   * If you also need to retrieve the related DOM elements and more information, use {@link getElementsByKinds} instead.
+   *
+   * @param bpmnKinds The BPMN kind of the element(s) to retrieve.
+   * @since 0.39.0
+   */
+  getModelElementsByKinds(bpmnKinds: BpmnElementKind | BpmnElementKind[]): BpmnSemantic[];
 
   /**
    * Get all elements by kinds.
@@ -182,8 +202,12 @@ export interface ElementsRegistry {
    * ...
    * ```
    *
+   * If you only need to retrieve the BPMN model data, use {@link getModelElementsByKinds} instead.
+   *
    * **WARNING**: this method is not designed to accept a large amount of types. It does DOM lookup to retrieve the HTML elements relative to the BPMN elements.
    * Attempts to retrieve too many elements, especially on large BPMN diagrams, may lead to performance issues.
+   *
+   * @param bpmnKinds The BPMN kind of the element(s) to retrieve.
    */
   getElementsByKinds(bpmnKinds: BpmnElementKind | BpmnElementKind[]): BpmnElement[];
 }

--- a/test/integration/model.elements.api.test.ts
+++ b/test/integration/model.elements.api.test.ts
@@ -93,7 +93,6 @@ describe('Registry API - retrieve Model Bpmn elements', () => {
       bv.load(readFileSync('../fixtures/bpmn/registry/1-pool-3-lanes-message-start-end-intermediate-events.bpmn'));
     });
 
-    // match userTasks
     test('Pass a single kind with matching elements', () => {
       const modelElements = bpmnElementsRegistry.getModelElementsByKinds(ShapeBpmnElementKind.TASK_USER);
 

--- a/test/shared/model/bpmn-semantic-utils.ts
+++ b/test/shared/model/bpmn-semantic-utils.ts
@@ -82,6 +82,11 @@ export function expectBoundaryEvent(bpmnSemantic: ShapeBpmnSemantic, expected: E
   expectedFlowNode(bpmnSemantic, expected);
 }
 
+export function expectParallelGateway(bpmnSemantic: BpmnSemantic, expected: ExpectedBaseBpmnElement): void {
+  expectShape(bpmnSemantic, expected);
+  expect(bpmnSemantic.kind).toEqual(ShapeBpmnElementKind.GATEWAY_PARALLEL);
+}
+
 export function expectLane(bpmnSemantic: BpmnSemantic, expected: ExpectedBaseBpmnElement): void {
   expectShape(bpmnSemantic, expected);
   expect(bpmnSemantic.kind).toEqual(ShapeBpmnElementKind.LANE);
@@ -100,6 +105,11 @@ export function expectTask(bpmnSemantic: ShapeBpmnSemantic, expected: ExpectedFl
 export function expectServiceTask(bpmnSemantic: BpmnSemantic, expected: ExpectedBaseBpmnElement): void {
   expectShape(bpmnSemantic, expected);
   expect(bpmnSemantic.kind).toEqual(ShapeBpmnElementKind.TASK_SERVICE);
+}
+
+export function expectUserTask(bpmnSemantic: ShapeBpmnSemantic, expected: ExpectedFlowNodeElement): void {
+  expect(bpmnSemantic.kind).toEqual(ShapeBpmnElementKind.TASK_USER);
+  expectedFlowNode(bpmnSemantic, expected);
 }
 
 export function expectSubprocess(bpmnSemantic: ShapeBpmnSemantic, expected: ExpectedFlowNodeElement): void {


### PR DESCRIPTION
Complement the existing method that also retrieves DOM information. This simplifies the API usage and reduce the amount of retrieved data when the caller only needs to get the information from the model.

In addition:
  - Simplify the existing `getElementsByKinds` implementation: use a flat array instead of an array of array. This is then also consistent with the implementation of the new method.
  - Use the new API in demo to simplify the code.
  - Rework the existing JSDoc for consistency

closes #2813