### PR TITLE
chore(eslint): add `unicorn/prefer-dom-node-text-content` rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -44,6 +44,7 @@ module.exports = {
     'unicorn/prefer-query-selector': 'error',
     'unicorn/prefer-add-event-listener': 'error',
     'unicorn/no-array-for-each': 'error',
+    'unicorn/prefer-dom-node-text-content': 'error',
     'import/newline-after-import': ['error', { count: 1 }],
     'import/first': 'error',
     'import/order': [

--- a/dev/ts/pages/bpmn-rendering.ts
+++ b/dev/ts/pages/bpmn-rendering.ts
@@ -18,8 +18,8 @@ import { documentReady, log, logError, startBpmnVisualization } from '../develop
 
 function statusFetchKO(errorMessage: string): void {
   logError(errorMessage);
-  const statusElt = document.querySelector('#status-zone') as HTMLDivElement;
-  statusElt.innerText = errorMessage;
+  const statusElt = document.querySelector<HTMLDivElement>('#status-zone');
+  statusElt.textContent = errorMessage;
   statusElt.className = 'status-ko';
   log('Status zone set with error:', errorMessage);
 }

--- a/dev/ts/pages/index.ts
+++ b/dev/ts/pages/index.ts
@@ -110,8 +110,8 @@ function configureDisplayedFooterContent(): void {
   const version = getVersion();
   const versionAsString = `bpmn-visualization@${version.lib}`;
   const dependenciesAsString = [...version.dependencies].map(([name, version]) => `${name}@${version}`).join('/');
-  const versionElt = document.querySelector('#footer-content') as HTMLDivElement;
-  versionElt.innerText = `${versionAsString} with ${dependenciesAsString}`;
+  const versionElt = document.querySelector('#footer-content');
+  versionElt.textContent = `${versionAsString} with ${dependenciesAsString}`;
 }
 
 // The following function `preventZoomingPage` serves to block the page content zoom.

--- a/dev/ts/pages/index.ts
+++ b/dev/ts/pages/index.ts
@@ -110,7 +110,7 @@ function configureDisplayedFooterContent(): void {
   const version = getVersion();
   const versionAsString = `bpmn-visualization@${version.lib}`;
   const dependenciesAsString = [...version.dependencies].map(([name, version]) => `${name}@${version}`).join('/');
-  const versionElt = document.querySelector('#footer-content');
+  const versionElt = document.querySelector<HTMLDivElement>('#footer-content');
   versionElt.textContent = `${versionAsString} with ${dependenciesAsString}`;
 }
 


### PR DESCRIPTION
To avoid to have to many changes by enabling `plugin:unicorn/recommended`, I choose to enable some rule one-by-one.

https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-dom-node-text-content.md

Part of #2824 

Covers #2742