### PR TITLE
chore(eslint): add `unicorn/prefer-logical-operator-over-ternary` rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -46,6 +46,7 @@ module.exports = {
     'unicorn/no-array-for-each': 'error',
     'unicorn/prefer-dom-node-text-content': 'error',
     'unicorn/prefer-ternary': 'error',
+    'unicorn/prefer-logical-operator-over-ternary': 'error',
     'import/newline-after-import': ['error', { count: 1 }],
     'import/first': 'error',
     'import/order': [

--- a/test/config/jest-playwright.cjs
+++ b/test/config/jest-playwright.cjs
@@ -44,7 +44,7 @@ const computeLaunchOptionsAndBrowsersConfiguration = defaultBrowsers => {
   /** @type {import('playwright-core/types/types').LaunchOptions} */
   const launchOptions = {
     headless: process.env.HEADLESS !== 'false',
-    slowMo: process.env.SLOWMO ? process.env.SLOWMO : 0,
+    slowMo: process.env.SLOWMO ?? 0,
   };
 
   const browsersAndChannelConfig = computeBrowsersAndChannelConfiguration(defaultBrowsers);

--- a/test/e2e/diagram.navigation.fit.test.ts
+++ b/test/e2e/diagram.navigation.fit.test.ts
@@ -35,7 +35,7 @@ class FitImageSnapshotConfigurator extends ImageSnapshotConfigurator {
     margin?: number;
   }): MatchImageSnapshotOptions {
     const config = super.getConfig(parameter);
-    config.customSnapshotsDir = FitImageSnapshotConfigurator.buildSnapshotFitDirectory(config.customSnapshotsDir, parameter.fitType, true, parameter.margin ? parameter.margin : 0);
+    config.customSnapshotsDir = FitImageSnapshotConfigurator.buildSnapshotFitDirectory(config.customSnapshotsDir, parameter.fitType, true, parameter.margin ?? 0);
     config.customDiffDir = parameter.buildCustomDiffDir(config, parameter.fitType, parameter.margin);
     return config;
   }

--- a/test/integration/matchers/toBeCell/index.ts
+++ b/test/integration/matchers/toBeCell/index.ts
@@ -57,7 +57,7 @@ function buildExpectedCell(id: string, expected: ExpectedCellWithGeometry): Expe
 
   return {
     id,
-    parent: { id: parentId ? parentId : getDefaultParentId() },
+    parent: { id: parentId ?? getDefaultParentId() },
     geometry: expect.objectContaining(expectedObject),
   };
 }

--- a/test/integration/matchers/toBeEdge/index.ts
+++ b/test/integration/matchers/toBeEdge/index.ts
@@ -65,7 +65,7 @@ function buildExpectedCell(id: string, expectedModel: ExpectedEdgeModelElement |
     styleViewState: buildExpectedEdgeCellStyle(expectedModel),
     edge: true,
     vertex: false,
-    parent: { id: parentId ? parentId : getDefaultParentId() },
+    parent: { id: parentId ?? getDefaultParentId() },
     overlays: expectedModel.overlays,
   };
 

--- a/test/integration/matchers/toBeShape/index.ts
+++ b/test/integration/matchers/toBeShape/index.ts
@@ -140,7 +140,7 @@ function buildExpectedCell(id: string, expectedModel: ExpectedShapeModelElement)
     styleViewState: buildExpectedShapeCellStyle(expectedModel),
     edge: false,
     vertex: true,
-    parent: { id: parentId ? parentId : getDefaultParentId() },
+    parent: { id: parentId ?? getDefaultParentId() },
     overlays: expectedModel.overlays,
   };
 }

--- a/test/unit/helpers/JsonBuilder.ts
+++ b/test/unit/helpers/JsonBuilder.ts
@@ -277,7 +277,7 @@ export function buildDefinitions({ process, messageFlows, globalTask }: BuildDef
 }
 
 function addParticipantProcessAndElements(processParameter: BuildProcessParameter, jsonModel: BpmnJsonModel, index: number): void {
-  const id = processParameter.id ? processParameter.id : String(index);
+  const id = processParameter.id ?? String(index);
   if (processParameter.withParticipant) {
     addParticipant(id, jsonModel);
   }
@@ -314,7 +314,7 @@ function addMessageFlow(messageFlowParameter: BuildMessageFlowParameter, jsonMod
 
 const addGlobalTask = ({ id, bpmnKind = 'globalTask', ...rest }: BuildGlobalTaskParameter, jsonModel: BpmnJsonModel, index: number): void => {
   const globalTask: TGlobalTask = {
-    id: id ? id : `${bpmnKind}_id_${index}`,
+    id: id ?? `${bpmnKind}_id_${index}`,
     ...rest,
   };
 
@@ -417,7 +417,7 @@ function enrichBpmnElement<T extends TBaseElement | DiagramElement>(currentEleme
 
 function addLane(jsonModel: BpmnJsonModel, { id, name, ...rest }: BuildLaneParameter, index: number, processIndex: number): void {
   const lane: TLane = {
-    id: id ? id : `lane_id_${processIndex}_${index}`,
+    id: id ?? `lane_id_${processIndex}_${index}`,
     ...rest,
   };
   if (name) {
@@ -453,7 +453,7 @@ function addProcessElementWithEdge(jsonModel: BpmnJsonModel, bpmnKind: keyof TPr
 
 function addProcessElement(jsonModel: BpmnJsonModel, bpmnKind: keyof TProcess, { id, index, processIndex, ...rest }: BuildProcessElementParameter): TFlowNode | TArtifact {
   const processElement: TFlowElement | TArtifact = {
-    id: id ? id : `${bpmnKind}_id_${processIndex}_${index}`,
+    id: id ?? `${bpmnKind}_id_${processIndex}_${index}`,
     ...rest,
   };
 
@@ -500,11 +500,9 @@ function addEventDefinitionsOnDefinition(jsonModel: BpmnJsonModel, buildParamete
     addEventDefinitions(jsonModel.definitions, { ...buildParameter, eventDefinition: { id: 'event_definition_id' } }, { id: 'other_event_definition_id' });
     (event.eventDefinitionRef as string[]) = ['event_definition_id', 'other_event_definition_id'];
   } else {
-    const eventDefinition = buildParameter.eventDefinition
-      ? buildParameter.eventDefinition
-      : buildParameter.withMultipleDefinitions
-      ? [{ id: 'event_definition_1_id' }, { id: 'event_definition_2_id' }]
-      : { id: 'event_definition_id' };
+    const eventDefinition =
+      buildParameter.eventDefinition ??
+      (buildParameter.withMultipleDefinitions ? [{ id: 'event_definition_1_id' }, { id: 'event_definition_2_id' }] : { id: 'event_definition_id' });
     addEventDefinitions(jsonModel.definitions, { ...buildParameter, eventDefinition });
     event.eventDefinitionRef = Array.isArray(eventDefinition)
       ? eventDefinition.map(eventDefinition => (typeof eventDefinition === 'string' ? eventDefinition : eventDefinition.id))
@@ -541,7 +539,7 @@ function buildEvent({
   outgoing?: string | string[];
 }): BPMNTEvent {
   const event: BPMNTEvent = {
-    id: id ? id : `event_id_${processIndex}_${index}`,
+    id: id ?? `event_id_${processIndex}_${index}`,
     name: name,
     incoming,
     outgoing,

--- a/test/unit/helpers/JsonBuilder.ts
+++ b/test/unit/helpers/JsonBuilder.ts
@@ -500,9 +500,12 @@ function addEventDefinitionsOnDefinition(jsonModel: BpmnJsonModel, buildParamete
     addEventDefinitions(jsonModel.definitions, { ...buildParameter, eventDefinition: { id: 'event_definition_id' } }, { id: 'other_event_definition_id' });
     (event.eventDefinitionRef as string[]) = ['event_definition_id', 'other_event_definition_id'];
   } else {
-    const eventDefinition =
-      buildParameter.eventDefinition ??
-      (buildParameter.withMultipleDefinitions ? [{ id: 'event_definition_1_id' }, { id: 'event_definition_2_id' }] : { id: 'event_definition_id' });
+    // eslint-disable-next-line unicorn/prefer-logical-operator-over-ternary -- Because if `eventDefinition` is an empty string, the logical operator returns `true` and the ternary returns `false`.
+    const eventDefinition = buildParameter.eventDefinition
+      ? buildParameter.eventDefinition
+      : buildParameter.withMultipleDefinitions
+      ? [{ id: 'event_definition_1_id' }, { id: 'event_definition_2_id' }]
+      : { id: 'event_definition_id' };
     addEventDefinitions(jsonModel.definitions, { ...buildParameter, eventDefinition });
     event.eventDefinitionRef = Array.isArray(eventDefinition)
       ? eventDefinition.map(eventDefinition => (typeof eventDefinition === 'string' ? eventDefinition : eventDefinition.id))


### PR DESCRIPTION
To avoid to have to many changes by enabling plugin:unicorn/recommended, I choose to enable some rule one-by-one.

https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-logical-operator-over-ternary.md

Part of #2824

⚠️ For the code coverage, it was already the case before this PR.

Covers #2742