### PR TITLE
chore(eslint): add `unicorn/consistent-function-scoping` rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -47,6 +47,7 @@ module.exports = {
     'unicorn/prefer-dom-node-text-content': 'error',
     'unicorn/prefer-ternary': 'error',
     'unicorn/prefer-logical-operator-over-ternary': 'error',
+    'unicorn/consistent-function-scoping': 'error',
     'import/newline-after-import': ['error', { count: 1 }],
     'import/first': 'error',
     'import/order': [

--- a/src/component/mxgraph/config/MarkerConfigurator.ts
+++ b/src/component/mxgraph/config/MarkerConfigurator.ts
@@ -42,6 +42,7 @@ export default class MarkerConfigurator {
       size: number,
       _source: mxCell,
       strokewidth: number,
+      // eslint-disable-next-line unicorn/consistent-function-scoping -- Code from mxGraph example
     ): (() => void) => {
       const nx = unitX * (size + strokewidth + 4);
       const ny = unitY * (size + strokewidth + 4);

--- a/src/component/parser/json/converter/ProcessConverter.ts
+++ b/src/component/parser/json/converter/ProcessConverter.ts
@@ -122,6 +122,7 @@ export default class ProcessConverter {
       shapeBpmnElementId: string,
       shapeBpmnElementAttributeName: keyof Pick<ShapeBpmnElement, 'outgoingIds' | 'incomingIds'>,
       valueToAdd: string,
+      // eslint-disable-next-line unicorn/consistent-function-scoping -- No need for now to move it
     ): void => {
       const shapeBpmnElement =
         this.convertedElements.findFlowNode(shapeBpmnElementId) ?? this.convertedElements.findLane(shapeBpmnElementId) ?? this.convertedElements.findPoolById(shapeBpmnElementId);

--- a/test/e2e/overlays.rendering.test.ts
+++ b/test/e2e/overlays.rendering.test.ts
@@ -124,12 +124,20 @@ class OverlaysPageTester extends PageTester {
 
 const pageTester = new OverlaysPageTester({ targetedPage: AvailableTestPages.OVERLAYS, diagramSubfolder: 'overlays' }, page);
 
+function getEdgeDirectory(directory: string): string {
+  return join(directory, `on.edge`);
+}
+
+function getEdgePositionDirectory(directory: string, position: OverlayEdgePosition): string {
+  return join(getEdgeDirectory(directory), `on-position-${position}`);
+}
+
+function getShapeDirectory(directory: string): string {
+  return join(directory, `on.shape`);
+}
+
 describe('BPMN Shapes with overlays', () => {
   const bpmnDiagramName = 'overlays.start.flow.task.gateway';
-
-  function getShapeDirectory(directory: string): string {
-    return join(directory, `on.shape`);
-  }
 
   it.each(overlayShapePositionValues)(`add overlay on StartEvent, Gateway and Task on %s`, async (position: OverlayShapePosition) => {
     await pageTester.gotoPageAndLoadBpmnDiagram(bpmnDiagramName);
@@ -186,14 +194,6 @@ describe('BPMN Edges with overlays', () => {
     ],
     ['overlays.edges.sequence.flows.complex.paths', 'sequence', ['Flow_039xs1c', 'Flow_0m2ldux', 'Flow_1r3oti3', 'Flow_1byeukq']],
   ])('diagram %s', (bpmnDiagramName: string, edgeKind: string, bpmnElementIds: string[]) => {
-    function getEdgeDirectory(directory: string): string {
-      return join(directory, `on.edge`);
-    }
-
-    function getEdgePositionDirectory(directory: string, position: OverlayEdgePosition): string {
-      return join(getEdgeDirectory(directory), `on-position-${position}`);
-    }
-
     it.each(overlayEdgePositionValues)(`add overlay on ${edgeKind} flow on %s`, async (position: OverlayEdgePosition) => {
       await pageTester.gotoPageAndLoadBpmnDiagram(bpmnDiagramName);
 

--- a/test/unit/component/mxgraph/shape/render/BpmnCanvas.test.ts
+++ b/test/unit/component/mxgraph/shape/render/BpmnCanvas.test.ts
@@ -21,29 +21,29 @@ import type { IconStyleConfiguration, ShapeConfiguration, Size } from '@lib/comp
 
 import { computeScaledIconSize } from '@lib/component/mxgraph/shape/render/BpmnCanvas';
 
-describe('compute scaled icon size', () => {
-  function newIconStyleConfiguration(strokeWidth = 0): IconStyleConfiguration {
-    return {
-      fillColor: 'do_not_care',
-      isFilled: false,
-      strokeColor: 'do_not_care',
-      strokeWidth: strokeWidth,
-      margin: 0,
-    };
-  }
-  function newShapeConfiguration(w: number, h: number): ShapeConfiguration {
-    return {
-      x: -1, // not relevant here
-      y: -1, // not relevant here
-      width: w,
-      height: h,
-    };
-  }
-  function expectSize(actual: Size, expected: Size): void {
-    expect(actual.width).toEqual(expected.width);
-    expect(actual.height).toEqual(expected.height);
-  }
+function newIconStyleConfiguration(strokeWidth = 0): IconStyleConfiguration {
+  return {
+    fillColor: 'do_not_care',
+    isFilled: false,
+    strokeColor: 'do_not_care',
+    strokeWidth: strokeWidth,
+    margin: 0,
+  };
+}
+function newShapeConfiguration(w: number, h: number): ShapeConfiguration {
+  return {
+    x: -1, // not relevant here
+    y: -1, // not relevant here
+    width: w,
+    height: h,
+  };
+}
+function expectSize(actual: Size, expected: Size): void {
+  expect(actual.width).toEqual(expected.width);
+  expect(actual.height).toEqual(expected.height);
+}
 
+describe('compute scaled icon size', () => {
   describe('parent square dimension', () => {
     it('original square icon', () => {
       const size = computeScaledIconSize({ width: 100, height: 100 }, newIconStyleConfiguration(), newShapeConfiguration(50, 50), 0.25);

--- a/test/unit/component/parser/json/BpmnJsonParser.group.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.group.test.ts
@@ -29,6 +29,17 @@ import {
 import { GroupUnknownCategoryValueWarning, ShapeUnknownBpmnElementWarning } from '@lib/component/parser/json/warnings';
 import { ShapeBpmnElementKind } from '@lib/model/bpmn/internal';
 
+function expectWarnings(): void {
+  const warnings = parsingMessageCollector.getWarnings();
+
+  const warning0 = expectAsWarning<GroupUnknownCategoryValueWarning>(warnings[0], GroupUnknownCategoryValueWarning);
+  expect(warning0.groupBpmnElementId).toBe('Group_0');
+  expect(warning0.categoryValueReference).toBe('unknown_CategoryValue_0');
+
+  const warning1 = expectAsWarning<ShapeUnknownBpmnElementWarning>(warnings[1], ShapeUnknownBpmnElementWarning);
+  expect(warning1.bpmnElementId).toBe('Group_0');
+}
+
 describe('parse bpmn as json for group', () => {
   it('Single Group with label in process', () => {
     const json: BpmnJsonModel = {
@@ -274,17 +285,6 @@ describe('parse bpmn as json for group', () => {
       parseJsonAndExpectOnlyWarnings(json, 2);
       expectWarnings();
     });
-
-    function expectWarnings(): void {
-      const warnings = parsingMessageCollector.getWarnings();
-
-      const warning0 = expectAsWarning<GroupUnknownCategoryValueWarning>(warnings[0], GroupUnknownCategoryValueWarning);
-      expect(warning0.groupBpmnElementId).toBe('Group_0');
-      expect(warning0.categoryValueReference).toBe('unknown_CategoryValue_0');
-
-      const warning1 = expectAsWarning<ShapeUnknownBpmnElementWarning>(warnings[1], ShapeUnknownBpmnElementWarning);
-      expect(warning1.bpmnElementId).toBe('Group_0');
-    }
 
     it('Single Group in collaboration without matching categoryValueRef', () => {
       const json: BpmnJsonModel = {

--- a/test/unit/component/parser/json/BpmnJsonParser.messageFlow.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.messageFlow.test.ts
@@ -30,6 +30,31 @@ import * as bpmndi from '@lib/model/bpmn/json/bpmndi';
 
 /** Test utils */
 
+function buildProcessParameter(kind: ShapeBpmnElementKind, id: string): BuildProcessParameter {
+  if (kind === ShapeBpmnElementKind.POOL) {
+    return { id, withParticipant: true };
+  } else if (ShapeUtil.isEvent(kind)) {
+    const isBoundaryEvent = kind === ShapeBpmnElementKind.EVENT_BOUNDARY;
+    const eventParameter: BuildEventsParameter = isBoundaryEvent
+      ? {
+          id,
+          bpmnKind: kind as 'boundaryEvent',
+          isInterrupting: true,
+          attachedToRef: 'task_id_0',
+          eventDefinitionParameter: { eventDefinitionKind: 'message', eventDefinitionOn: EventDefinitionOn.EVENT },
+        }
+      : {
+          id,
+          bpmnKind: kind as OtherBuildEventKind | 'startEvent',
+          eventDefinitionParameter: { eventDefinitionKind: 'message', eventDefinitionOn: EventDefinitionOn.EVENT },
+        };
+
+    return { withParticipant: true, event: eventParameter, task: isBoundaryEvent ? { id: 'task_id_0' } : undefined };
+  } else {
+    return { withParticipant: true, task: { id } };
+  }
+}
+
 describe('parse bpmn as json for message flow', () => {
   it(`should convert as Edge, when an message flow is an attribute (as object) of 'collaboration' (as object)`, () => {
     const json: BpmnJsonModel = {
@@ -348,29 +373,4 @@ describe('parse bpmn as json for message flow', () => {
       });
     });
   });
-
-  function buildProcessParameter(kind: ShapeBpmnElementKind, id: string): BuildProcessParameter {
-    if (kind === ShapeBpmnElementKind.POOL) {
-      return { id, withParticipant: true };
-    } else if (ShapeUtil.isEvent(kind)) {
-      const isBoundaryEvent = kind === ShapeBpmnElementKind.EVENT_BOUNDARY;
-      const eventParameter: BuildEventsParameter = isBoundaryEvent
-        ? {
-            id,
-            bpmnKind: kind as 'boundaryEvent',
-            isInterrupting: true,
-            attachedToRef: 'task_id_0',
-            eventDefinitionParameter: { eventDefinitionKind: 'message', eventDefinitionOn: EventDefinitionOn.EVENT },
-          }
-        : {
-            id,
-            bpmnKind: kind as OtherBuildEventKind | 'startEvent',
-            eventDefinitionParameter: { eventDefinitionKind: 'message', eventDefinitionOn: EventDefinitionOn.EVENT },
-          };
-
-      return { withParticipant: true, event: eventParameter, task: isBoundaryEvent ? { id: 'task_id_0' } : undefined };
-    } else {
-      return { withParticipant: true, task: { id } };
-    }
-  }
 });


### PR DESCRIPTION
To avoid to have to many changes by enabling plugin:unicorn/recommended, I choose to enable some rule one-by-one.

https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/consistent-function-scoping.md

Part of #2824 

Covers #2742