### PR TITLE
test(JsonBuilder): add new properties for link events

### DIFF
--- a/test/unit/component/parser/json/BpmnJsonParser.callActivity.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.callActivity.test.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import type { ExpectedShape } from '../../../helpers/bpmn-model-expect';
-import type { BuildCallActivityParameter, BuildGatewayKind, BuildTaskKind, OtherBuildEventKind, BpmnGlobalTaskKind } from '../../../helpers/JsonBuilder';
+import type { BuildCallActivityParameter, BuildGatewayKind, BuildTaskKind, BuildNotBoundaryEventKind, BpmnGlobalTaskKind } from '../../../helpers/JsonBuilder';
 import type { GlobalTaskKind } from '@lib/model/bpmn/internal';
 import type { BpmnJsonModel } from '@lib/model/bpmn/json/bpmn20';
 
@@ -215,7 +215,7 @@ describe('parse bpmn as json for callActivity', () => {
                 id: 'process_1',
                 event: {
                   id: `${expectedBpmnElementKind}_id`,
-                  bpmnKind: expectedBpmnElementKind as OtherBuildEventKind | 'startEvent',
+                  bpmnKind: expectedBpmnElementKind as BuildNotBoundaryEventKind,
                   eventDefinitionParameter: { eventDefinitionKind: 'message', eventDefinitionOn: EventDefinitionOn.EVENT },
                 },
               },

--- a/test/unit/component/parser/json/BpmnJsonParser.event.none.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.event.none.test.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import type { BuildEventDefinition, OtherBuildEventKind } from '../../../helpers/JsonBuilder';
+import type { BuildEventDefinition, BuildNotBoundaryEventKind } from '../../../helpers/JsonBuilder';
 
 import { verifyShape } from '../../../helpers/bpmn-model-expect';
 import { buildDefinitions, EventDefinitionOn } from '../../../helpers/JsonBuilder';
@@ -31,7 +31,7 @@ describe.each([
 ])('for none %s', (expectedShapeBpmnElementKind: ShapeBpmnElementKind, allDefinitionKinds: BuildEventDefinition[]) => {
   executeEventCommonTests(
     {
-      bpmnKind: expectedShapeBpmnElementKind as OtherBuildEventKind | 'startEvent',
+      bpmnKind: expectedShapeBpmnElementKind as BuildNotBoundaryEventKind,
       eventDefinitionParameter: { eventDefinitionOn: EventDefinitionOn.NONE },
     },
     {
@@ -49,11 +49,11 @@ describe.each([
           {
             id: `none_${expectedShapeBpmnElementKind}_id`,
             name: `none ${expectedShapeBpmnElementKind}`,
-            bpmnKind: expectedShapeBpmnElementKind as OtherBuildEventKind | 'startEvent',
+            bpmnKind: expectedShapeBpmnElementKind as BuildNotBoundaryEventKind,
             eventDefinitionParameter: { eventDefinitionOn: EventDefinitionOn.NONE },
           },
           {
-            bpmnKind: expectedShapeBpmnElementKind as OtherBuildEventKind | 'startEvent',
+            bpmnKind: expectedShapeBpmnElementKind as BuildNotBoundaryEventKind,
             eventDefinitionParameter: {
               eventDefinitionKind: 'message',
               eventDefinitionOn: EventDefinitionOn.EVENT,
@@ -61,7 +61,7 @@ describe.each([
             },
           },
           {
-            bpmnKind: expectedShapeBpmnElementKind as OtherBuildEventKind | 'startEvent',
+            bpmnKind: expectedShapeBpmnElementKind as BuildNotBoundaryEventKind,
             eventDefinitionParameter: {
               eventDefinitionKind: 'message',
               eventDefinitionOn: EventDefinitionOn.DEFINITIONS,
@@ -69,7 +69,7 @@ describe.each([
             },
           },
           {
-            bpmnKind: expectedShapeBpmnElementKind as OtherBuildEventKind | 'startEvent',
+            bpmnKind: expectedShapeBpmnElementKind as BuildNotBoundaryEventKind,
             eventDefinitionParameter: {
               eventDefinitionKind: 'message',
               eventDefinitionOn: EventDefinitionOn.BOTH,
@@ -79,7 +79,7 @@ describe.each([
 
           ...allDefinitionKinds.map((definitionKind, index) => ({
             id: `${definitionKind}_${expectedShapeBpmnElementKind}_id_${index}`,
-            bpmnKind: expectedShapeBpmnElementKind as OtherBuildEventKind | 'startEvent',
+            bpmnKind: expectedShapeBpmnElementKind as BuildNotBoundaryEventKind,
             eventDefinitionParameter: {
               eventDefinitionKind: definitionKind,
               eventDefinitionOn: EventDefinitionOn.EVENT,

--- a/test/unit/component/parser/json/BpmnJsonParser.event.with.event.definition.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.event.with.event.definition.test.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import type { BuildEventDefinition, OtherBuildEventKind } from '../../../helpers/JsonBuilder';
+import type { BuildEventDefinition, BuildNotBoundaryEventKind } from '../../../helpers/JsonBuilder';
 import type { TEventDefinition } from '@lib/model/bpmn/json/baseElement/rootElement/eventDefinition';
 
 import { EventDefinitionOn } from '../../../helpers/JsonBuilder';
@@ -67,7 +67,7 @@ describe.each([ShapeBpmnElementKind.EVENT_START, ShapeBpmnElementKind.EVENT_END,
         ];
         describe.each(titlesForEventDefinitionIsAttributeOf)(`when %s`, (titleForEventDefinitionIsAttributeOf: string, eventDefinitionOn: EventDefinitionOn) => {
           executeEventCommonTests(
-            { bpmnKind: expectedShapeBpmnElementKind as OtherBuildEventKind | 'startEvent', eventDefinitionParameter: { eventDefinitionKind, eventDefinitionOn } },
+            { bpmnKind: expectedShapeBpmnElementKind as BuildNotBoundaryEventKind, eventDefinitionParameter: { eventDefinitionKind, eventDefinitionOn } },
             {
               bpmnElementKind: expectedShapeBpmnElementKind,
               bpmnElementName: undefined,
@@ -86,7 +86,7 @@ describe.each([ShapeBpmnElementKind.EVENT_START, ShapeBpmnElementKind.EVENT_END,
             (title: string, eventDefinition: string | TEventDefinition) => {
               testMustConvertShapes(
                 {
-                  bpmnKind: expectedShapeBpmnElementKind as OtherBuildEventKind | 'startEvent',
+                  bpmnKind: expectedShapeBpmnElementKind as BuildNotBoundaryEventKind,
                   eventDefinitionParameter: { eventDefinitionKind, eventDefinitionOn, eventDefinition },
                 },
                 {

--- a/test/unit/component/parser/json/BpmnJsonParser.messageFlow.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.messageFlow.test.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 /** Internal model */
-import type { BuildProcessParameter, BuildEventsParameter, OtherBuildEventKind } from '../../../helpers/JsonBuilder';
+import type { BuildProcessParameter, BuildEventParameter, BuildNotBoundaryEventKind } from '../../../helpers/JsonBuilder';
 import type { BpmnJsonModel } from '@lib/model/bpmn/json/bpmn20';
 
 import { verifyEdge } from '../../../helpers/bpmn-model-expect';
@@ -35,7 +35,7 @@ function buildProcessParameter(kind: ShapeBpmnElementKind, id: string): BuildPro
     return { id, withParticipant: true };
   } else if (ShapeUtil.isEvent(kind)) {
     const isBoundaryEvent = kind === ShapeBpmnElementKind.EVENT_BOUNDARY;
-    const eventParameter: BuildEventsParameter = isBoundaryEvent
+    const eventParameter: BuildEventParameter = isBoundaryEvent
       ? {
           id,
           bpmnKind: kind as 'boundaryEvent',
@@ -45,7 +45,7 @@ function buildProcessParameter(kind: ShapeBpmnElementKind, id: string): BuildPro
         }
       : {
           id,
-          bpmnKind: kind as OtherBuildEventKind | 'startEvent',
+          bpmnKind: kind as BuildNotBoundaryEventKind,
           eventDefinitionParameter: { eventDefinitionKind: 'message', eventDefinitionOn: EventDefinitionOn.EVENT },
         };
 

--- a/test/unit/helpers/JsonBuilder.test.ts
+++ b/test/unit/helpers/JsonBuilder.test.ts
@@ -2835,10 +2835,10 @@ describe('build json', () => {
             definitions: {
               targetNamespace: '',
               collaboration: { id: 'collaboration_id_0' },
-              linkEventDefinition: { id: 'event_definition_id' },
+              linkEventDefinition: { id: 'link_event_definition_id_0_0' },
               process: {
                 id: '0',
-                intermediateCatchEvent: { id: 'event_id_0_0', source: 'event_definition_source_id', eventDefinitionRef: 'event_definition_id' },
+                intermediateCatchEvent: { id: 'event_id_0_0', source: 'event_definition_source_id', eventDefinitionRef: 'link_event_definition_id_0_0' },
               },
               BPMNDiagram: {
                 name: 'process 0',
@@ -2871,10 +2871,14 @@ describe('build json', () => {
             definitions: {
               targetNamespace: '',
               collaboration: { id: 'collaboration_id_0' },
-              linkEventDefinition: { id: 'event_definition_id' },
+              linkEventDefinition: { id: 'link_event_definition_id_0_0' },
               process: {
                 id: '0',
-                intermediateCatchEvent: { id: 'event_id_0_0', source: ['event_definition_source_1_id', 'event_definition_source_2_id'], eventDefinitionRef: 'event_definition_id' },
+                intermediateCatchEvent: {
+                  id: 'event_id_0_0',
+                  source: ['event_definition_source_1_id', 'event_definition_source_2_id'],
+                  eventDefinitionRef: 'link_event_definition_id_0_0',
+                },
               },
               BPMNDiagram: {
                 name: 'process 0',
@@ -2907,10 +2911,10 @@ describe('build json', () => {
             definitions: {
               targetNamespace: '',
               collaboration: { id: 'collaboration_id_0' },
-              messageEventDefinition: { id: 'event_definition_id' },
+              messageEventDefinition: { id: 'message_event_definition_id_0_0' },
               process: {
                 id: '0',
-                intermediateCatchEvent: { id: 'event_id_0_0', eventDefinitionRef: 'event_definition_id' },
+                intermediateCatchEvent: { id: 'event_id_0_0', eventDefinitionRef: 'message_event_definition_id_0_0' },
               },
               BPMNDiagram: {
                 name: 'process 0',
@@ -2945,10 +2949,10 @@ describe('build json', () => {
             definitions: {
               targetNamespace: '',
               collaboration: { id: 'collaboration_id_0' },
-              linkEventDefinition: { id: 'event_definition_id' },
+              linkEventDefinition: { id: 'link_event_definition_id_0_0' },
               process: {
                 id: '0',
-                intermediateThrowEvent: { id: 'event_id_0_0', target: 'event_definition_target_id', eventDefinitionRef: 'event_definition_id' },
+                intermediateThrowEvent: { id: 'event_id_0_0', target: 'event_definition_target_id', eventDefinitionRef: 'link_event_definition_id_0_0' },
               },
               BPMNDiagram: {
                 name: 'process 0',
@@ -2981,10 +2985,10 @@ describe('build json', () => {
             definitions: {
               targetNamespace: '',
               collaboration: { id: 'collaboration_id_0' },
-              messageEventDefinition: { id: 'event_definition_id' },
+              messageEventDefinition: { id: 'message_event_definition_id_0_0' },
               process: {
                 id: '0',
-                intermediateThrowEvent: { id: 'event_id_0_0', eventDefinitionRef: 'event_definition_id' },
+                intermediateThrowEvent: { id: 'event_id_0_0', eventDefinitionRef: 'message_event_definition_id_0_0' },
               },
               BPMNDiagram: {
                 name: 'process 0',

--- a/test/unit/helpers/JsonBuilder.test.ts
+++ b/test/unit/helpers/JsonBuilder.test.ts
@@ -73,6 +73,14 @@ describe('build json', () => {
                 eventDefinitionOn: EventDefinitionOn.DEFINITIONS,
               },
             },
+            {
+              bpmnKind: 'endEvent',
+              name: 'endEvent',
+              eventDefinitionParameter: {
+                eventDefinitionKind: 'terminate',
+                eventDefinitionOn: EventDefinitionOn.DEFINITIONS,
+              },
+            },
           ],
         },
         {
@@ -127,7 +135,7 @@ describe('build json', () => {
             targetRef: 'target_id_0',
           },
         },
-        terminateEventDefinition: { id: 'terminate_event_definition_id_0_1' },
+        terminateEventDefinition: [{ id: 'terminate_event_definition_id_0_1' }, { id: 'terminate_event_definition_id_0_2' }],
         timerEventDefinition: { id: 'timer_event_definition_id_2_0' },
         process: [
           {
@@ -135,16 +143,23 @@ describe('build json', () => {
             task: {
               id: 'task_id_0_0',
             },
-            endEvent: {
-              id: 'event_id_0_1',
-              name: 'endEvent',
-              eventDefinitionRef: 'terminate_event_definition_id_0_1',
-            },
+            endEvent: [
+              {
+                id: 'event_id_0_1',
+                name: 'endEvent',
+                eventDefinitionRef: 'terminate_event_definition_id_0_1',
+              },
+              {
+                id: 'event_id_0_2',
+                name: 'endEvent',
+                eventDefinitionRef: 'terminate_event_definition_id_0_2',
+              },
+            ],
             startEvent: {
-              cancelActivity: true,
               id: 'event_id_0_0',
               messageEventDefinition: '',
               name: 'startEvent',
+              cancelActivity: true,
             },
           },
           {
@@ -197,6 +212,11 @@ describe('build json', () => {
               {
                 bpmnElement: 'event_id_0_1',
                 id: 'shape_event_id_0_1',
+                Bounds: { x: 362, y: 232, height: 45, width: 36 },
+              },
+              {
+                bpmnElement: 'event_id_0_2',
+                id: 'shape_event_id_0_2',
                 Bounds: { x: 362, y: 232, height: 45, width: 36 },
               },
               {

--- a/test/unit/helpers/JsonBuilder.test.ts
+++ b/test/unit/helpers/JsonBuilder.test.ts
@@ -562,6 +562,8 @@ describe('build json', () => {
   });
 
   describe('build json with boundary event', () => {
+    // No link event definition for boundary events
+
     describe('build json with interrupting boundary event', () => {
       it('build json of definitions containing one process with task and interrupting boundary event (with empty messageEventDefinition, name & id)', () => {
         const json = buildDefinitions({
@@ -643,56 +645,6 @@ describe('build json', () => {
                 cancelActivity: true,
                 attachedToRef: 'task_id_0_0',
                 signalEventDefinition: '',
-              },
-            },
-            BPMNDiagram: {
-              name: 'process 0',
-              BPMNPlane: {
-                BPMNShape: [
-                  {
-                    id: 'shape_task_id_0_0',
-                    bpmnElement: 'task_id_0_0',
-                    Bounds: { x: 362, y: 232, width: 36, height: 45 },
-                  },
-                  {
-                    id: 'shape_event_id_0_0',
-                    bpmnElement: 'event_id_0_0',
-                    Bounds: { x: 362, y: 232, width: 36, height: 45 },
-                  },
-                ],
-              },
-            },
-          },
-        });
-      });
-
-      it('build json of definitions containing one process with task and interrupting boundary event (with empty linkEventDefinition)', () => {
-        const json = buildDefinitions({
-          process: {
-            event: [
-              {
-                bpmnKind: 'boundaryEvent',
-                isInterrupting: true,
-                eventDefinitionParameter: { eventDefinitionKind: 'link', eventDefinitionOn: EventDefinitionOn.EVENT },
-                attachedToRef: 'task_id_0_0',
-              },
-            ],
-            task: {},
-          },
-        });
-
-        expect(json).toEqual({
-          definitions: {
-            targetNamespace: '',
-            collaboration: { id: 'collaboration_id_0' },
-            process: {
-              id: '0',
-              task: { id: 'task_id_0_0' },
-              boundaryEvent: {
-                id: 'event_id_0_0',
-                cancelActivity: true,
-                attachedToRef: 'task_id_0_0',
-                linkEventDefinition: { id: 'link_event_definition_id_0_0' },
               },
             },
             BPMNDiagram: {
@@ -1439,56 +1391,6 @@ describe('build json', () => {
                 cancelActivity: false,
                 attachedToRef: 'task_id_0_0',
                 signalEventDefinition: '',
-              },
-            },
-            BPMNDiagram: {
-              name: 'process 0',
-              BPMNPlane: {
-                BPMNShape: [
-                  {
-                    id: 'shape_task_id_0_0',
-                    bpmnElement: 'task_id_0_0',
-                    Bounds: { x: 362, y: 232, width: 36, height: 45 },
-                  },
-                  {
-                    id: 'shape_event_id_0_0',
-                    bpmnElement: 'event_id_0_0',
-                    Bounds: { x: 362, y: 232, width: 36, height: 45 },
-                  },
-                ],
-              },
-            },
-          },
-        });
-      });
-
-      it('build json of definitions containing one process with task and non-interrupting boundary event (with empty linkEventDefinition)', () => {
-        const json = buildDefinitions({
-          process: {
-            event: [
-              {
-                bpmnKind: 'boundaryEvent',
-                isInterrupting: false,
-                eventDefinitionParameter: { eventDefinitionKind: 'link', eventDefinitionOn: EventDefinitionOn.EVENT },
-                attachedToRef: 'task_id_0_0',
-              },
-            ],
-            task: {},
-          },
-        });
-
-        expect(json).toEqual({
-          definitions: {
-            targetNamespace: '',
-            collaboration: { id: 'collaboration_id_0' },
-            process: {
-              id: '0',
-              task: { id: 'task_id_0_0' },
-              boundaryEvent: {
-                id: 'event_id_0_0',
-                cancelActivity: false,
-                attachedToRef: 'task_id_0_0',
-                linkEventDefinition: { id: 'link_event_definition_id_0_0' },
               },
             },
             BPMNDiagram: {

--- a/test/unit/helpers/JsonBuilder.test.ts
+++ b/test/unit/helpers/JsonBuilder.test.ts
@@ -102,8 +102,8 @@ describe('build json', () => {
               eventDefinitionParameter: {
                 eventDefinitionKind: 'link',
                 eventDefinitionOn: EventDefinitionOn.DEFINITIONS,
+                source: 'link_event_definition_id_2_1',
               },
-              source: 'link_event_definition_id_2_1',
             },
           ],
           gateway: {
@@ -128,8 +128,8 @@ describe('build json', () => {
               eventDefinitionParameter: {
                 eventDefinitionKind: 'link',
                 eventDefinitionOn: EventDefinitionOn.EVENT,
+                target: 'link_event_definition_id_1_1',
               },
-              target: 'link_event_definition_id_1_1',
             },
           ],
           callActivity: { calledElement: 'process_participant_0' },
@@ -155,7 +155,7 @@ describe('build json', () => {
         },
         terminateEventDefinition: [{ id: 'terminate_event_definition_id_0_1' }, { id: 'terminate_event_definition_id_0_2' }],
         timerEventDefinition: { id: 'timer_event_definition_id_2_0' },
-        linkEventDefinition: { id: 'link_event_definition_id_1_1' },
+        linkEventDefinition: { id: 'link_event_definition_id_1_1', source: 'link_event_definition_id_2_1' },
         process: [
           {
             id: 'process_participant_0',
@@ -192,7 +192,6 @@ describe('build json', () => {
               id: 'event_id_1_1',
               name: 'intermediateCatchEvent',
               eventDefinitionRef: 'link_event_definition_id_1_1',
-              source: 'link_event_definition_id_2_1',
             },
           },
           {
@@ -210,8 +209,7 @@ describe('build json', () => {
             intermediateThrowEvent: {
               id: 'event_id_2_1',
               name: 'intermediateThrowEvent',
-              linkEventDefinition: { id: 'link_event_definition_id_2_1' },
-              target: 'link_event_definition_id_1_1',
+              linkEventDefinition: { id: 'link_event_definition_id_2_1', target: 'link_event_definition_id_1_1' },
             },
           },
         ],
@@ -2720,14 +2718,13 @@ describe('build json', () => {
       }
 
       if (bpmnKind === 'intermediateCatchEvent') {
-        it('build json of definitions containing one process with intermediateCatchEvent (with one source) when eventDefinitionKind="link"', () => {
+        it('build json of definitions containing one process with intermediateCatchEvent (with link eventDefinition containing one source)', () => {
           const json = buildDefinitions({
             process: {
               event: [
                 {
                   bpmnKind: 'intermediateCatchEvent',
-                  eventDefinitionParameter: { eventDefinitionKind: 'link', eventDefinitionOn: EventDefinitionOn.DEFINITIONS },
-                  source: 'event_definition_source_id',
+                  eventDefinitionParameter: { eventDefinitionKind: 'link', eventDefinitionOn: EventDefinitionOn.DEFINITIONS, source: 'event_definition_source_id' },
                 },
               ],
             },
@@ -2737,10 +2734,10 @@ describe('build json', () => {
             definitions: {
               targetNamespace: '',
               collaboration: { id: 'collaboration_id_0' },
-              linkEventDefinition: { id: 'link_event_definition_id_0_0' },
+              linkEventDefinition: { id: 'link_event_definition_id_0_0', source: 'event_definition_source_id' },
               process: {
                 id: '0',
-                intermediateCatchEvent: { id: 'event_id_0_0', source: 'event_definition_source_id', eventDefinitionRef: 'link_event_definition_id_0_0' },
+                intermediateCatchEvent: { id: 'event_id_0_0', eventDefinitionRef: 'link_event_definition_id_0_0' },
               },
               BPMNDiagram: {
                 name: 'process 0',
@@ -2756,14 +2753,17 @@ describe('build json', () => {
           });
         });
 
-        it('build json of definitions containing one process with intermediateCatchEvent (with several sources) when eventDefinitionKind="link"', () => {
+        it('build json of definitions containing one process with intermediateCatchEvent (with link eventDefinition containing several sources)', () => {
           const json = buildDefinitions({
             process: {
               event: [
                 {
                   bpmnKind: 'intermediateCatchEvent',
-                  eventDefinitionParameter: { eventDefinitionKind: 'link', eventDefinitionOn: EventDefinitionOn.DEFINITIONS },
-                  source: ['event_definition_source_1_id', 'event_definition_source_2_id'],
+                  eventDefinitionParameter: {
+                    eventDefinitionKind: 'link',
+                    eventDefinitionOn: EventDefinitionOn.DEFINITIONS,
+                    source: ['event_definition_source_1_id', 'event_definition_source_2_id'],
+                  },
                 },
               ],
             },
@@ -2773,12 +2773,11 @@ describe('build json', () => {
             definitions: {
               targetNamespace: '',
               collaboration: { id: 'collaboration_id_0' },
-              linkEventDefinition: { id: 'link_event_definition_id_0_0' },
+              linkEventDefinition: { id: 'link_event_definition_id_0_0', source: ['event_definition_source_1_id', 'event_definition_source_2_id'] },
               process: {
                 id: '0',
                 intermediateCatchEvent: {
                   id: 'event_id_0_0',
-                  source: ['event_definition_source_1_id', 'event_definition_source_2_id'],
                   eventDefinitionRef: 'link_event_definition_id_0_0',
                 },
               },
@@ -2796,52 +2795,30 @@ describe('build json', () => {
           });
         });
 
-        it('build json of definitions containing one process with intermediateCatchEvent (without source) when eventDefinitionKind!="link"', () => {
-          const json = buildDefinitions({
-            process: {
-              event: [
-                {
-                  bpmnKind: 'intermediateCatchEvent',
-                  eventDefinitionParameter: { eventDefinitionKind: 'message', eventDefinitionOn: EventDefinitionOn.DEFINITIONS },
-                  source: 'event_definition_source_id',
-                },
-              ],
-            },
-          });
-
-          expect(json).toEqual({
-            definitions: {
-              targetNamespace: '',
-              collaboration: { id: 'collaboration_id_0' },
-              messageEventDefinition: { id: 'message_event_definition_id_0_0' },
+        it('not possible to have source with eventDefinitionKind different than link', () => {
+          expect(() => {
+            buildDefinitions({
               process: {
-                id: '0',
-                intermediateCatchEvent: { id: 'event_id_0_0', eventDefinitionRef: 'message_event_definition_id_0_0' },
-              },
-              BPMNDiagram: {
-                name: 'process 0',
-                BPMNPlane: {
-                  BPMNShape: {
-                    id: 'shape_event_id_0_0',
-                    bpmnElement: 'event_id_0_0',
-                    Bounds: { x: 362, y: 232, width: 36, height: 45 },
+                event: [
+                  {
+                    bpmnKind: 'intermediateCatchEvent',
+                    eventDefinitionParameter: { eventDefinitionKind: 'message', eventDefinitionOn: EventDefinitionOn.DEFINITIONS, source: 'event_definition_source_id' },
                   },
-                },
+                ],
               },
-            },
-          });
+            });
+          }).toThrow("'source' must be used only with Link IntermediateCatchEvent !!");
         });
       }
 
       if (bpmnKind === 'intermediateThrowEvent') {
-        it('build json of definitions containing one process with intermediateThrowEvent (with target) when eventDefinitionKind="link"', () => {
+        it('build json of definitions containing one process with intermediateThrowEvent (with link eventDefinition containing target)', () => {
           const json = buildDefinitions({
             process: {
               event: [
                 {
                   bpmnKind: 'intermediateThrowEvent',
-                  eventDefinitionParameter: { eventDefinitionKind: 'link', eventDefinitionOn: EventDefinitionOn.DEFINITIONS },
-                  target: 'event_definition_target_id',
+                  eventDefinitionParameter: { eventDefinitionKind: 'link', eventDefinitionOn: EventDefinitionOn.DEFINITIONS, target: 'event_definition_target_id' },
                 },
               ],
             },
@@ -2851,10 +2828,10 @@ describe('build json', () => {
             definitions: {
               targetNamespace: '',
               collaboration: { id: 'collaboration_id_0' },
-              linkEventDefinition: { id: 'link_event_definition_id_0_0' },
+              linkEventDefinition: { id: 'link_event_definition_id_0_0', target: 'event_definition_target_id' },
               process: {
                 id: '0',
-                intermediateThrowEvent: { id: 'event_id_0_0', target: 'event_definition_target_id', eventDefinitionRef: 'link_event_definition_id_0_0' },
+                intermediateThrowEvent: { id: 'event_id_0_0', eventDefinitionRef: 'link_event_definition_id_0_0' },
               },
               BPMNDiagram: {
                 name: 'process 0',
@@ -2870,40 +2847,19 @@ describe('build json', () => {
           });
         });
 
-        it('build json of definitions containing one process with intermediateThrowEvent (with no target) when eventDefinitionKind!="link"', () => {
-          const json = buildDefinitions({
-            process: {
-              event: [
-                {
-                  bpmnKind: 'intermediateThrowEvent',
-                  eventDefinitionParameter: { eventDefinitionKind: 'message', eventDefinitionOn: EventDefinitionOn.DEFINITIONS },
-                  target: 'event_definition_target_id',
-                },
-              ],
-            },
-          });
-
-          expect(json).toEqual({
-            definitions: {
-              targetNamespace: '',
-              collaboration: { id: 'collaboration_id_0' },
-              messageEventDefinition: { id: 'message_event_definition_id_0_0' },
+        it('not possible to have target with eventDefinitionKind different than link', () => {
+          expect(() => {
+            buildDefinitions({
               process: {
-                id: '0',
-                intermediateThrowEvent: { id: 'event_id_0_0', eventDefinitionRef: 'message_event_definition_id_0_0' },
-              },
-              BPMNDiagram: {
-                name: 'process 0',
-                BPMNPlane: {
-                  BPMNShape: {
-                    id: 'shape_event_id_0_0',
-                    bpmnElement: 'event_id_0_0',
-                    Bounds: { x: 362, y: 232, width: 36, height: 45 },
+                event: [
+                  {
+                    bpmnKind: 'intermediateThrowEvent',
+                    eventDefinitionParameter: { eventDefinitionKind: 'message', eventDefinitionOn: EventDefinitionOn.DEFINITIONS, target: 'event_definition_target_id' },
                   },
-                },
+                ],
               },
-            },
-          });
+            });
+          }).toThrow("'target' must be used only with Link IntermediateThrowEvent !!");
         });
       }
     },

--- a/test/unit/helpers/JsonBuilder.test.ts
+++ b/test/unit/helpers/JsonBuilder.test.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import type { BuildEventDefinitionParameter, OtherBuildEventKind, BuildTaskKind, BuildGatewayKind, BpmnGlobalTaskKind } from './JsonBuilder';
+import type { BuildEventDefinitionParameter, BuildTaskKind, BuildGatewayKind, BpmnGlobalTaskKind, BuildNotBoundaryEventKind } from './JsonBuilder';
 
 import { buildDefinitions, EventDefinitionOn } from './JsonBuilder';
 
@@ -2072,9 +2072,9 @@ describe('build json', () => {
     });
   });
 
-  describe.each(['startEvent', 'endEvent', 'intermediateCatchEvent', 'intermediateThrowEvent'] as (OtherBuildEventKind | 'startEvent')[])(
+  describe.each(['startEvent', 'endEvent', 'intermediateCatchEvent', 'intermediateThrowEvent'] as BuildNotBoundaryEventKind[])(
     'build json with %s',
-    (bpmnKind: OtherBuildEventKind | 'startEvent') => {
+    (bpmnKind: BuildNotBoundaryEventKind) => {
       it(`build json of definitions containing one process with ${bpmnKind} (with empty messageEventDefinition with generated id & without name)`, () => {
         const json = buildDefinitions({
           process: {
@@ -2766,6 +2766,190 @@ describe('build json', () => {
               process: {
                 id: '0',
                 startEvent: { id: 'event_id_0_0', cancelActivity: false, messageEventDefinition: {} },
+              },
+              BPMNDiagram: {
+                name: 'process 0',
+                BPMNPlane: {
+                  BPMNShape: {
+                    id: 'shape_event_id_0_0',
+                    bpmnElement: 'event_id_0_0',
+                    Bounds: { x: 362, y: 232, width: 36, height: 45 },
+                  },
+                },
+              },
+            },
+          });
+        });
+      }
+
+      if (bpmnKind === 'intermediateCatchEvent') {
+        it('build json of definitions containing one process with intermediateCatchEvent (with one source) when eventDefinitionKind="link"', () => {
+          const json = buildDefinitions({
+            process: {
+              event: [
+                {
+                  bpmnKind: 'intermediateCatchEvent',
+                  eventDefinitionParameter: { eventDefinitionKind: 'link', eventDefinitionOn: EventDefinitionOn.DEFINITIONS },
+                  source: 'event_definition_source_id',
+                },
+              ],
+            },
+          });
+
+          expect(json).toEqual({
+            definitions: {
+              targetNamespace: '',
+              collaboration: { id: 'collaboration_id_0' },
+              linkEventDefinition: { id: 'event_definition_id' },
+              process: {
+                id: '0',
+                intermediateCatchEvent: { id: 'event_id_0_0', source: 'event_definition_source_id', eventDefinitionRef: 'event_definition_id' },
+              },
+              BPMNDiagram: {
+                name: 'process 0',
+                BPMNPlane: {
+                  BPMNShape: {
+                    id: 'shape_event_id_0_0',
+                    bpmnElement: 'event_id_0_0',
+                    Bounds: { x: 362, y: 232, width: 36, height: 45 },
+                  },
+                },
+              },
+            },
+          });
+        });
+
+        it('build json of definitions containing one process with intermediateCatchEvent (with several sources) when eventDefinitionKind="link"', () => {
+          const json = buildDefinitions({
+            process: {
+              event: [
+                {
+                  bpmnKind: 'intermediateCatchEvent',
+                  eventDefinitionParameter: { eventDefinitionKind: 'link', eventDefinitionOn: EventDefinitionOn.DEFINITIONS },
+                  source: ['event_definition_source_1_id', 'event_definition_source_2_id'],
+                },
+              ],
+            },
+          });
+
+          expect(json).toEqual({
+            definitions: {
+              targetNamespace: '',
+              collaboration: { id: 'collaboration_id_0' },
+              linkEventDefinition: { id: 'event_definition_id' },
+              process: {
+                id: '0',
+                intermediateCatchEvent: { id: 'event_id_0_0', source: ['event_definition_source_1_id', 'event_definition_source_2_id'], eventDefinitionRef: 'event_definition_id' },
+              },
+              BPMNDiagram: {
+                name: 'process 0',
+                BPMNPlane: {
+                  BPMNShape: {
+                    id: 'shape_event_id_0_0',
+                    bpmnElement: 'event_id_0_0',
+                    Bounds: { x: 362, y: 232, width: 36, height: 45 },
+                  },
+                },
+              },
+            },
+          });
+        });
+
+        it('build json of definitions containing one process with intermediateCatchEvent (without source) when eventDefinitionKind!="link"', () => {
+          const json = buildDefinitions({
+            process: {
+              event: [
+                {
+                  bpmnKind: 'intermediateCatchEvent',
+                  eventDefinitionParameter: { eventDefinitionKind: 'message', eventDefinitionOn: EventDefinitionOn.DEFINITIONS },
+                  source: 'event_definition_source_id',
+                },
+              ],
+            },
+          });
+
+          expect(json).toEqual({
+            definitions: {
+              targetNamespace: '',
+              collaboration: { id: 'collaboration_id_0' },
+              messageEventDefinition: { id: 'event_definition_id' },
+              process: {
+                id: '0',
+                intermediateCatchEvent: { id: 'event_id_0_0', eventDefinitionRef: 'event_definition_id' },
+              },
+              BPMNDiagram: {
+                name: 'process 0',
+                BPMNPlane: {
+                  BPMNShape: {
+                    id: 'shape_event_id_0_0',
+                    bpmnElement: 'event_id_0_0',
+                    Bounds: { x: 362, y: 232, width: 36, height: 45 },
+                  },
+                },
+              },
+            },
+          });
+        });
+      }
+
+      if (bpmnKind === 'intermediateThrowEvent') {
+        it('build json of definitions containing one process with intermediateThrowEvent (with target) when eventDefinitionKind="link"', () => {
+          const json = buildDefinitions({
+            process: {
+              event: [
+                {
+                  bpmnKind: 'intermediateThrowEvent',
+                  eventDefinitionParameter: { eventDefinitionKind: 'link', eventDefinitionOn: EventDefinitionOn.DEFINITIONS },
+                  target: 'event_definition_target_id',
+                },
+              ],
+            },
+          });
+
+          expect(json).toEqual({
+            definitions: {
+              targetNamespace: '',
+              collaboration: { id: 'collaboration_id_0' },
+              linkEventDefinition: { id: 'event_definition_id' },
+              process: {
+                id: '0',
+                intermediateThrowEvent: { id: 'event_id_0_0', target: 'event_definition_target_id', eventDefinitionRef: 'event_definition_id' },
+              },
+              BPMNDiagram: {
+                name: 'process 0',
+                BPMNPlane: {
+                  BPMNShape: {
+                    id: 'shape_event_id_0_0',
+                    bpmnElement: 'event_id_0_0',
+                    Bounds: { x: 362, y: 232, width: 36, height: 45 },
+                  },
+                },
+              },
+            },
+          });
+        });
+
+        it('build json of definitions containing one process with intermediateThrowEvent (with no target) when eventDefinitionKind!="link"', () => {
+          const json = buildDefinitions({
+            process: {
+              event: [
+                {
+                  bpmnKind: 'intermediateThrowEvent',
+                  eventDefinitionParameter: { eventDefinitionKind: 'message', eventDefinitionOn: EventDefinitionOn.DEFINITIONS },
+                  target: 'event_definition_target_id',
+                },
+              ],
+            },
+          });
+
+          expect(json).toEqual({
+            definitions: {
+              targetNamespace: '',
+              collaboration: { id: 'collaboration_id_0' },
+              messageEventDefinition: { id: 'event_definition_id' },
+              process: {
+                id: '0',
+                intermediateThrowEvent: { id: 'event_id_0_0', eventDefinitionRef: 'event_definition_id' },
               },
               BPMNDiagram: {
                 name: 'process 0',

--- a/test/unit/helpers/JsonBuilder.test.ts
+++ b/test/unit/helpers/JsonBuilder.test.ts
@@ -96,6 +96,15 @@ describe('build json', () => {
                 eventDefinitionOn: EventDefinitionOn.NONE,
               },
             },
+            {
+              bpmnKind: 'intermediateCatchEvent',
+              name: 'intermediateCatchEvent',
+              eventDefinitionParameter: {
+                eventDefinitionKind: 'link',
+                eventDefinitionOn: EventDefinitionOn.DEFINITIONS,
+              },
+              source: 'link_event_definition_id_2_1',
+            },
           ],
           gateway: {
             id: 'exclusiveGateway',
@@ -112,6 +121,15 @@ describe('build json', () => {
                 eventDefinitionKind: 'timer',
                 eventDefinitionOn: EventDefinitionOn.BOTH,
               },
+            },
+            {
+              bpmnKind: 'intermediateThrowEvent',
+              name: 'intermediateThrowEvent',
+              eventDefinitionParameter: {
+                eventDefinitionKind: 'link',
+                eventDefinitionOn: EventDefinitionOn.EVENT,
+              },
+              target: 'link_event_definition_id_1_1',
             },
           ],
           callActivity: { calledElement: 'process_participant_0' },
@@ -137,12 +155,11 @@ describe('build json', () => {
         },
         terminateEventDefinition: [{ id: 'terminate_event_definition_id_0_1' }, { id: 'terminate_event_definition_id_0_2' }],
         timerEventDefinition: { id: 'timer_event_definition_id_2_0' },
+        linkEventDefinition: { id: 'link_event_definition_id_1_1' },
         process: [
           {
             id: 'process_participant_0',
-            task: {
-              id: 'task_id_0_0',
-            },
+            task: { id: 'task_id_0_0' },
             endEvent: [
               {
                 id: 'event_id_0_1',
@@ -164,16 +181,18 @@ describe('build json', () => {
           },
           {
             id: 'process_participant_1',
-            exclusiveGateway: {
-              id: 'exclusiveGateway',
-            },
+            exclusiveGateway: { id: 'exclusiveGateway' },
             startEvent: {
               cancelActivity: false,
               id: 'event_id_1_0',
               name: 'startEvent',
             },
-            task: {
-              id: 'task_id_1',
+            task: { id: 'task_id_1' },
+            intermediateCatchEvent: {
+              id: 'event_id_1_1',
+              name: 'intermediateCatchEvent',
+              eventDefinitionRef: 'link_event_definition_id_1_1',
+              source: 'link_event_definition_id_2_1',
             },
           },
           {
@@ -187,6 +206,12 @@ describe('build json', () => {
             callActivity: {
               id: 'callActivity_id_2_0',
               calledElement: 'process_participant_0',
+            },
+            intermediateThrowEvent: {
+              id: 'event_id_2_1',
+              name: 'intermediateThrowEvent',
+              linkEventDefinition: { id: 'link_event_definition_id_2_1' },
+              target: 'link_event_definition_id_1_1',
             },
           },
         ],
@@ -240,6 +265,11 @@ describe('build json', () => {
                 Bounds: { x: 362, y: 232, height: 45, width: 36 },
               },
               {
+                bpmnElement: 'event_id_1_1',
+                id: 'shape_event_id_1_1',
+                Bounds: { x: 362, y: 232, height: 45, width: 36 },
+              },
+              {
                 bpmnElement: 'callActivity_id_2_0',
                 id: 'shape_callActivity_id_2_0',
                 Bounds: { x: 346, y: 856, height: 56, width: 45 },
@@ -248,6 +278,11 @@ describe('build json', () => {
               {
                 bpmnElement: 'event_id_2_0',
                 id: 'shape_event_id_2_0',
+                Bounds: { x: 362, y: 232, height: 45, width: 36 },
+              },
+              {
+                bpmnElement: 'event_id_2_1',
+                id: 'shape_event_id_2_1',
                 Bounds: { x: 362, y: 232, height: 45, width: 36 },
               },
             ],

--- a/test/unit/helpers/JsonBuilder.ts
+++ b/test/unit/helpers/JsonBuilder.ts
@@ -56,6 +56,10 @@ type BuildInterruptingEventParameter = {
 } & CommonBuildEventParameter;
 
 export type BuildEventParameter = BuildNotBoundaryEventParameter | BuildBoundaryEventParameter;
+
+/**
+ * All event types, excepted Boundary Event
+ */
 export type BuildNotBoundaryEventParameter = BuildIntermediateCatchEventParameter | BuildIntermediateThrowEventParameter | BuildEndEventParameter | BuildStartEventParameter;
 
 export type BuildNotBoundaryEventKind = 'startEvent' | 'endEvent' | 'intermediateCatchEvent' | 'intermediateThrowEvent';

--- a/test/unit/helpers/TestUtils.BpmnJsonParser.event.ts
+++ b/test/unit/helpers/TestUtils.BpmnJsonParser.event.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import type { ExpectedBoundaryEventShape, ExpectedEventShape, ExpectedShape } from './bpmn-model-expect';
-import type { BuildEventDefinition, BuildEventsParameter } from './JsonBuilder';
+import type { BuildEventDefinition, BuildEventParameter } from './JsonBuilder';
 
 import { verifyShape } from './bpmn-model-expect';
 import { buildDefinitions, EventDefinitionOn } from './JsonBuilder';
@@ -33,7 +33,7 @@ export type OmitExpectedEventShape = Omit<ExpectedEventShape, 'shapeId' | 'bpmnE
 
 export const expectedBounds = { x: 362, y: 232, width: 36, height: 45 };
 
-export function testMustConvertShapes(buildEventParameter: BuildEventsParameter | BuildEventsParameter[], omitExpectedShape: OmitExpectedEventShape, processIsArray = false): void {
+export function testMustConvertShapes(buildEventParameter: BuildEventParameter | BuildEventParameter[], omitExpectedShape: OmitExpectedEventShape, processIsArray = false): void {
   const process = { event: buildEventParameter, task: {} };
   const json = buildDefinitions({ process: processIsArray ? [process] : process });
 
@@ -51,7 +51,7 @@ export function testMustConvertShapes(buildEventParameter: BuildEventsParameter 
   }
 }
 
-export function testMustNotConvertEvent(buildEventParameter: BuildEventsParameter): void {
+export function testMustNotConvertEvent(buildEventParameter: BuildEventParameter): void {
   const json = buildDefinitions({ process: { event: buildEventParameter, task: {} } });
 
   const bpmnModel = parseJsonAndExpectOnlyFlowNodes(json, 1, 1);
@@ -62,7 +62,7 @@ export function testMustNotConvertEvent(buildEventParameter: BuildEventsParamete
   expect(warning.bpmnElementId).toBe('event_id_0_0');
 }
 
-export function executeEventCommonTests(buildEventParameter: BuildEventsParameter, omitExpectedShape: OmitExpectedEventShape, titleSuffix: string): void {
+export function executeEventCommonTests(buildEventParameter: BuildEventParameter, omitExpectedShape: OmitExpectedEventShape, titleSuffix: string): void {
   it.each([
     ['object', 'object'],
     ['object', 'array'],


### PR DESCRIPTION
<!--
## PR Checklist

- [x] Addresses an existing open issue: closes #000 (if not, explain why).
- [x] The issue was marked with the [PR Accepted](https://github.com/process-analytics/bpmn-visualization-js/issues?q=is%3Aissue+is%3Aopen+label%3A%22PR+accepted%22) label.
- [x] You have discussed this issue with the maintainers of `bpmn-visualization`, and you are assigned to the issue. 
- [x] Steps in the [CONTRIBUTING guide](https://github.com/process-analytics/bpmn-visualization-js/blob/master/CONTRIBUTING.md) were taken.
- [x] The PR title follows the ["Conventional Commits"](https://www.conventionalcommits.org/en/v1.0.0/) guidelines.
-->

## Overview

Update the test helper `JsonBuilder` to set the properties:
- `source`: for Link event definition of Intermediate Catch Event
- `target`: for Link event definition of Intermediate Throw Event

And rename some existing types.

Covers #2906 
