### PR TITLE
test(JsonBuilder): not possible to have NONE `eventDefinitionOn` and `eventDefinitionKind` in same time in `BuildEventParameter`

### DIFF
--- a/test/unit/helpers/JsonBuilder.test.ts
+++ b/test/unit/helpers/JsonBuilder.test.ts
@@ -1908,7 +1908,7 @@ describe('build json', () => {
             event: [
               {
                 bpmnKind,
-                eventDefinitionParameter: { eventDefinitionKind: 'message', eventDefinitionOn: EventDefinitionOn.NONE, eventDefinition: { id: '9' } },
+                eventDefinitionParameter: { eventDefinitionKind: 'message', eventDefinitionOn: EventDefinitionOn.EVENT, eventDefinition: { id: '9' } },
               },
             ],
           },
@@ -1920,7 +1920,12 @@ describe('build json', () => {
             collaboration: { id: 'collaboration_id_0' },
             process: {
               id: '0',
-              [bpmnKind]: { id: 'event_id_0_0' },
+              [bpmnKind]: {
+                id: 'event_id_0_0',
+                messageEventDefinition: {
+                  id: '9',
+                },
+              },
             },
             BPMNDiagram: {
               name: 'process 0',
@@ -1934,6 +1939,21 @@ describe('build json', () => {
             },
           },
         });
+      });
+
+      it(`not possible to have eventDefinitionOn=NONE with defined eventDefinitionKind`, () => {
+        expect(() => {
+          buildDefinitions({
+            process: {
+              event: [
+                {
+                  bpmnKind,
+                  eventDefinitionParameter: { eventDefinitionKind: 'message', eventDefinitionOn: EventDefinitionOn.NONE },
+                },
+              ],
+            },
+          });
+        }).toThrow("Must use another value than NONE for 'eventDefinitionOn' when 'eventDefinitionKind' is set !!");
       });
 
       it(`build json of definitions containing one process with ${bpmnKind} (with one messageEventDefinition, name & id)`, () => {
@@ -2402,78 +2422,6 @@ describe('build json', () => {
         });
       });
 
-      if (bpmnKind === 'startEvent') {
-        it('build json of definitions containing one process with interrupting startEvent', () => {
-          const json = buildDefinitions({
-            process: {
-              event: [
-                {
-                  bpmnKind,
-                  eventDefinitionParameter: { eventDefinitionKind: 'message', eventDefinitionOn: EventDefinitionOn.NONE, eventDefinition: {} },
-                  isInterrupting: true,
-                },
-              ],
-            },
-          });
-
-          expect(json).toEqual({
-            definitions: {
-              targetNamespace: '',
-              collaboration: { id: 'collaboration_id_0' },
-              process: {
-                id: '0',
-                startEvent: { id: 'event_id_0_0', cancelActivity: true },
-              },
-              BPMNDiagram: {
-                name: 'process 0',
-                BPMNPlane: {
-                  BPMNShape: {
-                    id: 'shape_event_id_0_0',
-                    bpmnElement: 'event_id_0_0',
-                    Bounds: { x: 362, y: 232, width: 36, height: 45 },
-                  },
-                },
-              },
-            },
-          });
-        });
-
-        it('build json of definitions containing one process with non-interrupting startEvent', () => {
-          const json = buildDefinitions({
-            process: {
-              event: [
-                {
-                  bpmnKind,
-                  eventDefinitionParameter: { eventDefinitionKind: 'message', eventDefinitionOn: EventDefinitionOn.NONE, eventDefinition: {} },
-                  isInterrupting: false,
-                },
-              ],
-            },
-          });
-
-          expect(json).toEqual({
-            definitions: {
-              targetNamespace: '',
-              collaboration: { id: 'collaboration_id_0' },
-              process: {
-                id: '0',
-                startEvent: { id: 'event_id_0_0', cancelActivity: false },
-              },
-              BPMNDiagram: {
-                name: 'process 0',
-                BPMNPlane: {
-                  BPMNShape: {
-                    id: 'shape_event_id_0_0',
-                    bpmnElement: 'event_id_0_0',
-                    Bounds: { x: 362, y: 232, width: 36, height: 45 },
-                  },
-                },
-              },
-            },
-          });
-        });
-      }
-
       it(`incoming and outgoing for ${bpmnKind}`, () => {
         const json = buildDefinitions({
           process: {
@@ -2517,6 +2465,78 @@ describe('build json', () => {
           },
         });
       });
+
+      if (bpmnKind === 'startEvent') {
+        it('build json of definitions containing one process with interrupting startEvent', () => {
+          const json = buildDefinitions({
+            process: {
+              event: [
+                {
+                  bpmnKind,
+                  eventDefinitionParameter: { eventDefinitionKind: 'message', eventDefinitionOn: EventDefinitionOn.EVENT, eventDefinition: {} },
+                  isInterrupting: true,
+                },
+              ],
+            },
+          });
+
+          expect(json).toEqual({
+            definitions: {
+              targetNamespace: '',
+              collaboration: { id: 'collaboration_id_0' },
+              process: {
+                id: '0',
+                startEvent: { id: 'event_id_0_0', messageEventDefinition: {}, cancelActivity: true },
+              },
+              BPMNDiagram: {
+                name: 'process 0',
+                BPMNPlane: {
+                  BPMNShape: {
+                    id: 'shape_event_id_0_0',
+                    bpmnElement: 'event_id_0_0',
+                    Bounds: { x: 362, y: 232, width: 36, height: 45 },
+                  },
+                },
+              },
+            },
+          });
+        });
+
+        it('build json of definitions containing one process with non-interrupting startEvent', () => {
+          const json = buildDefinitions({
+            process: {
+              event: [
+                {
+                  bpmnKind,
+                  eventDefinitionParameter: { eventDefinitionKind: 'message', eventDefinitionOn: EventDefinitionOn.EVENT, eventDefinition: {} },
+                  isInterrupting: false,
+                },
+              ],
+            },
+          });
+
+          expect(json).toEqual({
+            definitions: {
+              targetNamespace: '',
+              collaboration: { id: 'collaboration_id_0' },
+              process: {
+                id: '0',
+                startEvent: { id: 'event_id_0_0', cancelActivity: false, messageEventDefinition: {} },
+              },
+              BPMNDiagram: {
+                name: 'process 0',
+                BPMNPlane: {
+                  BPMNShape: {
+                    id: 'shape_event_id_0_0',
+                    bpmnElement: 'event_id_0_0',
+                    Bounds: { x: 362, y: 232, width: 36, height: 45 },
+                  },
+                },
+              },
+            },
+          });
+        });
+      }
     },
   );
 

--- a/test/unit/helpers/JsonBuilder.test.ts
+++ b/test/unit/helpers/JsonBuilder.test.ts
@@ -1941,21 +1941,6 @@ describe('build json', () => {
         });
       });
 
-      it(`not possible to have eventDefinitionOn=NONE with defined eventDefinitionKind`, () => {
-        expect(() => {
-          buildDefinitions({
-            process: {
-              event: [
-                {
-                  bpmnKind,
-                  eventDefinitionParameter: { eventDefinitionKind: 'message', eventDefinitionOn: EventDefinitionOn.NONE },
-                },
-              ],
-            },
-          });
-        }).toThrow("Must use another value than NONE for 'eventDefinitionOn' when 'eventDefinitionKind' is set !!");
-      });
-
       it(`build json of definitions containing one process with ${bpmnKind} (with one messageEventDefinition, name & id)`, () => {
         const json = buildDefinitions({
           process: {
@@ -2420,6 +2405,57 @@ describe('build json', () => {
             },
           },
         });
+      });
+
+      it(`build json of definitions containing one process with none ${bpmnKind}`, () => {
+        const json = buildDefinitions({
+          process: {
+            event: [
+              {
+                bpmnKind,
+                eventDefinitionParameter: { eventDefinitionOn: EventDefinitionOn.NONE },
+              },
+            ],
+          },
+        });
+
+        expect(json).toEqual({
+          definitions: {
+            targetNamespace: '',
+            collaboration: { id: 'collaboration_id_0' },
+            process: {
+              id: '0',
+              [bpmnKind]: {
+                id: 'event_id_0_0',
+              },
+            },
+            BPMNDiagram: {
+              name: 'process 0',
+              BPMNPlane: {
+                BPMNShape: {
+                  id: 'shape_event_id_0_0',
+                  bpmnElement: 'event_id_0_0',
+                  Bounds: { x: 362, y: 232, width: 36, height: 45 },
+                },
+              },
+            },
+          },
+        });
+      });
+
+      it(`not possible to have eventDefinitionOn=NONE with defined eventDefinitionKind`, () => {
+        expect(() => {
+          buildDefinitions({
+            process: {
+              event: [
+                {
+                  bpmnKind,
+                  eventDefinitionParameter: { eventDefinitionKind: 'message', eventDefinitionOn: EventDefinitionOn.NONE },
+                },
+              ],
+            },
+          });
+        }).toThrow("Must use another value than NONE for 'eventDefinitionOn' when 'eventDefinitionKind' is set !!");
       });
 
       it(`incoming and outgoing for ${bpmnKind}`, () => {

--- a/test/unit/helpers/JsonBuilder.ts
+++ b/test/unit/helpers/JsonBuilder.ts
@@ -579,6 +579,9 @@ function addEvent(
       break;
     }
     case EventDefinitionOn.NONE: {
+      if (eventDefinitionParameter.eventDefinitionKind) {
+        throw new Error("Must use another value than NONE for 'eventDefinitionOn' when 'eventDefinitionKind' is set !!");
+      }
       break;
     }
   }


### PR DESCRIPTION
To avoid confusion, if the property `eventDefinitionOn` is set to `NONE` and the property `eventDefinitionKind` is set in the same instance of `BuildEventParameter`, an error is thrown.