### PR TITLE
test(JsonBuilder): avoid duplicated code when adding `EventDefinition`

### DIFF
--- a/test/unit/component/parser/json/BpmnJsonParser.event.with.event.definition.test.ts
+++ b/test/unit/component/parser/json/BpmnJsonParser.event.with.event.definition.test.ts
@@ -76,10 +76,12 @@ describe.each([ShapeBpmnElementKind.EVENT_START, ShapeBpmnElementKind.EVENT_END,
             titleForEventDefinitionIsAttributeOf,
           );
 
-          it.each([
-            ['empty string', ''],
-            ['object', { id: `${eventDefinitionKind}EventDefinition_1` }],
-          ])(
+          const eventDefinitionParameters: [[string, string | TEventDefinition]] = [['object', { id: `${eventDefinitionKind}EventDefinition_1` }]];
+          if (eventDefinitionOn === EventDefinitionOn.EVENT) {
+            eventDefinitionParameters.push(['empty string', '']); // Not possible to link an event to an EventDefinition without id, when the EventDefinition is not defined in the event
+          }
+
+          it.each(eventDefinitionParameters)(
             `should convert as Shape, when '${eventDefinitionKind}EventDefinition' is %s, ${titleForEventDefinitionIsAttributeOf}`,
             (title: string, eventDefinition: string | TEventDefinition) => {
               testMustConvertShapes(

--- a/test/unit/helpers/JsonBuilder.ts
+++ b/test/unit/helpers/JsonBuilder.ts
@@ -486,55 +486,44 @@ function addEventDefinition(event: BPMNTEvent | TDefinitions, eventDefinitionKin
   event[`${eventDefinitionKind}EventDefinition` as keyof typeof event] = eventDefinition;
 }
 
-function addEventDefinitionsOnDefinition(
-  definitions: TDefinitions,
+function addEventDefinitions(
+  elementWhereAddDefinition: TDefinitions | BPMNTEvent,
   { withMultipleDefinitions, withDifferentDefinition, eventDefinitionKind, eventDefinition }: BuildEventDefinitionParameter,
-  event: BPMNTEvent,
+  event?: BPMNTEvent,
 ): void {
   let eventDefinitions;
 
   if (withMultipleDefinitions) {
-    eventDefinitions = [{ id: 'event_definition_1_id' }, { id: 'event_definition_2_id' }];
+    eventDefinitions = event ? [{ id: 'event_definition_1_id' }, { id: 'event_definition_2_id' }] : ['', {}];
 
-    addEventDefinition(definitions, eventDefinitionKind, eventDefinitions);
+    addEventDefinition(elementWhereAddDefinition, eventDefinitionKind, eventDefinitions);
   } else if (withDifferentDefinition) {
     const otherEventDefinitionKind = eventDefinitionKind === 'signal' ? 'message' : 'signal';
 
-    eventDefinitions = [{ id: 'event_definition_id' }, { id: 'other_event_definition_id' }];
+    eventDefinitions = event ? [{ id: 'event_definition_id' }, { id: 'other_event_definition_id' }] : ['', ''];
 
-    addEventDefinition(definitions, eventDefinitionKind, eventDefinitions[0]);
-    addEventDefinition(definitions, otherEventDefinitionKind, eventDefinitions[1]);
+    addEventDefinition(elementWhereAddDefinition, eventDefinitionKind, eventDefinitions[0]);
+    addEventDefinition(elementWhereAddDefinition, otherEventDefinitionKind, eventDefinitions[1]);
   } else {
-    eventDefinitions = eventDefinition ?? ({} as TEventDefinition);
-    !Array.isArray(eventDefinition) && ((eventDefinitions as TEventDefinition).id ??= 'event_definition_id');
+    eventDefinitions = eventDefinition ?? (event ? ({} as TEventDefinition) : '');
+    event && !Array.isArray(eventDefinitions) && eventDefinitions !== '' && ((eventDefinitions as TEventDefinition).id ??= 'event_definition_id');
 
-    addEventDefinition(definitions, eventDefinitionKind, eventDefinitions);
+    addEventDefinition(elementWhereAddDefinition, eventDefinitionKind, eventDefinitions);
   }
 
-  event.eventDefinitionRef = Array.isArray(eventDefinitions)
-    ? (eventDefinitions as TEventDefinition[]).map(definition => definition.id)
-    : (eventDefinitions as TEventDefinition).id;
+  if (event) {
+    event.eventDefinitionRef = Array.isArray(eventDefinitions)
+      ? (eventDefinitions as TEventDefinition[]).map(definition => definition.id)
+      : (eventDefinitions as TEventDefinition).id;
+  }
 }
 
-function addEventDefinitionsOnEvent(
-  event: TCatchEvent | TThrowEvent | TBoundaryEvent,
-  { withMultipleDefinitions, withDifferentDefinition, eventDefinitionKind, eventDefinition }: BuildEventDefinitionParameter,
-): void {
-  if (withMultipleDefinitions) {
-    const eventDefinition = ['', {}];
-    addEventDefinition(event, eventDefinitionKind, eventDefinition);
-  } else if (withDifferentDefinition) {
-    const otherEventDefinitionKind = eventDefinitionKind === 'signal' ? 'message' : 'signal';
+function addEventDefinitionsOnDefinition(definitions: TDefinitions, eventDefinitionParameter: BuildEventDefinitionParameter, event: BPMNTEvent): void {
+  addEventDefinitions(definitions, eventDefinitionParameter, event);
+}
 
-    eventDefinition ??= '';
-    const otherEventDefinition = '';
-
-    addEventDefinition(event, eventDefinitionKind, eventDefinition);
-    addEventDefinition(event, otherEventDefinitionKind, otherEventDefinition);
-  } else {
-    eventDefinition ??= '';
-    addEventDefinition(event, eventDefinitionKind, eventDefinition);
-  }
+function addEventDefinitionsOnEvent(event: BPMNTEvent, eventDefinitionParameter: BuildEventDefinitionParameter): void {
+  addEventDefinitions(event, eventDefinitionParameter);
 }
 
 function buildEvent({

--- a/test/unit/helpers/JsonBuilder.ts
+++ b/test/unit/helpers/JsonBuilder.ts
@@ -518,14 +518,6 @@ function addEventDefinitions(
   }
 }
 
-function addEventDefinitionsOnDefinition(definitions: TDefinitions, eventDefinitionParameter: BuildEventDefinitionParameter, event: BPMNTEvent): void {
-  addEventDefinitions(definitions, eventDefinitionParameter, event);
-}
-
-function addEventDefinitionsOnEvent(event: BPMNTEvent, eventDefinitionParameter: BuildEventDefinitionParameter): void {
-  addEventDefinitions(event, eventDefinitionParameter);
-}
-
 function buildEvent({
   id,
   name,
@@ -570,16 +562,16 @@ function addEvent(
   const event = buildEvent({ id, name, index, processIndex, ...rest });
   switch (eventDefinitionParameter.eventDefinitionOn) {
     case EventDefinitionOn.BOTH: {
-      addEventDefinitionsOnEvent(event, eventDefinitionParameter);
-      addEventDefinitionsOnDefinition(jsonModel.definitions, eventDefinitionParameter, event);
+      addEventDefinitions(event, eventDefinitionParameter);
+      addEventDefinitions(jsonModel.definitions, eventDefinitionParameter, event);
       break;
     }
     case EventDefinitionOn.DEFINITIONS: {
-      addEventDefinitionsOnDefinition(jsonModel.definitions, eventDefinitionParameter, event);
+      addEventDefinitions(jsonModel.definitions, eventDefinitionParameter, event);
       break;
     }
     case EventDefinitionOn.EVENT: {
-      addEventDefinitionsOnEvent(event, eventDefinitionParameter);
+      addEventDefinitions(event, eventDefinitionParameter);
       break;
     }
     case EventDefinitionOn.NONE: {

--- a/test/unit/helpers/JsonBuilder.ts
+++ b/test/unit/helpers/JsonBuilder.ts
@@ -487,12 +487,10 @@ function addEventDefinition(event: BPMNTEvent | TDefinitions, eventDefinitionKin
 }
 
 function addEventDefinitionsOnDefinition(
-  jsonModel: BpmnJsonModel,
+  definitions: TDefinitions,
   { withMultipleDefinitions, withDifferentDefinition, eventDefinitionKind, eventDefinition }: BuildEventDefinitionParameter,
   event: BPMNTEvent,
 ): void {
-  const definitions: TDefinitions = jsonModel.definitions;
-
   if (withMultipleDefinitions) {
     const eventDefinition = [{ id: 'event_definition_1_id' }, { id: 'event_definition_2_id' }];
     event.eventDefinitionRef = eventDefinition.map(eventDefinition => eventDefinition.id);
@@ -580,11 +578,11 @@ function addEvent(
   switch (eventDefinitionParameter.eventDefinitionOn) {
     case EventDefinitionOn.BOTH: {
       addEventDefinitionsOnEvent(event, eventDefinitionParameter);
-      addEventDefinitionsOnDefinition(jsonModel, eventDefinitionParameter, event);
+      addEventDefinitionsOnDefinition(jsonModel.definitions, eventDefinitionParameter, event);
       break;
     }
     case EventDefinitionOn.DEFINITIONS: {
-      addEventDefinitionsOnDefinition(jsonModel, eventDefinitionParameter, event);
+      addEventDefinitionsOnDefinition(jsonModel.definitions, eventDefinitionParameter, event);
       break;
     }
     case EventDefinitionOn.EVENT: {

--- a/test/unit/helpers/JsonBuilder.ts
+++ b/test/unit/helpers/JsonBuilder.ts
@@ -491,25 +491,29 @@ function addEventDefinitionsOnDefinition(
   { withMultipleDefinitions, withDifferentDefinition, eventDefinitionKind, eventDefinition }: BuildEventDefinitionParameter,
   event: BPMNTEvent,
 ): void {
-  if (withMultipleDefinitions) {
-    const eventDefinition = [{ id: 'event_definition_1_id' }, { id: 'event_definition_2_id' }];
-    event.eventDefinitionRef = eventDefinition.map(eventDefinition => eventDefinition.id);
+  let eventDefinitions;
 
-    addEventDefinition(definitions, eventDefinitionKind, eventDefinition);
+  if (withMultipleDefinitions) {
+    eventDefinitions = [{ id: 'event_definition_1_id' }, { id: 'event_definition_2_id' }];
+
+    addEventDefinition(definitions, eventDefinitionKind, eventDefinitions);
   } else if (withDifferentDefinition) {
     const otherEventDefinitionKind = eventDefinitionKind === 'signal' ? 'message' : 'signal';
 
-    event.eventDefinitionRef = ['event_definition_id', 'other_event_definition_id'];
+    eventDefinitions = [{ id: 'event_definition_id' }, { id: 'other_event_definition_id' }];
 
-    addEventDefinition(definitions, eventDefinitionKind, { id: event.eventDefinitionRef[0] });
-    addEventDefinition(definitions, otherEventDefinitionKind, { id: event.eventDefinitionRef[1] });
+    addEventDefinition(definitions, eventDefinitionKind, eventDefinitions[0]);
+    addEventDefinition(definitions, otherEventDefinitionKind, eventDefinitions[1]);
   } else {
-    eventDefinition ??= {};
-    (eventDefinition as TEventDefinition).id ??= 'event_definition_id';
-    event.eventDefinitionRef = Array.isArray(eventDefinition) ? (eventDefinition as TEventDefinition[]).map(definition => definition.id) : (eventDefinition as TEventDefinition).id;
+    eventDefinitions = eventDefinition ?? ({} as TEventDefinition);
+    !Array.isArray(eventDefinition) && ((eventDefinitions as TEventDefinition).id ??= 'event_definition_id');
 
-    addEventDefinition(definitions, eventDefinitionKind, eventDefinition);
+    addEventDefinition(definitions, eventDefinitionKind, eventDefinitions);
   }
+
+  event.eventDefinitionRef = Array.isArray(eventDefinitions)
+    ? (eventDefinitions as TEventDefinition[]).map(definition => definition.id)
+    : (eventDefinitions as TEventDefinition).id;
 }
 
 function addEventDefinitionsOnEvent(

--- a/test/unit/helpers/JsonBuilder.ts
+++ b/test/unit/helpers/JsonBuilder.ts
@@ -499,12 +499,12 @@ function addEventDefinitionsOnDefinition(
 
     addEventDefinition(definitions, eventDefinitionKind, eventDefinition);
   } else if (withDifferentDefinition) {
-    const otherEventDefinition = eventDefinitionKind === 'signal' ? 'message' : 'signal';
+    const otherEventDefinitionKind = eventDefinitionKind === 'signal' ? 'message' : 'signal';
 
     event.eventDefinitionRef = ['event_definition_id', 'other_event_definition_id'];
 
     addEventDefinition(definitions, eventDefinitionKind, { id: event.eventDefinitionRef[0] });
-    addEventDefinition(definitions, otherEventDefinition, { id: event.eventDefinitionRef[1] });
+    addEventDefinition(definitions, otherEventDefinitionKind, { id: event.eventDefinitionRef[1] });
   } else {
     eventDefinition ??= {};
     (eventDefinition as TEventDefinition).id ??= 'event_definition_id';
@@ -514,16 +514,24 @@ function addEventDefinitionsOnDefinition(
   }
 }
 
-function addEventDefinitionsOnEvent(event: TCatchEvent | TThrowEvent | TBoundaryEvent, buildParameter: BuildEventDefinitionParameter): void {
-  if (buildParameter.withMultipleDefinitions) {
-    addEventDefinition(event, buildParameter.eventDefinitionKind, ['', {}]);
-  } else {
-    if (buildParameter.withDifferentDefinition) {
-      const otherEventDefinition = buildParameter.eventDefinitionKind === 'signal' ? 'message' : 'signal';
-      addEventDefinition(event, otherEventDefinition, '');
-    }
+function addEventDefinitionsOnEvent(
+  event: TCatchEvent | TThrowEvent | TBoundaryEvent,
+  { withMultipleDefinitions, withDifferentDefinition, eventDefinitionKind, eventDefinition }: BuildEventDefinitionParameter,
+): void {
+  if (withMultipleDefinitions) {
+    const eventDefinition = ['', {}];
+    addEventDefinition(event, eventDefinitionKind, eventDefinition);
+  } else if (withDifferentDefinition) {
+    const otherEventDefinitionKind = eventDefinitionKind === 'signal' ? 'message' : 'signal';
 
-    addEventDefinition(event, buildParameter.eventDefinitionKind, buildParameter.eventDefinition ?? '');
+    eventDefinition ??= '';
+    const otherEventDefinition = '';
+
+    addEventDefinition(event, eventDefinitionKind, eventDefinition);
+    addEventDefinition(event, otherEventDefinitionKind, otherEventDefinition);
+  } else {
+    eventDefinition ??= '';
+    addEventDefinition(event, eventDefinitionKind, eventDefinition);
   }
 }
 


### PR DESCRIPTION
Avoid duplication to add `EventDefinition` in the `Definitions` or in the `Event` objects:
- remove `addEventDefinitionsOnEvent` and `addEventDefinitionsOnDefinition`. The code was very similar.
- add `addEventDefinitions`