### PR TITLE
test(JsonBuilder): use the id of event for the id of eventDefinition

### DIFF
--- a/test/unit/helpers/JsonBuilder.test.ts
+++ b/test/unit/helpers/JsonBuilder.test.ts
@@ -2047,7 +2047,7 @@ describe('build json', () => {
         });
       });
 
-      it(`build json of definitions containing one process with ${bpmnKind} (with linkEventDefinition)`, () => {
+      it(`build json of definitions containing one process with ${bpmnKind} (with linkEventDefinition with generated id)`, () => {
         const json = buildDefinitions({
           process: {
             event: [
@@ -2076,6 +2076,44 @@ describe('build json', () => {
                 BPMNShape: {
                   id: 'shape_event_id_0_0',
                   bpmnElement: 'event_id_0_0',
+                  Bounds: { x: 362, y: 232, width: 36, height: 45 },
+                },
+              },
+            },
+          },
+        });
+      });
+
+      it(`build json of definitions containing one process with ${bpmnKind} (with linkEventDefinition with id from event)`, () => {
+        const json = buildDefinitions({
+          process: {
+            event: [
+              {
+                id: 'custom_id',
+                bpmnKind,
+                eventDefinitionParameter: { eventDefinitionKind: 'link', eventDefinitionOn: EventDefinitionOn.EVENT },
+              },
+            ],
+          },
+        });
+
+        expect(json).toEqual({
+          definitions: {
+            targetNamespace: '',
+            collaboration: { id: 'collaboration_id_0' },
+            process: {
+              id: '0',
+              [bpmnKind]: {
+                id: 'custom_id',
+                linkEventDefinition: { id: 'link_custom_id' },
+              },
+            },
+            BPMNDiagram: {
+              name: 'process 0',
+              BPMNPlane: {
+                BPMNShape: {
+                  id: 'shape_custom_id',
+                  bpmnElement: 'custom_id',
                   Bounds: { x: 362, y: 232, width: 36, height: 45 },
                 },
               },

--- a/test/unit/helpers/JsonBuilder.ts
+++ b/test/unit/helpers/JsonBuilder.ts
@@ -505,18 +505,8 @@ function addEventDefinition(event: BPMNTEvent | TDefinitions, eventDefinitionKin
   event[eventDefinitionName] = enrichBpmnElement(event[eventDefinitionName], eventDefinition);
 }
 
-function buildEventDefinition(
-  eventDefinitionKind: BuildEventDefinition,
-  initialEventId: string,
-  processIndex: number,
-  index: number,
-  source: string | string[],
-  target: string,
-  idSuffix = '',
-): TEventDefinition {
-  const suffixId = initialEventId ?? `event_definition_id_${processIndex}_${index}`;
-
-  const eventDefinition: TEventDefinition = { id: `${eventDefinitionKind}_${suffixId}${idSuffix}` };
+function buildEventDefinition(eventDefinitionKind: BuildEventDefinition, idSuffix: string, source: string | string[], target: string): TEventDefinition {
+  const eventDefinition: TEventDefinition = { id: `${eventDefinitionKind}_${idSuffix}` };
 
   if (eventDefinitionKind === ShapeBpmnEventDefinitionKind.LINK) {
     (eventDefinition as TLinkEventDefinition).source = source;
@@ -538,13 +528,12 @@ function addEventDefinitions(
   processIndex: number,
   event?: BPMNTEvent,
 ): void {
-  const suffixId = initialEventId ?? `event_definition_id_${processIndex}_${index}`;
+  const idSuffix = initialEventId ?? `event_definition_id_${processIndex}_${index}`;
 
   let eventDefinitions;
-
   if (withMultipleDefinitions) {
     eventDefinitions = event
-      ? [buildEventDefinition(eventDefinitionKind, initialEventId, processIndex, index, source, target, '_1'), buildEventDefinition(eventDefinitionKind, processIndex, index, source, target, '_2')]
+      ? [buildEventDefinition(eventDefinitionKind, `${idSuffix}_1`, source, target), buildEventDefinition(eventDefinitionKind, `${idSuffix}_2`, source, target)]
       : ['', {}];
 
     addEventDefinition(elementWhereAddDefinition, eventDefinitionKind, eventDefinitions);
@@ -552,7 +541,7 @@ function addEventDefinitions(
     const otherEventDefinitionKind = eventDefinitionKind === 'signal' ? 'message' : 'signal';
 
     eventDefinitions = event
-      ? [buildEventDefinition(eventDefinitionKind, initialEventId, processIndex, index, source, target), buildEventDefinition(otherEventDefinitionKind, processIndex, index, source, target)]
+      ? [buildEventDefinition(eventDefinitionKind, idSuffix, source, target), buildEventDefinition(otherEventDefinitionKind, idSuffix, source, target)]
       : ['', ''];
 
     addEventDefinition(elementWhereAddDefinition, eventDefinitionKind, eventDefinitions[0]);
@@ -562,7 +551,7 @@ function addEventDefinitions(
       event || eventDefinitionKind === ShapeBpmnEventDefinitionKind.LINK
         ? {
             ...(typeof eventDefinition === 'object' ? eventDefinition : { id: eventDefinition }),
-            ...buildEventDefinition(eventDefinitionKind, initialEventId, processIndex, index, source, target),
+            ...buildEventDefinition(eventDefinitionKind, idSuffix, source, target),
           }
         : eventDefinition ?? '';
 


### PR DESCRIPTION
For the unit tests for the link events, we need to have id for eventDefinition understandable and to have tests more readable.  
  
### Example of a generated json for `intermediateThrowEvent` with a `linkEventDefinition` (with an id calculated from the id of the event)
```json
      "intermediateThrowEvent": {
        "id": "source_id",

        "linkEventDefinition": {
          "id": "link_source_id",
          "target": "link_target_id"
        }
      }
```