### PR TITLE
chore(eslint): enable 3 rules of the unicorn plugin

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -72,6 +72,7 @@ module.exports = {
     'unicorn/prefer-switch': 'error',
     'unicorn/switch-case-braces': 'error',
     'unicorn/prefer-spread': 'error',
+    'unicorn/text-encoding-identifier-case': 'error',
     'import/newline-after-import': ['error', { count: 1 }],
     'import/first': 'error',
     'import/order': [

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -49,6 +49,7 @@ module.exports = {
     'unicorn/prefer-logical-operator-over-ternary': 'error',
     'unicorn/consistent-function-scoping': 'error',
     'unicorn/prefer-dom-node-append': 'error',
+    'unicorn/prefer-dom-node-dataset': 'error',
     'unicorn/prefer-dom-node-remove': 'error',
     'unicorn/no-negated-condition': 'error',
     'unicorn/no-array-callback-reference': 'error',

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -48,6 +48,7 @@ module.exports = {
     'unicorn/prefer-ternary': 'error',
     'unicorn/prefer-logical-operator-over-ternary': 'error',
     'unicorn/consistent-function-scoping': 'error',
+    'unicorn/prefer-at': 'error',
     'unicorn/prefer-dom-node-append': 'error',
     'unicorn/prefer-dom-node-dataset': 'error',
     'unicorn/prefer-dom-node-remove': 'error',

--- a/scripts/utils/parseBpmn.ts
+++ b/scripts/utils/parseBpmn.ts
@@ -44,7 +44,7 @@ if (!['json', 'model'].includes(outputType)) {
 console.info('Use BPMN diagram located at "%s"', bpmnFilePath);
 
 const xmlParser = new BpmnXmlParser();
-const json = xmlParser.parse(readFileSync(bpmnFilePath, 'utf-8', __dirname));
+const json = xmlParser.parse(readFileSync(bpmnFilePath, 'utf8', __dirname));
 const prettyString = (object: BpmnJsonModel | BpmnModel): string => JSON.stringify(object, null, 2);
 
 let result = '';

--- a/src/component/mxgraph/BpmnCellRenderer.ts
+++ b/src/component/mxgraph/BpmnCellRenderer.ts
@@ -61,7 +61,7 @@ export class BpmnCellRenderer extends mxgraph.mxCellRenderer {
         // START bpmn-visualization CUSTOMIZATION
         if (overlayShape instanceof OverlayBadgeShape) {
           overlayShape.node.classList.add('overlay-badge');
-          overlayShape.node.setAttribute('data-bpmn-id', state.cell.id);
+          overlayShape.node.dataset.bpmnId = state.cell.id;
         }
         // END bpmn-visualization CUSTOMIZATION
 

--- a/src/component/mxgraph/BpmnGraph.ts
+++ b/src/component/mxgraph/BpmnGraph.ts
@@ -244,6 +244,6 @@ class BpmnGraphView extends mxgraph.mxGraphView {
       return super.getFloatingTerminalPoint(edge, start, end, source);
     }
     const pts = edge.absolutePoints;
-    return source ? pts[1] : pts[pts.length - 2];
+    return source ? pts[1] : pts.at(-2);
   }
 }

--- a/src/component/mxgraph/config/ShapeConfigurator.ts
+++ b/src/component/mxgraph/config/ShapeConfigurator.ts
@@ -154,7 +154,7 @@ export default class ShapeConfigurator {
         }
 
         this.node.setAttribute('class', allBpmnClassNames.join(' '));
-        this.node.setAttribute('data-bpmn-id', this.state.cell.id);
+        this.node.dataset.bpmnId = this.state.cell.id;
       }
       // END bpmn-visualization CUSTOMIZATION
       canvas.minStrokeWidth = this.minSvgStrokeWidth;

--- a/src/component/mxgraph/overlay/custom-overlay.ts
+++ b/src/component/mxgraph/overlay/custom-overlay.ts
@@ -101,7 +101,7 @@ export class MxGraphCustomOverlay extends mxgraph.mxCellOverlay {
     }
     // last point for end position
     else {
-      return pts[pts.length - 1];
+      return pts.at(-1);
     }
   }
 }

--- a/src/component/mxgraph/renderer/CoordinatesTranslator.ts
+++ b/src/component/mxgraph/renderer/CoordinatesTranslator.ts
@@ -69,7 +69,7 @@ export default class CoordinatesTranslator {
     const points: mxPointType[] = edge.geometry.points;
 
     const p0 = points[0];
-    const pe = points[points.length - 1];
+    const pe = points.at(-1);
 
     if (p0 != null && pe != null) {
       const dx = pe.x - p0.x;

--- a/src/component/registry/bpmn-elements-registry.ts
+++ b/src/component/registry/bpmn-elements-registry.ts
@@ -102,7 +102,7 @@ export class BpmnElementsRegistry implements CssClassesRegistry, ElementsRegistr
   }
 
   private getRelatedBpmnSemantic(htmlElement: HTMLElement): BpmnSemantic {
-    return this.bpmnModelRegistry.getBpmnSemantic(htmlElement.getAttribute('data-bpmn-id'));
+    return this.bpmnModelRegistry.getBpmnSemantic(htmlElement.dataset.bpmnId);
   }
 
   addCssClasses(bpmnElementIds: string | string[], classNames: string | string[]): void {

--- a/test/shared/file-helper.ts
+++ b/test/shared/file-helper.ts
@@ -17,7 +17,7 @@ limitations under the License.
 import { readdirSync, readFileSync as fsReadFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-export function readFileSync(relativePathToSourceFile: string, encoding: BufferEncoding = 'utf-8', directoryName = __dirname): string {
+export function readFileSync(relativePathToSourceFile: string, encoding: BufferEncoding = 'utf8', directoryName = __dirname): string {
   return fsReadFileSync(join(directoryName, relativePathToSourceFile), { encoding });
 }
 


### PR DESCRIPTION
Add \`unicorn/prefer-at\`, \`unicorn/prefer-dom-node-dataset\`, \`unicorn/text-encoding-identifier-case\` rules.

https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/text-encoding-identifier-case.md  
https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-dom-node-dataset.md  
https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-at.md

Covers #2742