### PR TITLE
refactor: internally store more data of event definitions

### DIFF
--- a/src/component/parser/json/converter/EventDefinitionConverter.ts
+++ b/src/component/parser/json/converter/EventDefinitionConverter.ts
@@ -15,10 +15,11 @@ limitations under the License.
 */
 
 import type { ConvertedElements } from './utils';
-import type { TEventDefinition } from '../../../../model/bpmn/json/baseElement/rootElement/eventDefinition';
+import type { TEventDefinition, TLinkEventDefinition } from '../../../../model/bpmn/json/baseElement/rootElement/eventDefinition';
 import type { TDefinitions } from '../../../../model/bpmn/json/bpmn20';
 
 import { eventDefinitionKinds } from '../../../../model/bpmn/internal/shape/utils';
+import { isTLinkEventDefinition } from '../../../../model/bpmn/json/baseElement/rootElement/eventDefinition';
 import { ensureIsArray } from '../../../helpers/array-utils';
 
 type EventDefinitions = string | TEventDefinition | (string | TEventDefinition)[];
@@ -33,8 +34,19 @@ export default class EventDefinitionConverter {
     for (const eventDefinitionKind of eventDefinitionKinds) {
       // sometimes eventDefinition is simple, and therefore it is parsed as empty string "", in that case eventDefinition will be converted to an empty object
       const eventDefinitions = definitions[(eventDefinitionKind + 'EventDefinition') as keyof TDefinitions] as EventDefinitions;
-      for (const eventDefinition of ensureIsArray<TEventDefinition>(eventDefinitions, true))
-        this.convertedElements.registerEventDefinitionsOfDefinition(eventDefinition.id, eventDefinitionKind);
+      for (const eventDefinition of ensureIsArray<TEventDefinition>(eventDefinitions, true)) {
+        this.convertedElements.registerEventDefinitionsOfDefinition(eventDefinition.id, {
+          id: eventDefinition.id,
+          kind: eventDefinitionKind,
+
+          ...(isTLinkEventDefinition(eventDefinition)
+            ? ({
+                source: eventDefinition.source,
+                target: eventDefinition.target,
+              } satisfies Pick<TLinkEventDefinition, 'source' | 'target'>)
+            : {}),
+        });
+      }
     }
   }
 }

--- a/src/component/parser/json/converter/utils.ts
+++ b/src/component/parser/json/converter/utils.ts
@@ -17,11 +17,16 @@ limitations under the License.
 import type { GlobalTaskKind, ShapeBpmnEventDefinitionKind } from '../../../../model/bpmn/internal';
 import type { Flow, AssociationFlow, MessageFlow, SequenceFlow } from '../../../../model/bpmn/internal/edge/flows';
 import type { TGroup } from '../../../../model/bpmn/json/baseElement/artifact';
+import type { TEventDefinition, TLinkEventDefinition } from '../../../../model/bpmn/json/baseElement/rootElement/eventDefinition';
 import type { ParsingMessageCollector } from '../../parsing-messages';
 
 import { ShapeBpmnElementKind } from '../../../../model/bpmn/internal';
 import ShapeBpmnElement from '../../../../model/bpmn/internal/shape/ShapeBpmnElement';
 import { GroupUnknownCategoryValueWarning } from '../warnings';
+
+export type RegisteredEventDefinition = (Pick<TEventDefinition, 'id'> & Pick<TLinkEventDefinition, 'source' | 'target'>) & {
+  kind: ShapeBpmnEventDefinitionKind;
+};
 
 /**
  * @internal
@@ -86,11 +91,11 @@ export class ConvertedElements {
     this.associationFlows.set(associationFlow.id, associationFlow);
   }
 
-  private eventDefinitionsOfDefinitions = new Map<string, ShapeBpmnEventDefinitionKind>();
-  findEventDefinitionOfDefinition(id: string): ShapeBpmnEventDefinitionKind {
+  private eventDefinitionsOfDefinitions = new Map<string, RegisteredEventDefinition>();
+  findEventDefinitionOfDefinition(id: string): RegisteredEventDefinition {
     return this.eventDefinitionsOfDefinitions.get(id);
   }
-  registerEventDefinitionsOfDefinition(id: string, eventDefinition: ShapeBpmnEventDefinitionKind): void {
+  registerEventDefinitionsOfDefinition(id: string, eventDefinition: RegisteredEventDefinition): void {
     this.eventDefinitionsOfDefinitions.set(id, eventDefinition);
   }
 

--- a/src/model/bpmn/json/baseElement/rootElement/eventDefinition.ts
+++ b/src/model/bpmn/json/baseElement/rootElement/eventDefinition.ts
@@ -17,6 +17,8 @@ limitations under the License.
 import type { TRootElement } from './rootElement';
 import type { TExpression } from '../expression';
 
+export const isTLinkEventDefinition = (eventDefinition: TEventDefinition): eventDefinition is TLinkEventDefinition => 'source' in eventDefinition || 'target' in eventDefinition;
+
 // abstract="true"
 export type TEventDefinition = TRootElement;
 


### PR DESCRIPTION
Before, we only internally stored the `id`, `kind` and the number of occurrences of a `kind`.

For the link events, we need more data, like `source` and `target`.

Covers #2855 