### PR TITLE
feat: allow to disable parser console logs

### DIFF
--- a/src/component/options.ts
+++ b/src/component/options.ts
@@ -183,6 +183,11 @@ export type ParserOptions = {
    * @param val the value of the 'name' attribute to be processed.
    */
   additionalXmlAttributeProcessor?: (value: string) => string;
+  /**
+   * If `true`, disable the console logs produced by the parser.
+   * @default false
+   */
+  disableConsoleLog?: boolean;
 };
 
 /**

--- a/src/component/parser/BpmnParser.ts
+++ b/src/component/parser/BpmnParser.ts
@@ -41,5 +41,5 @@ class BpmnParser {
  * @internal
  */
 export function newBpmnParser(options?: ParserOptions): BpmnParser {
-  return new BpmnParser(newBpmnJsonParser(new ParsingMessageCollector()), new BpmnXmlParser(options));
+  return new BpmnParser(newBpmnJsonParser(new ParsingMessageCollector(options)), new BpmnXmlParser(options));
 }

--- a/src/component/parser/parsing-messages.ts
+++ b/src/component/parser/parsing-messages.ts
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import type { ParserOptions } from '../options';
+
 export interface MessageDetails {
   template: string;
   arguments: string[];
@@ -23,8 +25,15 @@ export abstract class JsonParsingWarning {
   abstract getMessage(): MessageDetails;
 }
 
+export type ParsingMessageCollectorOptions = Pick<ParserOptions, 'disableConsoleLog'>;
+
 export class ParsingMessageCollector {
+  constructor(private options?: ParsingMessageCollectorOptions) {}
+
   warning(warning: JsonParsingWarning): void {
+    if (this.options?.disableConsoleLog) {
+      return;
+    }
     const message = warning.getMessage();
     console.warn(`[bv-parser] ${message.template}`, ...message.arguments);
   }

--- a/test/unit/component/parser/parsing-messages.test.ts
+++ b/test/unit/component/parser/parsing-messages.test.ts
@@ -75,4 +75,18 @@ describe('parsing message collector', () => {
       );
     });
   });
+
+  describe('disabled logs: no console.warn when warning is registered', () => {
+    const parsingMessageCollector = new ParsingMessageCollector({ disableConsoleLog: true });
+
+    it('unknown edge bpmn element', () => {
+      parsingMessageCollector.warning(new EdgeUnknownBpmnElementWarning('edge-bpmnElement-unknown'));
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+
+    it('missing font in label style', () => {
+      parsingMessageCollector.warning(new LabelStyleMissingFontWarning('BPMNEdge_id_0', 'non-existing_style_id'));
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
Add a new option to prevent `ParserMessageCollector` from displaying warnings in the browser console.

closes #2698