### PR TITLE
feat: introduce a dedicated function to get the version

### DIFF
--- a/dev/ts/shared/main.ts
+++ b/dev/ts/shared/main.ts
@@ -27,7 +27,6 @@ import type {
   Overlay,
   PoolFilter,
   StyleUpdate,
-  Version,
   ZoomType,
 } from '../../../src/bpmn-visualization';
 import type { mxCell } from 'mxgraph';
@@ -352,12 +351,6 @@ export function downloadSvg(): void {
 export function downloadPng(): void {
   logDownload('Trigger PNG Download');
   downloadAsPng(new SvgExporter(bpmnVisualization.graph).exportSvgForPng());
-}
-
-export function getVersion(): Version {
-  const version = bpmnVisualization.getVersion();
-  log('Version:', version);
-  return version;
 }
 
 export function updateStyle(bpmnElementIds: string | string[], style: StyleUpdate): void {

--- a/src/bpmn-visualization.ts
+++ b/src/bpmn-visualization.ts
@@ -21,7 +21,7 @@ limitations under the License.
 export * from './component/options';
 export { BpmnVisualization } from './component/BpmnVisualization';
 export * from './component/registry';
-export type { Version } from './component/version';
+export * from './component/version';
 export type { Navigation } from './component/navigation';
 export * from './model/bpmn/internal';
 

--- a/src/component/BpmnVisualization.ts
+++ b/src/component/BpmnVisualization.ts
@@ -25,7 +25,7 @@ import { Navigation } from './navigation';
 import { newBpmnParser } from './parser/BpmnParser';
 import { createNewBpmnElementsRegistry } from './registry/bpmn-elements-registry';
 import { BpmnModelRegistry } from './registry/bpmn-model-registry';
-import { version, type Version } from './version';
+import { getVersion, type Version } from './version';
 
 /**
  * Let initialize `bpmn-visualization`. It requires at minimum to pass the HTMLElement in the page where the BPMN diagram is rendered.
@@ -96,7 +96,11 @@ export class BpmnVisualization {
     newBpmnRenderer(this.graph, this.rendererOptions).render(renderedModel, options?.fit);
   }
 
+  /**
+   * Returns the version of `bpmn-visualization` and the version of its dependencies.
+   * @deprecated As of `0.43.0`, use {@link getVersion} instead. This method will be removed in `0.45.0`.
+   */
   getVersion(): Version {
-    return version();
+    return getVersion();
   }
 }

--- a/src/component/version.ts
+++ b/src/component/version.ts
@@ -21,15 +21,15 @@ import { mxClient } from './mxgraph/initializer';
 const libraryVersion = '0.42.0-post';
 
 /**
- * @internal
+ * Returns the version of `bpmn-visualization` and the version of its dependencies.
+ * @since 0.43.0
  */
-export const version = (): Version => {
+export const getVersion = (): Version => {
   return { lib: libraryVersion, dependencies: new Map([['mxGraph', mxClient.VERSION]]) };
 };
 
 /**
- * Version of `bpmn-visualization` and its dependencies.
- * @category Initialization & Configuration
+ * The version of `bpmn-visualization` and the version of its dependencies.
  */
 export interface Version {
   /** The `bpmn-visualization` version. */

--- a/test/integration/BpmnVisualization.test.ts
+++ b/test/integration/BpmnVisualization.test.ts
@@ -65,6 +65,8 @@ describe('BpmnVisualization API', () => {
     });
   });
 
+  // Note: the tests here are duplicated with test/unit/component/version.test.ts
+  // They will be removed when the deprecated `BpmnVisualization.getVersion` method is removed
   describe('Version', () => {
     it('lib version', () => {
       expect(bpmnVisualization.getVersion().lib).toBe(getLibraryVersionFromPackageJson());

--- a/test/unit/component/version.test.ts
+++ b/test/unit/component/version.test.ts
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment jsdom
+ */
+/*
+Copyright 2023 Bonitasoft S.A.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { getVersion } from '@lib/component/version';
+import { readFileSync } from '@test/shared/file-helper';
+
+const getLibraryVersionFromPackageJson = (): string => {
+  const json = readFileSync('../../package.json');
+  const packageJson = JSON.parse(json);
+  return packageJson.version;
+};
+
+describe('Version', () => {
+  test('lib version', () => {
+    expect(getVersion().lib).toBe(getLibraryVersionFromPackageJson());
+  });
+
+  test('mxGraph version', () => {
+    expect(getVersion().dependencies.get('mxGraph')).toBeDefined();
+  });
+
+  test('not modifiable version', () => {
+    const initialVersion = getVersion();
+    initialVersion.lib = 'set by test';
+    initialVersion.dependencies.set('extra', 'added in test');
+
+    const newVersion = getVersion();
+    expect(newVersion.lib).not.toBe(initialVersion.lib);
+    expect(newVersion.dependencies).not.toBe(initialVersion.dependencies);
+  });
+});

--- a/tsconfig.typedoc.json
+++ b/tsconfig.typedoc.json
@@ -1,3 +1,6 @@
 {
   "extends": "./tsconfig.json",
+  "include": [
+    "src/**/*"
+  ]
 }


### PR DESCRIPTION
This simplifies the process of obtaining the version of `bpmn-visualization`.

Previously, it was necessary to instantiate `BpmnVisualization` to obtain the version, whereas this information was available without any other prerequisites.
The version can now be retrieved directly by calling the new `getVersion` function. The old `BpmnVisualization.getVersion` method has therefore been marked as deprecated, and will be removed in the future. In the API documentation, the new function and the existing `Version` type are not categorized. The `Version` type was previously categorized as "Initialization & Configuration", but in fact is not related to this topic.

In addition, the TypeScript configuration dedicated to Typedoc has been updated to take into account only the `src` folder and no longer the demo folder, which is not part of the API documentation. This speeds up documentation generation.