### PR TITLE
fix: ignore invalid event definition reference

### DIFF
--- a/src/component/parser/json/converter/ProcessConverter.ts
+++ b/src/component/parser/json/converter/ProcessConverter.ts
@@ -339,9 +339,6 @@ export default class ProcessConverter {
 
     for (const eventDefinitionReference of ensureIsArray<string>(bpmnElement.eventDefinitionRef)) {
       const eventDefinition = this.convertedElements.findEventDefinitionOfDefinition(eventDefinitionReference);
-      // TODO need to write a unit test
-      // eventDefinitionsByKind.get(eventDefinition.kind).push(eventDefinition);
-      // fix
       eventDefinition && eventDefinitionsByKind.get(eventDefinition.kind).push(eventDefinition);
     }
 

--- a/src/component/parser/json/converter/ProcessConverter.ts
+++ b/src/component/parser/json/converter/ProcessConverter.ts
@@ -339,7 +339,10 @@ export default class ProcessConverter {
 
     for (const eventDefinitionReference of ensureIsArray<string>(bpmnElement.eventDefinitionRef)) {
       const eventDefinition = this.convertedElements.findEventDefinitionOfDefinition(eventDefinitionReference);
-      eventDefinitionsByKind.get(eventDefinition.kind).push(eventDefinition);
+      // TODO need to write a unit test
+      // eventDefinitionsByKind.get(eventDefinition.kind).push(eventDefinition);
+      // fix
+      eventDefinition && eventDefinitionsByKind.get(eventDefinition.kind).push(eventDefinition);
     }
 
     for (const [kind] of [...eventDefinitionsByKind.entries()].filter(([, registeredEventDefinitions]) => registeredEventDefinitions.length === 0)) {

--- a/test/fixtures/bpmn/model-invalid-event-def-ref.bpmn
+++ b/test/fixtures/bpmn/model-invalid-event-def-ref.bpmn
@@ -1,0 +1,44 @@
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0x0opj6" targetNamespace="http://example.bpmn.com/schema/bpmn">
+<bpmn:process id="Process_1" isExecutable="false">
+  <bpmn:startEvent id="StartEvent_1" name="Start Event with invalid event definition reference">
+    <bpmn:eventDefinitionRef>top_message_definition_id_invalid_reference</bpmn:eventDefinitionRef>
+    <bpmn:outgoing>Flow_1</bpmn:outgoing>
+  </bpmn:startEvent>
+  <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="Activity_1" name="Sequence Flow 1" />
+  <bpmn:task id="Activity_1" name="Task 1">
+    <bpmn:incoming>Flow_1</bpmn:incoming>
+    <bpmn:outgoing>Flow_2</bpmn:outgoing>
+  </bpmn:task>
+  <bpmn:endEvent id="EndEvent_1" name="End Event 1">
+    <bpmn:incoming>Flow_2</bpmn:incoming>
+  </bpmn:endEvent>
+  <bpmn:sequenceFlow id="Flow_2" sourceRef="Activity_1" targetRef="EndEvent_1" />
+</bpmn:process>
+<bpmndi:BPMNDiagram id="BPMNDiagram_1">
+  <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+    <bpmndi:BPMNEdge id="BPMNEdge_Flow_1" bpmnElement="Flow_1">
+      <di:waypoint x="192" y="99" />
+      <di:waypoint x="250" y="99" />
+    </bpmndi:BPMNEdge>
+    <bpmndi:BPMNEdge id="BPMNEdge_Flow_2" bpmnElement="Flow_2">
+      <di:waypoint x="350" y="99" />
+      <di:waypoint x="412" y="99" />
+    </bpmndi:BPMNEdge>
+    <bpmndi:BPMNShape id="BPMNShape_StartEvent_1" bpmnElement="StartEvent_1">
+      <dc:Bounds x="156" y="81" width="36" height="36" />
+      <bpmndi:BPMNLabel>
+        <dc:Bounds x="158" y="124" width="33" height="14" />
+      </bpmndi:BPMNLabel>
+    </bpmndi:BPMNShape>
+    <bpmndi:BPMNShape id="BPMNShape_Activity_1" bpmnElement="Activity_1">
+      <dc:Bounds x="250" y="59" width="100" height="80" />
+    </bpmndi:BPMNShape>
+    <bpmndi:BPMNShape id="BPMNShape_EndEvent_1" bpmnElement="EndEvent_1">
+      <dc:Bounds x="412" y="81" width="36" height="36" />
+      <bpmndi:BPMNLabel>
+        <dc:Bounds x="416" y="124" width="29" height="14" />
+      </bpmndi:BPMNLabel>
+    </bpmndi:BPMNShape>
+  </bpmndi:BPMNPlane>
+</bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/integration/model.elements.api.test.ts
+++ b/test/integration/model.elements.api.test.ts
@@ -238,7 +238,7 @@ describe('Registry API - retrieve Model Bpmn elements', () => {
 
       expect(modelElements).toHaveLength(1);
       expectStartEvent(modelElements[0] as ShapeBpmnSemantic, {
-        eventDefinitionKind: ShapeBpmnEventDefinitionKind.NONE,
+        eventDefinitionKind: ShapeBpmnEventDefinitionKind.NONE, // no event definition reference, so use default
         id: 'StartEvent_1',
         name: 'Start Event with invalid event definition reference',
         outgoing: ['Flow_1'],

--- a/test/integration/model.elements.api.test.ts
+++ b/test/integration/model.elements.api.test.ts
@@ -229,6 +229,24 @@ describe('Registry API - retrieve Model Bpmn elements', () => {
     });
   });
 
+  describe('Get by ids - invalid references in diagram', () => {
+    test('Invalid event definition reference', () => {
+      const bpmnElementsRegistry = bpmnVisualization.bpmnElementsRegistry;
+
+      bpmnVisualization.load(readFileSync('../fixtures/bpmn/model-invalid-event-def-ref.bpmn'));
+      const modelElements = bpmnElementsRegistry.getModelElementsByIds('StartEvent_1');
+
+      expect(modelElements).toHaveLength(1);
+      expectStartEvent(modelElements[0] as ShapeBpmnSemantic, {
+        eventDefinitionKind: ShapeBpmnEventDefinitionKind.NONE,
+        id: 'StartEvent_1',
+        name: 'Start Event with invalid event definition reference',
+        outgoing: ['Flow_1'],
+        parentId: undefined,
+      });
+    });
+  });
+
   describe('Get by kinds', () => {
     const bv = initializeBpmnVisualization(null);
     const bpmnElementsRegistry = bv.bpmnElementsRegistry;


### PR DESCRIPTION
Previously, the parser assumed that the identifier reference in the event definition was valid, i.e. that the identifier was defined at the top level.
If this was not the case, the corresponding event definition was not retrieved. The following code attempted to access properties with undefined values.
This generated an error.

### Notes

- to reproduce the problem and check the fix in demo, you can use the diagram used in the new integration test introduced in this PR.
- this PR only adds an integration test and not a parsing unit test. If you think a unit test is required, please let me know.