### PR TITLE
test: check parsing of empty content

### DIFF
--- a/test/unit/component/parser/BpmnParser.test.ts
+++ b/test/unit/component/parser/BpmnParser.test.ts
@@ -33,6 +33,10 @@ describe('parse xml to model', () => {
   describe('error management', () => {
     const parsingErrorMessage = `XML parsing failed. Unable to retrieve 'definitions' from the BPMN source.`;
 
+    it('Parse empty content', () => {
+      expect(() => newBpmnParser().parse('')).toThrow(parsingErrorMessage);
+    });
+
     it('Parse a text file', () => {
       expect(() => newBpmnParser().parse(readFileSync('../fixtures/bpmn/xml-parsing/special/text-only.txt'))).toThrow(parsingErrorMessage);
     });


### PR DESCRIPTION
Add a test to check this use case.
This completes the textual content check.