### PR TITLE
fix: ensure numeric attributes are parsed as number

### DIFF
--- a/test/fixtures/bpmn/xml-parsing/itp-commerce_Vizi-Modeler-for-Microsoft-Visio_7.7151.18707_bug-2857.bpmn
+++ b/test/fixtures/bpmn/xml-parsing/itp-commerce_Vizi-Modeler-for-Microsoft-Visio_7.7151.18707_bug-2857.bpmn
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--Created by Vizi Modeler  for Microsoft Visio (http://www.itp-commerce.com)-->
+<definitions targetNamespace="http://www.itp-commerce.com" xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:itp="http://www.itp-commerce.com/BPMN2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://www.omg.org/spec/BPMN/20100501" exporter="Vizi Modeler for Microsoft Visio" exporterVersion="7.7151.18707" name="My Diagram" itp:version="1.0" itp:author="yonat" itp:creationDate="9/9/2023 12:14:12 AM" itp:modificationDate="9/17/2023 2:02:06 AM" itp:createdWithVersion="7.7151.18707" itp:conformanceSubClass="Full" id="_79f1a0ed-1f90-4caf-9b19-eb39daaecf52" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0">
+  <process id="_e455f64a-5bc7-4b3b-a677-fa2016390629" name="Example Process" processType="None" itp:isMainProcess="true">
+    <startEvent id="_e2f0bc4a-3322-47d0-b498-1a7e7c3bea7f" name="Engineer Troubleshooting">
+      <outgoing>_0a5cddd1-ba79-4a79-a523-f865393d895c</outgoing>
+    </startEvent>
+    <exclusiveGateway id="_7f712f24-9734-4df0-af0b-e8f9d3a62396" name="Does it move?" gatewayDirection="Diverging">
+      <incoming>_0a5cddd1-ba79-4a79-a523-f865393d895c</incoming>
+      <outgoing>_07921065-0775-4224-bbe2-248230479a18</outgoing>
+      <outgoing>_316925d8-db99-456f-8fab-b4b06e8ea139</outgoing>
+    </exclusiveGateway>
+    <exclusiveGateway id="_c15633c7-86a6-4900-80ad-ed39e70ad49d" name="Moves, should it?" gatewayDirection="Diverging">
+      <incoming>_316925d8-db99-456f-8fab-b4b06e8ea139</incoming>
+      <outgoing>_003a851a-471f-4b88-b386-9e9538b4c12c</outgoing>
+      <outgoing>_782252f0-e833-421c-a958-c3da4dc791a1</outgoing>
+    </exclusiveGateway>
+    <exclusiveGateway id="_ff03f209-68f1-4ff6-a677-688ac4893443" name="Doesn’t move, should it?" gatewayDirection="Diverging">
+      <incoming>_07921065-0775-4224-bbe2-248230479a18</incoming>
+      <outgoing>_1a8fd619-0ffc-4e68-88b0-eb09e2bca9b4</outgoing>
+      <outgoing>_1edba66a-70a3-4a01-b084-886e3a1eb2ed</outgoing>
+    </exclusiveGateway>
+    <task id="_16946daa-72b3-42d7-8ad1-5ea5b5004eb4" name="Solution - no problem">
+      <incoming>_782252f0-e833-421c-a958-c3da4dc791a1</incoming>
+    </task>
+    <task id="_ad7e6a77-80c9-4e88-af61-ca708d4269f1" name="Solution – Gaffer Tape">
+      <incoming>_003a851a-471f-4b88-b386-9e9538b4c12c</incoming>
+    </task>
+    <task id="_736e76d2-04bc-4bf7-9a1e-22e41e04a095" name="Solution – WD40">
+      <incoming>_1a8fd619-0ffc-4e68-88b0-eb09e2bca9b4</incoming>
+    </task>
+    <task id="_e4503f67-3673-48fd-8b2a-815cea2f8795" name="Solution – no problem">
+      <incoming>_1edba66a-70a3-4a01-b084-886e3a1eb2ed</incoming>
+    </task>
+    <sequenceFlow id="_0a5cddd1-ba79-4a79-a523-f865393d895c" sourceRef="_e2f0bc4a-3322-47d0-b498-1a7e7c3bea7f" targetRef="_7f712f24-9734-4df0-af0b-e8f9d3a62396">
+    </sequenceFlow>
+    <sequenceFlow id="_07921065-0775-4224-bbe2-248230479a18" name="Does it move&#xD;&#xA;no" sourceRef="_7f712f24-9734-4df0-af0b-e8f9d3a62396" targetRef="_ff03f209-68f1-4ff6-a677-688ac4893443">
+      <conditionExpression>test='Does it move - no'</conditionExpression>
+    </sequenceFlow>
+    <sequenceFlow id="_316925d8-db99-456f-8fab-b4b06e8ea139" name="Does it move&#xD;&#xA;yes" sourceRef="_7f712f24-9734-4df0-af0b-e8f9d3a62396" targetRef="_c15633c7-86a6-4900-80ad-ed39e70ad49d">
+      <conditionExpression>test='Does it move - no'</conditionExpression>
+    </sequenceFlow>
+    <sequenceFlow id="_1a8fd619-0ffc-4e68-88b0-eb09e2bca9b4" name="Should it move&#xD;&#xA;yes" sourceRef="_ff03f209-68f1-4ff6-a677-688ac4893443" targetRef="_736e76d2-04bc-4bf7-9a1e-22e41e04a095">
+      <conditionExpression>test='Should it move
+        yes'
+      </conditionExpression>
+    </sequenceFlow>
+    <sequenceFlow id="_003a851a-471f-4b88-b386-9e9538b4c12c" name="Should it move&#xD;&#xA;no" sourceRef="_c15633c7-86a6-4900-80ad-ed39e70ad49d" targetRef="_ad7e6a77-80c9-4e88-af61-ca708d4269f1">
+      <conditionExpression>test='Should it move – no'</conditionExpression>
+    </sequenceFlow>
+    <sequenceFlow id="_782252f0-e833-421c-a958-c3da4dc791a1" name="Should it move&#xD;&#xA;yes" sourceRef="_c15633c7-86a6-4900-80ad-ed39e70ad49d" targetRef="_16946daa-72b3-42d7-8ad1-5ea5b5004eb4">
+      <conditionExpression>test='Should it move – yes'</conditionExpression>
+    </sequenceFlow>
+    <sequenceFlow id="_1edba66a-70a3-4a01-b084-886e3a1eb2ed" name="Should it move&#xD;&#xA;no" sourceRef="_ff03f209-68f1-4ff6-a677-688ac4893443" targetRef="_e4503f67-3673-48fd-8b2a-815cea2f8795">
+      <conditionExpression>test='Should it move
+        yes'
+      </conditionExpression>
+    </sequenceFlow>
+  </process>
+  <bpmndi:BPMNDiagram name="My Diagram (1)" resolution="72" id="fsafsasa">
+    <bpmndi:BPMNPlane id="_1" bpmnElement="_e455f64a-5bc7-4b3b-a677-fa2016390629">
+      <bpmndi:BPMNShape id="_BA5FD27D-30DD-4F4F-93B3-A76CC5C4D0D2" bpmnElement="_e2f0bc4a-3322-47d0-b498-1a7e7c3bea7f" itp:label="Engineer Troubleshooting" itp:elementType="startEvent" color:background-color="#F2F2F2" color:border-color="#3F3F3F">
+        <dc:Bounds x="415.2755905511811" y="82.204724409448886" width="17.007874015748033" height="17.007874015748033" />
+        <bpmndi:BPMNLabel labelStyle="_48d532ae-841e-4133-bd67-f56ac81e8ca1" color:color="#3F3F3F">
+          <dc:Bounds x="396.36" y="100.995590551181" width="55.44" height="19.44" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_00F67C55-1CB2-4F9A-AC31-AEA25B38FB7F" bpmnElement="_7f712f24-9734-4df0-af0b-e8f9d3a62396" isMarkerVisible="false" itp:label="Does it move?" itp:elementType="exclusiveGateway" color:background-color="#F2F2F2" color:border-color="#3F3F3F">
+        <dc:Bounds x="402.51968503937007" y="166.53543307086613" width="42.519685039370081" height="31.889763779527563" />
+        <bpmndi:BPMNLabel labelStyle="_48d532ae-841e-4133-bd67-f56ac81e8ca1" color:color="#3F3F3F">
+          <dc:Bounds x="399.96" y="201.075590551181" width="48.24" height="9.36" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_F796B6B4-E15B-40B1-AAC5-C5A3DE4494A7" bpmnElement="_c15633c7-86a6-4900-80ad-ed39e70ad49d" isMarkerVisible="false" itp:label="Moves, should it?" itp:elementType="exclusiveGateway" color:background-color="#F2F2F2" color:border-color="#3F3F3F">
+        <dc:Bounds x="262.20472440944883" y="239.17322834645671" width="42.519685039370081" height="31.889763779527563" />
+        <bpmndi:BPMNLabel labelStyle="_48d532ae-841e-4133-bd67-f56ac81e8ca1" color:color="#3F3F3F">
+          <dc:Bounds x="254.16" y="273.795590551181" width="59.04" height="9.36" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_71610F1A-495C-4A2D-80E1-81EF744B0830" bpmnElement="_ff03f209-68f1-4ff6-a677-688ac4893443" isMarkerVisible="false" itp:label="Doesn’t move, should it?" itp:elementType="exclusiveGateway" color:background-color="#F2F2F2" color:border-color="#3F3F3F">
+        <dc:Bounds x="556.29921259842513" y="239.17322834645671" width="42.519685039370081" height="31.889763779527563" />
+        <bpmndi:BPMNLabel labelStyle="_48d532ae-841e-4133-bd67-f56ac81e8ca1" color:color="#3F3F3F">
+          <dc:Bounds x="536.04" y="273.795590551181" width="82.8" height="9.36" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_795D0D8D-0AE5-4DE0-87CB-4EAB74C3B17D" bpmnElement="_16946daa-72b3-42d7-8ad1-5ea5b5004eb4" itp:label="Solution - no problem" itp:elementType="task" color:background-color="#F2F2F2" color:border-color="#3F3F3F">
+        <dc:Bounds x="160.62987401574804" y="340.15748031496065" width="85.039370078740163" height="42.519685039370081" />
+        <bpmndi:BPMNLabel labelStyle="_48d532ae-841e-4133-bd67-f56ac81e8ca1" color:color="#3F3F3F">
+          <dc:Bounds x="166.68" y="357.315590551181" width="72.72" height="7.92" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_575DFE12-EBF8-4C00-9F42-8B9527AB6D2B" bpmnElement="_ad7e6a77-80c9-4e88-af61-ca708d4269f1" itp:label="Solution – Gaffer Tape" itp:elementType="task" color:background-color="#F2F2F2" color:border-color="#3F3F3F">
+        <dc:Bounds x="327.75590551181108" y="340.15748031496065" width="85.039370078740163" height="42.519685039370081" />
+        <bpmndi:BPMNLabel labelStyle="_48d532ae-841e-4133-bd67-f56ac81e8ca1" color:color="#3F3F3F">
+          <dc:Bounds x="332.64" y="357.315590551181" width="74.88" height="7.92" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_42B1F06C-D6E0-44AE-83D6-C4AE7A110C6D" bpmnElement="_736e76d2-04bc-4bf7-9a1e-22e41e04a095" itp:label="Solution – WD40" itp:elementType="task" color:background-color="#F2F2F2" color:border-color="#3F3F3F">
+        <dc:Bounds x="460.62992125984255" y="340.15748031496065" width="85.039370078740163" height="42.519685039370081" />
+        <bpmndi:BPMNLabel labelStyle="_48d532ae-841e-4133-bd67-f56ac81e8ca1" color:color="#3F3F3F">
+          <dc:Bounds x="475.2" y="357.315590551181" width="56.16" height="7.92" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_55A4384C-7AEB-424C-9F11-0064D086A1BE" bpmnElement="_e4503f67-3673-48fd-8b2a-815cea2f8795" itp:label="Solution – no problem" itp:elementType="task" color:background-color="#F2F2F2" color:border-color="#3F3F3F">
+        <dc:Bounds x="634.251968503937" y="340.15748031496065" width="85.039370078740163" height="42.519685039370081" />
+        <bpmndi:BPMNLabel labelStyle="_48d532ae-841e-4133-bd67-f56ac81e8ca1" color:color="#3F3F3F">
+          <dc:Bounds x="639.72" y="357.315590551181" width="74.16" height="7.92" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_3D0F724C-6376-4BA9-AE0D-112FA1C941A5" bpmnElement="_0a5cddd1-ba79-4a79-a523-f865393d895c" itp:label="(unnamed)" itp:elementType="sequenceFlow" color:border-color="#404040">
+        <di:waypoint x="423.77952755905511" y="99.212598425196916" />
+        <di:waypoint x="423.77952755905511" y="166.53543307086613" />
+        <bpmndi:BPMNLabel labelStyle="_48d532ae-841e-4133-bd67-f56ac81e8ca1" color:color="#404040">
+          <dc:Bounds x="426.6" y="124.395590551181" width="7.92" height="17.28" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_7A3B4F0A-FB98-41F2-A77E-DE47B57C3C28" bpmnElement="_07921065-0775-4224-bbe2-248230479a18" itp:label="Does it move&#xD;&#xA;no" itp:elementType="sequenceFlow" color:border-color="#404040">
+        <di:waypoint x="445.03937007874021" y="182.48031496062993" />
+        <di:waypoint x="577.55905511811022" y="182.48031496062993" />
+        <di:waypoint x="577.55905511811022" y="239.17322834645677" />
+        <bpmndi:BPMNLabel labelStyle="_48d532ae-841e-4133-bd67-f56ac81e8ca1" color:color="#404040">
+          <dc:Bounds x="488.16" y="172.995590551181" width="46.08" height="19.44" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_45049049-69BA-49BC-A96D-C0E9CB49936B" bpmnElement="_316925d8-db99-456f-8fab-b4b06e8ea139" itp:label="Does it move&#xD;&#xA;yes" itp:elementType="sequenceFlow" color:border-color="#404040">
+        <di:waypoint x="402.51968503937013" y="182.48031496062993" />
+        <di:waypoint x="283.46456692913387" y="182.48031496062993" />
+        <di:waypoint x="283.46456692913387" y="239.17322834645677" />
+        <bpmndi:BPMNLabel labelStyle="_48d532ae-841e-4133-bd67-f56ac81e8ca1" color:color="#404040">
+          <dc:Bounds x="319.68" y="172.995590551181" width="46.08" height="19.44" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_07F8A89B-3C87-45C1-9C35-168DA71B59E8" bpmnElement="_1a8fd619-0ffc-4e68-88b0-eb09e2bca9b4" itp:label="Should it move&#xD;&#xA;yes" itp:elementType="sequenceFlow" color:border-color="#404040">
+        <di:waypoint x="556.29921259842524" y="255.1181102362205" />
+        <di:waypoint x="503.14960629921262" y="255.1181102362205" />
+        <di:waypoint x="503.14960629921262" y="340.15748031496065" />
+        <bpmndi:BPMNLabel labelStyle="_48d532ae-841e-4133-bd67-f56ac81e8ca1" color:color="#404040">
+          <dc:Bounds x="488.16" y="283.515590551181" width="30.24" height="28.8" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_752529A0-4272-4730-819E-7DBD2E873026" bpmnElement="_003a851a-471f-4b88-b386-9e9538b4c12c" itp:label="Should it move&#xD;&#xA;no" itp:elementType="sequenceFlow" color:border-color="#404040">
+        <di:waypoint x="304.72440944881896" y="255.1181102362205" />
+        <di:waypoint x="370.27559055118115" y="255.1181102362205" />
+        <di:waypoint x="370.27559055118115" y="340.15748031496065" />
+        <bpmndi:BPMNLabel labelStyle="_48d532ae-841e-4133-bd67-f56ac81e8ca1" color:color="#404040">
+          <dc:Bounds x="354.96" y="283.515590551181" width="30.24" height="28.8" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_B693A9D0-2D74-4A95-BEFB-4E0477B49040" bpmnElement="_782252f0-e833-421c-a958-c3da4dc791a1" itp:label="Should it move&#xD;&#xA;yes" itp:elementType="sequenceFlow" color:border-color="#404040">
+        <di:waypoint x="262.20472440944883" y="255.1181102362205" />
+        <di:waypoint x="203.14955905511812" y="255.1181102362205" />
+        <di:waypoint x="203.14955905511812" y="340.15748031496065" />
+        <bpmndi:BPMNLabel labelStyle="_48d532ae-841e-4133-bd67-f56ac81e8ca1" color:color="#404040">
+          <dc:Bounds x="187.92" y="283.515590551181" width="30.24" height="28.8" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_8A5FE0E0-EE32-4913-B2C8-DD1E5D74493C" bpmnElement="_1edba66a-70a3-4a01-b084-886e3a1eb2ed" itp:label="Should it move&#xD;&#xA;no" itp:elementType="sequenceFlow" color:border-color="#404040">
+        <di:waypoint x="598.81889763779532" y="255.1181102362205" />
+        <di:waypoint x="676.771653543307" y="255.1181102362205" />
+        <di:waypoint x="676.771653543307" y="340.15748031496065" />
+        <bpmndi:BPMNLabel labelStyle="_48d532ae-841e-4133-bd67-f56ac81e8ca1" color:color="#404040">
+          <dc:Bounds x="661.68" y="283.515590551181" width="30.24" height="28.8" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+    <bpmndi:BPMNLabelStyle id="_48d532ae-841e-4133-bd67-f56ac81e8ca1">
+      <dc:Font name="Calibri" size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" />
+    </bpmndi:BPMNLabelStyle>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/test/fixtures/bpmn/xml-parsing/special/simple-start-task-end_large_numbers_and_large_decimals.bpmn
+++ b/test/fixtures/bpmn/xml-parsing/special/simple-start-task-end_large_numbers_and_large_decimals.bpmn
@@ -16,21 +16,27 @@
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
       <bpmndi:BPMNEdge id="BPMNEdge_Flow_1" bpmnElement="Flow_1">
-        <di:waypoint x="192" y="99" />
-        <di:waypoint x="250" y="99" />
+        <di:waypoint x="192" y="99.4" />
+        <di:waypoint x="250.12" y="99.9246" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="258.6546874216876435469813" y="94.549684316846518435138654654687" width="53.1264613658746467887414" height="84.4318764313576846543564684651454646" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="BPMNEdge_Flow_2" bpmnElement="Flow_2">
-        <di:waypoint x="350" y="99" />
-        <di:waypoint x="412" y="99" />
+        <di:waypoint x="350.010000000545455749847855625445" y="99.000000000048548464923279646" />
+        <di:waypoint x="412.658" y="99.12" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="BPMNShape_StartEvent_1" bpmnElement="StartEvent_1">
-        <dc:Bounds x="156.10001" y="81.345000000000009" width="36.0003450001000002" height="36.0000001" />
+        <dc:Bounds x="156.10001000256464316843136874561354684" y="81.345000000000009" width="36.0003450001000002" height="36.00000010035496143139997251548445" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="158" y="124" width="33" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_Activity_1" bpmnElement="Activity_1">
-        <dc:Bounds x="250" y="59" width="100" height="80" />
+        <dc:Bounds x="250" y="59.7954442" width="100.6789421" height="80" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="251.546168735168735133580035789" y="62.5357631000046898412244767058" width="33.659851435460054800548744548" height="18.245131658435165843221640005446841658416841" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_EndEvent_1" bpmnElement="EndEvent_1">
         <dc:Bounds x="412" y="81" width="36" height="36" />

--- a/test/integration/mxGraph.model.bpmn.elements.test.ts
+++ b/test/integration/mxGraph.model.bpmn.elements.test.ts
@@ -36,7 +36,7 @@ import {
   ShapeBpmnMarkerKind,
   ShapeBpmnSubProcessKind,
 } from '@lib/bpmn-visualization';
-import { mxgraph, mxConstants, mxPoint } from '@lib/component/mxgraph/initializer';
+import { mxConstants, mxgraph, mxPoint } from '@lib/component/mxgraph/initializer';
 import { readFileSync } from '@test/shared/file-helper';
 
 const mxGeometry = mxgraph.mxGeometry;
@@ -44,8 +44,10 @@ const mxGeometry = mxgraph.mxGeometry;
 describe('mxGraph model - BPMN elements', () => {
   describe('BPMN elements should be available in the mxGraph model', () => {
     describe('Diagram with all the kind of elements', () => {
-      // load BPMN
-      bpmnVisualization.load(readFileSync('../fixtures/bpmn/model-complete-semantic.bpmn'));
+      beforeAll(() => {
+        // load BPMN
+        bpmnVisualization.load(readFileSync('../fixtures/bpmn/model-complete-semantic.bpmn'));
+      });
 
       const expectedBoldFont = {
         isBold: true,
@@ -1517,8 +1519,7 @@ describe('mxGraph model - BPMN elements', () => {
 
     it('Diagram with a not displayed pool (without shape) with elements', () => {
       // load BPMN
-      const bpmnDiagramToFilter = readFileSync('../fixtures/bpmn/bpmn-rendering/pools.04.not.displayed.with.elements.bpmn');
-      bpmnVisualization.load(bpmnDiagramToFilter);
+      bpmnVisualization.load(readFileSync('../fixtures/bpmn/bpmn-rendering/pools.04.not.displayed.with.elements.bpmn'));
 
       expectPoolsInModel(0);
 
@@ -1678,28 +1679,29 @@ describe('mxGraph model - BPMN elements', () => {
     it('Parse a diagram with large numbers and large decimals', () => {
       bpmnVisualization.load(readFileSync('../fixtures/bpmn/xml-parsing/special/simple-start-task-end_large_numbers_and_large_decimals.bpmn'));
 
+      const startEvent1Geometry = new mxGeometry(
+        156.100_010_002_564_63,
+        81.345_000_000_000_01, // 81.345000000000009 in the diagram
+        // eslint-disable-next-line @typescript-eslint/no-loss-of-precision
+        36.000_345_000_100_000_2, // 36.0003450001000002 in the diagram
+        36.000_000_100_354_96,
+      );
+      startEvent1Geometry.offset = new mxPoint(1.899_989_997_435_369_6, 42.654_999_999_999_99);
       expect('StartEvent_1').toBeCellWithParentAndGeometry({
         parentId: defaultParentId,
-        geometry: new mxGeometry(
-          156.100_01,
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
-          '81.3450000000000090', // 81.345000000000009 in the diagram
-          '36.0003450001000002',
-          36.000_000_1,
-        ),
+        geometry: startEvent1Geometry,
       });
 
       expect('Activity_1').toBeCellWithParentAndGeometry({
         parentId: defaultParentId,
-        geometry: new mxGeometry(250, 59, 100, 80),
+        geometry: new mxGeometry(250, 59.795_444_2, 100.678_942_1, 80),
       });
 
-      const geometry = new mxGeometry(412, 81, 36, 36);
-      geometry.offset = new mxPoint(4.16e25, 1.240_000_000_03e29);
+      const endEvent1Geometry = new mxGeometry(412, 81, 36, 36);
+      endEvent1Geometry.offset = new mxPoint(4.16e25, 1.240_000_000_03e29);
       expect('EndEvent_1').toBeCellWithParentAndGeometry({
         parentId: defaultParentId,
-        geometry: geometry,
+        geometry: endEvent1Geometry,
       });
     });
 
@@ -1709,10 +1711,8 @@ describe('mxGraph model - BPMN elements', () => {
       expect('Activity_1').toBeCellWithParentAndGeometry({
         parentId: defaultParentId,
         geometry: new mxGeometry(
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore malformed source, conversion result
-          'not_a_number0', // from 'not_a_number'
-          'not a number too0', // from 'not a number too'
+          Number.NaN, // from 'not_a_number'
+          Number.NaN, // from 'not a number too'
           -100,
           -80,
         ),

--- a/test/unit/component/parser/xml/BpmnXmlParser.00.special.parsing.cases.test.ts
+++ b/test/unit/component/parser/xml/BpmnXmlParser.00.special.parsing.cases.test.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import type { BPMNDiagram, BPMNLabel, BPMNShape } from '@lib/model/bpmn/json/bpmndi';
+import type { BPMNDiagram, BPMNEdge, BPMNLabel, BPMNShape } from '@lib/model/bpmn/json/bpmndi';
 
 import BpmnXmlParser from '@lib/component/parser/xml/BpmnXmlParser';
 import Bounds from '@lib/model/bpmn/internal/Bounds';
@@ -38,18 +38,58 @@ describe('Special parsing cases', () => {
     const shapes = bpmnDiagram.BPMNPlane.BPMNShape as BPMNShape[];
     const getShape = (id: string): BPMNShape => shapes.find(s => s.id == id);
 
-    // string instead of number
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore width and y are parsed as string. They have too many decimals
-    expect(getShape('BPMNShape_StartEvent_1').Bounds).toEqual(new Bounds(156.100_01, '81.345000000000009', '36.0003450001000002', 36.000_000_1));
+    const edges = bpmnDiagram.BPMNPlane.BPMNEdge as BPMNEdge[];
+    const getEdge = (id: string): BPMNEdge => edges.find(s => s.id == id);
 
-    expect(getShape('BPMNShape_Activity_1').Bounds).toEqual(new Bounds(250, 59, 100, 80));
+    expect(getShape('BPMNShape_StartEvent_1').Bounds).toEqual(
+      new Bounds(
+        156.100_010_002_564_63, // 156.10001000256464316843136874561354684 in the diagram
+        81.345_000_000_000_01, // 81.345000000000009 in the diagram
+        36.000_345_000_1, // 36.0003450001000002 in the diagram
+        36.000_000_100_354_96, // 36.00000010035496143139997251548445 in the diagram
+      ),
+    );
+
+    const activity1 = getShape('BPMNShape_Activity_1');
+    // standard numbers for bounds
+    expect(activity1.Bounds).toEqual(new Bounds(250, 59.795_444_2, 100.678_942_1, 80));
+    // large number decimals for label bounds
+    expect((activity1.BPMNLabel as BPMNLabel).Bounds).toEqual(
+      new Bounds(
+        251.546_168_735_168_75, // 251.546168735168735133580035789 in the diagram
+        62.535_763_100_004_69, // 62.5357631000046898412244767058 in the diagram
+        33.659_851_435_460_055, // 33.659851435460054800548744548 in the diagram
+        18.245_131_658_435_167, // '18.245131658435165843221640005446841658416841 in the diagram
+      ),
+    );
 
     // large numbers use scientific notation or converted as string
     const endEventShape = getShape('BPMNShape_EndEvent_1');
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore width converted to string to not get a truncated number at runtime
-    expect((endEventShape.BPMNLabel as BPMNLabel).Bounds).toEqual(new Bounds(4.16e25, 1.240_000_000_03e29, '20000000000000000009', 1.4e21));
+    expect((endEventShape.BPMNLabel as BPMNLabel).Bounds).toEqual(new Bounds(4.16e25, 1.240_000_000_03e29, 20_000_000_000_000_000_000, 1.4e21));
+
+    // label bounds of edge
+    const edge1 = getEdge('BPMNEdge_Flow_1');
+    expect((edge1.BPMNLabel as BPMNLabel).Bounds).toEqual(
+      new Bounds(
+        258.654_687_421_687_64, // 258.6546874216876435469813 in the diagram
+        94.549_684_316_846_52, // 94.549684316846518435138654654687 in the diagram
+        53.126_461_365_874_65, // 53.1264613658746467887414 in the diagram
+        84.431_876_431_357_68, // 84.4318764313576846543564684651454646 in the diagram
+      ),
+    );
+    const edge1Waypoints = edge1.waypoint;
+    expect(edge1Waypoints).toHaveLength(2);
+    expect(edge1Waypoints[0]).toEqual({ x: 192, y: 99.4 });
+    expect(edge1Waypoints[1]).toEqual({ x: 250.12, y: 99.9246 });
+
+    // waypoints of edge
+    const edge2Waypoints = getEdge('BPMNEdge_Flow_2').waypoint;
+    expect(edge2Waypoints).toHaveLength(2);
+    expect(edge2Waypoints[0]).toEqual({
+      x: 350.010_000_000_545_46, // 350.010000000545455749847855625445 in the diagram
+      y: 99.000_000_000_048_54, // 99.000000000048548464923279646 in the diagram
+    });
+    expect(edge2Waypoints[1]).toEqual({ x: 412.658, y: 99.12 });
   });
 
   it('Parse a diagram with numbers not parsable as number', () => {
@@ -60,9 +100,14 @@ describe('Special parsing cases', () => {
     const getShape = (id: string): BPMNShape => shapes.find(s => s.id == id);
 
     // x and y values are string instead of number in the source diagram
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore x and y are parsed as string as defined in the BPMN diagram
-    expect(getShape('BPMNShape_Activity_1').Bounds).toEqual(new Bounds('not_a_number', 'not a number too', -100, -80));
+    expect(getShape('BPMNShape_Activity_1').Bounds).toEqual(
+      new Bounds(
+        Number.NaN, // 'not_a_number' in the diagram
+        Number.NaN, // 'not a number too' in the diagram
+        -100,
+        -80,
+      ),
+    );
   });
 
   it('Parse a diagram with entities in the name attributes', () => {

--- a/test/unit/component/parser/xml/BpmnXmlParser.itp-commerce.7-7151-18707.test.ts
+++ b/test/unit/component/parser/xml/BpmnXmlParser.itp-commerce.7-7151-18707.test.ts
@@ -39,12 +39,6 @@ describe('parse bpmn as xml for ipt-commerce Vizi Modeler for Microsoft Visio 7.
 
     // Ensure that coordinates are parsed correctly as number. Fix for https://github.com/process-analytics/bpmn-visualization-js/issues/2857
     const shapeBounds = shapes.find(shape => shape.id === '_BA5FD27D-30DD-4F4F-93B3-A76CC5C4D0D2').Bounds;
-    // <bpmndi:BPMNShape id="_BA5FD27D-30DD-4F4F-93B3-A76CC5C4D0D2" bpmnElement="_e2f0bc4a-3322-47d0-b498-1a7e7c3bea7f" itp:label="Engineer Troubleshooting" itp:elementType="startEvent" color:background-color="#F2F2F2" color:border-color="#3F3F3F">
-    //   <dc:Bounds x="415.2755905511811" y="82.204724409448886" width="17.007874015748033" height="17.007874015748033" />
-    //   <bpmndi:BPMNLabel labelStyle="_48d532ae-841e-4133-bd67-f56ac81e8ca1" color:color="#3F3F3F">
-    //     <dc:Bounds x="396.36" y="100.995590551181" width="55.44" height="19.44" />
-    //   </bpmndi:BPMNLabel>
-    // </bpmndi:BPMNShape>
     expect(shapeBounds).toEqual({
       x: 415.275_590_551_181_1,
       y: 82.204_724_409_448_89,
@@ -52,14 +46,6 @@ describe('parse bpmn as xml for ipt-commerce Vizi Modeler for Microsoft Visio 7.
       height: 17.007_874_015_748_033,
     });
 
-    // <bpmndi:BPMNEdge id="_7A3B4F0A-FB98-41F2-A77E-DE47B57C3C28" bpmnElement="_07921065-0775-4224-bbe2-248230479a18" itp:label="Does it move&#xD;&#xA;no" itp:elementType="sequenceFlow" color:border-color="#404040">
-    //   <di:waypoint x="445.03937007874021" y="182.48031496062993" />
-    //   <di:waypoint x="577.55905511811022" y="182.48031496062993" />
-    //   <di:waypoint x="577.55905511811022" y="239.17322834645677" />
-    //   <bpmndi:BPMNLabel labelStyle="_48d532ae-841e-4133-bd67-f56ac81e8ca1" color:color="#404040">
-    //     <dc:Bounds x="488.16" y="172.995590551181" width="46.08" height="19.44" />
-    //   </bpmndi:BPMNLabel>
-    // </bpmndi:BPMNEdge>
     const edgeWaypoints = edges.find(edge => edge.id === '_7A3B4F0A-FB98-41F2-A77E-DE47B57C3C28').waypoint;
     expect(edgeWaypoints).toEqual([
       { x: 445.039_370_078_740_21, y: 182.480_314_960_629_93 },

--- a/test/unit/component/parser/xml/BpmnXmlParser.itp-commerce.7-7151-18707.test.ts
+++ b/test/unit/component/parser/xml/BpmnXmlParser.itp-commerce.7-7151-18707.test.ts
@@ -1,0 +1,70 @@
+/*
+Copyright 2024 Bonitasoft S.A.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import type { TProcess } from '@lib/model/bpmn/json/baseElement/rootElement/rootElement';
+import type { BPMNDiagram, BPMNEdge, BPMNShape } from '@lib/model/bpmn/json/bpmndi';
+
+import BpmnXmlParser from '@lib/component/parser/xml/BpmnXmlParser';
+import { readFileSync } from '@test/shared/file-helper';
+
+describe('parse bpmn as xml for ipt-commerce Vizi Modeler for Microsoft Visio 7.7151.18707', () => {
+  it('bpmn with process with extension, ensure elements are present', () => {
+    const a20Process = readFileSync('../fixtures/bpmn/xml-parsing/itp-commerce_Vizi-Modeler-for-Microsoft-Visio_7.7151.18707_bug-2857.bpmn');
+
+    const json = new BpmnXmlParser().parse(a20Process);
+
+    const process: TProcess = json.definitions.process as TProcess;
+    expect(process.task).toHaveLength(4);
+    expect(process.exclusiveGateway).toHaveLength(3);
+    expect(process.sequenceFlow).toHaveLength(7);
+
+    const bpmnPlane = (json.definitions.BPMNDiagram as BPMNDiagram).BPMNPlane;
+    const shapes = bpmnPlane.BPMNShape as BPMNShape[];
+    expect(shapes).toHaveLength(8);
+    const edges = bpmnPlane.BPMNEdge as BPMNEdge[];
+    expect(edges).toHaveLength(7);
+
+    // Ensure that coordinates are parsed correctly as number. Fix for https://github.com/process-analytics/bpmn-visualization-js/issues/2857
+    const shapeBounds = shapes.find(shape => shape.id === '_BA5FD27D-30DD-4F4F-93B3-A76CC5C4D0D2').Bounds;
+    // <bpmndi:BPMNShape id="_BA5FD27D-30DD-4F4F-93B3-A76CC5C4D0D2" bpmnElement="_e2f0bc4a-3322-47d0-b498-1a7e7c3bea7f" itp:label="Engineer Troubleshooting" itp:elementType="startEvent" color:background-color="#F2F2F2" color:border-color="#3F3F3F">
+    //   <dc:Bounds x="415.2755905511811" y="82.204724409448886" width="17.007874015748033" height="17.007874015748033" />
+    //   <bpmndi:BPMNLabel labelStyle="_48d532ae-841e-4133-bd67-f56ac81e8ca1" color:color="#3F3F3F">
+    //     <dc:Bounds x="396.36" y="100.995590551181" width="55.44" height="19.44" />
+    //   </bpmndi:BPMNLabel>
+    // </bpmndi:BPMNShape>
+    expect(shapeBounds).toEqual({
+      x: 415.275_590_551_181_1,
+      y: 82.204_724_409_448_89,
+      width: 17.007_874_015_748_033,
+      height: 17.007_874_015_748_033,
+    });
+
+    // <bpmndi:BPMNEdge id="_7A3B4F0A-FB98-41F2-A77E-DE47B57C3C28" bpmnElement="_07921065-0775-4224-bbe2-248230479a18" itp:label="Does it move&#xD;&#xA;no" itp:elementType="sequenceFlow" color:border-color="#404040">
+    //   <di:waypoint x="445.03937007874021" y="182.48031496062993" />
+    //   <di:waypoint x="577.55905511811022" y="182.48031496062993" />
+    //   <di:waypoint x="577.55905511811022" y="239.17322834645677" />
+    //   <bpmndi:BPMNLabel labelStyle="_48d532ae-841e-4133-bd67-f56ac81e8ca1" color:color="#404040">
+    //     <dc:Bounds x="488.16" y="172.995590551181" width="46.08" height="19.44" />
+    //   </bpmndi:BPMNLabel>
+    // </bpmndi:BPMNEdge>
+    const edgeWaypoints = edges.find(edge => edge.id === '_7A3B4F0A-FB98-41F2-A77E-DE47B57C3C28').waypoint;
+    expect(edgeWaypoints).toEqual([
+      { x: 445.039_370_078_740_21, y: 182.480_314_960_629_93 },
+      { x: 577.559_055_118_110_2, y: 182.480_314_960_629_93 },
+      { x: 577.559_055_118_110_2, y: 239.173_228_346_456_77 },
+    ]);
+  });
+});


### PR DESCRIPTION
The XML parser now ensures that the following elements have numeric attributes
  - bounds of shapes
  - label bounds of shapes and edges
  - waypoints of edges

Previously, when the attribute contained too many decimals, the value was converted to a string instead of a number. Existing tests exhibited this behavior; they have been modified and enriched to cover all use cases and show that the issue is now fixed.
A high-level parsing test has also been added to use the diagram that was provided by the community to show the past problem.

closes #2857

### Screencasts

Using the diagram provided to exhibit the issue in #2857 

https://github.com/process-analytics/bpmn-visualization-js/assets/27200110/d9cc22c3-73aa-4e30-bdb5-9971fbe3de45

