### PR TITLE
refactor: use internal functions rather than static private methods

### DIFF
--- a/src/component/mxgraph/overlay/converter.ts
+++ b/src/component/mxgraph/overlay/converter.ts
@@ -19,72 +19,70 @@ import type { Overlay, OverlayFont, OverlayPosition, OverlayFill, OverlayStroke 
 
 import { StyleDefault } from '../style';
 
-export class OverlayConverter {
-  private overlayPositions = new Map<OverlayPosition, MxGraphCustomOverlayPosition>([
-    // Edge
-    ['start', { horizontalAlign: 'left', verticalAlign: 'top' }],
-    ['middle', { horizontalAlign: 'center', verticalAlign: 'top' }],
-    ['end', { horizontalAlign: 'right', verticalAlign: 'top' }],
-    // Shape
-    ['top-left', { horizontalAlign: 'left', verticalAlign: 'top' }],
-    ['top-right', { horizontalAlign: 'right', verticalAlign: 'top' }],
-    ['top-center', { horizontalAlign: 'center', verticalAlign: 'top' }],
-    ['bottom-left', { horizontalAlign: 'left', verticalAlign: 'bottom' }],
-    ['bottom-right', { horizontalAlign: 'right', verticalAlign: 'bottom' }],
-    ['bottom-center', { horizontalAlign: 'center', verticalAlign: 'bottom' }],
-    ['middle-left', { horizontalAlign: 'left', verticalAlign: 'middle' }],
-    ['middle-right', { horizontalAlign: 'right', verticalAlign: 'middle' }],
-  ]);
+const overlayPositions = new Map<OverlayPosition, MxGraphCustomOverlayPosition>([
+  // Edge
+  ['start', { horizontalAlign: 'left', verticalAlign: 'top' }],
+  ['middle', { horizontalAlign: 'center', verticalAlign: 'top' }],
+  ['end', { horizontalAlign: 'right', verticalAlign: 'top' }],
+  // Shape
+  ['top-left', { horizontalAlign: 'left', verticalAlign: 'top' }],
+  ['top-right', { horizontalAlign: 'right', verticalAlign: 'top' }],
+  ['top-center', { horizontalAlign: 'center', verticalAlign: 'top' }],
+  ['bottom-left', { horizontalAlign: 'left', verticalAlign: 'bottom' }],
+  ['bottom-right', { horizontalAlign: 'right', verticalAlign: 'bottom' }],
+  ['bottom-center', { horizontalAlign: 'center', verticalAlign: 'bottom' }],
+  ['middle-left', { horizontalAlign: 'left', verticalAlign: 'middle' }],
+  ['middle-right', { horizontalAlign: 'right', verticalAlign: 'middle' }],
+]);
 
-  convert(overlay: Overlay): MxGraphCustomOverlayOptions {
-    const position = this.convertPosition(overlay);
-    const style = OverlayConverter.convertStyle(overlay);
-    return { position, style };
+const convertPosition = (overlay: Overlay): MxGraphCustomOverlayPosition => overlayPositions.get(overlay.position);
+
+const convertFill = (convertedStyle: MxGraphCustomOverlayStyle, apiFill: OverlayFill): void => {
+  if (apiFill) {
+    convertedStyle.fill.color = apiFill.color ?? convertedStyle.fill.color;
+    convertedStyle.fill.opacity = apiFill.opacity ?? convertedStyle.fill.opacity;
   }
+};
 
-  private convertPosition(overlay: Overlay): MxGraphCustomOverlayPosition {
-    return this.overlayPositions.get(overlay.position);
+const convertStroke = (convertedStyle: MxGraphCustomOverlayStyle, apiStroke: OverlayStroke): void => {
+  if (apiStroke) {
+    convertedStyle.stroke.color = apiStroke.color ?? convertedStyle.stroke.color;
+    convertedStyle.stroke.width = apiStroke.width ?? convertedStyle.stroke.width;
   }
+};
 
-  private static convertStyle(overlay: Overlay): MxGraphCustomOverlayStyle {
-    // recompute the style at each call to ensure we consider default changes that could occur after lib initialization
-    const defaultStyle = {
-      fill: { color: StyleDefault.DEFAULT_OVERLAY_FILL_COLOR.valueOf(), opacity: StyleDefault.DEFAULT_OVERLAY_FILL_OPACITY.valueOf() },
-      stroke: { color: StyleDefault.DEFAULT_OVERLAY_STROKE_COLOR.valueOf(), width: StyleDefault.DEFAULT_OVERLAY_STROKE_WIDTH.valueOf() },
-      font: { color: StyleDefault.DEFAULT_OVERLAY_FONT_COLOR.valueOf(), size: StyleDefault.DEFAULT_OVERLAY_FONT_SIZE.valueOf() },
-    };
+const convertFont = (convertedStyle: MxGraphCustomOverlayStyle, apiFont: OverlayFont): void => {
+  if (apiFont) {
+    convertedStyle.font.color = apiFont.color ?? convertedStyle.font.color;
+    convertedStyle.font.size = apiFont.size ?? convertedStyle.font.size;
+  }
+};
 
-    const style = overlay.style;
-    const convertedStyle = { ...defaultStyle } as MxGraphCustomOverlayStyle;
-    if (!style) {
-      return convertedStyle;
-    }
+const convertStyle = (overlay: Overlay): MxGraphCustomOverlayStyle => {
+  // recompute the style at each call to ensure we consider default changes that could occur after lib initialization
+  const defaultStyle = {
+    fill: { color: StyleDefault.DEFAULT_OVERLAY_FILL_COLOR.valueOf(), opacity: StyleDefault.DEFAULT_OVERLAY_FILL_OPACITY.valueOf() },
+    stroke: { color: StyleDefault.DEFAULT_OVERLAY_STROKE_COLOR.valueOf(), width: StyleDefault.DEFAULT_OVERLAY_STROKE_WIDTH.valueOf() },
+    font: { color: StyleDefault.DEFAULT_OVERLAY_FONT_COLOR.valueOf(), size: StyleDefault.DEFAULT_OVERLAY_FONT_SIZE.valueOf() },
+  };
 
-    this.convertFill(convertedStyle, style.fill);
-    this.convertStroke(convertedStyle, style.stroke);
-    this.convertFont(convertedStyle, style.font);
-
+  const style = overlay.style;
+  const convertedStyle = { ...defaultStyle } as MxGraphCustomOverlayStyle;
+  if (!style) {
     return convertedStyle;
   }
 
-  private static convertFill(convertedStyle: MxGraphCustomOverlayStyle, apiFill: OverlayFill): void {
-    if (apiFill) {
-      convertedStyle.fill.color = apiFill.color ?? convertedStyle.fill.color;
-      convertedStyle.fill.opacity = apiFill.opacity ?? convertedStyle.fill.opacity;
-    }
-  }
+  convertFill(convertedStyle, style.fill);
+  convertStroke(convertedStyle, style.stroke);
+  convertFont(convertedStyle, style.font);
 
-  private static convertStroke(convertedStyle: MxGraphCustomOverlayStyle, apiStroke: OverlayStroke): void {
-    if (apiStroke) {
-      convertedStyle.stroke.color = apiStroke.color ?? convertedStyle.stroke.color;
-      convertedStyle.stroke.width = apiStroke.width ?? convertedStyle.stroke.width;
-    }
-  }
+  return convertedStyle;
+};
 
-  private static convertFont(convertedStyle: MxGraphCustomOverlayStyle, apiFont: OverlayFont): void {
-    if (apiFont) {
-      convertedStyle.font.color = apiFont.color ?? convertedStyle.font.color;
-      convertedStyle.font.size = apiFont.size ?? convertedStyle.font.size;
-    }
+export class OverlayConverter {
+  convert(overlay: Overlay): MxGraphCustomOverlayOptions {
+    const position = convertPosition(overlay);
+    const style = convertStyle(overlay);
+    return { position, style };
   }
 }

--- a/src/component/mxgraph/shape/event-shapes.ts
+++ b/src/component/mxgraph/shape/event-shapes.ts
@@ -90,9 +90,9 @@ export class EventShape extends mxgraph.mxEllipse {
   override paintVertexShape(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): void {
     const paintParameter = buildPaintParameter({ canvas: c, x, y, width: w, height: h, shape: this, isFilled: this.withFilledIcon });
 
-    EventShape.setDashedOuterShapePattern(paintParameter, mxUtils.getValue(this.style, BpmnStyleIdentifier.IS_INTERRUPTING, undefined));
+    setDashedOuterShapePattern(paintParameter, mxUtils.getValue(this.style, BpmnStyleIdentifier.IS_INTERRUPTING, undefined));
     this.paintOuterShape(paintParameter);
-    EventShape.restoreOriginalOuterShapePattern(paintParameter);
+    restoreOriginalOuterShapePattern(paintParameter);
 
     this.paintInnerShape(paintParameter);
   }
@@ -107,18 +107,18 @@ export class EventShape extends mxgraph.mxEllipse {
       (() => this.iconPainter.paintEmptyIcon());
     paintIcon(paintParameter);
   }
+}
 
-  private static setDashedOuterShapePattern(paintParameter: PaintParameter, isInterrupting: string): void {
-    paintParameter.canvas.save(); // ensure we can later restore the configuration
-    if (isInterrupting === 'false') {
-      paintParameter.canvas.setDashed(true, false);
-      paintParameter.canvas.setDashPattern('3 2');
-    }
+function setDashedOuterShapePattern(paintParameter: PaintParameter, isInterrupting: string): void {
+  paintParameter.canvas.save(); // ensure we can later restore the configuration
+  if (isInterrupting === 'false') {
+    paintParameter.canvas.setDashed(true, false);
+    paintParameter.canvas.setDashPattern('3 2');
   }
+}
 
-  private static restoreOriginalOuterShapePattern(paintParameter: PaintParameter): void {
-    paintParameter.canvas.restore();
-  }
+function restoreOriginalOuterShapePattern(paintParameter: PaintParameter): void {
+  paintParameter.canvas.restore();
 }
 
 /**

--- a/src/component/mxgraph/shape/render/icon-painter.ts
+++ b/src/component/mxgraph/shape/render/icon-painter.ts
@@ -513,106 +513,11 @@ export class IconPainter {
     const canvas = this.newBpmnCanvas(paintParameter, { height: 100, width: 100 });
 
     // background
-    IconPainter.paintGearIconBackground(canvas);
+    paintGearIconBackground(canvas);
 
     // foreground
     canvas.translateIconOrigin(14, 14);
-    IconPainter.paintGearIconForeground(canvas);
-  }
-
-  private static paintGearIconBackground(canvas: BpmnCanvas): void {
-    canvas.begin();
-    canvas.moveTo(2.06, 24.62);
-    canvas.lineTo(10.17, 30.95);
-    canvas.lineTo(9.29, 37.73);
-    canvas.lineTo(0, 41.42);
-    canvas.lineTo(2.95, 54.24);
-    canvas.lineTo(13.41, 52.92);
-    canvas.lineTo(17.39, 58.52);
-    canvas.lineTo(13.56, 67.66);
-    canvas.lineTo(24.47, 74.44);
-    canvas.lineTo(30.81, 66.33);
-    canvas.lineTo(37.88, 67.21);
-    canvas.lineTo(41.57, 76.5);
-    canvas.lineTo(54.24, 73.55);
-    canvas.lineTo(53.06, 62.94);
-    canvas.lineTo(58.52, 58.52);
-    canvas.lineTo(67.21, 63.09);
-    canvas.lineTo(74.58, 51.88);
-    canvas.lineTo(66.03, 45.25);
-    canvas.lineTo(66.92, 38.62);
-    canvas.lineTo(76.5, 34.93);
-    canvas.lineTo(73.7, 22.26);
-    canvas.lineTo(62.64, 23.44);
-    canvas.lineTo(58.81, 18.42);
-    canvas.lineTo(62.79, 8.7);
-    canvas.lineTo(51.74, 2.21);
-    canvas.lineTo(44.81, 10.47);
-    canvas.lineTo(38.03, 9.43);
-    canvas.lineTo(33.75, 0);
-    canvas.lineTo(21.52, 3.24);
-    canvas.lineTo(22.7, 13.56);
-    canvas.lineTo(18.13, 17.54);
-    canvas.lineTo(8.7, 13.56);
-    canvas.close();
-
-    const arcStartX = 24.8;
-    const arcStartY = 39;
-    IconPainter.paintGearInnerCircle(canvas, arcStartX, arcStartY);
-  }
-
-  private static paintGearIconForeground(canvas: BpmnCanvas): void {
-    canvas.begin();
-    canvas.moveTo(16.46, 41.42);
-    canvas.lineTo(24.57, 47.75);
-    canvas.lineTo(23.69, 54.53);
-    canvas.lineTo(14.4, 58.22);
-    canvas.lineTo(17.35, 71.04);
-    canvas.lineTo(27.81, 69.72);
-    canvas.lineTo(31.79, 75.32);
-    canvas.lineTo(27.96, 84.46);
-    canvas.lineTo(38.87, 91.24);
-    canvas.lineTo(45.21, 83.13);
-    canvas.lineTo(52.28, 84.01);
-    canvas.lineTo(55.97, 93.3);
-    canvas.lineTo(68.64, 90.35);
-    canvas.lineTo(67.46, 79.74);
-    canvas.lineTo(72.92, 75.32);
-    canvas.lineTo(81.61, 79.89);
-    canvas.lineTo(88.98, 68.68);
-    canvas.lineTo(80.43, 62.05);
-    canvas.lineTo(81.32, 55.42);
-    canvas.lineTo(90.9, 51.73);
-    canvas.lineTo(88.1, 39.06);
-    canvas.lineTo(77.04, 40.24);
-    canvas.lineTo(73.21, 35.22);
-    canvas.lineTo(77.19, 25.5);
-    canvas.lineTo(66.14, 19.01);
-    canvas.lineTo(59.21, 27.27);
-    canvas.lineTo(52.43, 26.23);
-    canvas.lineTo(48.15, 16.8);
-    canvas.lineTo(35.92, 20.04);
-    canvas.lineTo(37.1, 30.36);
-    canvas.lineTo(32.53, 34.34);
-    canvas.lineTo(23.1, 30.36);
-    canvas.close();
-
-    const arcStartX = 39.2;
-    const arcStartY = 55.8;
-    IconPainter.paintGearInnerCircle(canvas, arcStartX, arcStartY);
-
-    // fill the inner circle to mask the background
-    canvas.begin();
-    IconPainter.paintGearInnerCircle(canvas, arcStartX, arcStartY);
-  }
-
-  private static paintGearInnerCircle(canvas: BpmnCanvas, arcStartX: number, arcStartY: number): void {
-    const arcRay = 13.5;
-    canvas.moveTo(arcStartX, arcStartY);
-    canvas.arcTo(arcRay, arcRay, 0, 1, 1, arcStartX + 2 * arcRay, arcStartY);
-    canvas.arcTo(arcRay, arcRay, 0, 0, 1, arcStartX, arcStartY);
-    canvas.close();
-    canvas.fillAndStroke();
+    paintGearIconForeground(canvas);
   }
 
   /**
@@ -935,6 +840,101 @@ function drawVerticalLine(paintParameter: PaintParameter, canvas: BpmnCanvas): v
   canvas.lineTo(0.62, 1);
   canvas.lineTo(0.38, 1);
   canvas.close();
+}
+
+function paintGearIconBackground(canvas: BpmnCanvas): void {
+  canvas.begin();
+  canvas.moveTo(2.06, 24.62);
+  canvas.lineTo(10.17, 30.95);
+  canvas.lineTo(9.29, 37.73);
+  canvas.lineTo(0, 41.42);
+  canvas.lineTo(2.95, 54.24);
+  canvas.lineTo(13.41, 52.92);
+  canvas.lineTo(17.39, 58.52);
+  canvas.lineTo(13.56, 67.66);
+  canvas.lineTo(24.47, 74.44);
+  canvas.lineTo(30.81, 66.33);
+  canvas.lineTo(37.88, 67.21);
+  canvas.lineTo(41.57, 76.5);
+  canvas.lineTo(54.24, 73.55);
+  canvas.lineTo(53.06, 62.94);
+  canvas.lineTo(58.52, 58.52);
+  canvas.lineTo(67.21, 63.09);
+  canvas.lineTo(74.58, 51.88);
+  canvas.lineTo(66.03, 45.25);
+  canvas.lineTo(66.92, 38.62);
+  canvas.lineTo(76.5, 34.93);
+  canvas.lineTo(73.7, 22.26);
+  canvas.lineTo(62.64, 23.44);
+  canvas.lineTo(58.81, 18.42);
+  canvas.lineTo(62.79, 8.7);
+  canvas.lineTo(51.74, 2.21);
+  canvas.lineTo(44.81, 10.47);
+  canvas.lineTo(38.03, 9.43);
+  canvas.lineTo(33.75, 0);
+  canvas.lineTo(21.52, 3.24);
+  canvas.lineTo(22.7, 13.56);
+  canvas.lineTo(18.13, 17.54);
+  canvas.lineTo(8.7, 13.56);
+  canvas.close();
+
+  const arcStartX = 24.8;
+  const arcStartY = 39;
+  paintGearInnerCircle(canvas, arcStartX, arcStartY);
+}
+
+function paintGearIconForeground(canvas: BpmnCanvas): void {
+  canvas.begin();
+  canvas.moveTo(16.46, 41.42);
+  canvas.lineTo(24.57, 47.75);
+  canvas.lineTo(23.69, 54.53);
+  canvas.lineTo(14.4, 58.22);
+  canvas.lineTo(17.35, 71.04);
+  canvas.lineTo(27.81, 69.72);
+  canvas.lineTo(31.79, 75.32);
+  canvas.lineTo(27.96, 84.46);
+  canvas.lineTo(38.87, 91.24);
+  canvas.lineTo(45.21, 83.13);
+  canvas.lineTo(52.28, 84.01);
+  canvas.lineTo(55.97, 93.3);
+  canvas.lineTo(68.64, 90.35);
+  canvas.lineTo(67.46, 79.74);
+  canvas.lineTo(72.92, 75.32);
+  canvas.lineTo(81.61, 79.89);
+  canvas.lineTo(88.98, 68.68);
+  canvas.lineTo(80.43, 62.05);
+  canvas.lineTo(81.32, 55.42);
+  canvas.lineTo(90.9, 51.73);
+  canvas.lineTo(88.1, 39.06);
+  canvas.lineTo(77.04, 40.24);
+  canvas.lineTo(73.21, 35.22);
+  canvas.lineTo(77.19, 25.5);
+  canvas.lineTo(66.14, 19.01);
+  canvas.lineTo(59.21, 27.27);
+  canvas.lineTo(52.43, 26.23);
+  canvas.lineTo(48.15, 16.8);
+  canvas.lineTo(35.92, 20.04);
+  canvas.lineTo(37.1, 30.36);
+  canvas.lineTo(32.53, 34.34);
+  canvas.lineTo(23.1, 30.36);
+  canvas.close();
+
+  const arcStartX = 39.2;
+  const arcStartY = 55.8;
+  paintGearInnerCircle(canvas, arcStartX, arcStartY);
+
+  // fill the inner circle to mask the background
+  canvas.begin();
+  paintGearInnerCircle(canvas, arcStartX, arcStartY);
+}
+
+function paintGearInnerCircle(canvas: BpmnCanvas, arcStartX: number, arcStartY: number): void {
+  const arcRay = 13.5;
+  canvas.moveTo(arcStartX, arcStartY);
+  canvas.arcTo(arcRay, arcRay, 0, 1, 1, arcStartX + 2 * arcRay, arcStartY);
+  canvas.arcTo(arcRay, arcRay, 0, 0, 1, arcStartX, arcStartY);
+  canvas.close();
+  canvas.fillAndStroke();
 }
 
 /**

--- a/src/component/parser/json/converter/DiagramConverter.ts
+++ b/src/component/parser/json/converter/DiagramConverter.ts
@@ -108,7 +108,7 @@ export default class DiagramConverter {
   private deserializeShape(bpmnShape: BPMNShape, findShapeElement: (bpmnElement: string) => ShapeBpmnElement): Shape | undefined {
     const bpmnElement = findShapeElement(bpmnShape.bpmnElement);
     if (bpmnElement) {
-      const bounds = DiagramConverter.deserializeBounds(bpmnShape);
+      const bounds = deserializeBounds(bpmnShape);
 
       if (
         (bpmnElement instanceof ShapeBpmnSubProcess ||
@@ -126,30 +126,9 @@ export default class DiagramConverter {
       const bpmnLabel = bpmnShape.BPMNLabel;
       const label = this.deserializeLabel(bpmnLabel, bpmnShape.id);
       const shape = new Shape(bpmnShape.id, bpmnElement, bounds, label, isHorizontal);
-      DiagramConverter.setColorExtensionsOnShape(shape, bpmnShape);
+      setColorExtensionsOnShape(shape, bpmnShape);
 
       return shape;
-    }
-  }
-
-  // 'BPMN in Color' extensions with fallback to bpmn.io colors
-  private static setColorExtensionsOnShape(shape: Shape, bpmnShape: BPMNShape): void {
-    if ('background-color' in bpmnShape) {
-      shape.extensions.fillColor = bpmnShape['background-color'] as string;
-    } else if ('fill' in bpmnShape) {
-      shape.extensions.fillColor = bpmnShape.fill as string;
-    }
-    if ('border-color' in bpmnShape) {
-      shape.extensions.strokeColor = bpmnShape['border-color'] as string;
-    } else if ('stroke' in bpmnShape) {
-      shape.extensions.strokeColor = bpmnShape.stroke as string;
-    }
-  }
-
-  private static deserializeBounds(boundedElement: BPMNShape | BPMNLabel): Bounds {
-    const bounds = boundedElement.Bounds;
-    if (bounds) {
-      return new Bounds(bounds.x, bounds.y, bounds.width, bounds.height);
     }
   }
 
@@ -171,19 +150,10 @@ export default class DiagramConverter {
         const messageVisibleKind = bpmnEdge.messageVisibleKind ? (bpmnEdge.messageVisibleKind as unknown as MessageVisibleKind) : MessageVisibleKind.NONE;
 
         const edge = new Edge(bpmnEdge.id, flow, waypoints, label, messageVisibleKind);
-        DiagramConverter.setColorExtensionsOnEdge(edge, bpmnEdge);
+        setColorExtensionsOnEdge(edge, bpmnEdge);
         return edge;
       })
       .filter(Boolean);
-  }
-
-  // 'BPMN in Color' extensions  with fallback to bpmn.io colors
-  private static setColorExtensionsOnEdge(edge: Edge, bpmnEdge: BPMNEdge): void {
-    if ('border-color' in bpmnEdge) {
-      edge.extensions.strokeColor = bpmnEdge['border-color'] as string;
-    } else if ('stroke' in bpmnEdge) {
-      edge.extensions.strokeColor = bpmnEdge.stroke as string;
-    }
   }
 
   private deserializeWaypoints(waypoints: Point[]): Waypoint[] {
@@ -193,7 +163,7 @@ export default class DiagramConverter {
   private deserializeLabel(bpmnLabel: string | BPMNLabel, id: string): Label {
     if (bpmnLabel && typeof bpmnLabel === 'object') {
       const font = this.findFont(bpmnLabel.labelStyle, id);
-      const bounds = DiagramConverter.deserializeBounds(bpmnLabel);
+      const bounds = deserializeBounds(bpmnLabel);
       const label = new Label(font, bounds);
       if ('color' in bpmnLabel) {
         label.extensions.color = bpmnLabel.color as string;
@@ -216,5 +186,35 @@ export default class DiagramConverter {
     }
 
     return font;
+  }
+}
+
+// 'BPMN in Color' extensions with fallback to bpmn.io colors
+function setColorExtensionsOnShape(shape: Shape, bpmnShape: BPMNShape): void {
+  if ('background-color' in bpmnShape) {
+    shape.extensions.fillColor = bpmnShape['background-color'] as string;
+  } else if ('fill' in bpmnShape) {
+    shape.extensions.fillColor = bpmnShape.fill as string;
+  }
+  if ('border-color' in bpmnShape) {
+    shape.extensions.strokeColor = bpmnShape['border-color'] as string;
+  } else if ('stroke' in bpmnShape) {
+    shape.extensions.strokeColor = bpmnShape.stroke as string;
+  }
+}
+
+function deserializeBounds(boundedElement: BPMNShape | BPMNLabel): Bounds {
+  const bounds = boundedElement.Bounds;
+  if (bounds) {
+    return new Bounds(bounds.x, bounds.y, bounds.width, bounds.height);
+  }
+}
+
+// 'BPMN in Color' extensions  with fallback to bpmn.io colors
+function setColorExtensionsOnEdge(edge: Edge, bpmnEdge: BPMNEdge): void {
+  if ('border-color' in bpmnEdge) {
+    edge.extensions.strokeColor = bpmnEdge['border-color'] as string;
+  } else if ('stroke' in bpmnEdge) {
+    edge.extensions.strokeColor = bpmnEdge.stroke as string;
   }
 }


### PR DESCRIPTION
Replace pure private static methods (i.e. method not using static property) by functions to better encapsulate the implementation logic.
These methods are generated as public in the JavaScript code, which is not necessary.