### PR TITLE
refactor: inject IconPainter when possible

### DIFF
--- a/src/component/mxgraph/BpmnCellRenderer.ts
+++ b/src/component/mxgraph/BpmnCellRenderer.ts
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import type { IconPainter } from './shape/render';
 import type { mxCellState, mxImageShape, mxShape } from 'mxgraph';
 
 import { mxgraph, mxRectangle } from './initializer';
@@ -21,6 +22,10 @@ import { MxGraphCustomOverlay } from './overlay/custom-overlay';
 import { OverlayBadgeShape } from './overlay/shapes';
 
 export class BpmnCellRenderer extends mxgraph.mxCellRenderer {
+  constructor(private iconPainter: IconPainter) {
+    super();
+  }
+
   override createCellOverlays(state: mxCellState): void {
     const graph = state.view.graph;
     const overlays = graph.getCellOverlays(state.cell);
@@ -78,5 +83,13 @@ export class BpmnCellRenderer extends mxgraph.mxCellRenderer {
     }
 
     state.overlays = dict;
+  }
+
+  override createShape(state: mxCellState): mxShape {
+    const shape = super.createShape(state);
+    if ('iconPainter' in shape) {
+      shape.iconPainter = this.iconPainter;
+    }
+    return shape;
   }
 }

--- a/src/component/mxgraph/BpmnGraph.ts
+++ b/src/component/mxgraph/BpmnGraph.ts
@@ -24,6 +24,7 @@ import { FitType } from '../options';
 
 import { BpmnCellRenderer } from './BpmnCellRenderer';
 import { mxgraph, mxEvent } from './initializer';
+import { IconPainterProvider } from './shape/render';
 
 const zoomFactorIn = 1.25;
 const zoomFactorOut = 1 / zoomFactorIn;
@@ -51,7 +52,8 @@ export class BpmnGraph extends mxgraph.mxGraph {
   }
 
   override createCellRenderer(): mxCellRenderer {
-    return new BpmnCellRenderer();
+    // in the future, the IconPainter could be configured at library initialization and the provider could be removed
+    return new BpmnCellRenderer(IconPainterProvider.get());
   }
 
   /**

--- a/src/component/mxgraph/shape/event-shapes.ts
+++ b/src/component/mxgraph/shape/event-shapes.ts
@@ -14,21 +14,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import type { BpmnCanvas, PaintParameter } from './render';
+import type { BpmnCanvas, PaintParameter, IconPainter } from './render';
 import type { mxAbstractCanvas2D } from 'mxgraph';
 
 import { ShapeBpmnEventDefinitionKind } from '../../../model/bpmn/internal';
 import { mxgraph, mxUtils } from '../initializer';
 import { BpmnStyleIdentifier, StyleDefault } from '../style';
 
-import { IconPainterProvider } from './render';
 import { buildPaintParameter } from './render/icon-painter';
 
 /**
  * @internal
  */
 export class EventShape extends mxgraph.mxEllipse {
-  protected iconPainter = IconPainterProvider.get();
+  // The actual value is injected at runtime by BpmnCellRenderer
+  protected iconPainter: IconPainter = undefined;
 
   // refactor: when all/more event types will be supported, we could move to a Record/MappedType
   private iconPainters = new Map<ShapeBpmnEventDefinitionKind, (paintParameter: PaintParameter) => void>([

--- a/src/component/mxgraph/shape/flow-shapes.ts
+++ b/src/component/mxgraph/shape/flow-shapes.ts
@@ -14,19 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import type { IconPainter } from './render';
 import type { mxAbstractCanvas2D } from 'mxgraph';
 
 import { mxRectangleShape, mxUtils } from '../initializer';
 import { BpmnStyleIdentifier } from '../style';
 
-import { IconPainterProvider } from './render';
 import { buildPaintParameter } from './render/icon-painter';
 
 /**
  * @internal
  */
 export class MessageFlowIconShape extends mxRectangleShape {
-  protected iconPainter = IconPainterProvider.get();
+  // The actual value is injected at runtime by BpmnCellRenderer
+  protected iconPainter: IconPainter = undefined;
 
   override paintVertexShape(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): void {
     const paintParameter = buildPaintParameter({

--- a/src/component/mxgraph/shape/gateway-shapes.ts
+++ b/src/component/mxgraph/shape/gateway-shapes.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import type { PaintParameter } from './render';
+import type { IconPainter, PaintParameter } from './render';
 import type { mxAbstractCanvas2D } from 'mxgraph';
 
 import { ShapeBpmnEventBasedGatewayKind } from '../../../model/bpmn/internal';
@@ -22,11 +22,11 @@ import { mxgraph, mxUtils } from '../initializer';
 import { BpmnStyleIdentifier, StyleDefault } from '../style';
 import { getBpmnIsInstantiating } from '../style/utils';
 
-import { IconPainterProvider } from './render';
 import { buildPaintParameter } from './render/icon-painter';
 
 abstract class GatewayShape extends mxgraph.mxRhombus {
-  protected iconPainter = IconPainterProvider.get();
+  // The actual value is injected at runtime by BpmnCellRenderer
+  protected iconPainter: IconPainter = undefined;
 
   protected abstract paintInnerShape(paintParameter: PaintParameter): void;
 


### PR DESCRIPTION
Previously, the shapes relied on `IconPainterProvider` to get the `IconPainter` instance. This instance is now injected at shape instantiation by `BpmnCellRenderer`. This reduces the adherence to a global state.

This is a first step to remove the `IconPainterProvider` global state. This may be done later as it would imply to:
  - introduce a new configuration options, for example a `render.iconPainter` property
  - change how the `BpmnGraph` is initialized and configured
  - manage the breaking changes introduced by the provider removal
