### PR TITLE
refactor: use internals instead of private class elements

### DIFF
--- a/src/component/mxgraph/config/StyleConfigurator.ts
+++ b/src/component/mxgraph/config/StyleConfigurator.ts
@@ -23,6 +23,90 @@ import { BpmnStyleIdentifier, MarkerIdentifier, StyleDefault } from '../style';
 
 const arrowDefaultSize = 12;
 
+class MapWithDefault<T> extends Map<T, (style: StyleMap) => void> {
+  override get(key: T): (style: StyleMap) => void {
+    return (
+      super.get(key) ??
+      (() => {
+        // do nothing intentionally, there is no extra style to configure
+      })
+    );
+  }
+}
+
+const specificFlowStyles = new MapWithDefault<FlowKind>([
+  [
+    FlowKind.SEQUENCE_FLOW,
+    (style: StyleMap) => {
+      style[mxConstants.STYLE_ENDARROW] = mxConstants.ARROW_BLOCK_THIN;
+    },
+  ],
+  [
+    FlowKind.MESSAGE_FLOW,
+    (style: StyleMap) => {
+      style[mxConstants.STYLE_DASHED] = true;
+      style[mxConstants.STYLE_DASH_PATTERN] = '8 5';
+      style[mxConstants.STYLE_STARTARROW] = mxConstants.ARROW_OVAL;
+      style[mxConstants.STYLE_STARTSIZE] = 8;
+      style[mxConstants.STYLE_STARTFILL] = true;
+      style[BpmnStyleIdentifier.EDGE_START_FILL_COLOR] = StyleDefault.MESSAGE_FLOW_MARKER_START_FILL_COLOR;
+      style[mxConstants.STYLE_ENDARROW] = mxConstants.ARROW_BLOCK_THIN;
+      style[mxConstants.STYLE_ENDFILL] = true;
+      style[BpmnStyleIdentifier.EDGE_END_FILL_COLOR] = StyleDefault.MESSAGE_FLOW_MARKER_END_FILL_COLOR;
+    },
+  ],
+  [
+    FlowKind.ASSOCIATION_FLOW,
+    (style: StyleMap) => {
+      style[mxConstants.STYLE_DASHED] = true;
+      style[mxConstants.STYLE_DASH_PATTERN] = '1 2';
+      // STYLE_ENDARROW and STYLE_STARTARROW are defined in specific AssociationDirectionKind styles when needed
+      style[mxConstants.STYLE_STARTSIZE] = arrowDefaultSize;
+    },
+  ],
+]);
+
+const specificSequenceFlowStyles = new MapWithDefault<SequenceFlowKind>([
+  [
+    SequenceFlowKind.DEFAULT,
+    (style: StyleMap) => {
+      style[mxConstants.STYLE_STARTARROW] = MarkerIdentifier.ARROW_DASH;
+    },
+  ],
+  [
+    SequenceFlowKind.CONDITIONAL_FROM_ACTIVITY,
+    (style: StyleMap) => {
+      style[mxConstants.STYLE_STARTARROW] = mxConstants.ARROW_DIAMOND_THIN;
+      style[mxConstants.STYLE_STARTSIZE] = 18;
+      style[mxConstants.STYLE_STARTFILL] = true;
+      style[BpmnStyleIdentifier.EDGE_START_FILL_COLOR] = StyleDefault.SEQUENCE_FLOW_CONDITIONAL_FROM_ACTIVITY_MARKER_FILL_COLOR;
+    },
+  ],
+]);
+
+const specificAssociationFlowStyles = new MapWithDefault<AssociationDirectionKind>([
+  [
+    AssociationDirectionKind.NONE,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- prefix parameter name - common practice to acknowledge the fact that some parameter is unused (e.g. in TypeScript compiler)
+    (_style: StyleMap) => {
+      // the style is fully managed by the FlowKind.ASSOCIATION_FLOW style
+    },
+  ],
+  [
+    AssociationDirectionKind.ONE,
+    (style: StyleMap) => {
+      style[mxConstants.STYLE_ENDARROW] = mxConstants.ARROW_OPEN_THIN;
+    },
+  ],
+  [
+    AssociationDirectionKind.BOTH,
+    (style: StyleMap) => {
+      style[mxConstants.STYLE_STARTARROW] = mxConstants.ARROW_OPEN_THIN;
+      style[mxConstants.STYLE_ENDARROW] = mxConstants.ARROW_OPEN_THIN;
+    },
+  ],
+]);
+
 /**
  * Configure the styles used for BPMN rendering.
  *
@@ -32,77 +116,6 @@ const arrowDefaultSize = 12;
  * @experimental
  */
 export class StyleConfigurator {
-  private specificFlowStyles = new MapWithDefault<FlowKind>([
-    [
-      FlowKind.SEQUENCE_FLOW,
-      (style: StyleMap) => {
-        style[mxConstants.STYLE_ENDARROW] = mxConstants.ARROW_BLOCK_THIN;
-      },
-    ],
-    [
-      FlowKind.MESSAGE_FLOW,
-      (style: StyleMap) => {
-        style[mxConstants.STYLE_DASHED] = true;
-        style[mxConstants.STYLE_DASH_PATTERN] = '8 5';
-        style[mxConstants.STYLE_STARTARROW] = mxConstants.ARROW_OVAL;
-        style[mxConstants.STYLE_STARTSIZE] = 8;
-        style[mxConstants.STYLE_STARTFILL] = true;
-        style[BpmnStyleIdentifier.EDGE_START_FILL_COLOR] = StyleDefault.MESSAGE_FLOW_MARKER_START_FILL_COLOR;
-        style[mxConstants.STYLE_ENDARROW] = mxConstants.ARROW_BLOCK_THIN;
-        style[mxConstants.STYLE_ENDFILL] = true;
-        style[BpmnStyleIdentifier.EDGE_END_FILL_COLOR] = StyleDefault.MESSAGE_FLOW_MARKER_END_FILL_COLOR;
-      },
-    ],
-    [
-      FlowKind.ASSOCIATION_FLOW,
-      (style: StyleMap) => {
-        style[mxConstants.STYLE_DASHED] = true;
-        style[mxConstants.STYLE_DASH_PATTERN] = '1 2';
-        // STYLE_ENDARROW and STYLE_STARTARROW are defined in specific AssociationDirectionKind styles when needed
-        style[mxConstants.STYLE_STARTSIZE] = arrowDefaultSize;
-      },
-    ],
-  ]);
-  private specificSequenceFlowStyles = new MapWithDefault<SequenceFlowKind>([
-    [
-      SequenceFlowKind.DEFAULT,
-      (style: StyleMap) => {
-        style[mxConstants.STYLE_STARTARROW] = MarkerIdentifier.ARROW_DASH;
-      },
-    ],
-    [
-      SequenceFlowKind.CONDITIONAL_FROM_ACTIVITY,
-      (style: StyleMap) => {
-        style[mxConstants.STYLE_STARTARROW] = mxConstants.ARROW_DIAMOND_THIN;
-        style[mxConstants.STYLE_STARTSIZE] = 18;
-        style[mxConstants.STYLE_STARTFILL] = true;
-        style[BpmnStyleIdentifier.EDGE_START_FILL_COLOR] = StyleDefault.SEQUENCE_FLOW_CONDITIONAL_FROM_ACTIVITY_MARKER_FILL_COLOR;
-      },
-    ],
-  ]);
-  private specificAssociationFlowStyles = new MapWithDefault<AssociationDirectionKind>([
-    [
-      AssociationDirectionKind.NONE,
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars -- prefix parameter name - common practice to acknowledge the fact that some parameter is unused (e.g. in TypeScript compiler)
-      (_style: StyleMap) => {
-        // the style is fully managed by the FlowKind.ASSOCIATION_FLOW style
-      },
-    ],
-    [
-      AssociationDirectionKind.ONE,
-      (style: StyleMap) => {
-        style[mxConstants.STYLE_ENDARROW] = mxConstants.ARROW_OPEN_THIN;
-      },
-    ],
-    [
-      AssociationDirectionKind.BOTH,
-      (style: StyleMap) => {
-        style[mxConstants.STYLE_STARTARROW] = mxConstants.ARROW_OPEN_THIN;
-        style[mxConstants.STYLE_ENDARROW] = mxConstants.ARROW_OPEN_THIN;
-      },
-    ],
-  ]);
-
   constructor(private graph: BpmnGraph) {}
 
   configureStyles(): void {
@@ -252,9 +265,9 @@ export class StyleConfigurator {
   }
 
   private configureFlowStyles(): void {
-    this.configureEdgeStyles<FlowKind>(Object.values(FlowKind), this.specificFlowStyles);
-    this.configureEdgeStyles<SequenceFlowKind>(Object.values(SequenceFlowKind), this.specificSequenceFlowStyles);
-    this.configureEdgeStyles<AssociationDirectionKind>(Object.values(AssociationDirectionKind), this.specificAssociationFlowStyles);
+    this.configureEdgeStyles<FlowKind>(Object.values(FlowKind), specificFlowStyles);
+    this.configureEdgeStyles<SequenceFlowKind>(Object.values(SequenceFlowKind), specificSequenceFlowStyles);
+    this.configureEdgeStyles<AssociationDirectionKind>(Object.values(AssociationDirectionKind), specificAssociationFlowStyles);
   }
 }
 
@@ -268,15 +281,4 @@ function configureCommonDefaultStyle(style: StyleMap): void {
 
   // only works with html labels (enabled by GraphConfigurator)
   style[mxConstants.STYLE_WHITE_SPACE] = 'wrap';
-}
-
-class MapWithDefault<T> extends Map<T, (style: StyleMap) => void> {
-  override get(key: T): (style: StyleMap) => void {
-    return (
-      super.get(key) ??
-      (() => {
-        // do nothing intentionally, there is no extra style to configure
-      })
-    );
-  }
 }

--- a/src/component/mxgraph/shape/activity-shapes.ts
+++ b/src/component/mxgraph/shape/activity-shapes.ts
@@ -25,6 +25,18 @@ import { getBpmnIsInstantiating } from '../style/utils';
 import { buildPaintParameter } from './render/icon-painter';
 import { orderActivityMarkers } from './render/utils';
 
+function getMarkerIconOriginFunction(allMarkers: number, markerOrder: number): (canvas: BpmnCanvas) => void {
+  return allMarkers === 1
+    ? (canvas: BpmnCanvas) => canvas.setIconOriginForIconBottomCentered()
+    : (canvas: BpmnCanvas) => {
+        // Here we suppose that we have 'allMarkers === 2'
+        // More markers will be supported when implementing adhoc subprocess or compensation marker
+        canvas.setIconOriginForIconBottomCentered();
+        const xTranslation = Math.pow(-1, markerOrder) * (StyleDefault.SHAPE_ACTIVITY_MARKER_ICON_SIZE / 2 + StyleDefault.SHAPE_ACTIVITY_MARKER_ICON_MARGIN);
+        canvas.translateIconOrigin(xTranslation, 0);
+      };
+}
+
 /**
  * @internal
  */
@@ -49,7 +61,7 @@ export abstract class BaseActivityShape extends mxRectangleShape {
       for (const [index, marker] of orderedMarkers.entries()) {
         paintParameter = {
           ...paintParameter,
-          setIconOriginFunct: this.getMarkerIconOriginFunction(orderedMarkers.length, index + 1),
+          setIconOriginFunct: getMarkerIconOriginFunction(orderedMarkers.length, index + 1),
         };
         paintParameter.canvas.save(); // ensure we can later restore the configuration
         switch (marker) {
@@ -83,19 +95,6 @@ export abstract class BaseActivityShape extends mxRectangleShape {
       ratioFromParent: 0.2,
       iconStyleConfig: { ...paintParameter.iconStyleConfig, isFilled: isFilled },
     });
-  }
-
-  private getMarkerIconOriginFunction(allMarkers: number, markerOrder: number): (canvas: BpmnCanvas) => void {
-    return allMarkers === 1
-      ? (canvas: BpmnCanvas) => canvas.setIconOriginForIconBottomCentered()
-      : (canvas: BpmnCanvas) => {
-          // Here we suppose that we have 'allMarkers === 2'
-          // More markers will be supported when implementing adhoc subprocess or compensation marker
-
-          canvas.setIconOriginForIconBottomCentered();
-          const xTranslation = Math.pow(-1, markerOrder) * (StyleDefault.SHAPE_ACTIVITY_MARKER_ICON_SIZE / 2 + StyleDefault.SHAPE_ACTIVITY_MARKER_ICON_MARGIN);
-          canvas.translateIconOrigin(xTranslation, 0);
-        };
   }
 }
 


### PR DESCRIPTION
Replace pure private methods (i.e. method not using class instance property) by functions to better encapsulate the implementation logic.
Do the same for private properties that can be replaced by constants. Such private methods and properties were generated as public in the JavaScript code, which was not necessary.

### Notes

Continue the work started in #3041.