### PR TITLE
refactor!: simplify code for shapes without icon

### DIFF
--- a/src/component/mxgraph/shape/activity-shapes.ts
+++ b/src/component/mxgraph/shape/activity-shapes.ts
@@ -114,7 +114,6 @@ export class TaskShape extends BaseTaskShape {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars -- prefix parameter name - common practice to acknowledge the fact that some parameter is unused (e.g. in TypeScript compiler)
   protected paintTaskIcon(_paintParameter: PaintParameter): void {
     // No symbol for the BPMN Task
-    this.iconPainter.paintEmptyIcon();
   }
 }
 
@@ -244,10 +243,8 @@ export class CallActivityShape extends BaseActivityShape {
         });
         break;
       }
-      default: {
-        // No symbol for the Call Activity calling a Global Task or calling a Process
-        this.iconPainter.paintEmptyIcon();
-      }
+      default:
+      // No symbol for the Call Activity calling a Global Task or calling a Process
     }
   }
 }

--- a/src/component/mxgraph/shape/event-shapes.ts
+++ b/src/component/mxgraph/shape/event-shapes.ts
@@ -102,10 +102,8 @@ export class EventShape extends mxgraph.mxEllipse {
   }
 
   private paintInnerShape(paintParameter: PaintParameter): void {
-    const paintIcon =
-      this.iconPainters.get(mxUtils.getValue(this.style, BpmnStyleIdentifier.EVENT_DEFINITION_KIND, ShapeBpmnEventDefinitionKind.NONE)) ??
-      (() => this.iconPainter.paintEmptyIcon());
-    paintIcon(paintParameter);
+    const paintIcon = this.iconPainters.get(mxUtils.getValue(this.style, BpmnStyleIdentifier.EVENT_DEFINITION_KIND, ShapeBpmnEventDefinitionKind.NONE));
+    paintIcon?.(paintParameter);
   }
 }
 

--- a/src/component/mxgraph/shape/render/icon-painter.ts
+++ b/src/component/mxgraph/shape/render/icon-painter.ts
@@ -86,10 +86,6 @@ export function buildPaintParameter({
  * @experimental
  */
 export class IconPainter {
-  paintEmptyIcon(): void {
-    // empty by nature
-  }
-
   /**
    * Utility paint icon methods to easily instantiate a {@link BpmnCanvas} from a {@link PaintParameter}.
    *


### PR DESCRIPTION
Use simple alternative to the former usage of `IconPainter.paintEmptyIcon`.

BREAKING CHANGES: remove `IconPainter.paintEmptyIcon`.
This has no impact for users and applications that extend `IconPainter` have no reason to override this method, so this has a very limited impact.

### Notes

Detected in #2724 