### PR TITLE
refactor: simplify `GraphConfigurator`

### DIFF
--- a/src/component/mxgraph/GraphConfigurator.ts
+++ b/src/component/mxgraph/GraphConfigurator.ts
@@ -34,7 +34,7 @@ import { mxEvent } from './initializer';
 export default class GraphConfigurator {
   private readonly graph: BpmnGraph;
 
-  constructor(readonly container: HTMLElement) {
+  constructor(container: HTMLElement) {
     this.graph = new BpmnGraph(container);
   }
 
@@ -91,6 +91,6 @@ export default class GraphConfigurator {
 
 function setContainerCursor(graph: BpmnGraph, cursor: 'grab' | 'default'): () => void {
   return (): void => {
-    graph.isEnabled() && (graph.container.style.cursor = cursor);
+    graph.container.style.cursor = cursor;
   };
 }


### PR DESCRIPTION
Remove the container property as it is not used (it was defined in the constructor)
Panning cursor: remove extra condition as the graph is always enabled