### PR TITLE
refactor: simplify some code using the mxGraph API

### DIFF
--- a/src/component/mxgraph/BpmnRenderer.ts
+++ b/src/component/mxgraph/BpmnRenderer.ts
@@ -96,14 +96,12 @@ export class BpmnRenderer {
         edge.geometry.height = labelBounds.height;
 
         const edgeCenterCoordinate = this.coordinatesTranslator.computeEdgeCenter(edge);
-        if (edgeCenterCoordinate) {
-          edge.geometry.relative = false;
+        edge.geometry.relative = false;
 
-          const labelBoundsRelativeCoordinateFromParent = this.coordinatesTranslator.computeRelativeCoordinates(edge.parent, new mxPoint(labelBounds.x, labelBounds.y));
-          const relativeLabelX = labelBoundsRelativeCoordinateFromParent.x + labelBounds.width / 2 - edgeCenterCoordinate.x;
-          const relativeLabelY = labelBoundsRelativeCoordinateFromParent.y - edgeCenterCoordinate.y;
-          edge.geometry.offset = new mxPoint(relativeLabelX, relativeLabelY);
-        }
+        const labelBoundsRelativeCoordinateFromParent = this.coordinatesTranslator.computeRelativeCoordinates(edge.parent, new mxPoint(labelBounds.x, labelBounds.y));
+        const relativeLabelX = labelBoundsRelativeCoordinateFromParent.x + labelBounds.width / 2 - edgeCenterCoordinate.x;
+        const relativeLabelY = labelBoundsRelativeCoordinateFromParent.y - edgeCenterCoordinate.y;
+        edge.geometry.offset = new mxPoint(relativeLabelX, relativeLabelY);
       }
 
       this.insertMessageFlowIconIfNeeded(internalEdge, edge);

--- a/src/component/mxgraph/renderer/CoordinatesTranslator.ts
+++ b/src/component/mxgraph/renderer/CoordinatesTranslator.ts
@@ -71,12 +71,9 @@ export default class CoordinatesTranslator {
     const p0 = points[0];
     const pe = points.at(-1);
 
-    if (p0 != null && pe != null) {
-      const dx = pe.x - p0.x;
-      const dy = pe.y - p0.y;
-      return new mxPoint(p0.x + dx / 2, p0.y + dy / 2);
-    }
-
-    return undefined;
+    // p0 and pe are always set (all tests passed so far)
+    const dx = pe.x - p0.x;
+    const dy = pe.y - p0.y;
+    return new mxPoint(p0.x + dx / 2, p0.y + dy / 2);
   }
 }

--- a/src/component/mxgraph/shape/render/icon-painter.ts
+++ b/src/component/mxgraph/shape/render/icon-painter.ts
@@ -68,9 +68,9 @@ export function buildPaintParameter({
   isFilled?: boolean;
   iconStrokeWidth?: number;
 }): PaintParameter {
-  const shapeStrokeWidth = shape.strokewidth || mxUtils.getValue(shape.style, mxConstants.STYLE_STROKEWIDTH, StyleDefault.STROKE_WIDTH_THIN);
-  const fillColor = shape.fill || mxUtils.getValue(shape.style, mxConstants.STYLE_FILLCOLOR, StyleDefault.DEFAULT_FILL_COLOR);
-  const strokeColor = shape.stroke || mxUtils.getValue(shape.style, mxConstants.STYLE_STROKECOLOR, StyleDefault.DEFAULT_STROKE_COLOR);
+  const shapeStrokeWidth = mxUtils.getValue(shape.style, mxConstants.STYLE_STROKEWIDTH, StyleDefault.STROKE_WIDTH_THIN);
+  const fillColor = mxUtils.getValue(shape.style, mxConstants.STYLE_FILLCOLOR, StyleDefault.DEFAULT_FILL_COLOR);
+  const strokeColor = mxUtils.getValue(shape.style, mxConstants.STYLE_STROKECOLOR, StyleDefault.DEFAULT_STROKE_COLOR);
   const margin = mxUtils.getValue(shape.style, mxConstants.STYLE_MARGIN, StyleDefault.DEFAULT_MARGIN);
   ratioFromParent ??= 0.25;
   isFilled ??= false;


### PR DESCRIPTION
`CoordinatesTranslator`: remove extra null check

`buildParameter`: shape properties are assumed to be set by the CellRender, according to the cell style. So only use properties for the shape style.

NOTE: we have a large number of tests, very varied, so they would have detected regressions in code changes if there were any.