### PR TITLE
ci: fix notification workflows used during releases

### DIFF
--- a/.github/workflows/notify-new-version-available-on-npm.yml
+++ b/.github/workflows/notify-new-version-available-on-npm.yml
@@ -20,11 +20,8 @@ jobs:
         repository:
           - bpmn-visualization-R'
     steps:
-    # TODO log version and event as json
       # Need to checkout to access to the internal action
       - uses: actions/checkout@v4
-        with:
-          ref: v${{ env.VERSION }}
       - name: Notify that a new bpmn-visualization version is available
         uses: ./.github/actions/notify-PA-repo-of-new-version
         with:

--- a/.github/workflows/notify-new-version-available-on-npm.yml
+++ b/.github/workflows/notify-new-version-available-on-npm.yml
@@ -20,6 +20,11 @@ jobs:
         repository:
           - bpmn-visualization-R'
     steps:
+    # TODO log version and event as json
+      # Need to checkout to access to the internal action
+      - uses: actions/checkout@v4
+        with:
+          ref: v${{ env.VERSION }}
       - name: Notify that a new bpmn-visualization version is available
         uses: ./.github/actions/notify-PA-repo-of-new-version
         with:

--- a/.github/workflows/notify-new-version-available-on-npm.yml
+++ b/.github/workflows/notify-new-version-available-on-npm.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         repository:
-          - bpmn-visualization-R'
+          - bpmn-visualization-R
     steps:
       # Need to checkout to access to the internal action
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           # use the default GITHUB_TOKEN, this is possible because we are dispatching the same repository
           event-type: new_version_available_on_npm
-          client-payload: '{ "version": "${{ inputs.version }}" }'
+          client-payload: "{ version: ${{ inputs.version }} }"
       - name: Send message to Slack channel
         if: success()
         uses: slackapi/slack-github-action@v1.26.0


### PR DESCRIPTION
The event send by the "npm publish" workflow was incorrect, it didn't correctly integrate the configuration tested in the playground repository.
The workflow notifying the R package included 2 issues
  - the internal action wasn't checkout
  - the name of the target repository contained a typo

The problems above have impacted the release of version `0.44.0`.
Running the fixed workflow manually fixed the problems for this particular release.

## Notes

#3156 didn't provide a complete solution.

Problems detected during the 0.44.0 release:
- notif R package: no access to the internal action https://github.com/process-analytics/bpmn-visualization-js/actions/runs/10628821965/job/29464398491 
- build demo: version is not correctly resolved, it is empty so the checkout of the tag failed. https://github.com/process-analytics/bpmn-visualization-js/actions/runs/10628821964/job/29464398464. The configuration of the "event" hadn't been correctly ported from https://github.com/process-analytics/github-actions-playground/pull/373/files


### R package

Run with workflow_dispatch with the branch of this PR

❌ Commit: 35b6dfc failed

https://github.com/process-analytics/bpmn-visualization-js/actions/runs/10630529613/job/29469577907

```
Run peter-evans/repository-dispatch@v3
  with:
    token: ***
    repository: process-analytics/bpmn-visualization-R'
    event-type: update_bpmn_visualization_version
    client-payload: {"version":"0.44.0"}
  env:
    VERSION: 0.44.0
    CLIENT_PAYLOAD: {"version":"0.44.0"}
Error: Repository not found, OR token has insufficient permissions.
```

There is an extra quote at the end of the name of the repository: process-analytics/bpmn-visualization-R'
Seen in the URL of the endpoint used when running the job in debug https://github.com/process-analytics/bpmn-visualization-js/actions/runs/10630529613/job/29470436154
```
https://api.github.com/repos/process-analytics/bpmn-visualization-R%27/dispatches',
```

✔️ Commit 974e1a6 succeeded

The PR was created successfully: https://github.com/process-analytics/bpmn-visualization-R/pull/281
https://github.com/process-analytics/bpmn-visualization-js/actions/runs/10633555566/job/29478864552
```
Run peter-evans/repository-dispatch@v3
  with:
    token: ***
    repository: process-analytics/bpmn-visualization-R
    event-type: update_bpmn_visualization_version
    client-payload: {"version":"0.44.0"}
  env:
    VERSION: 0.44.0
    CLIENT_PAYLOAD: {"version":"0.44.0"}
```

### Repository of examples

Run manually from the `master` branch, using version `0.44.0`, https://github.com/process-analytics/bpmn-visualization-js/actions/runs/10630742335/job/29470243002
The PR was created successfully: https://github.com/process-analytics/bpmn-visualization-examples/pull/599
