### PR TITLE
ci: add workaround to prevent "no space left on device" error

### DIFF
--- a/.github/actions/free-runner-disk-space-ubuntu/action.yml
+++ b/.github/actions/free-runner-disk-space-ubuntu/action.yml
@@ -1,0 +1,27 @@
+name: 'Free disk space on Ubuntu runner'
+description: 'Remove unused cached tools, to free disk space'
+
+runs:
+  using: composite
+  steps:
+    #
+    # https://github.com/actions/runner-images/issues/2840#issuecomment-2272410832 (2024-08-07), taking implementation done in https://github.com/cilium/cilium/commit/e553bd23443ef14c8cbbeeafa7ebab3bb30c3fac and remove only tools that we don't use
+    # We may also use https://github.com/jlumbroso/free-disk-space mentioned in https://github.com/actions/runner-images/issues/2875#issuecomment-1163363045
+    - name: Free up disk space
+      shell: bash
+      run: |
+        echo "Disk space before cleanup..."
+        df -kh
+        echo "Removing unnecessary files to free up disk space..."
+        sudo rm -rf \
+          "$AGENT_TOOLSDIRECTORY" \
+          /opt/microsoft/powershell \
+          /opt/pipx \
+          /usr/lib/mono \
+          /usr/local/julia* \
+          /usr/local/lib/android \
+          /usr/local/share/powershell \
+          /usr/share/dotnet \
+          /usr/share/swift
+        echo "Disk space after cleanup..."
+        df -kh

--- a/.github/actions/log-disk-space/action.yml
+++ b/.github/actions/log-disk-space/action.yml
@@ -1,0 +1,16 @@
+name: 'Log disk space'
+description: 'Log disk space (for troubleshooting)'
+
+runs:
+  using: "composite"
+
+  steps:
+    - name: Log disk space on Unix based OS
+      shell: bash
+      if: runner.os != 'Windows'
+      run: df -kh
+    - name: Log disk space on Windows
+      shell: pwsh
+      if: runner.os == 'Windows'
+      run: Get-Volume
+

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -61,17 +61,25 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Free disk space on Ubuntu runner
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/free-runner-disk-space-ubuntu
       - name: Build Setup
         uses: ./.github/actions/build-setup
       - name: Install ${{matrix.browser}}
         uses: ./.github/actions/install-playwright-browser
         with:
           browser: ${{matrix.browser}}
+      - name: Log disk space
+        uses: ./.github/actions/log-disk-space
       - name: Test Application End to End
         id: 'test_e2e'
         env:
           BROWSERS: ${{matrix.browser}}
         run: npm run test:e2e:verbose
+      - name: Log disk space
+        uses: ./.github/actions/log-disk-space
+        if: always()
       - name: Upload e2e test results
         if: ${{ failure() && steps.test_e2e.outcome == 'failure' }}
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The error had been occurring for a few weeks when running e2e tests for Chrome on Ubuntu.
Remove some cached tools to free up space as suggested in the official "runner-images" repository.

### Notes

They have been some related issues reported since the end of August:
- 2024-08-30 https://github.com/actions/runner-images/issues/10511 on macOS. New version of XCode and related simulators were added to the images, so there is less space available
- 2024-09-29 https://github.com/actions/runner-images/issues/10699 on Ubuntu 24 which is very closed to the error we got [logs_29267977676.zip](https://github.com/user-attachments/files/17270168/logs_29267977676.zip)

