### PR TITLE
refactor!: remove `BpmnVisualization.getVersion`

### DIFF
--- a/src/component/BpmnVisualization.ts
+++ b/src/component/BpmnVisualization.ts
@@ -25,7 +25,6 @@ import { Navigation } from './navigation';
 import { newBpmnParser } from './parser/BpmnParser';
 import { createNewBpmnElementsRegistry } from './registry/bpmn-elements-registry';
 import { BpmnModelRegistry } from './registry/bpmn-model-registry';
-import { getVersion, type Version } from './version';
 
 /**
  * Let initialize `bpmn-visualization`. It requires at minimum to pass the HTMLElement in the page where the BPMN diagram is rendered.
@@ -94,13 +93,5 @@ export class BpmnVisualization {
     const bpmnModel = newBpmnParser(this.parserOptions).parse(xml);
     const renderedModel = this.bpmnModelRegistry.load(bpmnModel, options?.modelFilter);
     newBpmnRenderer(this.graph, this.rendererOptions).render(renderedModel, options?.fit);
-  }
-
-  /**
-   * Returns the version of `bpmn-visualization` and the version of its dependencies.
-   * @deprecated As of `0.43.0`, use {@link getVersion} instead. This method will be removed in `0.45.0`.
-   */
-  getVersion(): Version {
-    return getVersion();
   }
 }

--- a/test/integration/BpmnVisualization.test.ts
+++ b/test/integration/BpmnVisualization.test.ts
@@ -65,26 +65,6 @@ describe('BpmnVisualization API', () => {
     });
   });
 
-  // Note: the tests here are duplicated with test/unit/component/version.test.ts
-  // They will be removed when the deprecated `BpmnVisualization.getVersion` method is removed
-  describe('Version', () => {
-    it('lib version', () => {
-      expect(bpmnVisualization.getVersion().lib).toBe(getLibraryVersionFromPackageJson());
-    });
-    it('mxGraph version', () => {
-      expect(bpmnVisualization.getVersion().dependencies.get('mxGraph')).toBeDefined();
-    });
-    it('not modifiable version', () => {
-      const initialVersion = bpmnVisualization.getVersion();
-      initialVersion.lib = 'set by test';
-      initialVersion.dependencies.set('extra', 'added in test');
-
-      const newVersion = bpmnVisualization.getVersion();
-      expect(newVersion.lib).not.toBe(initialVersion.lib);
-      expect(newVersion.dependencies).not.toBe(initialVersion.dependencies);
-    });
-  });
-
   // The API should not fail
   describe('Registry access when no loaded diagram', () => {
     const bv = initializeBpmnVisualizationWithContainerId('bpmn-no-loaded-diagram');
@@ -114,9 +94,3 @@ describe('BpmnVisualization API', () => {
     });
   });
 });
-
-function getLibraryVersionFromPackageJson(): string {
-  const json = readFileSync('../../package.json');
-  const packageJson = JSON.parse(json);
-  return packageJson.version;
-}


### PR DESCRIPTION
This method was deprecated in 0.43.0 and replaced by the `getVersion` function.

BREAKING CHANGES: The `BpmnVisualization.getVersion` method is now removed. Use the `getVersion` function instead.


## Notes

Closes #2966

Version 0.43.0 was released over a year ago, so the depreciation period is sufficient to remove the method.
What's more, all the examples and demonstrations in the Process Analytics organization already use the new function, so we can safely remove the old method.