### PR TITLE
ci(build): switch to sonarqube-scan-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,9 +106,7 @@ jobs:
       # No need to run the analysis from all environments
       - name: SonarCloud Scan
         if: ${{ success() && contains(matrix.os.coverage, 'coverage') && env.SONAR_TOKEN != '' }}
-        # This action is now deprecated, so in the future, we should use the new one
-        # Fore more details, see https://community.sonarsource.com/t/upcoming-last-release-v-4-0-0-remove-docker-and-deprecation-of-github-action-for-sonarqube-cloud/131480
-        uses: SonarSource/sonarcloud-github-action@v4.0.0
+        uses: SonarSource/sonarqube-scan-action@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
The former sonar action was deprecated.
Use this new action which is a drop-replacement.
