### PR TITLE
docs: update the branch naming convention in the Contributing Guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing
+# Contributing Guidelines
 
 You are here to help on `bpmn-visualization`? Awesome, feel welcome and read the following guidelines in order to know how to contribute, to ask questions and to make `bpmn-visualization` such a great tool.
 
@@ -56,12 +56,13 @@ test everything).
 
 [Fork bpmn-visualization](https://help.github.com/articles/fork-a-repo) and create a branch with a descriptive name. 
 
-A good branch name would be (where issue #25 is the ticket you're working on): **25-annotations_to_tasks**  
+A good branch name would be (where issue `25` is the ticket you're working on): **feat/25-annotations_to_tasks**. For a bug, it could be **fix/25-annotations_to_tasks**.
+For more details about the branch naming convention, see the in the [general contribute guidelines](https://github.com/process-analytics/.github/blob/01771492665a92526e2aa1f2b47d781f83e2cd81/CONTRIBUTING.md#branching).
 
-ℹ️ Please don't forget to leave a comment under the issue to let other contributors know that this issue is under the development \[i.e "in progress", "i am on it"\]
+ℹ️ Please don't forget to leave a comment under the issue to let other contributors know that this issue is under the development \[i.e "in progress", "I am on it"\]
 
 ```sh
-git checkout -b 25-annotations_to_tasks
+git checkout -b feat/25-annotations_to_tasks
 ```
 
 ### IDE configuration

--- a/docs/contributors/pull-request.md
+++ b/docs/contributors/pull-request.md
@@ -14,12 +14,12 @@ git pull upstream master
 Then update your feature branch from your local copy of master, and push it!
 
 ```sh
-git checkout 25-annotations_to_tasks
+git checkout feat/25-annotations_to_tasks
 git rebase master
-git push --set-upstream origin 25-annotations_to_tasks
+git push --set-upstream origin feat/25-annotations_to_tasks
 ```
 
-Finally, go to GitHub and [make a Pull Request](https://help.github.com/articles/creating-a-pull-request) ​with labels 😄 \
+Finally, go to GitHub and [create a Pull Request](https://help.github.com/articles/creating-a-pull-request) with labels (labels can only be defined by people with write access to the repository) 😄 \
 For the title, follow the directives of the Pull Request template.
 
 ⚠️ We care about quality. So your PR won't be merged until all tests pass.
@@ -43,9 +43,9 @@ If a maintainer asks you to [rebase](http://git-scm.com/book/en/Git-Branching-Re
 Here's the suggested workflow:
 
 ```sh
-git checkout 25-annotations_to_tasks
+git checkout feat/25-annotations_to_tasks
 git pull --rebase upstream master
-git push --force-with-lease 25-annotations_to_tasks
+git push --force-with-lease feat/25-annotations_to_tasks
 ```
 
 ## Draft Pull Request


### PR DESCRIPTION
Use the same convention as in other repositories of the Process Analytics project.