### PR TITLE
docs: add information for contributors

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,7 @@
+# Sources of the `bpmn-visualization` documentation
+
+If you are a user, you can see the documentation at 🔥 Some add-on features are available through a dedicated package: [__⏩ bpmn-visualization-addons__](https://github.com/process-analytics/bpmn-visualization-addons/)
+
+If you are a contributor to the code of `bpmn-visualization`, you can find the documentation in the [contributors](contributors/README.md) folder.
+
+If you want to contribute to the documentation, please first read the [documentation guidelines](contributors/documentation-guidelines.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,8 @@
 # Sources of the `bpmn-visualization` documentation
 
-If you are a user, you can see the documentation at 🔥 Some add-on features are available through a dedicated package: [__⏩ bpmn-visualization-addons__](https://github.com/process-analytics/bpmn-visualization-addons/)
+If you are a user, you can see the documentation on the [__⏩ documentation site__](https://process-analytics.github.io/bpmn-visualization-js/).
 
 If you are a contributor to the code of `bpmn-visualization`, you can find the documentation in the [contributors](contributors/README.md) folder.
 
 If you want to contribute to the documentation, please first read the [documentation guidelines](contributors/documentation-guidelines.md).
+Then, you can modify the sources of the user documentation that are available in the [users](users/) folder.

--- a/docs/contributors/README.md
+++ b/docs/contributors/README.md
@@ -8,8 +8,8 @@ Here are some tips to help during development.
 
 ## Build and develop
 
-- Architecture: information about the library internals are available in the [architecture folder](../users/architecture) or in HTML form in the [documentation site](https://process-analytics.github.io/bpmn-visualization-js/#_architecture_and_development)
-- [how to build & code style](development.md)
+- Architecture: Information about the library internals are available in the [architecture folder](../users/architecture) or in HTML form in the [documentation site](https://process-analytics.github.io/bpmn-visualization-js/#_architecture_and_development).
+- [How to build & Code style](development.md)
 - [IDE configuration](ide-configuration.md)
 
 ## Contributing
@@ -22,6 +22,6 @@ Here are some tips to help during development.
 - [mxGraph version bump](mxgraph-version-bump.md)
 
 ## Misc
-- [documentation guidelines](documentation-guidelines.md)
-- [for the maintainers](maintainers.md): in particular, how to release a new version
-- automations (CI/CD, release, etc.) are managed by [GitHub Actions](https://docs.github.com/en/actions). The related configuration in available in the [actions](../../.github/actions) and [workflows](../../.github/workflows) directories
+- [Documentation guidelines](documentation-guidelines.md)
+- [For the maintainers](maintainers.md): in particular, how to release a new version.
+- Automations (CI/CD, release, etc.) are managed by [GitHub Actions](https://docs.github.com/en/actions). The related configuration in available in the [actions](../../.github/actions) and [workflows](../../.github/workflows) directories.

--- a/docs/contributors/README.md
+++ b/docs/contributors/README.md
@@ -1,12 +1,14 @@
 # Guidelines for Contributors and Development
 
 General information are available in the [Contributing Guide](../../CONTRIBUTING.md).
-Information about the library internals are available in the [architecture folder](../users/architecture) or in html form in the [documentation site](https://process-analytics.github.io/bpmn-visualization-js/#_architecture_and_development)
 
 Here are some tips to help during development.
 
+🔥 Remember that some add-on features are developed in the [__⏩ bpmn-visualization-addons__](https://github.com/process-analytics/bpmn-visualization-addons/) repository.
+
 ## Build and develop
 
+- Architecture: information about the library internals are available in the [architecture folder](../users/architecture) or in HTML form in the [documentation site](https://process-analytics.github.io/bpmn-visualization-js/#_architecture_and_development)
 - [how to build & code style](development.md)
 - [IDE configuration](ide-configuration.md)
 
@@ -21,4 +23,5 @@ Here are some tips to help during development.
 
 ## Misc
 - [documentation guidelines](documentation-guidelines.md)
-- [for the maintainers](maintainers.md)
+- [for the maintainers](maintainers.md): in particular, how to release a new version
+- automations (CI/CD, release, etc.) are managed by [GitHub Actions](https://docs.github.com/en/actions). The related configuration in available in the [actions](../../.github/actions) and [workflows](../../.github/workflows) directories

--- a/docs/contributors/demo-page-css.md
+++ b/docs/contributors/demo-page-css.md
@@ -5,6 +5,5 @@ The project demo page (`index.html`) uses [tailwindcss](https://tailwindcss.com/
 Vite automatically processes the CSS rules using `postcss`.
 
 Feel free to preview config files:
-- [postcss.config.cjs](postcss.config.cjs)
-- [tailwind.config.js](tailwind.config.js)
-
+- [postcss.config.cjs](../../postcss.config.cjs)
+- [tailwind.config.js](../../tailwind.config.js)

--- a/docs/contributors/development.md
+++ b/docs/contributors/development.md
@@ -26,7 +26,7 @@ Your patch should follow the same conventions & pass the same code quality check
 
 Project, in major line, follows the code style suggested by [airbnb](https://github.com/airbnb/javascript) which is explicit and well documented.
 
-Typescript have been chosen as it's strongly typed, and we believe it adds some syntactical benefits to the JavaScript language
+Typescript was chosen because it's strongly typed, and we believe it adds some syntactical benefits to the JavaScript language.
 More information here: [Typescript](development.md#typescript) 
 
 To enforce best practices we use ESLint and husky.
@@ -48,7 +48,8 @@ For more details, see
 
 
 ## Typescript
-Although Linting, Sonar and Tests keeps the code in a good shape
-We strongly recommend that you read the following resources to write code that conforms to best practices:
+Although Linting, Sonar and Tests keeps the code in a good shape.
+
+To write code that conforms to best practices, we strongly recommend that you review the following resources:
 - [basics](https://www.typescriptlang.org/docs/handbook/basic-types.html)
 - [do's and don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)

--- a/docs/contributors/development.md
+++ b/docs/contributors/development.md
@@ -26,7 +26,7 @@ Your patch should follow the same conventions & pass the same code quality check
 
 Project, in major line, follows the code style suggested by [airbnb](https://github.com/airbnb/javascript) which is explicit and well documented.
 
-Typescript have been chosen as it's strongly typed and we believe it adds some syntactical benefits to the JavaScript language
+Typescript have been chosen as it's strongly typed, and we believe it adds some syntactical benefits to the JavaScript language
 More information here: [Typescript](development.md#typescript) 
 
 To enforce best practices we use ESLint and husky.
@@ -49,6 +49,6 @@ For more details, see
 
 ## Typescript
 Although Linting, Sonar and Tests keeps the code in a good shape
-We strongly recommend you to read following resources to be able to write code that is conform to the best practices:
+We strongly recommend you to read following resources to be able to write code that is conformed to the best practices:
 - [basics](https://www.typescriptlang.org/docs/handbook/basic-types.html)
 - [do's and don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)

--- a/docs/contributors/development.md
+++ b/docs/contributors/development.md
@@ -49,6 +49,6 @@ For more details, see
 
 ## Typescript
 Although Linting, Sonar and Tests keeps the code in a good shape
-We strongly recommend you to read following resources to be able to write code that is conformed to the best practices:
+We strongly recommend that you read the following resources to write code that conforms to best practices:
 - [basics](https://www.typescriptlang.org/docs/handbook/basic-types.html)
 - [do's and don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)

--- a/docs/contributors/documentation-guidelines.md
+++ b/docs/contributors/documentation-guidelines.md
@@ -23,7 +23,7 @@ The root README file content should not be overwhelming and supposed to contain 
 ## Building the HTML documentation
 
 **DISCLAIMER**:
-The documentation sources are in the AsciiDoctor format. 
+The documentation sources are in the AsciiDoctor format.
 Depending on the rendering engine, the display may not work completely (font-awesome icons and some links). 
 This is the case when viewing directly on GitHub Web.
 

--- a/docs/contributors/documentation-guidelines.md
+++ b/docs/contributors/documentation-guidelines.md
@@ -23,8 +23,9 @@ The root README file content should not be overwhelming and supposed to contain 
 ## Building the HTML documentation
 
 **DISCLAIMER**:
-The documentation sources are in the AsciiDoctor format. The display may not fully work (font-awesome icons and some links) depending on the rendering engine.
-This is the case when displayed directly on GitHub Web.
+The documentation sources are in the AsciiDoctor format. 
+Depending on the rendering engine, the display may not work completely (font-awesome icons and some links). 
+This is the case when viewing directly on GitHub Web.
 
 - From the root folder of the repository, run 
 ```bash

--- a/docs/contributors/documentation-guidelines.md
+++ b/docs/contributors/documentation-guidelines.md
@@ -24,7 +24,7 @@ The root README file content should not be overwhelming and supposed to contain 
 
 **DISCLAIMER**:
 The documentation sources are in the AsciiDoctor format.
-Depending on the rendering engine, the display may not work completely (font-awesome icons and some links). 
+Depending on the rendering engine, the display may not work completely (font-awesome icons and some links).
 This is the case when viewing directly on GitHub Web.
 
 - From the root folder of the repository, run 

--- a/docs/contributors/documentation-guidelines.md
+++ b/docs/contributors/documentation-guidelines.md
@@ -2,13 +2,13 @@
 Below guidance should serve to write the properly distributed documentation and to avoid any duplications.
 
 Projects documentation consists of:
-- HTML documentation - everything under the /docs/users folder, with AsciiDoctor sources
+- HTML documentation - everything under the [/docs/users](../users) folder, with AsciiDoctor sources
     - High level information
     - Contextual content
     - BPMN support details
     - Architecture overview
     
-- Markdown documentation for Developers / Integrators - all .md files in project root and under /docs/contributors
+- Markdown documentation for Developers / Integrators - all .md files in project root and under [/docs/contributors](../contributors) folder
     - Development guidance
     - How tos
     - Detailed usage
@@ -20,12 +20,11 @@ The root README file content should not be overwhelming and supposed to contain 
  - Links to examples and developers or html documentation for more details
 
 
-## Building the html documentation
+## Building the HTML documentation
 
 **DISCLAIMER**:
-The documentation sources are in the AsciiDoctor format. The display
-may not fully work (font-awesome icons and some links) depending on the rendering engine. This is the case when
-displayed directly on GitHub Web.
+The documentation sources are in the AsciiDoctor format. The display may not fully work (font-awesome icons and some links) depending on the rendering engine.
+This is the case when displayed directly on GitHub Web.
 
 - From the root folder of the repository, run 
 ```bash


### PR DESCRIPTION
Add information about GitHub Actions and the addons repository
Highlight the architecture and documentation guidelines
Fix some typos and links