### PR TITLE
docs: update "how-ot bump mxgraph" with up-to-date information

### DIFF
--- a/docs/contributors/mxgraph-version-bump.md
+++ b/docs/contributors/mxgraph-version-bump.md
@@ -5,7 +5,7 @@
 - check the [mxGraph changelog](https://github.com/jgraph/mxgraph/blob/master/ChangeLog) to see what could impact the lib
 - review issues list, in particular in the [BPMN Rendering Improvements milestone](https://github.com/process-analytics/bpmn-visualization-js/milestone/14) which could be impacted or fixed by the version bump
 - apply the version bump
-- review the overridden mxgraph code, generally, we redefine prototype, so search for the `prototype` string   
+- review the overridden mxGraph code, generally, we extends the mxGraph objects, so search for the `extends mxgraph.mx` string   
 - ensure we have enough visual tests to cover any regression or changes introduced
 - run the [performance tests](./testing.md#performance-tests) on all OS, ensure we don't see any performance regressions and save the results
 
@@ -24,7 +24,7 @@ In the repository of `bpmn-visualization`, test pages are also available (some a
 ## Resources
 
 - Examples of visual testing failures: [Pull Request #502](https://github.com/process-analytics/bpmn-visualization-js/pull/502)
-- Attempt to Bump mxgraph from 4.1.0 to 4.1.1: [Pull Request #547](https://github.com/process-analytics/bpmn-visualization-js/pull/547#issuecomment-678959718)
+- Attempt to "Bump mxgraph from 4.1.0 to 4.1.1": [Pull Request #547](https://github.com/process-analytics/bpmn-visualization-js/pull/547#issuecomment-678959718)
 
 
 


### PR DESCRIPTION
We no longer override prototype, we extend mxGraph objects.
