### PR TITLE
ci: fix "client-payload" in the event sent after npm publish

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -26,4 +26,4 @@ jobs:
         with:
           # use the default GITHUB_TOKEN, this is possible because we are dispatching the same repository
           event-type: new_version_available_on_npm
-          client-payload: "{ version: ${{ env.VERSION }} }"
+          client-payload: '{ "version": "${{ env.VERSION }}" }'


### PR DESCRIPTION
The client-payload was invalid, the property name and value must be enclosed in double quotes.

### Notes

Fixes #3275 

Inspiration: https://github.com/bonitasoft/bonita-doc/blob/43c8063dc7dae0a976ed95b23f0ce59872215675/.github/workflows/push-content.yml