### PR TITLE
chore(deps-dev): bump typescript from 5.4.5 to 5.8.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,8 +22,6 @@ updates:
       - dependency-name: "eslint"
       # eslint-plugin-unicorn v57+ requires eslint v9 and flat configuration
       - dependency-name: "eslint-plugin-unicorn"
-      # TMP: ignore until we have found a fix to bump to TS 5.5+, see https://github.com/process-analytics/bpmn-visualization-js/pull/3124
-      - dependency-name: "typescript"
     groups:
        css:
           patterns:
@@ -51,11 +49,10 @@ updates:
             - "@rollup/*"
             - "rollup"
             - "rollup-plugin-*"
-# TMP: disabled until we have found a fix to bump to TS 5.5+, see https://github.com/process-analytics/bpmn-visualization-js/pull/3124
-#       typescript:
-#          patterns:
-#            - "typedoc"
-#            - "typescript"
+       typescript:
+          patterns:
+            - "typedoc"
+            - "typescript"
 
   - package-ecosystem: "github-actions"
     # Workflow files stored in the default location of `.github/workflows`

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "tailwindcss": "~4.0.8",
         "ts-jest": "~29.2.6",
         "typedoc": "~0.27.9",
-        "typescript": "~5.4.5",
+        "typescript": "~5.8.2",
         "vite": "~6.2.1"
       }
     },
@@ -3026,10 +3026,14 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "16.18.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.3.tgz",
-      "integrity": "sha512-jh6m0QUhIRcZpNv7Z/rpN+ZWXOicUUQbSoWks7Htkbb9IjFQj4kzcX/xFCkjstCj5flMsN8FiSvt+q+Tcs4Llg==",
-      "dev": true
+      "version": "20.17.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.24.tgz",
+      "integrity": "sha512-d7fGCyB96w9BnWQrOsJtpyiSaBcAYYr75bnK6ZRjDbql2cGLj/3GsL5OYmLPNq76l7Gf2q4Rv9J2o6h5CrD9sA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -13273,9 +13277,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -13307,6 +13311,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unicorn-magic": {
       "version": "0.1.0",
@@ -14815,7 +14826,7 @@
       "dev": true,
       "requires": {
         "@jest/types": "^29.6.3",
-        "@types/node": "^16.18.0",
+        "@types/node": "^20.17.24",
         "chalk": "^4.0.0",
         "jest-message-util": "^29.7.0",
         "jest-util": "^29.7.0",
@@ -14833,7 +14844,7 @@
         "@jest/test-result": "^29.7.0",
         "@jest/transform": "^29.7.0",
         "@jest/types": "^29.6.3",
-        "@types/node": "^16.18.0",
+        "@types/node": "^20.17.24",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
@@ -14866,7 +14877,7 @@
       "requires": {
         "@jest/fake-timers": "^29.7.0",
         "@jest/types": "^29.6.3",
-        "@types/node": "^16.18.0",
+        "@types/node": "^20.17.24",
         "jest-mock": "^29.7.0"
       }
     },
@@ -14897,7 +14908,7 @@
       "requires": {
         "@jest/types": "^29.6.3",
         "@sinonjs/fake-timers": "^10.0.2",
-        "@types/node": "^16.18.0",
+        "@types/node": "^20.17.24",
         "jest-message-util": "^29.7.0",
         "jest-mock": "^29.7.0",
         "jest-util": "^29.7.0"
@@ -14927,7 +14938,7 @@
         "@jest/transform": "^29.7.0",
         "@jest/types": "^29.6.3",
         "@jridgewell/trace-mapping": "^0.3.18",
-        "@types/node": "^16.18.0",
+        "@types/node": "^20.17.24",
         "chalk": "^4.0.0",
         "collect-v8-coverage": "^1.0.0",
         "exit": "^0.1.2",
@@ -15056,7 +15067,7 @@
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "^16.18.0",
+        "@types/node": "^20.17.24",
         "@types/yargs": "^17.0.8",
         "chalk": "^4.0.0"
       }
@@ -15852,7 +15863,7 @@
       "integrity": "sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==",
       "dev": true,
       "requires": {
-        "@types/node": "^16.18.0"
+        "@types/node": "^20.17.24"
       }
     },
     "@types/hast": {
@@ -15909,7 +15920,7 @@
       "integrity": "sha512-YfAchFs0yM1QPDrLm2VHe+WHGtqms3NXnXAMolrgrVP6fgBHHXy1ozAbo/dFtPNtZC/m66bPiCTWYmqp1F14gA==",
       "dev": true,
       "requires": {
-        "@types/node": "^16.18.0",
+        "@types/node": "^20.17.24",
         "@types/tough-cookie": "*",
         "parse5": "^7.0.0"
       }
@@ -15931,10 +15942,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.18.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.3.tgz",
-      "integrity": "sha512-jh6m0QUhIRcZpNv7Z/rpN+ZWXOicUUQbSoWks7Htkbb9IjFQj4kzcX/xFCkjstCj5flMsN8FiSvt+q+Tcs4Llg==",
-      "dev": true
+      "version": "20.17.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.24.tgz",
+      "integrity": "sha512-d7fGCyB96w9BnWQrOsJtpyiSaBcAYYr75bnK6ZRjDbql2cGLj/3GsL5OYmLPNq76l7Gf2q4Rv9J2o6h5CrD9sA==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~6.19.2"
+      }
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -15946,7 +15960,7 @@
       "version": "5.2.4",
       "dev": true,
       "requires": {
-        "@types/node": "^16.18.0"
+        "@types/node": "^20.17.24"
       }
     },
     "@types/resolve": {
@@ -15977,7 +15991,7 @@
       "integrity": "sha512-EBsPjFMrFlMbbUFf9D1Fp+PAB2TwmUn7a3YtHyD9RLuTIk1jDd8SxXVAoez2Ciy+8Jsceo2MYEYZzJ/DvorOKw==",
       "dev": true,
       "requires": {
-        "@types/node": "^16.18.0"
+        "@types/node": "^20.17.24"
       }
     },
     "@types/yargs": {
@@ -19096,7 +19110,7 @@
         "@jest/expect": "^29.7.0",
         "@jest/test-result": "^29.7.0",
         "@jest/types": "^29.6.3",
-        "@types/node": "^16.18.0",
+        "@types/node": "^20.17.24",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
         "dedent": "^1.0.0",
@@ -19289,7 +19303,7 @@
         "@jest/fake-timers": "^29.7.0",
         "@jest/types": "^29.6.3",
         "@types/jsdom": "^20.0.0",
-        "@types/node": "^16.18.0",
+        "@types/node": "^20.17.24",
         "jest-mock": "^29.7.0",
         "jest-util": "^29.7.0",
         "jsdom": "^20.0.0"
@@ -19304,7 +19318,7 @@
         "@jest/environment": "^29.7.0",
         "@jest/fake-timers": "^29.7.0",
         "@jest/types": "^29.6.3",
-        "@types/node": "^16.18.0",
+        "@types/node": "^20.17.24",
         "jest-mock": "^29.7.0",
         "jest-util": "^29.7.0"
       }
@@ -19333,7 +19347,7 @@
       "requires": {
         "@jest/types": "^29.6.3",
         "@types/graceful-fs": "^4.1.3",
-        "@types/node": "^16.18.0",
+        "@types/node": "^20.17.24",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
         "fsevents": "^2.3.2",
@@ -19454,7 +19468,7 @@
       "dev": true,
       "requires": {
         "@jest/types": "^29.6.3",
-        "@types/node": "^16.18.0",
+        "@types/node": "^20.17.24",
         "jest-util": "^29.7.0"
       }
     },
@@ -19552,7 +19566,7 @@
         "@jest/test-result": "^29.7.0",
         "@jest/transform": "^29.7.0",
         "@jest/types": "^29.6.3",
-        "@types/node": "^16.18.0",
+        "@types/node": "^20.17.24",
         "chalk": "^4.0.0",
         "emittery": "^0.13.1",
         "graceful-fs": "^4.2.9",
@@ -19604,7 +19618,7 @@
         "@jest/test-result": "^29.7.0",
         "@jest/transform": "^29.7.0",
         "@jest/types": "^29.6.3",
-        "@types/node": "^16.18.0",
+        "@types/node": "^20.17.24",
         "chalk": "^4.0.0",
         "cjs-module-lexer": "^1.0.0",
         "collect-v8-coverage": "^1.0.0",
@@ -19674,7 +19688,7 @@
       "dev": true,
       "requires": {
         "@jest/types": "^29.6.3",
-        "@types/node": "^16.18.0",
+        "@types/node": "^20.17.24",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
         "graceful-fs": "^4.2.9",
@@ -19719,7 +19733,7 @@
       "requires": {
         "@jest/test-result": "^29.7.0",
         "@jest/types": "^29.6.3",
-        "@types/node": "^16.18.0",
+        "@types/node": "^20.17.24",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "emittery": "^0.13.1",
@@ -19733,7 +19747,7 @@
       "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
       "dev": true,
       "requires": {
-        "@types/node": "^16.18.0",
+        "@types/node": "^20.17.24",
         "jest-util": "^29.7.0",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.0.0"
@@ -22783,9 +22797,9 @@
       }
     },
     "typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "dev": true
     },
     "uc.micro": {
@@ -22805,6 +22819,12 @@
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true
     },
     "unicorn-magic": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -163,11 +163,11 @@
     "tailwindcss": "~4.0.8",
     "ts-jest": "~29.2.6",
     "typedoc": "~0.27.9",
-    "typescript": "~5.4.5",
+    "typescript": "~5.8.2",
     "vite": "~6.2.1"
   },
   "overrides": {
-    "@types/node": "^16.18.0"
+    "@types/node": "^20.17.24"
   },
   "lint-staged": {
     "*.{js,cjs,mjs,ts,cts,mts}": [

--- a/src/bpmn-visualization.ts
+++ b/src/bpmn-visualization.ts
@@ -15,7 +15,10 @@ limitations under the License.
 */
 
 // Use mxgraph types
-/// <reference types="@typed-mxgraph/typed-mxgraph" />
+// The `preserve="true"` directive is required to retain types in the output starting from TypeScript 5.5.
+// See https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html#preservetrue for details.
+// It is sufficient to add the `preserve` attribute once across all triple-slash directives, as the API Extractor will merge them when generating the final single definition file.
+/// <reference types="@typed-mxgraph/typed-mxgraph" preserve="true"/>
 
 // Public API
 export * from './component/options';

--- a/src/component/parser/json/converter/ProcessConverter.ts
+++ b/src/component/parser/json/converter/ProcessConverter.ts
@@ -334,8 +334,8 @@ export default class ProcessConverter {
 
     for (const eventDefinitionKind of eventDefinitionKinds) {
       // sometimes eventDefinition is simple, and therefore it is parsed as empty string "", in that case eventDefinition will be converted to an empty object
-      const eventDefinition = bpmnElement[`${eventDefinitionKind}EventDefinition`];
-      eventDefinitionsByKind.set(eventDefinitionKind, ensureIsArray(eventDefinition, true));
+      const eventDefinition = bpmnElement[`${eventDefinitionKind}EventDefinition`] as string | RegisteredEventDefinition;
+      eventDefinitionsByKind.set(eventDefinitionKind, ensureIsArray<RegisteredEventDefinition>(eventDefinition, true));
     }
 
     for (const eventDefinitionReference of ensureIsArray<string>(bpmnElement.eventDefinitionRef)) {


### PR DESCRIPTION
Update configuration and code to ensure compatibility with the new TypeScript version.

- Use a recent version of `@types/node` that matches the Node.js version used for building the project.  
  The previous version had type issues related to `AbortSignal`, similar to the upgrade to TypeScript 4.9 (see 6356b3e).
- Add an attribute to retain the triple-slash reference to `mxGraph` types in the type definitions included in the npm package.  
  As of TypeScript 5.5, this is required; otherwise, the reference is omitted.


## Notes

This work started in #3124 in August 2024. At that time, we haven't found in the TypeScript documentation the behavior change about triple slash references. 
