### PR TITLE
chore(deps-dev): bump playwright from 1.52.0 to 1.53.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "minimist": "~1.2.8",
         "npm-run-all": "~4.1.5",
         "pinst": "~3.0.0",
-        "playwright": "~1.52.0",
+        "playwright": "~1.53.0",
         "postcss": "~8.5.3",
         "postcss-cli": "~11.0.1",
         "prettier": "~3.5.3",
@@ -11091,13 +11091,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
-      "integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.53.0.tgz",
+      "integrity": "sha512-ghGNnIEYZC4E+YtclRn4/p6oYbdPiASELBIYkBXfaTVKreQUYbMUYQDwS12a8F0/HtIjr/CkGjtwABeFPGcS4Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.52.0"
+        "playwright-core": "1.53.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -11110,9 +11110,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
-      "integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.0.tgz",
+      "integrity": "sha512-mGLg8m0pm4+mmtB7M89Xw/GSqoNC+twivl8ITteqvAndachozYe2ZA7srU6uleV1vEdAHYqjq+SV8SNxRRFYBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -21871,19 +21871,19 @@
       }
     },
     "playwright": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
-      "integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.53.0.tgz",
+      "integrity": "sha512-ghGNnIEYZC4E+YtclRn4/p6oYbdPiASELBIYkBXfaTVKreQUYbMUYQDwS12a8F0/HtIjr/CkGjtwABeFPGcS4Q==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2",
-        "playwright-core": "1.52.0"
+        "playwright-core": "1.53.0"
       }
     },
     "playwright-core": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
-      "integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.0.tgz",
+      "integrity": "sha512-mGLg8m0pm4+mmtB7M89Xw/GSqoNC+twivl8ITteqvAndachozYe2ZA7srU6uleV1vEdAHYqjq+SV8SNxRRFYBw==",
       "dev": true
     },
     "pluralize": {

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "minimist": "~1.2.8",
     "npm-run-all": "~4.1.5",
     "pinst": "~3.0.0",
-    "playwright": "~1.52.0",
+    "playwright": "~1.53.0",
     "postcss": "~8.5.3",
     "postcss-cli": "~11.0.1",
     "prettier": "~3.5.3",

--- a/test/e2e/overlays.rendering.test.ts
+++ b/test/e2e/overlays.rendering.test.ts
@@ -52,6 +52,7 @@ class ImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
       [
         'overlays.edges.message.flows.complex.paths',
         {
+          linux: 0.18 / 100, // max 0.17328979983225468%
           macos: 0.39 / 100, // max 0.38845092259515157%
           windows: 0.2 / 100, // max 0.1989755797400572%
         },
@@ -337,6 +338,7 @@ describe('Overlay style', () => {
         [
           'fill',
           {
+            linux: 0.13 / 100, // 0.12108823641220345%%
             macos: 0.15 / 100, // 0.14612951118292417%
             windows: 0.15 / 100, // 0.14250607890964326%
           },
@@ -351,6 +353,7 @@ describe('Overlay style', () => {
         [
           'stroke',
           {
+            linux: 0.04 / 100, // 0.03319006305509964%
             macos: 0.22 / 100, // 0.21534933042920423%
             windows: 0.24 / 100, // 0.23679453599644296%
           },


### PR DESCRIPTION
Update Chromium thresholds for linux to match the new browser version.