### PR TITLE
test(e2e): fix thresold for firefox on macos

### DIFF
--- a/test/e2e/overlays.rendering.test.ts
+++ b/test/e2e/overlays.rendering.test.ts
@@ -86,7 +86,7 @@ class ImageSnapshotThresholds extends MultiBrowserImageSnapshotThresholds {
         'overlays.edges.message.flows.complex.paths',
         {
           linux: 0.71 / 100, // 0.7075048726484345%
-          macos: 0.71 / 100, // 0.7082393664009867%
+          macos: 0.72 / 100, // 0.7142164089951275%
           windows: 0.73 / 100, // 0.7201733271427924%
         },
       ],


### PR DESCRIPTION
The threshold hadn't been updated during the latest playwright update (4a8ca7382f2333075d4854bc047bed629bb0976e) because, strangely, at that time, the test didn't fail.
