### PR TITLE
fix(e2e): stabilize flaky BPMN container initialization check

### DIFF
--- a/test/shared/visu/bpmn-page-utils.ts
+++ b/test/shared/visu/bpmn-page-utils.ts
@@ -46,10 +46,12 @@ class BpmnPage {
   ) {}
 
   async expectAvailableBpmnContainer(options?: PageWaitForSelectorOptions): Promise<void> {
-    pageCheckLog('Expecting the BPMN container available (confirm bpmn-visualization initialization)');
+    pageCheckLog('Waiting for the BPMN container to be initialized (verifying bpmn-visualization setup)');
+    // Check that mxGraph updated the DOM with the SVG element. This is done during the bpmn-visualization initialization.
+    // See BpmnQuerySelectors, the 2nd 'g' node contains the BPMN elements
     // eslint-disable-next-line jest/no-standalone-expect
-    await expect(this.page).toMatchAttribute(`#${this.bpmnContainerId}`, 'style', /cursor: default/, options);
-    pageCheckLog('BPMN container available');
+    await expect(this.page).toHaveSelector(`#${this.bpmnContainerId} > svg > g > g:nth-child(2)`, options);
+    pageCheckLog('BPMN container initialized');
   }
 
   async expectPageTitle(title: string): Promise<void> {


### PR DESCRIPTION
Previously, the test checked for a style attribute to determine if the BPMN container was initialized.
This approach was unreliable, especially on macOS with Firefox in CI environments, because the attribute could exist before its value was updated by the library, causing the test to miss the actual initialization and fail intermittently.

This commit replaces the attribute check with a more robust method: it now waits for the presence of SVG elements (specifically, the expected group nodes) in the DOM, which reliably indicates that the library has completed initialization and rendering.

This change improves test stability and reduces flakiness in CI environments.