### PR TITLE
fix!: ShapeUtil does not include BPMN artifacts in flow node kinds 

### DIFF
--- a/src/component/parser/json/converter/ProcessConverter.ts
+++ b/src/component/parser/json/converter/ProcessConverter.ts
@@ -73,6 +73,7 @@ const computeSubProcessKind = (processedSemanticType: BpmnSemanticType, bpmnElem
   }
 };
 
+//  semantically speaking, artifacts are not FlowNodes, but for the purpose of conversion, we consider them as FlowNodes here
 const orderedFlowNodeBpmnTypes: BpmnSemanticType[] = [
   // specific management for adhoc and transaction sub-processes which are handled with a dedicated ShapeBpmnSubProcessKind
   'adHocSubProcess',

--- a/src/component/parser/json/converter/ProcessConverter.ts
+++ b/src/component/parser/json/converter/ProcessConverter.ts
@@ -78,7 +78,7 @@ const orderedFlowNodeBpmnTypes: BpmnSemanticType[] = [
   'adHocSubProcess',
   'transaction',
   // process boundary events afterward as we need its parent activity to be available when building it
-  ...(ShapeUtil.flowNodeKinds().filter(kind => kind !== ShapeBpmnElementKind.EVENT_BOUNDARY) as BpmnSemanticType[]),
+  ...([...ShapeUtil.flowNodeKinds(), ...ShapeUtil.artifactKinds()].filter(kind => kind !== ShapeBpmnElementKind.EVENT_BOUNDARY) as BpmnSemanticType[]),
   ShapeBpmnElementKind.EVENT_BOUNDARY,
 ];
 

--- a/src/model/bpmn/internal/shape/utils.ts
+++ b/src/model/bpmn/internal/shape/utils.ts
@@ -104,7 +104,7 @@ export class ShapeUtil {
   }
 
   static flowNodeKinds(): ShapeBpmnElementKind[] {
-    return Object.values(ShapeBpmnElementKind).filter(kind => !ShapeUtil.isPoolOrLane(kind));
+    return Object.values(ShapeBpmnElementKind).filter(kind => !ShapeUtil.isPoolOrLane(kind) && !ShapeUtil.isArtifact(kind));
   }
 
   /**

--- a/test/unit/component/mxgraph/renderer/StyleComputer.test.ts
+++ b/test/unit/component/mxgraph/renderer/StyleComputer.test.ts
@@ -556,6 +556,7 @@ describe('Style Computer', () => {
           const additionalColorsStyle = expectAdditionalColorsStyle ? ';fillColor=#000003;strokeColor=#FF0203;fontColor=#010101' : '';
           expect(computeStyleWithRendererOptions(shape)).toBe(`${kind}${additionalColorsStyle}`);
         });
+
         it.each([ShapeBpmnElementKind.LANE, ShapeBpmnElementKind.POOL])('%s', (kind: ShapeBpmnElementKind) => {
           const shape = newShape(newShapeBpmnElement(kind), newLabelExtension('#aa0101'));
           shape.extensions.fillColor = '#AA0003';
@@ -563,6 +564,15 @@ describe('Style Computer', () => {
           const additionalColorsStyle = expectAdditionalColorsStyle ? ';fillColor=#AA0003;swimlaneFillColor=#AA0003;strokeColor=#FF02AA;fontColor=#aa0101' : '';
           expect(computeStyleWithRendererOptions(shape)).toBe(`${kind};horizontal=1${additionalColorsStyle}`);
         });
+
+        it.each([ShapeBpmnElementKind.GROUP, ShapeBpmnElementKind.TEXT_ANNOTATION])('%s', (kind: ShapeBpmnElementKind) => {
+          const shape = newShape(newShapeBpmnElement(kind), newLabelExtension('#aa0101'));
+          shape.extensions.fillColor = '#AA0003';
+          shape.extensions.strokeColor = '#FF02AA';
+          const additionalColorsStyle = expectAdditionalColorsStyle ? ';fillColor=#AA0003;strokeColor=#FF02AA;fontColor=#aa0101' : '';
+          expect(computeStyleWithRendererOptions(shape)).toBe(`${kind}${additionalColorsStyle}`);
+        });
+
         it('no extension', () => {
           const shape = newShape(newShapeBpmnElement(ShapeBpmnElementKind.TASK));
           expect(computeStyleWithRendererOptions(shape)).toBe(`task`);

--- a/test/unit/model/bpmn/internal/shape/utils.test.ts
+++ b/test/unit/model/bpmn/internal/shape/utils.test.ts
@@ -31,10 +31,13 @@ describe('ShapeUtil', () => {
 
   it('flow node kinds', () => {
     const flowNodeKinds = ShapeUtil.flowNodeKinds();
-    expect(flowNodeKinds).toContain(ShapeBpmnElementKind.TASK);
-    expect(flowNodeKinds).toContain(ShapeBpmnElementKind.EVENT_INTERMEDIATE_CATCH);
-    expect(flowNodeKinds).toContain(ShapeBpmnElementKind.GROUP); // artifact should not be included
+
+    expect(flowNodeKinds).toEqual(expect.arrayContaining(ShapeUtil.activityKinds()));
+    expect(flowNodeKinds).toEqual(expect.arrayContaining(ShapeUtil.eventKinds()));
+    expect(flowNodeKinds).toEqual(expect.arrayContaining(ShapeUtil.gatewayKinds()));
+
     expect(flowNodeKinds).not.toContain(ShapeBpmnElementKind.POOL);
+    expect(flowNodeKinds).not.toContain(ShapeBpmnElementKind.GROUP);
   });
 
   it('artifact kinds', () => {
@@ -90,8 +93,8 @@ describe('ShapeUtil', () => {
       ${ShapeBpmnElementKind.CALL_ACTIVITY}    | ${true}
       ${ShapeBpmnElementKind.POOL}             | ${false}
       ${ShapeBpmnElementKind.LANE}             | ${false}
-      ${ShapeBpmnElementKind.GROUP}            | ${true}
-      ${ShapeBpmnElementKind.TEXT_ANNOTATION}  | ${true}
+      ${ShapeBpmnElementKind.GROUP}            | ${false}
+      ${ShapeBpmnElementKind.TEXT_ANNOTATION}  | ${false}
       ${FlowKind.MESSAGE_FLOW}                 | ${false}
       ${'unknown'}                             | ${false}
       ${'receiveTask'}                         | ${true}


### PR DESCRIPTION
Regarding the BPMN semantic, artifacts are not executable flow nodes so they are no longer returned in the result of the `ShapeUtil.flowNodeKinds` method.

BREAKING CHANGES: artifacts are no longer considered as flow nodes.
Code using the `ShapeUtil.flowNodeKinds` method may need to be updated to concatenate the array returned by the `ShapeUtil.artifactKinds` method and restore the previous behavior.