### PR TITLE
chore(deps): bump fast-xml-parser from 5.5.10 to 5.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@typed-mxgraph/typed-mxgraph": "~1.0.8",
         "es-toolkit": "~1.45.0",
-        "fast-xml-parser": "5.6.0",
+        "fast-xml-parser": "5.7.1",
         "mxgraph": "4.2.2"
       },
       "devDependencies": {
@@ -3150,9 +3150,9 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-1.1.0.tgz",
-      "integrity": "sha512-bidpxmTBP0pOsxULw6XlxzQpTgrAGLDHGBK/JuWhPDL6ZV0GZ/PmN9CA9do6e+A9lYI6qx6ikJUtJYRxup141g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
       "funding": [
         {
           "type": "github",
@@ -7848,9 +7848,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
       "funding": [
         {
           "type": "github",
@@ -7862,9 +7862,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.6.0.tgz",
-      "integrity": "sha512-5G+uaEBbOm9M4dgMOV3K/rBzfUNGqGqoUTaYJM3hBwM8t71w07gxLQZoTsjkY8FtfjabqgQHEkeIySBDYeBmJw==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
+      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
       "funding": [
         {
           "type": "github",
@@ -7873,8 +7873,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@nodable/entities": "^1.1.0",
-        "fast-xml-builder": "^1.1.4",
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
         "path-expression-matcher": "^1.5.0",
         "strnum": "^2.2.3"
       },
@@ -19973,9 +19973,9 @@
       }
     },
     "@nodable/entities": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-1.1.0.tgz",
-      "integrity": "sha512-bidpxmTBP0pOsxULw6XlxzQpTgrAGLDHGBK/JuWhPDL6ZV0GZ/PmN9CA9do6e+A9lYI6qx6ikJUtJYRxup141g=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -23090,20 +23090,20 @@
       "dev": true
     },
     "fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
       "requires": {
         "path-expression-matcher": "^1.1.3"
       }
     },
     "fast-xml-parser": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.6.0.tgz",
-      "integrity": "sha512-5G+uaEBbOm9M4dgMOV3K/rBzfUNGqGqoUTaYJM3hBwM8t71w07gxLQZoTsjkY8FtfjabqgQHEkeIySBDYeBmJw==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
+      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
       "requires": {
-        "@nodable/entities": "^1.1.0",
-        "fast-xml-builder": "^1.1.4",
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
         "path-expression-matcher": "^1.5.0",
         "strnum": "^2.2.3"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@typed-mxgraph/typed-mxgraph": "~1.0.8",
         "es-toolkit": "~1.45.0",
-        "fast-xml-parser": "5.5.10",
+        "fast-xml-parser": "5.6.0",
         "mxgraph": "4.2.2"
       },
       "devDependencies": {
@@ -3148,6 +3148,18 @@
         "@emnapi/runtime": "^1.4.3",
         "@tybys/wasm-util": "^0.9.0"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-1.1.0.tgz",
+      "integrity": "sha512-bidpxmTBP0pOsxULw6XlxzQpTgrAGLDHGBK/JuWhPDL6ZV0GZ/PmN9CA9do6e+A9lYI6qx6ikJUtJYRxup141g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -7850,9 +7862,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.10",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.10.tgz",
-      "integrity": "sha512-go2J2xODMc32hT+4Xr/bBGXMaIoiCwrwp2mMtAvKyvEFW6S/v5Gn2pBmE4nvbwNjGhpcAiOwEv7R6/GZ6XRa9w==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.6.0.tgz",
+      "integrity": "sha512-5G+uaEBbOm9M4dgMOV3K/rBzfUNGqGqoUTaYJM3hBwM8t71w07gxLQZoTsjkY8FtfjabqgQHEkeIySBDYeBmJw==",
       "funding": [
         {
           "type": "github",
@@ -7861,9 +7873,10 @@
       ],
       "license": "MIT",
       "dependencies": {
+        "@nodable/entities": "^1.1.0",
         "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.1",
-        "strnum": "^2.2.2"
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -13941,9 +13954,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.4.0.tgz",
-      "integrity": "sha512-s4DQMxIdhj3jLFWd9LxHOplj4p9yQ4ffMGowFf3cpEgrrJjEhN0V5nxw4Ye1EViAGDoL4/1AeO6qHpqYPOzE4Q==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
       "funding": [
         {
           "type": "github",
@@ -19959,6 +19972,11 @@
         "@tybys/wasm-util": "^0.9.0"
       }
     },
+    "@nodable/entities": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-1.1.0.tgz",
+      "integrity": "sha512-bidpxmTBP0pOsxULw6XlxzQpTgrAGLDHGBK/JuWhPDL6ZV0GZ/PmN9CA9do6e+A9lYI6qx6ikJUtJYRxup141g=="
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "dev": true,
@@ -23080,13 +23098,14 @@
       }
     },
     "fast-xml-parser": {
-      "version": "5.5.10",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.10.tgz",
-      "integrity": "sha512-go2J2xODMc32hT+4Xr/bBGXMaIoiCwrwp2mMtAvKyvEFW6S/v5Gn2pBmE4nvbwNjGhpcAiOwEv7R6/GZ6XRa9w==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.6.0.tgz",
+      "integrity": "sha512-5G+uaEBbOm9M4dgMOV3K/rBzfUNGqGqoUTaYJM3hBwM8t71w07gxLQZoTsjkY8FtfjabqgQHEkeIySBDYeBmJw==",
       "requires": {
+        "@nodable/entities": "^1.1.0",
         "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.1",
-        "strnum": "^2.2.2"
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       }
     },
     "fastq": {
@@ -27266,9 +27285,9 @@
       "dev": true
     },
     "path-expression-matcher": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.4.0.tgz",
-      "integrity": "sha512-s4DQMxIdhj3jLFWd9LxHOplj4p9yQ4ffMGowFf3cpEgrrJjEhN0V5nxw4Ye1EViAGDoL4/1AeO6qHpqYPOzE4Q=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="
     },
     "path-is-absolute": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
   "dependencies": {
     "@typed-mxgraph/typed-mxgraph": "~1.0.8",
     "es-toolkit": "~1.45.0",
-    "fast-xml-parser": "5.5.10",
+    "fast-xml-parser": "5.6.0",
     "mxgraph": "4.2.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
   "dependencies": {
     "@typed-mxgraph/typed-mxgraph": "~1.0.8",
     "es-toolkit": "~1.45.0",
-    "fast-xml-parser": "5.6.0",
+    "fast-xml-parser": "5.7.1",
     "mxgraph": "4.2.2"
   },
   "devDependencies": {


### PR DESCRIPTION
The new versions includes various security fixes and new features that bpmn-visualization doesn't use.
The entity management is now done by an external dependency (@nodable/entities).

The update increases the size of the minified file from 4 KB to 4.5 KB.

## Impacts on the size of the bundles

### Npm package

| bundle | fxp 5.5.10 on master 61a634f415558541809daae8dad5baacc996447f | fxp 5.6.0 | fxp 5.7.1 |
|---|---|---|---|
| bpmn-visualization.min.js | 998 629 bytes | 1 003 826 bytes |1 003 235 bytes |
| | 975.2 kB | 980.3 kB |979.7 kB |
| bpmn-visualization.js | 1 744 247 bytes | 1 752 621 bytes |1 752 597 bytes |
| | 1703.4 kB | 1711.5 kB |1711.5 kB |
| bpmn-visualization.esm.js | 208 039 bytes | 208 039 bytes |208 039 bytes |
| | 203.2 kB | 203.2 kB | 203.2 kB |



### Demo

| Dependency | fxp 5.5.10 on master 61a634f415558541809daae8dad5baacc996447f  | fxp 5.6.0 | fxp 5.7.1 |
|---|---|---|---|
| bpmn-visualization | 87.59 kB | 87.59 kB | 87.59 kB |
| es-toolkit | 0.88 kB | 0.88 kB | 0.88 kB |
| fast-xml-parser | 36.40 kB | 41.17 kB | 40.38 kB |
| mxgraph | 837.26 kB | 837.26 kB | 837.26 kB |
| **TOTAL** | **962.13 kB** | **966.90 kB** | **966.11 kB** |
