### PR TITLE
chore!: prefer interfaces over types for public type definitions

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -107,8 +107,6 @@ module.exports = {
           },
         ],
         '@typescript-eslint/consistent-type-imports': ['error'],
-        // We choose to disable it and choose later if we want to enable it. See https://github.com/process-analytics/bpmn-visualization-js/pull/2821.
-        '@typescript-eslint/consistent-type-definitions': 'off',
         '@typescript-eslint/dot-notation': 'error',
 
         'require-await': 'off', // disable the base eslint rule as it can report incorrect errors when '@typescript-eslint/require-await' is enabled (see official documentation)

--- a/src/bpmn-visualization.ts
+++ b/src/bpmn-visualization.ts
@@ -27,6 +27,8 @@ export * from './component/registry';
 export * from './component/version';
 export type { Navigation } from './component/navigation';
 export * from './model/bpmn/internal';
+export type { BpmnGraph } from './component/mxgraph/BpmnGraph';
+export type * from './component/types';
 
 // not part of the public API but needed for the custom theme examples
 export { StyleConfigurator } from './component/mxgraph/config/StyleConfigurator';

--- a/src/component/mxgraph/BpmnGraph.ts
+++ b/src/component/mxgraph/BpmnGraph.ts
@@ -95,8 +95,7 @@ export class BpmnGraph extends mxGraph {
    *
    * @param callbackFunction the update to be made in the transaction.
    *
-   * @experimental subject to change, may move to a subclass of {@link mxGraphModel}
-   * @alpha
+   * @experimental subject to change, may move to a subclass of `mxGraphModel`
    */
   batchUpdate(callbackFunction: () => void): void {
     this.model.beginUpdate();

--- a/src/component/mxgraph/shape/render/icon-painter.ts
+++ b/src/component/mxgraph/shape/render/icon-painter.ts
@@ -97,15 +97,12 @@ export class IconPainter {
   /**
    * Utility paint icon methods to easily instantiate a {@link BpmnCanvas} from a {@link PaintParameter}.
    *
-   * @param canvas                  `mxAbstractCanvas2D` in charge of performing the paint operations.
-   * @param ratioFromParent         the actual size of the icon will be computed from the shape dimensions using this ratio.
-   * @param setIconOriginFunct      called function to set the origin of the icon. Generally, it calls a method of {@link BpmnCanvas}.
-   * @param shapeConfig             dimension and style of the shape where the icon is painted.
-   * @param iconStyleConfig         style of the icon.
-   * @param originalIconSize        original size of the icon used to compute the scaling/ratio in {@link BpmnCanvas}.
+   * @param paintParameter   aggregates the canvas, the shape/icon configuration and the rendering helpers used to paint the icon. See {@link PaintParameter}.
+   * @param originalIconSize original size of the icon used to compute the scaling/ratio in {@link BpmnCanvas}.
    * @protected
    */
-  protected newBpmnCanvas({ canvas, ratioFromParent, setIconOriginFunct, shapeConfig, iconStyleConfig }: PaintParameter, originalIconSize: Size): BpmnCanvas {
+  protected newBpmnCanvas(paintParameter: PaintParameter, originalIconSize: Size): BpmnCanvas {
+    const { canvas, ratioFromParent, setIconOriginFunct, shapeConfig, iconStyleConfig } = paintParameter;
     return new BpmnCanvas({
       canvas,
       shapeConfig,

--- a/src/component/options.ts
+++ b/src/component/options.ts
@@ -168,7 +168,7 @@ export enum ZoomType {
  * Configure the BPMN parser.
  * @category Initialization & Configuration
  */
-export type ParserOptions = {
+export interface ParserOptions {
   /**
    * Apply additional processing to the XML attributes in the BPMN source.
    *
@@ -182,7 +182,7 @@ export type ParserOptions = {
    *   }
    * }
    * ```
-   * @param val the value of the 'name' attribute to be processed.
+   * @param value the value of the 'name' attribute to be processed.
    */
   additionalXmlAttributeProcessor?: (value: string) => string;
   /**
@@ -190,7 +190,7 @@ export type ParserOptions = {
    * @default false
    */
   disableConsoleLog?: boolean;
-};
+}
 
 /**
  * Global configuration for the rendering of the BPMN elements.
@@ -198,7 +198,7 @@ export type ParserOptions = {
  * @category Initialization & Configuration
  * @since 0.35.0
  */
-export type RendererOptions = {
+export interface RendererOptions {
   /**
    * Custom {@link IconPainter} instance to use for rendering BPMN element icons.
    * This allows you to customize how icons are rendered on tasks, events, and other BPMN elements.
@@ -264,4 +264,4 @@ export type RendererOptions = {
    * @since 0.48.0
    */
   ignoreTaskLabelBounds?: boolean;
-};
+}

--- a/src/component/parser/xml/BpmnXmlParser.ts
+++ b/src/component/parser/xml/BpmnXmlParser.ts
@@ -19,10 +19,10 @@ import type { ParserOptions } from '../../options';
 
 import { XMLParser, type X2jOptions } from 'fast-xml-parser';
 
-type Replacement = {
+interface Replacement {
   regex: RegExp;
   val: string;
-};
+}
 const entitiesReplacements: Replacement[] = [
   { regex: /&(amp|#38|#x26);/g, val: '&' },
   { regex: /&(apos|#39|#x27);/g, val: "'" },

--- a/src/component/registry/types.ts
+++ b/src/component/registry/types.ts
@@ -431,27 +431,27 @@ export type OverlayPosition = OverlayShapePosition | OverlayEdgePosition;
 /**
  * @category Overlays
  */
-export type OverlayStyle = {
+export interface OverlayStyle {
   font?: OverlayFont;
   fill?: OverlayFill;
   stroke?: OverlayStroke;
-};
+}
 
 /**
  * The font family is {@link StyleDefault.DEFAULT_FONT_FAMILY}.
  * @category Overlays
  */
-export type OverlayFont = {
+export interface OverlayFont {
   /** @default {@link StyleDefault.DEFAULT_OVERLAY_FONT_COLOR} */
   color?: string;
   /** @default {@link StyleDefault.DEFAULT_OVERLAY_FONT_SIZE} */
   size?: number;
-};
+}
 
 /**
  * @category Overlays
  */
-export type OverlayFill = {
+export interface OverlayFill {
   /** @default {@link StyleDefault.DEFAULT_OVERLAY_FILL_COLOR} */
   color?: string;
   /**
@@ -463,12 +463,12 @@ export type OverlayFill = {
    * @default {@link StyleDefault.DEFAULT_OVERLAY_FILL_OPACITY}
    */
   opacity?: number;
-};
+}
 
 /**
  * @category Overlays
  */
-export type OverlayStroke = {
+export interface OverlayStroke {
   /**
    * If you don't want to display a stroke, you can set the color to
    *   * `transparent`
@@ -482,16 +482,16 @@ export type OverlayStroke = {
    * @default {@link StyleDefault.DEFAULT_OVERLAY_STROKE_WIDTH}
    */
   width?: number;
-};
+}
 
 /**
  * @category Overlays
  */
-export type Overlay = {
+export interface Overlay {
   position: OverlayPosition;
   label?: string;
   style?: OverlayStyle;
-};
+}
 
 /**
  * @category Element Style
@@ -501,7 +501,7 @@ export type StyleUpdate = EdgeStyleUpdate | ShapeStyleUpdate;
 /**
  * @category Element Style
  */
-export type EdgeStyleUpdate = {
+export interface EdgeStyleUpdate {
   font?: Font;
   /**
    * The value must be between 0 and 100:
@@ -516,7 +516,7 @@ export type EdgeStyleUpdate = {
    */
   opacity?: Opacity;
   stroke?: Stroke;
-};
+}
 
 /**
  * @category Element Style
@@ -636,7 +636,7 @@ export type Fill = StyleWithOpacity & {
  *
  * @category Element Style
  */
-export type FillColorGradient = {
+export interface FillColorGradient {
   /**
    * It can be any HTML color name or HEX code, as well as special keywords such as:
    * - `inherit` to apply the fill color of the direct parent element.
@@ -661,7 +661,7 @@ export type FillColorGradient = {
    * @see {@link GradientDirection}
    */
   direction: GradientDirection;
-};
+}
 
 /**
  * @category Element Style
@@ -671,7 +671,7 @@ export type GradientDirection = 'left-to-right' | 'right-to-left' | 'bottom-to-t
 /**
  * @category Element Style
  */
-export type StyleWithOpacity = {
+export interface StyleWithOpacity {
   /**
    * The value must be between 0 and 100:
    * - If the set value is less than 0, the used value is 0.
@@ -682,7 +682,7 @@ export type StyleWithOpacity = {
    * - It can be used when the style is first updated and then needs to be reset to its initial value.
    */
   opacity?: Opacity;
-};
+}
 
 /**
  *  @category Element Style

--- a/src/model/bpmn/internal/types.ts
+++ b/src/model/bpmn/internal/types.ts
@@ -17,21 +17,21 @@ limitations under the License.
 /**
  * @internal
  */
-export type ShapeExtensions = {
+export interface ShapeExtensions {
   fillColor?: string;
   strokeColor?: string;
-};
+}
 
 /**
  * @internal
  */
-export type EdgeExtensions = {
+export interface EdgeExtensions {
   strokeColor?: string;
-};
+}
 
 /**
  * @internal
  */
-export type LabelExtensions = {
+export interface LabelExtensions {
   color?: string;
-};
+}

--- a/test/config/jest.image.ts
+++ b/test/config/jest.image.ts
@@ -108,11 +108,11 @@ async function attachImagesForReport(images: LocationOfImagesForTestReport, matc
   }
 }
 
-type LocationOfImagesForTestReport = {
+interface LocationOfImagesForTestReport {
   diff: string;
   expected: string;
   received: string;
-};
+}
 
 function saveImages(options: MatchImageSnapshotOptions): LocationOfImagesForTestReport {
   const snapshotIdentifier = options.customSnapshotIdentifier as string;

--- a/test/integration/helpers/model-expect.ts
+++ b/test/integration/helpers/model-expect.ts
@@ -137,12 +137,12 @@ expect.extend({
   toBeTextAnnotation,
 });
 
-export type ExpectedCellWithGeometry = {
+export interface ExpectedCellWithGeometry {
   parentId?: string;
   geometry: mxGeometry;
-};
+}
 
-export type ExpectedFont = {
+export interface ExpectedFont {
   color?: string;
   family?: string;
   size?: number;
@@ -151,12 +151,12 @@ export type ExpectedFont = {
   isUnderline?: boolean;
   isStrikeThrough?: boolean;
   opacity?: Opacity;
-};
+}
 
 export type HorizontalAlign = 'center' | 'left' | 'right';
 export type VerticalAlign = 'bottom' | 'middle' | 'top';
 
-type ExpectedModelElement = {
+interface ExpectedModelElement {
   align?: HorizontalAlign;
   font?: ExpectedFont;
   label?: string;
@@ -167,19 +167,19 @@ type ExpectedModelElement = {
   opacity?: number;
   // custom bpmn-visualization
   extraCssClasses?: string[];
-};
+}
 
-export type ExpectedFill = {
+export interface ExpectedFill {
   color?: string;
   opacity?: Opacity;
-};
+}
 
 export type ExpectedDirection = 'west' | 'east' | 'north' | 'south';
 
-export type ExpectedGradient = {
+export interface ExpectedGradient {
   color: string;
   direction?: ExpectedDirection;
-};
+}
 
 export type ExpectedShapeModelElement = {
   kind?: ShapeBpmnElementKind;

--- a/test/typescript-support/src/index.ts
+++ b/test/typescript-support/src/index.ts
@@ -27,4 +27,5 @@ bpmnVisualization.load(`fake BPMN content`);
 // Validate the access to the BpmnGraph type and some mxGraph derived methods and properties
 const graph: BpmnGraph = bpmnVisualization.graph;
 graph.view.revalidate();
-graph.getStylesheet() satisfies mxStylesheet;
+const stylesheet: mxStylesheet = graph.getStylesheet();
+stylesheet.putCellStyle('customStyle', { fillColor: '#FF0000' });

--- a/test/typescript-support/src/index.ts
+++ b/test/typescript-support/src/index.ts
@@ -14,8 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// eslint-disable-next-line import/no-unresolved -- The bpmn-visualization package may not have been built prior running eslint (it happens when running GitHub Actions)
+// eslint-disable-next-line import/no-unresolved -- The bpmn-visualization package may not have been built before running eslint (it happens when running GitHub Actions)
+import type { BpmnGraph } from 'bpmn-visualization';
+import type { mxStylesheet } from 'mxgraph';
+
+// eslint-disable-next-line import/no-unresolved -- The bpmn-visualization package may not have been built before running eslint (it happens when running GitHub Actions)
 import { BpmnVisualization } from 'bpmn-visualization';
 
 const bpmnVisualization = new BpmnVisualization({ container: 'bpmn-container' });
 bpmnVisualization.load(`fake BPMN content`);
+
+// Validate the access to the BpmnGraph type and some mxGraph derived methods and properties
+const graph: BpmnGraph = bpmnVisualization.graph;
+graph.view.revalidate();
+graph.getStylesheet() satisfies mxStylesheet;

--- a/test/unit/helpers/JsonBuilder.ts
+++ b/test/unit/helpers/JsonBuilder.ts
@@ -86,7 +86,7 @@ type BuildBoundaryEventParameter = {
 } & BuildInterruptingEventParameter;
 
 export type BuildEventDefinition = 'message' | 'signal' | 'timer' | 'error' | 'escalation' | 'cancel' | 'compensate' | 'conditional' | 'link' | 'terminate';
-export type BuildEventDefinitionParameter = {
+export interface BuildEventDefinitionParameter {
   eventDefinitionKind?: BuildEventDefinition;
   eventDefinitionOn: EventDefinitionOn;
   eventDefinition?: BPMNEventDefinition;
@@ -94,7 +94,7 @@ export type BuildEventDefinitionParameter = {
   withMultipleDefinitions?: boolean;
   source?: string | string[];
   target?: string;
-};
+}
 
 export type BuildTaskKind = 'task' | 'businessRuleTask' | 'manualTask' | 'receiveTask' | 'sendTask' | 'serviceTask' | 'scriptTask' | 'userTask';
 /**
@@ -164,7 +164,7 @@ export type BuildAssociationParameter = Pick<TAssociation, 'id' | 'sourceRef' | 
  */
 export type BuildTextAnnotationParameter = Pick<TTextAnnotation, 'id' | 'text'>;
 
-export type BuildProcessParameter = {
+export interface BuildProcessParameter {
   lane?: BuildLaneParameter | BuildLaneParameter[];
   task?: BuildTaskParameter | BuildTaskParameter[];
   event?: BuildEventParameter | BuildEventParameter[];
@@ -242,28 +242,28 @@ export type BuildProcessParameter = {
 
   /** @default false */
   withParticipant?: boolean;
-};
+}
 
-export type BuildMessageFlowParameter = {
+export interface BuildMessageFlowParameter {
   id: string;
   name?: string;
   sourceRef: string;
   targetRef: string;
-};
+}
 
 export type BpmnGlobalTaskKind = keyof Pick<TDefinitions, 'globalTask' | 'globalBusinessRuleTask' | 'globalManualTask' | 'globalScriptTask' | 'globalUserTask'>;
-export type BuildGlobalTaskParameter = {
+export interface BuildGlobalTaskParameter {
   id?: string;
 
   /** @default 'globalTask' */
   bpmnKind?: BpmnGlobalTaskKind;
-};
+}
 
-export type BuildDefinitionParameter = {
+export interface BuildDefinitionParameter {
   process: BuildProcessParameter | BuildProcessParameter[];
   messageFlows?: BuildMessageFlowParameter | BuildMessageFlowParameter[];
   globalTask?: BuildGlobalTaskParameter | BuildGlobalTaskParameter[];
-};
+}
 
 export function buildDefinitions({ process, messageFlows, globalTask }: BuildDefinitionParameter): BpmnJsonModel {
   const json: BpmnJsonModel = {

--- a/test/unit/helpers/bpmn-model-expect.ts
+++ b/test/unit/helpers/bpmn-model-expect.ts
@@ -80,11 +80,11 @@ export interface ExpectedSequenceEdge extends ExpectedEdge {
   bpmnElementSequenceFlowKind?: SequenceFlowKind;
 }
 
-export type ExpectedLabel = {
+export interface ExpectedLabel {
   bounds?: ExpectedBounds;
   extensions?: LabelExtensions;
   font?: ExpectedFont;
-};
+}
 
 export interface ExpectedFont {
   name?: string;

--- a/test/unit/helpers/bpmn-model-utils.ts
+++ b/test/unit/helpers/bpmn-model-utils.ts
@@ -105,10 +105,10 @@ const withExtras = (bpmnElement: ShapeBpmnElement, extras?: ShapeBpmnElementExtr
   return bpmnElement;
 };
 
-export type ShapeBpmnElementExtraProperties = {
+export interface ShapeBpmnElementExtraProperties {
   incomingIds?: string[];
   outgoingIds?: string[];
-};
+}
 
 const newStartEvent = (parent: string, id: string, name: string, extras?: ShapeBpmnElementExtraProperties): Shape => {
   return new Shape(buildShapeId(id), withExtras(new ShapeBpmnStartEvent(id, name, ShapeBpmnEventDefinitionKind.TIMER, parent), extras));


### PR DESCRIPTION
Convert public type-alias declarations to `interface` declarations so that consumers can augment them via
TypeScript declaration merging. This unlocks extension by downstream libs such as `bpmn-visualization-addons`
without forking the types.

The eslint rule `@typescript-eslint/consistent-type-definitions` was previously disabled. Removing the disable
lets the default `prefer-interface` configuration take effect and keeps future declarations consistent.

Also surface a couple of types and tighten the API documentation:
- export `BpmnGraph` and `Disposable` (as types) so consumers can reference them directly;
- silence typedoc warnings: unused `@param` entries on the destructured parameter of
  `IconPainter.newBpmnCanvas`, unresolved `{@link}` references, mismatched param names;
- add a type-only test under `test/typescript-support/` proving `BpmnGraph` is reachable from a consumer
  package and that mxGraph-derived members (`graph.view.revalidate()`, `graph.getStylesheet()`) compile.

BREAKING CHANGE:
- Public types previously declared with \`type X = { ... }\` are now \`interface X { ... }\`. Object-shape
  usages (Pick, Omit, intersection with \`&\`, \`extends\`) are unaffected. Consumers relying on type-alias-only
  semantics (e.g. assignability of a union/tuple alias) would need to adapt, though no such usage is known.