### PR TITLE
refactor: extract insertEdge private method in BpmnRenderer

### DIFF
--- a/src/component/mxgraph/BpmnRenderer.ts
+++ b/src/component/mxgraph/BpmnRenderer.ts
@@ -92,22 +92,8 @@ export class BpmnRenderer {
       const target = this.getCell(bpmnElement.targetReferenceId);
       const labelBounds = internalEdge.label?.bounds;
       const style = this.styleComputer.computeStyle(internalEdge, labelBounds);
-      const edge = this.graph.insertEdge(parent, bpmnElement.id, bpmnElement.name, source, target, style);
-      this.insertWaypoints(internalEdge.waypoints, edge);
 
-      if (labelBounds) {
-        edge.geometry.width = labelBounds.width;
-        edge.geometry.height = labelBounds.height;
-
-        const edgeCenterCoordinate = this.coordinatesTranslator.computeEdgeCenter(edge);
-        edge.geometry.relative = false;
-
-        const labelBoundsRelativeCoordinateFromParent = this.coordinatesTranslator.computeRelativeCoordinates(edge.parent, new mxPoint(labelBounds.x, labelBounds.y));
-        const relativeLabelX = labelBoundsRelativeCoordinateFromParent.x + labelBounds.width / 2 - edgeCenterCoordinate.x;
-        const relativeLabelY = labelBoundsRelativeCoordinateFromParent.y - edgeCenterCoordinate.y;
-        edge.geometry.offset = new mxPoint(relativeLabelX, relativeLabelY);
-      }
-
+      const edge = this.insertEdge(parent, bpmnElement.id, bpmnElement.name, source, target, internalEdge.waypoints, labelBounds, style);
       this.insertMessageFlowIconIfNeeded(internalEdge, edge);
     }
   }
@@ -128,6 +114,24 @@ export class BpmnRenderer {
 
   private getCell(id: string): mxCell {
     return this.graph.getModel().getCell(id);
+  }
+
+  private insertEdge(parent: mxCell, id: string | null, value: string, source: mxCell, target: mxCell, waypoints: Waypoint[], labelBounds: Bounds, style: string): mxCell {
+    const edge = this.graph.insertEdge(parent, id, value, source, target, style);
+    this.insertWaypoints(waypoints, edge);
+
+    if (labelBounds) {
+      edge.geometry.width = labelBounds.width;
+      edge.geometry.height = labelBounds.height;
+      edge.geometry.relative = false;
+
+      const edgeCenterCoordinate = this.coordinatesTranslator.computeEdgeCenter(edge);
+      const labelBoundsRelativeCoordinateFromParent = this.coordinatesTranslator.computeRelativeCoordinates(edge.parent, new mxPoint(labelBounds.x, labelBounds.y));
+      const relativeLabelX = labelBoundsRelativeCoordinateFromParent.x + labelBounds.width / 2 - edgeCenterCoordinate.x;
+      const relativeLabelY = labelBoundsRelativeCoordinateFromParent.y - edgeCenterCoordinate.y;
+      edge.geometry.offset = new mxPoint(relativeLabelX, relativeLabelY);
+    }
+    return edge;
   }
 
   private insertVertex(parent: mxCell, id: string | null, value: string, bounds: Bounds, labelBounds: Bounds, style?: string): mxCell {

--- a/src/component/mxgraph/BpmnRenderer.ts
+++ b/src/component/mxgraph/BpmnRenderer.ts
@@ -86,14 +86,7 @@ export class BpmnRenderer {
 
   private insertEdges(edges: Edge[]): void {
     for (const internalEdge of edges) {
-      const bpmnElement = internalEdge.bpmnElement;
-      const parent = this.graph.getDefaultParent();
-      const source = this.getCell(bpmnElement.sourceReferenceId);
-      const target = this.getCell(bpmnElement.targetReferenceId);
-      const labelBounds = internalEdge.label?.bounds;
-      const style = this.styleComputer.computeStyle(internalEdge, labelBounds);
-
-      const edge = this.insertEdge(parent, bpmnElement.id, bpmnElement.name, source, target, internalEdge.waypoints, labelBounds, style);
+      const edge = this.insertEdge(internalEdge);
       this.insertMessageFlowIconIfNeeded(internalEdge, edge);
     }
   }
@@ -116,9 +109,15 @@ export class BpmnRenderer {
     return this.graph.getModel().getCell(id);
   }
 
-  private insertEdge(parent: mxCell, id: string | null, value: string, source: mxCell, target: mxCell, waypoints: Waypoint[], labelBounds: Bounds, style: string): mxCell {
-    const edge = this.graph.insertEdge(parent, id, value, source, target, style);
-    this.insertWaypoints(waypoints, edge);
+  private insertEdge(internalEdge: Edge): mxCell {
+    const bpmnElement = internalEdge.bpmnElement;
+    const parent = this.graph.getDefaultParent();
+    const source = this.getCell(bpmnElement.sourceReferenceId);
+    const target = this.getCell(bpmnElement.targetReferenceId);
+    const labelBounds = internalEdge.label?.bounds;
+    const style = this.styleComputer.computeStyle(internalEdge, labelBounds);
+    const edge = this.graph.insertEdge(parent, bpmnElement.id, bpmnElement.name, source, target, style);
+    this.insertWaypoints(internalEdge.waypoints, edge);
 
     if (labelBounds) {
       edge.geometry.width = labelBounds.width;


### PR DESCRIPTION
Mirror the existing insertVertex helper by extracting an insertEdge private method that encapsulates edge cell
creation, waypoints insertion, and label-bounds geometry. The previous insertEdges loop inlined all three concerns,
producing an asymmetry with the shape path where insertVertex already encapsulates the equivalent responsibilities.

The waypoint-before-label-bounds ordering is preserved inside the new helper because computeEdgeCenter reads
edge.geometry.points, which is set by insertWaypoints. Message flow icon insertion stays at the loop level since it
is a separate child-cell concern rather than part of the edge cell geometry.

No behavior change: build, unit tests (BpmnRenderer.test.ts, 38 tests) and integration tests (14 suites, 312 tests)
all pass.