### PR TITLE
refactor!: stop exporting StyleConfigurator and mxImageExport

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -83,7 +83,7 @@ jobs:
           registry-url: ${{ inputs.registry-url }}
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
-        if: inputs.install-dependencies == 'true'
+        #        if: inputs.install-dependencies == 'true'
         with:
           install-command: npm ci --ignore-scripts --prefer-offline --audit false
 # END OF temporary workaround

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -71,8 +71,22 @@ jobs:
       - name: Free disk space on Ubuntu runner
         if: runner.os == 'Linux'
         uses: ./.github/actions/free-runner-disk-space-ubuntu
-      - name: Build Setup
-        uses: ./.github/actions/build-setup
+# START temporary workaround
+# Browser download failure with Node 24. See https://github.com/microsoft/playwright/issues/41185 and https://github.com/microsoft/playwright-cli/issues/419#issuecomment-4646958277 (that mentions that it should work with Node 22)
+#      - name: Build Setup
+#        uses: ./.github/actions/build-setup
+      - name: Setup node
+        uses: actions/setup-node@v6
+        with:
+#          node-version-file: '.nvmrc'
+          node-version: '22'
+          registry-url: ${{ inputs.registry-url }}
+      - name: Install dependencies
+        uses: bahmutov/npm-install@v1
+        if: inputs.install-dependencies == 'true'
+        with:
+          install-command: npm ci --ignore-scripts --prefer-offline --audit false
+# END OF temporary workaround
       - name: Install ${{matrix.browser}}
         uses: ./.github/actions/install-playwright-browser
         with:

--- a/.github/workflows/test-npm-package.yml
+++ b/.github/workflows/test-npm-package.yml
@@ -59,7 +59,7 @@ jobs:
           registry-url: ${{ inputs.registry-url }}
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
-        if: inputs.install-dependencies == 'true'
+        #        if: inputs.install-dependencies == 'true'
         with:
           install-command: npm ci --ignore-scripts --prefer-offline --audit false
       # END OF temporary workaround

--- a/.github/workflows/test-npm-package.yml
+++ b/.github/workflows/test-npm-package.yml
@@ -47,8 +47,22 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Build Setup
-        uses: ./.github/actions/build-setup
+      # START temporary workaround
+      # Browser download failure with Node 24. See https://github.com/microsoft/playwright/issues/41185 and https://github.com/microsoft/playwright-cli/issues/419#issuecomment-4646958277 (that mentions that it should work with Node 22)
+      #      - name: Build Setup
+      #        uses: ./.github/actions/build-setup
+      - name: Setup node
+        uses: actions/setup-node@v6
+        with:
+          #          node-version-file: '.nvmrc'
+          node-version: '22'
+          registry-url: ${{ inputs.registry-url }}
+      - name: Install dependencies
+        uses: bahmutov/npm-install@v1
+        if: inputs.install-dependencies == 'true'
+        with:
+          install-command: npm ci --ignore-scripts --prefer-offline --audit false
+      # END OF temporary workaround
       - name: Build npm package
         run: npm pack
       - name: List the size of the npm package bundles

--- a/dev/ts/component/SvgExporter.ts
+++ b/dev/ts/component/SvgExporter.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import type { mxGraph, mxSvgCanvas2D as mxSvgCanvas2DType } from 'mxgraph';
 
-import { mxClient, mxConstants, mxImageExport, mxSvgCanvas2D, mxUtils } from '../../../src/component/mxgraph/initializer';
+import { mxClient, mxConstants, mxgraph, mxSvgCanvas2D, mxUtils } from '../../../src/component/mxgraph/initializer';
 
 interface SvgExportOptions {
   scale: number;
@@ -92,7 +92,7 @@ ${svgAsString}
 
     svgCanvas.scale(s);
 
-    const imgExport = new mxImageExport();
+    const imgExport = new mxgraph.mxImageExport();
     // FIXME only the first overlay is placed at the right position
     // overlays put on element of subprocess/call-activity are not placed correctly in svg export
     imgExport.includeOverlays = true;

--- a/dev/ts/component/ThemedBpmnVisualization.ts
+++ b/dev/ts/component/ThemedBpmnVisualization.ts
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { BpmnVisualization, FlowKind, ShapeBpmnElementKind, ShapeUtil, StyleConfigurator, StyleDefault } from '../../../src/bpmn-visualization';
+import { BpmnVisualization, FlowKind, ShapeBpmnElementKind, ShapeUtil, StyleDefault } from '../../../src/bpmn-visualization';
+import { StyleConfigurator } from '../../../src/component/mxgraph/config/StyleConfigurator';
 import { mxConstants } from '../../../src/component/mxgraph/initializer';
 import { logStartup } from '../shared/internal-helpers';
 

--- a/dev/ts/shared/main.ts
+++ b/dev/ts/shared/main.ts
@@ -402,6 +402,7 @@ function updateStyleOfElementsIfRequested(): void {
   }
 }
 
+// May have bad performance for large diagrams as it does a lot of DOM lookups
 function retrieveAllBpmnElementIds(): string[] {
   log('Retrieving ids of all BPMN elements');
   const allKinds = [...Object.values(ShapeBpmnElementKind), ...Object.values(FlowKind)];

--- a/dev/ts/shared/main.ts
+++ b/dev/ts/shared/main.ts
@@ -402,7 +402,6 @@ function updateStyleOfElementsIfRequested(): void {
   }
 }
 
-// May have bad performance for large diagrams as it does CSS selector
 function retrieveAllBpmnElementIds(): string[] {
   log('Retrieving ids of all BPMN elements');
   const allKinds = [...Object.values(ShapeBpmnElementKind), ...Object.values(FlowKind)];

--- a/src/bpmn-visualization.ts
+++ b/src/bpmn-visualization.ts
@@ -31,7 +31,6 @@ export type { BpmnGraph } from './component/mxgraph/BpmnGraph';
 export type * from './component/types';
 
 // not part of the public API but needed for the custom theme examples
-export { StyleConfigurator } from './component/mxgraph/config/StyleConfigurator';
 export * from './component/mxgraph/style';
 export * from './component/mxgraph/shape/render';
 

--- a/src/component/mxgraph/initializer.ts
+++ b/src/component/mxgraph/initializer.ts
@@ -46,7 +46,6 @@ export const {
   mxEvent,
   mxGeometry, // at least used in tests
   mxGraphView,
-  mxImageExport,
   mxImageShape,
   mxMarker,
   mxPerimeter,

--- a/src/component/registry/types.ts
+++ b/src/component/registry/types.ts
@@ -185,6 +185,9 @@ export interface ElementsRegistry {
    *
    * If you also need to retrieve the related DOM elements and more information, use {@link getElementsByKinds} instead.
    *
+   * **WARNING**: this method is not designed to accept a large number of types. Its implementation currently does DOM lookup to retrieve the BPMN elements for a given kind (some technical limitations require this).
+   * Attempts to retrieve too many elements, especially on large BPMN diagrams, may lead to performance issues.
+   *
    * @param bpmnKinds The BPMN kind of the element(s) to retrieve.
    * @since 0.39.0
    */
@@ -204,7 +207,7 @@ export interface ElementsRegistry {
    *
    * If you only need to retrieve the BPMN model data, use {@link getModelElementsByKinds} instead.
    *
-   * **WARNING**: this method is not designed to accept a large amount of types. It does DOM lookup to retrieve the HTML elements relative to the BPMN elements.
+   * **WARNING**: this method is not designed to accept a large number of types. It does DOM lookup to retrieve the HTML elements relative to the BPMN elements.
    * Attempts to retrieve too many elements, especially on large BPMN diagrams, may lead to performance issues.
    *
    * @param bpmnKinds The BPMN kind of the element(s) to retrieve.


### PR DESCRIPTION
StyleConfigurator and mxImageExport were exposed through the public entry points but are mxGraph implementation details that should not be part of the supported API surface. Removing them keeps the public API focused and avoids leaking mxGraph internals to consumers.

The dev examples that relied on them now import StyleConfigurator from its internal path and call 
mxgraph.mxImageExport() directly. This is not a breaking change as this export had never been released.

BREAKING CHANGE:
- StyleConfigurator is no longer exported from the bpmn-visualization entry point. It is internals only and should not have been exported. There is no known usage of StyleConfigurator, so the impact should be very limited or null.
