### PR TITLE
fix(scripts): compute bundle size KB with 1000 not 1024

### DIFF
--- a/scripts/list-npm-bundle-sizes.sh
+++ b/scripts/list-npm-bundle-sizes.sh
@@ -35,7 +35,7 @@ for bundle in "${BUNDLES[@]}"; do
     exit 1
   fi
   size_bytes=$(stat --format=%s "$file")
-  size_kb=$(LC_NUMERIC=C awk "BEGIN {printf \"%.1f\", $size_bytes / 1024}")
+  size_kb=$(LC_NUMERIC=C awk "BEGIN {printf \"%.1f\", $size_bytes / 1000}")
   # Format bytes with space as thousands separator (e.g. 998629 -> "998 629")
   size_bytes_fmt=$(echo "$size_bytes" | sed ':a;s/\B[0-9]\{3\}\>/ &/;ta')
   names+=("$bundle")


### PR DESCRIPTION
## Summary

- Fixes the byte-to-kilobyte conversion divisor in `scripts/list-npm-bundle-sizes.sh` from 1024 to 1000
- kB (kilobyte) is conventionally 1000 bytes in the context of file/bundle sizes, matching how npm and most bundler tools report sizes
- The previous value (1024) produced KiB (kibibyte) values, causing a mismatch with the expected reporting unit

## Test plan

- [x] Run `npm run build-bundles` and then `bash scripts/list-npm-bundle-sizes.sh` to verify sizes are reported in kB (consistent with npm output)